### PR TITLE
[SEDONA-236] Fix flaky python tests related to converting GeoPandas DataFrames to Spark DataFrames

### DIFF
--- a/python/tests/serialization/test_deserializers.py
+++ b/python/tests/serialization/test_deserializers.py
@@ -19,6 +19,7 @@ import os
 
 from shapely.geometry import MultiPoint, Point, MultiLineString, LineString, Polygon, MultiPolygon, GeometryCollection
 import geopandas as gpd
+import pandas as pd
 
 from tests import tests_resource
 from tests.test_base import TestBase
@@ -112,6 +113,7 @@ class TestGeometryConvert(TestBase):
 
     def test_from_geopandas_convert(self):
         gdf = gpd.read_file(os.path.join(tests_resource, "shapefiles/gis_osm_pois_free_1/"))
+        gdf = gdf.replace(pd.NA, '')
 
         self.spark.createDataFrame(
             gdf

--- a/python/tests/serialization/test_serializers.py
+++ b/python/tests/serialization/test_serializers.py
@@ -19,6 +19,7 @@ import os
 
 from pyspark.sql.types import IntegerType
 import geopandas as gpd
+import pandas as pd
 
 from tests import tests_resource
 from sedona.sql.types import GeometryType
@@ -145,6 +146,7 @@ class TestsSerializers(TestBase):
 
     def test_geopandas_convertion(self):
         gdf = gpd.read_file(os.path.join(tests_resource, "shapefiles/gis_osm_pois_free_1/"))
+        gdf = gdf.replace(pd.NA, '')
         print(self.spark.createDataFrame(
             gdf
         ).toPandas())


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-236. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Fix test failures caused by converting pandas DataFrames containing lots of missing values to Spark DataFrames. We replaced missing values in the pandas DataFrame to get rid of this problem.

## How was this patch tested?

This patch was verified on an AWS EC2 instance where the problem could be constantly reproduced.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
