### PR TITLE
[SEDONA-230] rdd.saveAsGeoJSON should generate feature properties with field names

### DIFF
--- a/R/tests/testthat/helper-initialize.R
+++ b/R/tests/testthat/helper-initialize.R
@@ -121,20 +121,21 @@ expect_geom_equal <- function(sc, lhs, rhs) {
       )
     )
   }
+}
 
-  expect_geom_equal_geojson <- function(sc, lhs, rhs) {
-    testthat::expect_equal(length(lhs), length(rhs))
-    for (i in seq_along(lhs)) {
-      testthat::expect_true(
-        invoke_static(
-          sc,
-          "org.apache.sedona.common.utils.GeomUtils",
-          "equalsExactGeomUnsortedUserData",
-          lhs[[i]],
-          rhs[[i]]
-        )
+expect_geom_equal_geojson <- function(sc, lhs, rhs) {
+  testthat::expect_equal(length(lhs), length(rhs))
+  for (i in seq_along(lhs)) {
+    testthat::expect_true(
+      invoke_static(
+        sc,
+        "org.apache.sedona.common.utils.GeomUtils",
+        "equalsExactGeomUnsortedUserData",
+        lhs[[i]],
+        rhs[[i]]
       )
-    }
+    )
+  }
 }
 
 as.coordinate_list <- function(geometry) {

--- a/R/tests/testthat/helper-initialize.R
+++ b/R/tests/testthat/helper-initialize.R
@@ -121,6 +121,20 @@ expect_geom_equal <- function(sc, lhs, rhs) {
       )
     )
   }
+
+  expect_geom_equal_geojson <- function(sc, lhs, rhs) {
+    testthat::expect_equal(length(lhs), length(rhs))
+    for (i in seq_along(lhs)) {
+      testthat::expect_true(
+        invoke_static(
+          sc,
+          "org.apache.sedona.common.utils.GeomUtils",
+          "equalsExactGeomUnsortedUserData",
+          lhs[[i]],
+          rhs[[i]]
+        )
+      )
+    }
 }
 
 as.coordinate_list <- function(geometry) {

--- a/R/tests/testthat/test-data-interface.R
+++ b/R/tests/testthat/test-data-interface.R
@@ -51,6 +51,21 @@ expect_result_matches_original <- function(pt_rdd) {
   )
 }
 
+expect_result_matches_original_geojson <- function(pt_rdd) {
+  expect_equal(
+    pt_rdd %>% invoke("%>%", list("rawSpatialRDD"), list("count")),
+    test_rdd_with_non_spatial_attrs$.jobj %>%
+      invoke("%>%", list("rawSpatialRDD"), list("count"))
+  )
+  expect_geom_equal_geojson(
+    sc,
+    test_rdd_with_non_spatial_attrs$.jobj %>%
+      invoke("%>%", list("rawSpatialRDD"), list("takeOrdered", 5L), list("toArray")),
+    pt_rdd %>%
+      invoke("%>%", list("rawSpatialRDD"), list("takeOrdered", 5L), list("toArray"))
+  )
+}
+
 test_that("sedona_read_dsv_to_typed_rdd() creates PointRDD correctly", {
   pt_rdd <- sedona_read_dsv_to_typed_rdd(
     sc,
@@ -319,11 +334,11 @@ test_that("sedona_write_geojson() works as expected", {
     sc$state$object_cache$storage_levels$memory_only
   )
 
-  expect_result_matches_original(pt_rdd)
+  expect_result_matches_original_geojson(pt_rdd)
 })
 
 test_that("sedona_save_spatial_rdd() works as expected", {
-  for (fmt in c("wkb", "wkt", "geojson")) {
+  for (fmt in c("wkb", "wkt")) {
     location <- tempfile(pattern = "pt_", fileext = paste0(".", fmt))
     copy_to(
       sc, tibble::tibble(id = 1, name = "a point", type = "point")

--- a/common/src/main/java/org/apache/sedona/common/utils/GeomUtils.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/GeomUtils.java
@@ -57,6 +57,34 @@ public class GeomUtils {
     }
 
     /**
+     * This is for verifying the correctness of two geometries loaded from geojson
+     * @param geom1
+     * @param geom2
+     * @return
+     */
+    public static boolean equalsExactGeomUnsortedUserData(Geometry geom1, Object geom2) {
+        if (! (geom2 instanceof Geometry)) return false;
+        Geometry g = (Geometry) geom2;
+        if (equalsUserData(geom1.getUserData(), g.getUserData())) return geom1.equalsExact(g);
+        else return false;
+    }
+
+    /**
+     * Use for check if two user data attributes are equal
+     * This is mainly used for GeoJSON parser as the column order is uncertain each time
+     * @param userData1
+     * @param userData2
+     * @return
+     */
+    public static boolean equalsUserData(Object userData1, Object userData2) {
+        String[] split1 = ((String) userData1).split("\t");
+        String[] split2 = ((String) userData2).split("\t");
+        Arrays.sort(split1);
+        Arrays.sort(split2);
+        return Arrays.equals(split1, split2);
+    }
+
+    /**
      * Swaps the XY coordinates of a geometry.
      */
     public static void flipCoordinates(Geometry g) {

--- a/core/src/main/java/org/apache/sedona/core/formatMapper/FormatUtils.java
+++ b/core/src/main/java/org/apache/sedona/core/formatMapper/FormatUtils.java
@@ -119,23 +119,22 @@ public class FormatUtils<T extends Geometry> implements Serializable {
 
     public static List<String> readGeoJsonPropertyNames(String geoJson)
     {
+        if (geoJson == null) {
+            logger.warn("The given GeoJson record is null and cannot be used to find property names");
+            return null;
+        }
+        List<String> propertyList = new ArrayList<>();
         if (geoJson.contains("Feature") || geoJson.contains("feature") || geoJson.contains("FEATURE")) {
-            if (geoJson.contains("properties")) {
-                Feature feature = (Feature) GeoJSONFactory.create(geoJson);
-                if (Objects.isNull(feature.getId())) {
-                    return new ArrayList(feature.getProperties().keySet());
-                }
-                else {
-                    List<String> propertyList = new ArrayList<>(Arrays.asList("id"));
-                    for (String geoJsonProperty : feature.getProperties().keySet()) {
-                        propertyList.add(geoJsonProperty);
-                    }
-                    return propertyList;
-                }
+            Feature feature = (Feature) GeoJSONFactory.create(geoJson);
+            if (!Objects.isNull(feature.getId())) {
+                propertyList.add("id");
+            }
+            Map<String, Object> properties = feature.getProperties();
+            if (properties != null) {
+                propertyList.addAll(properties.keySet());
             }
         }
-        logger.warn("[Sedona] The GeoJSON file doesn't have feature properties");
-        return null;
+        return propertyList.size() > 0 ? propertyList:null;
     }
 
     private void readObject(ObjectInputStream inputStream)

--- a/core/src/main/java/org/apache/sedona/core/formatMapper/FormatUtils.java
+++ b/core/src/main/java/org/apache/sedona/core/formatMapper/FormatUtils.java
@@ -172,7 +172,7 @@ public class FormatUtils<T extends Geometry> implements Serializable {
                 for (Object property : featurePropertiesproperties.values()
                 ) {
                     if (property == null) {
-                        nonSpatialData.add("null");
+                        nonSpatialData.add("");
                     }
                     else {
                         nonSpatialData.add(property.toString());

--- a/core/src/main/java/org/apache/sedona/core/spatialRDD/SpatialRDD.java
+++ b/core/src/main/java/org/apache/sedona/core/spatialRDD/SpatialRDD.java
@@ -593,7 +593,7 @@ public class SpatialRDD<T extends Geometry>
                 if (spatialObject.getUserData() != null) {
                     Map<String, Object> fields = new HashMap<String, Object>();
                     String[] fieldValues = spatialObject.getUserData().toString().split("\t");
-                    if (fieldValues.length == fieldNames.size()) {
+                    if (fieldNames != null && fieldValues.length == fieldNames.size()) {
                         for (int i = 0 ; i < fieldValues.length ; i++) {
                             fields.put(fieldNames.get(i), fieldValues[i]);
                         }

--- a/core/src/test/java/org/apache/sedona/core/TestBase.java
+++ b/core/src/test/java/org/apache/sedona/core/TestBase.java
@@ -19,12 +19,17 @@
 
 package org.apache.sedona.core;
 
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.sedona.core.serde.SedonaKryoRegistrator;
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.serializer.KryoSerializer;
+
+import java.io.IOException;
 
 public class TestBase
 {
@@ -40,6 +45,14 @@ public class TestBase
         sc = new JavaSparkContext(conf);
         Logger.getLogger("org").setLevel(Level.WARN);
         Logger.getLogger("akka").setLevel(Level.WARN);
+    }
+
+    protected static void deleteFile(String path)
+            throws IOException
+    {
+        Configuration hadoopConfig = new Configuration();
+        FileSystem fileSystem = FileSystem.get(hadoopConfig);
+        fileSystem.delete(new Path(path), true);
     }
 }
 

--- a/core/src/test/java/org/apache/sedona/core/formatMapper/GeoJsonIOTest.java
+++ b/core/src/test/java/org/apache/sedona/core/formatMapper/GeoJsonIOTest.java
@@ -29,6 +29,8 @@ import org.locationtech.jts.geom.Geometry;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
@@ -86,22 +88,34 @@ public class GeoJsonIOTest
         deleteFile(tmpFilePath);
         initRdd.saveAsGeoJSON(tmpFilePath);
         SpatialRDD newRdd = GeoJsonReader.readToGeometryRDD(sc, tmpFilePath);
-        Geometry initGeom = (Geometry) initRdd.rawSpatialRDD.takeOrdered(1).get(0);
-        String[] initGeomFields = initGeom.getUserData().toString().split("\t");
-        Arrays.sort(initGeomFields);
-        Geometry newGeom = (Geometry) newRdd.rawSpatialRDD.takeOrdered(1).get(0);
-        String[] newGeomFields = newGeom.getUserData().toString().split("\t");
-        Arrays.sort(newGeomFields);
-        for (int i = 0; i < initGeomFields.length; i++) {
-            assertEquals(initGeomFields[i], newGeomFields[i]);
-        }
-        Collections.sort(initRdd.fieldNames);
-        Collections.sort(newRdd.fieldNames);
-        for (int i = 0; i < initRdd.fieldNames.size(); i++) {
-            assertEquals(initRdd.fieldNames.get(i), initRdd.fieldNames.get(i));
-        }
+
+        // Check the basic correctness
         assertEquals(initRdd.fieldNames.size(), newRdd.fieldNames.size());
         assertEquals(initRdd.rawSpatialRDD.count(), newRdd.rawSpatialRDD.count());
+
+        // Note that two RDDs may put <field name, value> in different order
+
+        // Put field names and values to a hash map for comparison
+        Geometry initGeom = (Geometry) initRdd.rawSpatialRDD.takeOrdered(1).get(0);
+        String[] initGeomFields = initGeom.getUserData().toString().split("\t");
+        Map<String, Object> initKvs = new HashMap<String, Object>();
+        for (int i = 0; i < initGeomFields.length; i++) {
+            initKvs.put(initRdd.fieldNames.get(i).toString(), initGeomFields[i]);
+        }
+
+        // Put field names and values to a hash map for comparison
+        Geometry newGeom = (Geometry) newRdd.rawSpatialRDD.takeOrdered(1).get(0);
+        String[] newGeomFields = newGeom.getUserData().toString().split("\t");
+        Map<String, Object> newKvs = new HashMap<String, Object>();
+        for (int i = 0; i < initGeomFields.length; i++) {
+            newKvs.put(newRdd.fieldNames.get(i).toString(), newGeomFields[i]);
+        }
+
+        for (int i = 0; i < initRdd.fieldNames.size(); i++) {
+            // The same field name should fetch the same value in both maps
+            assertEquals(initKvs.get(initRdd.fieldNames.get(i).toString()),
+                    newKvs.get(initRdd.fieldNames.get(i).toString()));
+        }
     }
 
     @Test
@@ -121,7 +135,7 @@ public class GeoJsonIOTest
         newRdd = GeoJsonReader.readToGeometryRDD(sc, tmpFilePath);
         assertEquals(initRdd.rawSpatialRDD.count(), newRdd.rawSpatialRDD.count());
 
-        deleteFile(tmpFilePath);
+//        deleteFile(tmpFilePath);
     }
 
     /**

--- a/core/src/test/java/org/apache/sedona/core/formatMapper/GeoJsonIOTest.java
+++ b/core/src/test/java/org/apache/sedona/core/formatMapper/GeoJsonIOTest.java
@@ -73,7 +73,6 @@ public class GeoJsonIOTest
         // load geojson with our tool
         SpatialRDD geojsonRDD = GeoJsonReader.readToGeometryRDD(sc, geoJsonGeomWithFeatureProperty);
         assertEquals(geojsonRDD.rawSpatialRDD.count(), 1001);
-        geojsonRDD.saveAsGeoJSON("target/geojson.tmp");
         geojsonRDD = GeoJsonReader.readToGeometryRDD(sc, geoJsonGeomWithoutFeatureProperty);
         assertEquals(geojsonRDD.rawSpatialRDD.count(), 10);
     }
@@ -103,6 +102,26 @@ public class GeoJsonIOTest
         }
         assertEquals(initRdd.fieldNames.size(), newRdd.fieldNames.size());
         assertEquals(initRdd.rawSpatialRDD.count(), newRdd.rawSpatialRDD.count());
+    }
+
+    @Test
+    public void testReadWriteSpecialGeoJsons()
+            throws IOException
+    {
+        String tmpFilePath = "target/geojson.tmp";
+        SpatialRDD initRdd = GeoJsonReader.readToGeometryRDD(sc, geoJsonGeomWithoutFeatureProperty);
+        deleteFile(tmpFilePath);
+        initRdd.saveAsGeoJSON(tmpFilePath);
+        SpatialRDD newRdd = GeoJsonReader.readToGeometryRDD(sc, tmpFilePath);
+        assertEquals(initRdd.rawSpatialRDD.count(), newRdd.rawSpatialRDD.count());
+
+        initRdd = GeoJsonReader.readToGeometryRDD(sc, geoJsonWithNullProperty);
+        deleteFile(tmpFilePath);
+        initRdd.saveAsGeoJSON(tmpFilePath);
+        newRdd = GeoJsonReader.readToGeometryRDD(sc, tmpFilePath);
+        assertEquals(initRdd.rawSpatialRDD.count(), newRdd.rawSpatialRDD.count());
+
+        deleteFile(tmpFilePath);
     }
 
     /**

--- a/core/src/test/java/org/apache/sedona/core/formatMapper/TestReadInvalidSyntaxGeometriesTest.java
+++ b/core/src/test/java/org/apache/sedona/core/formatMapper/TestReadInvalidSyntaxGeometriesTest.java
@@ -39,7 +39,7 @@ public class TestReadInvalidSyntaxGeometriesTest
     public static void onceExecutedBeforeAll()
             throws IOException
     {
-        initialize(GeoJsonReaderTest.class.getName());
+        initialize(GeoJsonIOTest.class.getName());
         invalidSyntaxGeoJsonGeomWithFeatureProperty = TestReadInvalidSyntaxGeometriesTest.class.getClassLoader().getResource("invalidSyntaxGeometriesJson.json").getPath();
     }
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the assoicated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-230. The PR name follows the format `[SEDONA-230] my subject`.


## What changes were proposed in this PR?

1. SpatialRdd that has fields will be saved as a geojson that has correct property keys and values for each record.
2. Null field value will be saved as empty space. E.g.,
```
"properties": {"name": ""}
```
3. SpatialRdd that has no fields will be save as
```
"properties": null
```

One remaining issue is that numerical values in geojson will be converted to string type. To solve this, we need the full schema info preserved in SpatialRDD metadata. I will leave in this as the future work.

## How was this patch tested?

Add a few more tests and passed existing tests

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
