### PR TITLE
[SEDONA-207] Fix ambiguity of empty multi-geometries and multi geometries containing only empty geometries

### DIFF
--- a/common/src/test/java/org/apache/sedona/common/geometrySerde/GeometryCollectionSerdeTest.java
+++ b/common/src/test/java/org/apache/sedona/common/geometrySerde/GeometryCollectionSerdeTest.java
@@ -32,6 +32,8 @@ import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygon;
 
+import javax.sound.sampled.Line;
+
 public class GeometryCollectionSerdeTest {
     private static final GeometryFactory gf = new GeometryFactory();
 
@@ -82,9 +84,23 @@ public class GeometryCollectionSerdeTest {
                                 gf.createMultiPoint(),
                                 gf.createMultiLineString(),
                                 gf.createMultiPolygon(),
+                                gf.createMultiPoint(new Point[] {
+                                        gf.createPoint(),
+                                        gf.createPoint()
+                                }),
+                                gf.createMultiLineString(new LineString[] {
+                                        gf.createLineString(),
+                                        gf.createLineString()
+                                }),
+                                gf.createMultiPolygon(new Polygon[] {
+                                        gf.createPolygon(),
+                                        gf.createPolygon(),
+                                        gf.createPolygon()
+                                }),
                                 multiPoint,
                                 multiLineString,
-                                multiPolygon
+                                multiPolygon,
+                                point
                         });
         geometryCollection.setSRID(4326);
         byte[] bytes = GeometrySerializer.serialize(geometryCollection);

--- a/common/src/test/java/org/apache/sedona/common/geometrySerde/MultiLineStringSerdeTest.java
+++ b/common/src/test/java/org/apache/sedona/common/geometrySerde/MultiLineStringSerdeTest.java
@@ -65,4 +65,20 @@ public class MultiLineStringSerdeTest {
         Assert.assertEquals(3, multiLineString2.getNumGeometries());
         Assert.assertEquals(multiLineString, multiLineString2);
     }
+
+    @Test
+    public void testMultiLineStringContainingEmptyLineStrings() {
+        MultiLineString multiLineString = gf.createMultiLineString(
+                new LineString[] {
+                        gf.createLineString(),
+                        gf.createLineString(),
+                        gf.createLineString()
+                }
+        );
+        multiLineString.setSRID(4326);
+        byte[] bytes = GeometrySerializer.serialize(multiLineString);
+        Geometry geom = GeometrySerializer.deserialize(bytes);
+        Assert.assertEquals(3, geom.getNumGeometries());
+        Assert.assertEquals(multiLineString, geom);
+    }
 }

--- a/common/src/test/java/org/apache/sedona/common/geometrySerde/MultiPointSerdeTest.java
+++ b/common/src/test/java/org/apache/sedona/common/geometrySerde/MultiPointSerdeTest.java
@@ -87,6 +87,21 @@ public class MultiPointSerdeTest {
     }
 
     @Test
+    public void testMultiPointWithEmptyPointsOnly() {
+        Point[] points =
+                new Point[]{
+                        gf.createPoint(),
+                        gf.createPoint(),
+                        gf.createPoint()
+                };
+        MultiPoint multiPoint = gf.createMultiPoint(points);
+        byte[] bytes = GeometrySerializer.serialize(multiPoint);
+        Geometry geom = GeometrySerializer.deserialize(bytes);
+        Assert.assertEquals(3, geom.getNumGeometries());
+        Assert.assertEquals(multiPoint, geom);
+    }
+
+    @Test
     public void testMultiPointXYM() {
         MultiPoint multiPoint =
                 gf.createMultiPointFromCoords(

--- a/common/src/test/java/org/apache/sedona/common/geometrySerde/MultiPolygonSerdeTest.java
+++ b/common/src/test/java/org/apache/sedona/common/geometrySerde/MultiPolygonSerdeTest.java
@@ -86,4 +86,19 @@ public class MultiPolygonSerdeTest {
         Assert.assertEquals(3, mp.getNumGeometries());
         Assert.assertEquals(multiPolygon, mp);
     }
+
+    @Test
+    public void testMultiPolygonContainingEmptyPolygons() {
+        MultiPolygon multiPolygon =
+                gf.createMultiPolygon(
+                        new Polygon[]{
+                                gf.createPolygon(),
+                                gf.createPolygon()
+                        });
+        multiPolygon.setSRID(4326);
+        byte[] bytes = GeometrySerializer.serialize(multiPolygon);
+        Geometry geom = GeometrySerializer.deserialize(bytes);
+        Assert.assertEquals(2, geom.getNumGeometries());
+        Assert.assertEquals(multiPolygon, geom);
+    }
 }

--- a/python/tests/utils/test_geometry_serde.py
+++ b/python/tests/utils/test_geometry_serde.py
@@ -16,8 +16,9 @@
 #  under the License.
 import pytest
 
-from pyspark.sql.types import StructType
+from pyspark.sql.types import (StructType, StringType)
 from sedona.sql.types import GeometryType
+from pyspark.sql.functions import expr
 from sedona.utils import geometry_serde
 
 from shapely.geometry.base import BaseGeometry
@@ -55,6 +56,101 @@ class TestGeometrySerde(TestBase):
     def test_spark_serde(self, geom):
         returned_geom = TestGeometrySerde.spark.createDataFrame([(geom,)], StructType().add("geom", GeometryType())).take(1)[0][0]
         assert geom.equals_exact(returned_geom, 1e-6)
+
+    @pytest.mark.parametrize("wkt", [
+        # empty geometries
+        'POINT EMPTY',
+        'LINESTRING EMPTY',
+        'POLYGON EMPTY',
+        'MULTIPOINT EMPTY',
+        'MULTILINESTRING EMPTY',
+        'MULTIPOLYGON EMPTY',
+        'GEOMETRYCOLLECTION EMPTY',
+        # non-empty geometries
+        'POINT (10 20)',
+        'POINT (10 20 30)',
+        'LINESTRING (10 20, 30 40)',
+        'LINESTRING (10 20 30, 40 50 60)',
+        'POLYGON ((10 10, 20 20, 20 10, 10 10))',
+        'POLYGON ((10 10 10, 20 20 10, 20 10 10, 10 10 10))',
+        'POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1))',
+        # non-empty multi geometries
+        'MULTIPOINT ((10 20), (30 40))',
+        'MULTIPOINT ((10 20 30), (40 50 60))',
+        'MULTILINESTRING ((10 20, 30 40), (50 60, 70 80))',
+        'MULTILINESTRING ((10 20 30, 40 50 60), (70 80 90, 100 110 120))',
+        'MULTIPOLYGON (((10 10, 20 20, 20 10, 10 10)), ((-10 -10, -20 -20, -20 -10, -10 -10)))',
+        'MULTIPOLYGON (((10 10, 20 20, 20 10, 10 10)), ((0 0, 0 10, 10 10, 10 0, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1)))',
+        'GEOMETRYCOLLECTION (POINT (10 20), LINESTRING (10 20, 30 40))',
+        'GEOMETRYCOLLECTION (POINT (10 20 30), LINESTRING (10 20 30, 40 50 60))',
+        'GEOMETRYCOLLECTION (POINT (10 20), LINESTRING (10 20, 30 40), POLYGON ((10 10, 20 20, 20 10, 10 10)))',
+        # nested geometry collection
+        'GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (10 20), LINESTRING (10 20, 30 40)))',
+        'GEOMETRYCOLLECTION (POINT (1 2), GEOMETRYCOLLECTION (POINT (10 20), LINESTRING (10 20, 30 40)))',
+        # multi geometries containing empty geometries
+        'MULTIPOINT (EMPTY, (10 20))',
+        'MULTIPOINT (EMPTY, EMPTY)',
+        'MULTILINESTRING (EMPTY, (10 20, 30 40))',
+        'MULTILINESTRING (EMPTY, EMPTY)',
+        'MULTIPOLYGON (EMPTY, ((10 10, 20 20, 20 10, 10 10)))',
+        'MULTIPOLYGON (EMPTY, EMPTY)',
+        'GEOMETRYCOLLECTION (POINT (10 20), POINT EMPTY, LINESTRING (10 20, 30 40))',
+        'GEOMETRYCOLLECTION (MULTIPOINT EMPTY, MULTILINESTRING EMPTY, MULTIPOLYGON EMPTY, GEOMETRYCOLLECTION EMPTY)',
+    ])
+    def test_spark_serde_compatibility_with_scala(self, wkt):
+        geom = wkt_loads(wkt)
+        schema = StructType().add("geom", GeometryType())
+        returned_geom = TestGeometrySerde.spark.createDataFrame([(geom,)], schema).take(1)[0][0]
+        assert geom.equals(returned_geom)
+
+        # serialized by python, deserialized by scala
+        returned_wkt = TestGeometrySerde.spark.createDataFrame([(geom,)], schema).selectExpr("ST_AsText(geom)").take(1)[0][0]
+        assert wkt_loads(returned_wkt).equals(geom)
+
+        # serialized by scala, deserialized by python
+        schema = StructType().add("wkt", StringType())
+        returned_geom = TestGeometrySerde.spark.createDataFrame([(wkt,)], schema).selectExpr("ST_GeomFromText(wkt)").take(1)[0][0]
+        assert geom.equals(returned_geom)
+
+    @pytest.mark.parametrize("wkt", [
+        'POINT ZM (1 2 3 4)',
+        'LINESTRING ZM (1 2 3 4, 5 6 7 8)',
+        'POLYGON ZM ((10 10 10 1, 20 20 10 1, 20 10 10 1, 10 10 10 1))',
+        'MULTIPOINT ZM ((10 20 30 1), (40 50 60 1))',
+        'MULTILINESTRING ZM ((10 20 30 1, 40 50 60 1), (70 80 90 1, 100 110 120 1))',
+        'MULTIPOLYGON ZM (((10 10 10 1, 20 20 10 1, 20 10 10 1, 10 10 10 1)), ' +
+        '((0 0 0 1, 0 10 0 1, 10 10 0 1, 10 0 0 1, 0 0 0 1), (1 1 0 1, 1 2 0 1, 2 2 0 1, 2 1 0 1, 1 1 0 1)))',
+        'GEOMETRYCOLLECTION (POINT ZM (10 20 30 1), LINESTRING ZM (10 20 30 1, 40 50 60 1))',
+    ])
+    def test_spark_serde_on_4d_geoms(self, wkt):
+        geom = wkt_loads(wkt)
+        schema = StructType().add("wkt", StringType())
+        returned_geom, n_dims = TestGeometrySerde.spark.createDataFrame([(wkt,)], schema)\
+            .selectExpr("ST_GeomFromText(wkt)", "ST_NDims(ST_GeomFromText(wkt))")\
+            .take(1)[0]
+        assert n_dims == 4
+        assert geom.equals(returned_geom)
+
+    @pytest.mark.parametrize("wkt", [
+        'POINT M (1 2 3)',
+        'LINESTRING M (1 2 3, 5 6 7)',
+        'POLYGON M ((10 10 10, 20 20 10, 20 10 10, 10 10 10))',
+        'MULTIPOINT M ((10 20 30), (40 50 60))',
+        'MULTILINESTRING M ((10 20 30, 40 50 60), (70 80 90, 100 110 120))',
+        'MULTIPOLYGON M (((10 10 10, 20 20 10, 20 10 10, 10 10 10)), ' +
+        '((0 0 0, 0 10 0, 10 10 0, 10 0 0, 0 0 0), (1 1 0, 1 2 0, 2 2 0, 2 1 0, 1 1 0)))',
+        'GEOMETRYCOLLECTION (POINT M (10 20 30), LINESTRING M (10 20 30, 40 50 60))',
+        ])
+    def test_spark_serde_on_xym_geoms(self, wkt):
+        geom = wkt_loads(wkt)
+        schema = StructType().add("wkt", StringType())
+        returned_geom, n_dims, z_min = TestGeometrySerde.spark.createDataFrame([(wkt,)], schema) \
+            .withColumn("geom", expr("ST_GeomFromText(wkt)")) \
+            .selectExpr("geom", "ST_NDims(geom)", "ST_ZMin(geom)") \
+            .take(1)[0]
+        assert n_dims == 3
+        assert z_min is None
+        assert geom.equals(returned_geom)
 
     def test_point(self):
         points = [


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-207. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

This pull request fixes the handling of empty multi-geometries in the geometry serializer. In the current implementation, we omitted structure data for multi-geometries containing only empty geometries, such as `MULTILINESTRING (EMPTY, EMPTY)`. In this case, we cannot tell if it is an empty multi-geometry or multi-geometry containing only empty geometries. This patch fixes the problem by always writing structure data for multi geometries.

This patch also fixes other issues with the geometry serializer:

* Python geometry serializer will drop M coordinates when deserializing XYM/XYZM geometries, instead of raising an exception.
* Avoid allocating a huge amounts of memory when deserializing malformed data.

## How was this patch tested?

Unit tests were added to test this patch.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
