### PR TITLE
[DOCS] Fix broken links, spelling and whitespace

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,14 +2,13 @@
 
 ## Did you read the Contributor Guide?
 
-- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)
+- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)
 
 - No, I haven't read it.
 
 ## Is this PR related to a JIRA ticket?
 
-- Yes, the URL of the assoicated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-XXX. The PR name follows the format `[SEDONA-XXX] my subject`.
-
+- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-XXX. The PR name follows the format `[SEDONA-XXX] my subject`.
 
 - No, this is a documentation update. The PR name follows the format `[DOCS] my subject`.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Apache Sedona™ is a cluster computing system for processing large-scale spatia
 
 ## Compile the source code
 
-Please refer to [Sedona website](http://sedona.apache.org/setup/compile/)
+Please refer to [Sedona website](https://sedona.apache.org/latest-snapshot/setup/compile/)
 
 ## Contact
 

--- a/docs/tutorial/rdd.md
+++ b/docs/tutorial/rdd.md
@@ -63,7 +63,7 @@ val pointRDDSplitter = FileDataSplitter.TSV
 #### PolygonRDD/LineStringRDD from CSV/TSV
 In general, polygon and line string data is stored in WKT, WKB, GeoJSON and Shapefile formats instead of CSV/TSV because the geometries in a file may have different lengths. However, if all polygons / line strings in your CSV/TSV possess the same length, you can create PolygonRDD and LineStringRDD from these files.
 
-Suppose we have a `checkinshape.csv` CSV file at Path `/Download/checkinshape.csv ` as follows:
+Suppose we have a `checkinshape.csv` CSV file at Path `/Download/checkinshape.csv` as follows:
 ```
 -88.331492,32.324142,-88.331492,32.324142,-88.331492,32.324142,-88.331492,32.324142,-88.331492,32.324142,hotel
 -88.175933,32.360763,-88.175933,32.360763,-88.175933,32.360763,-88.175933,32.360763,-88.175933,32.360763,gas


### PR DESCRIPTION
Remove unneeded space from inside code span element

sedona % mdl -r MD038 docs
docs/tutorial/rdd.md:66: MD038 Spaces inside code span elements

https://github.com/markdownlint/markdownlint

https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md038---spaces-inside-code-span-elements



## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)

## Is this PR related to a JIRA ticket?

- No, this is a documentation update. The PR name follows the format `[DOCS] my subject`.


## What changes were proposed in this PR?

Mainly fixing links and general clean up

Spelling `assoicated ` -> `associated `

## How was this patch tested?


## Did this PR include necessary documentation updates?

- Yes, I am adding a new API. I am using the [current SNAPSHOT version number](https://github.com/apache/sedona/blob/master/pom.xml#L29) in since `vX.Y.Z` format.
- Yes, I have updated the documentation update.
- No, this PR does not affect any public API so no need to change the docs.
