### PR TITLE
[SEDONA-253] Upgrade geotools to version 28.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
 
         <cdm.version>5.4.2</cdm.version>
-        <geotools.version>24.0</geotools.version>
+        <geotools.version>28.2</geotools.version>
         <hadoop.version>3.2.4</hadoop.version>
         <jackson.version>2.13.4</jackson.version>
         <jts.version>1.19.0</jts.version>


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-253. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Upgrade geotools to the latest version, 28.2.
There is also a PR for geotools-wrapper at: https://github.com/jiayuasu/geotools-wrapper/pull/3

## How was this patch tested?

All tests pass

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
