### PR TITLE
[DOCS] fix spelling

### DIFF
--- a/docs/api/flink/Function.md
+++ b/docs/api/flink/Function.md
@@ -707,7 +707,7 @@ Result:
 
 ## ST_SetSRID
 
-Introduction: Sets the spatial refence system identifier (SRID) of the geometry.
+Introduction: Sets the spatial reference system identifier (SRID) of the geometry.
 
 Format: `ST_SetSRID (A:geometry, srid: integer)`
 
@@ -721,7 +721,7 @@ FROM polygondf
 
 ## ST_SRID
 
-Introduction: Return the spatial refence system identifier (SRID) of the geometry.
+Introduction: Return the spatial reference system identifier (SRID) of the geometry.
 
 Format: `ST_SRID (A:geometry)`
 

--- a/docs/api/sql/Function.md
+++ b/docs/api/sql/Function.md
@@ -1127,7 +1127,7 @@ Result:
 
 ## ST_SetSRID
 
-Introduction: Sets the spatial refence system identifier (SRID) of the geometry.
+Introduction: Sets the spatial reference system identifier (SRID) of the geometry.
 
 Format: `ST_SetSRID (A:geometry, srid: Integer)`
 
@@ -1178,7 +1178,7 @@ Output: `MULTILINESTRING ((0 0, 0.5 0.5), (0.5 0.5, 1 1), (1 1, 1.5 1.5, 2 2))`
 
 ## ST_SRID
 
-Introduction: Return the spatial refence system identifier (SRID) of the geometry.
+Introduction: Return the spatial reference system identifier (SRID) of the geometry.
 
 Format: `ST_SRID (A:geometry)`
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, but both links in the "Yes" option are broken with 404 not found:

https://sedona.apache.org/community/rule/
https://sedona.apache.org/community/develop/

I think it should be https://sedona.apache.org/latest-snapshot/community/rule/ etc

## Is this PR related to a JIRA ticket?

- No, this is a documentation update. The PR name follows the format `[DOCS] my subject`.


## What changes were proposed in this PR?

Fixing some typos

## How was this patch tested?


## Did this PR include necessary documentation updates?

- Yes, I am adding a new API. I am using the [current SNAPSHOT version number](https://github.com/apache/sedona/blob/master/pom.xml#L29) in since `vX.Y.Z` format.
- Yes, I have updated the documentation update.
- No, this PR does not affect any public API so no need to change the docs.
