### PR TITLE
[SEDONA-232] Upgrade CICD From Spark 3.2.0 to 3.2.3

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -28,7 +28,7 @@ jobs:
             scala: 2.12.15
             jdk: '11'
             skipTests: '-DskipTests'            
-          - spark: 3.2.0
+          - spark: 3.2.3
             scala: 2.12.15
             jdk: '8'
             skipTests: ''            


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the assoicated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-232. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Upgrade the patch version of Spark 3.2 used in CICD from 0 to 3 (3.2.0 to 3.2.3).

## How was this patch tested?

Existing unit tests pass.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
