### PR TITLE
[SEDONA-142] Add ST_Collect to Flink Catalog

### DIFF
--- a/flink/src/main/java/org/apache/sedona/flink/SedonaFlinkRegistrator.java
+++ b/flink/src/main/java/org/apache/sedona/flink/SedonaFlinkRegistrator.java
@@ -13,12 +13,17 @@
  */
 package org.apache.sedona.flink;
 
+import org.apache.calcite.runtime.Geometries;
+import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
-import org.apache.sedona.common.geometryObjects.Circle;
+import org.apache.flink.table.functions.UserDefinedFunction;
+import org.apache.sedona.core.geometryObjects.Circle;
 import org.apache.sedona.core.geometryObjects.GeometrySerde;
 import org.apache.sedona.core.geometryObjects.SpatialIndexSerde;
 import org.apache.sedona.core.spatialPartitioning.PartitioningUtils;
+import org.apache.sedona.flink.expressions.ST_Collect;
 import org.locationtech.jts.geom.*;
 import org.locationtech.jts.index.quadtree.Quadtree;
 import org.locationtech.jts.index.strtree.STRtree;
@@ -36,9 +41,24 @@ public class SedonaFlinkRegistrator {
         );
     }
 
+    /**
+     * This is needed because for Resolving the RAW Geometry DataType in ST_Collect (MapView in Accumulator)
+     * the serializer needs to be known. To get the registered Serializer the ExecutionEnvironment is needed and
+     * to add the UDF the TableEnvironment ist needed.
+     * @param env
+     * @param tblEnv
+     */
+    public static void registerCollect(StreamExecutionEnvironment env, StreamTableEnvironment tblEnv)
+    {
+        KryoSerializer<Geometry> serializer = new KryoSerializer(Geometry.class, env.getConfig());
+        UserDefinedFunction fun = new ST_Collect(DataTypes.RAW(Geometry.class, serializer));
+        tblEnv.createTemporarySystemFunction(fun.getClass().getSimpleName(), fun);
+    }
+
     public static void registerType(StreamExecutionEnvironment env) {
         GeometrySerde serializer = new GeometrySerde();
         SpatialIndexSerde indexSerializer = new SpatialIndexSerde(serializer);
+        env.getConfig().registerTypeWithKryoSerializer(Geometry.class, serializer);
         env.getConfig().registerTypeWithKryoSerializer(Point.class, serializer);
         env.getConfig().registerTypeWithKryoSerializer(LineString.class, serializer);
         env.getConfig().registerTypeWithKryoSerializer(Polygon.class, serializer);

--- a/flink/src/main/java/org/apache/sedona/flink/expressions/ST_Collect.java
+++ b/flink/src/main/java/org/apache/sedona/flink/expressions/ST_Collect.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sedona.flink.expressions;
+
+import org.apache.flink.table.annotation.DataTypeHint;
+import org.apache.flink.table.annotation.FunctionHint;
+import org.apache.flink.table.annotation.InputGroup;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.dataview.MapView;
+import org.apache.flink.table.catalog.DataTypeFactory;
+import org.apache.flink.table.functions.AggregateFunction;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.TypeInference;
+import org.apache.flink.table.types.inference.strategies.ExplicitTypeStrategy;
+
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryCollection;
+import org.locationtech.jts.geom.GeometryFactory;
+
+import java.util.Map;
+
+/**
+ * This class is basically a copy of
+ * flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/aggregate/CollectAggFunction.java/
+ * specialized for Geometries, so it does return a GeometryCollection instead of Multiset of Geometries.
+ * The type currently is always geometry collection even for homogenous geometries.
+ */
+@FunctionHint(
+        input = @DataTypeHint(inputGroup = InputGroup.ANY, value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class),
+        output = @DataTypeHint(inputGroup = InputGroup.ANY, value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class),
+        accumulator = @DataTypeHint(bridgedTo = ST_Collect.GeometryCollectAccumulator.class)
+)
+public class ST_Collect extends AggregateFunction<Geometry, ST_Collect.GeometryCollectAccumulator> {
+    private final transient DataType elementDataType;
+    public ST_Collect(DataType geomType)
+    {
+        this.elementDataType = geomType;
+    }
+
+    /**
+     *   Manual type inference because we need to specify
+     *          - the output type (Raw bridged to geometry)
+     *          - and for the Accumulator, because the key type of the mapview gets erased
+     * @param typeFactory
+     * @return
+     */
+    @Override
+    public TypeInference getTypeInference(DataTypeFactory typeFactory) {
+
+        DataType accumulatorType = DataTypes.STRUCTURED(
+                GeometryCollectAccumulator.class,
+                DataTypes.FIELD(
+                        "map",
+                        MapView.newMapViewDataType(elementDataType.notNull(), DataTypes.INT())));
+
+        return TypeInference.
+                newBuilder().
+                accumulatorTypeStrategy(new ExplicitTypeStrategy(accumulatorType)).
+                outputTypeStrategy(new ExplicitTypeStrategy(elementDataType.bridgedTo(Geometry.class))).build();
+    }
+
+    public static class GeometryCollectAccumulator {
+        @DataTypeHint(value = "MAP<RAW, INT>")
+        public MapView<Geometry, Integer> map = new MapView<>();
+    }
+
+
+    @Override
+    @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class)
+    public Geometry getValue(ST_Collect.GeometryCollectAccumulator accumulator) {
+        Map<Geometry, Integer> map = accumulator.map.getMap();
+        GeometryFactory fact = new GeometryFactory();
+        GeometryCollection collection = fact.createGeometryCollection(map.keySet().toArray(new Geometry[0]));
+        return collection;
+    }
+
+    @Override
+    public ST_Collect.GeometryCollectAccumulator createAccumulator() {
+        final ST_Collect.GeometryCollectAccumulator acc = new ST_Collect.GeometryCollectAccumulator();
+        return acc;
+    }
+
+    public void accumulate(ST_Collect.GeometryCollectAccumulator accumulator,
+                          @DataTypeHint(inputGroup = InputGroup.ANY, value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o) throws Exception {
+        Geometry geom = (Geometry) o;
+        if (geom != null) {
+            Integer count = accumulator.map.get(geom);
+            if (count != null) {
+                accumulator.map.put(geom, count + 1);
+            } else {
+                accumulator.map.put(geom, 1);
+            }
+        }
+    }
+
+    public void retract(ST_Collect.GeometryCollectAccumulator accumulator,
+                        @DataTypeHint(inputGroup =InputGroup.ANY, value ="RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o) throws Exception {
+        Geometry geom = (Geometry) o;
+        if (geom != null) {
+            Integer count = accumulator.map.get(geom);
+            if (count != null) {
+                if (count == 1) {
+                    accumulator.map.remove(geom);
+                } else {
+                    accumulator.map.put(geom, count - 1);
+                }
+            } else {
+                accumulator.map.put(geom, -1);
+            }
+        }
+    }
+
+    public void merge(ST_Collect.GeometryCollectAccumulator accumulator, Iterable<ST_Collect.GeometryCollectAccumulator> others)
+            throws Exception {
+        for (ST_Collect.GeometryCollectAccumulator other : others) {
+            for (Map.Entry<Geometry, Integer> entry : other.map.entries()) {
+                Geometry key = entry.getKey();
+                Integer newCount = entry.getValue();
+                Integer oldCount = accumulator.map.get(key);
+                if (oldCount == null) {
+                    accumulator.map.put(key, newCount);
+                } else {
+                    accumulator.map.put(key, oldCount + newCount);
+                }
+            }
+        }
+    }
+
+    public void resetAccumulator(ST_Collect.GeometryCollectAccumulator accumulator) {
+        accumulator.map.clear();
+    }
+}


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)

- Yes.

## Is this PR related to a JIRA ticket?

- Yes, the URL of the assoicated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-142. The PR name follows the format `[SEDONA-142] Add ST_Collect to Flink Catalog`.

I actually created to JIRA tickets by accident ([SEDONA-141](https://issues.apache.org/jira/browse/SEDONA-141)). One could/should be deleted. Sorry for that.

## What changes were proposed in this PR?
This is the first attempt to add ST_Collect aggregation to the flink api.

## How was this patch tested?
In progress
For myself I only tested aggregations with group by.
I guess it would be necessary to test window/over aggregations as well. Does anyone have specific data/queries for these in mind?

## Did this PR include necessary documentation updates?
Currently not.

In advance this pull request is mainly done to discuss if this is a feasible approach to implement ST_Collect.
The PR would have to be cleaned up (split up), tests would need to be added and it would need to be documented.

I basically took the Internal Collect Aggregator from flink-table and adjusted it's types, letting it return a GeometryCollection.
The getTypeInference needs to be overriden otherwise reflection fails for the mapview / selecting the right serializer fails.
One Problem is/was that this function is not instantiated from a BuiltInFunctionDefinition/, 
so it is not possible to implement it as BuiltInAggregateFunction and let it pass a SpecializedFunction.SpecializedContext to its constructor. And flinks collect function is constructed through its AggFunctionFactory which also passes the argType.
So I needed to pass the Datatype for the geometry manually when constructing and adding it to the catalog, therefore needing a util function in the registrator.

If needed I add separate prs to ST_MakeValid which is an almost 1-t port/copy from the spark version, and the ST_Intersection, ST_Difference which just wrap the jts locationtech functions.
