### PR TITLE
[SEDONA-256] R GitHub workflow update

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -3,7 +3,7 @@ name: R build
 on:
   push:
     branches:
-      - r-workflow-update
+      - master
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -85,8 +85,8 @@ jobs:
           args: 'c("--no-build-vignettes", "--no-manual", "--no-tests")'
           error-on: '"warning"'
           working-directory: './R'
-          env:
-            _R_CHECK_FORCE_SUGGESTS_: false
+        env:
+          _R_CHECK_FORCE_SUGGESTS_: false
       - name: Install apache.sedona from source
         run: Rscript -e 'install.packages("./R/", repos = NULL, type = "source")'
       - name: Run tests

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -3,7 +3,7 @@ name: R build
 on:
   push:
     branches:
-      - master
+      - r-workflow-update
   pull_request:
     branches:
       - '*'
@@ -15,9 +15,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        spark: [3.0.3, 3.1.2, 3.2.1, 3.3.0]
+        spark: [3.3.0]
         scala: [2.12.15]
-        r: [oldrel, release]
+        r: [release]
 
     env:
       SPARK_VERSION: ${{ matrix.spark }}
@@ -41,49 +41,36 @@ jobs:
         run: |
           sudo apt-get -y remove --purge default-jdk adoptopenjdk-11-hotspot || :
         shell: bash
-      - uses: actions/checkout@v2
-      - uses: r-lib/actions/setup-r@v2-branch
+      - uses: actions/checkout@v3
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.r }}
-      - uses: actions/setup-java@v1
+          use-public-rspm: true
+      - uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           java-version: '8'
+          cache: 'maven'
       - name: Query R dependencies
-        run: |
-          print(R.version)
-          install.packages("remotes")
-          saveRDS(remotes::dev_package_deps("./R/", dependencies = TRUE), ".github/deps.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          cache: true
+          extra-packages: |
+            any::testthat
+            any::rcmdcheck
+          working-directory : './R'
       - name: Get OS name
         id: os-name
         run: |
           # `os_name` will be like "Ubuntu-20.04.1-LTS"
           OS_NAME=$(lsb_release -ds | sed 's/\s/-/g')
-          echo "::set-output name=os-name::$OS_NAME"
-      - name: Cache R packages
-        if: runner.os != 'Windows'
-        uses: actions/cache@master
-        with:
-          path: ${{ env.R_LIBS_USER }}
-          key: apache.sedona-${{ steps.os-name.outputs.os-name }}-${{ hashFiles('.github/R-version') }}-${{ hashFiles('.github/deps.Rds') }}
-          restore-keys: apache.sedona-${{ steps.os-name.outputs.os-name }}-${{ hashFiles('.github/R-version') }}
+          echo "os-name=$OS_NAME" >> $GITHUB_OUTPUT
       - name: Cache Spark installations
         if: runner.os != 'Windows'
         uses: actions/cache@master
         with:
           path: ~/spark
           key: apache.sedona-apache-spark-${{ steps.os-name.outputs.os-name }}-${{ env.SPARK_VERSION }}
-      - name: Install system dependencies
-        run: source ./.github/workflows/scripts/install_system_deps_for_r_build.sh
-      - name: Install R dependencies
-        run: source ./.github/workflows/scripts/install_r_deps.sh
-      - name: Cache Maven packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
       - name: Build Sedona libraries
         run: |
           if [ ${SPARK_VERSION:0:1} == "3" ]; then

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -15,9 +15,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        spark: [3.3.0]
+        spark: [3.0.3, 3.1.2, 3.2.1, 3.3.0]
         scala: [2.12.15]
-        r: [release]
+        r: [oldrel, release]
 
     env:
       SPARK_VERSION: ${{ matrix.spark }}
@@ -78,17 +78,15 @@ jobs:
           else
             mvn -q clean install -DskipTests -Dscala=${SCALA_VERSION:0:4} -Dspark=2.4 -Dgeotools
           fi
-      - name: Build R package
-        env:
-          WARNINGS_ARE_ERRORS: 1
-        run: R CMD build --no-build-vignettes ./R
-      - name: Check
-        env:
-          _R_CHECK_FORCE_SUGGESTS_: false
-          WARNINGS_ARE_ERRORS: 1
-        run: |
-          R CMD check --no-build-vignettes --no-manual --no-tests apache.sedona*.tar.gz
-          rm -f apache.sedona*.tar.gz
+      - name: Build and check R package
+        uses: r-lib/actions/check-r-package@v2
+        with:
+          build_args: 'c("--no-build-vignettes")'
+          args: 'c("--no-build-vignettes", "--no-manual", "--no-tests")'
+          error-on: '"warning"'
+          working-directory: './R'
+          env:
+            _R_CHECK_FORCE_SUGGESTS_: false
       - name: Install apache.sedona from source
         run: Rscript -e 'install.packages("./R/", repos = NULL, type = "source")'
       - name: Run tests

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -81,9 +81,9 @@ jobs:
       - name: Build and check R package
         uses: r-lib/actions/check-r-package@v2
         with:
-          build_args: 'c("--no-build-vignettes")'
+          build_args: 'c("--no-build-vignettes", "--no-manual")'
           args: 'c("--no-build-vignettes", "--no-manual", "--no-tests")'
-          error-on: '"warning"'
+          error-on: '"error"'
           working-directory: './R'
         env:
           _R_CHECK_FORCE_SUGGESTS_: false

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -46,11 +46,6 @@ jobs:
         with:
           r-version: ${{ matrix.r }}
           use-public-rspm: true
-      - uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '8'
-          cache: 'maven'
       - name: Query R dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
@@ -59,6 +54,22 @@ jobs:
             any::testthat
             any::rcmdcheck
           working-directory : './R'
+      - name: Build and check R package
+        uses: r-lib/actions/check-r-package@v2
+        with:
+          build_args: 'c("--no-build-vignettes", "--no-manual")'
+          args: 'c("--no-build-vignettes", "--no-manual", "--no-tests")'
+          error-on: '"error"'
+          working-directory: './R'
+        env:
+          _R_CHECK_FORCE_SUGGESTS_: false
+      - name: Install apache.sedona from source
+        run: Rscript -e 'install.packages("./R/", repos = NULL, type = "source")'
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+          cache: 'maven'
       - name: Get OS name
         id: os-name
         run: |
@@ -78,17 +89,6 @@ jobs:
           else
             mvn -q clean install -DskipTests -Dscala=${SCALA_VERSION:0:4} -Dspark=2.4 -Dgeotools
           fi
-      - name: Build and check R package
-        uses: r-lib/actions/check-r-package@v2
-        with:
-          build_args: 'c("--no-build-vignettes", "--no-manual")'
-          args: 'c("--no-build-vignettes", "--no-manual", "--no-tests")'
-          error-on: '"error"'
-          working-directory: './R'
-        env:
-          _R_CHECK_FORCE_SUGGESTS_: false
-      - name: Install apache.sedona from source
-        run: Rscript -e 'install.packages("./R/", repos = NULL, type = "source")'
       - name: Run tests
         run: |
           export SPARKLYR_LOG_FILE='/tmp/sparklyr.log'


### PR DESCRIPTION
## Is this PR related to a JIRA ticket?
https://issues.apache.org/jira/projects/SEDONA/issues/SEDONA-256

## What changes were proposed in this PR?
Update to the R testing workflow:
* Update to latest version of actions
* Replace steps with prepackaged actions: (R dependencies, R checks)
* Reorder to check R package before building Sedona

Removed cache steps (maven, R packages) already handled by prepackaged actions

Not yet updating to Ubuntu 22.04

## How was this patch tested?
On my fork

## Did this PR include necessary documentation updates?
No, this PR does not affect any public API so no need to change the docs.
