### PR TITLE
[SEDONA-199] Update documentation for ST_NDims as it now supports M dimension.

### DIFF
--- a/docs/api/flink/Function.md
+++ b/docs/api/flink/Function.md
@@ -536,7 +536,7 @@ FROM polygondf
 
 ## ST_NDims
 
-Introduction: Returns the coordinate dimension of the geometry. It supports 2 - (x,y) , 3 - (x,y,z). Currently the geometry serializer in sedona-sql does not support M dimension, 4D geometries with ZM coordinates will have their M coordinates dropped and became 3D geometries. We're working on a new geometry serializer to resolve this issue.
+Introduction: Returns the coordinate dimension of the geometry.
 
 Format: `ST_NDims(geom: geometry)`
 

--- a/docs/api/sql/Function.md
+++ b/docs/api/sql/Function.md
@@ -897,7 +897,7 @@ Result:
 ```
 ## ST_NDims
 
-Introduction: Returns the coordinate dimension of the geometry. It supports 2 - (x,y) , 3 - (x,y,z). Currently the geometry serializer in sedona-sql does not support M dimension, 4D geometries with ZM coordinates will have their M coordinates dropped and became 3D geometries. We're working on a new geometry serializer to resolve this issue.
+Introduction: Returns the coordinate dimension of the geometry.
 
 Format: `ST_NDims(geom: geometry)`
 

--- a/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
@@ -432,6 +432,15 @@ public class FunctionTest extends TestBase{
         int result = (int) first(polygonTable).getField(0);
         assertEquals(3, result, 0);
     }
+
+    @Test
+    public void testNDimsForMCoordinate() {
+        Object result = first(tableEnv.sqlQuery("SELECT ST_NDims(ST_GeomFromWKT('POINT M (1 2 3)'))")).getField(0);
+        assertEquals(result, 3);
+        result = first(tableEnv.sqlQuery("SELECT ST_NDims(ST_GeomFromWKT('POINT ZM (1 2 3 4)'))")).getField(0);
+        assertEquals(result, 4);
+    }
+
     @Test
     public void testXMax() {
         Table polygonTable = createPolygonTable(1);

--- a/sql/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
+++ b/sql/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
@@ -481,6 +481,16 @@ class functionTestScala extends TestBaseScala with Matchers with GeometrySample 
       assert(test.take(1)(0).get(0).asInstanceOf[Int] == 3)
     }
 
+    it("Passed ST_NDims with XYM point") {
+      val test = sparkSession.sql("SELECT ST_NDims(ST_GeomFromWKT('POINT M(1 2 3)'))")
+      assert(test.take(1)(0).get(0).asInstanceOf[Int] == 3)
+    }
+
+    it("Passed ST_NDims with XYZM point") {
+      val test = sparkSession.sql("SELECT ST_NDims(ST_GeomFromWKT('POINT ZM(1 2 3 4)'))")
+      assert(test.take(1)(0).get(0).asInstanceOf[Int] == 4)
+    }
+
     it("Passed ST_GeometryType") {
       var test = sparkSession.sql("SELECT ST_GeometryType(ST_GeomFromText('LINESTRING(77.29 29.07,77.42 29.26,77.27 29.31,77.29 29.07)'))")
       assert(test.take(1)(0).get(0).asInstanceOf[String].toUpperCase() == "ST_LINESTRING")


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-199. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

`ST_NDims` could handle M dimension correctly since https://github.com/apache/sedona/pull/739, so we remove the statements about its limitations. 

## How was this patch tested?

Added tests to show that `ST_NDims` works on XYM/XYZM geometries.

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation update.
