### PR TITLE
[SEDONA-229] Fix Flink Return Tags

### DIFF
--- a/flink/src/main/java/org/apache/sedona/flink/expressions/Predicates.java
+++ b/flink/src/main/java/org/apache/sedona/flink/expressions/Predicates.java
@@ -53,7 +53,7 @@ public class Predicates {
          * @param key
          * @param o1
          * @param o2
-         * @return
+         * @return True if intersecting, false otherwise
          */
         @DataTypeHint("Boolean")
         public Boolean eval(@DataTypeHint("INT") Integer key, @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o1, @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o2) {
@@ -93,7 +93,7 @@ public class Predicates {
          * @param key
          * @param o1
          * @param o2
-         * @return
+         * @return True if o1 contains o2, false otherwise
          */
         @DataTypeHint("Boolean")
         public Boolean eval(@DataTypeHint("INT") Integer key, @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o1, @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o2) {
@@ -133,7 +133,7 @@ public class Predicates {
          * @param key
          * @param o1
          * @param o2
-         * @return
+         * @return True if o1 is within o2, false otherwise
          */
         @DataTypeHint("Boolean")
         public Boolean eval(@DataTypeHint("INT") Integer key, @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o1, @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o2) {
@@ -173,7 +173,7 @@ public class Predicates {
          * @param key
          * @param o1
          * @param o2
-         * @return
+         * @return True if o1 covers o2, false otherwise
          */
         @DataTypeHint("Boolean")
         public Boolean eval(@DataTypeHint("INT") Integer key, @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o1, @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o2) {
@@ -213,7 +213,7 @@ public class Predicates {
          * @param key
          * @param o1
          * @param o2
-         * @return
+         * @return True if o1 is covered by o2, false otherwise
          */
         @DataTypeHint("Boolean")
         public Boolean eval(@DataTypeHint("INT") Integer key, @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o1, @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o2) {


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-229. This PR only changes javadoc comments but it is a part of the linter clean up issue.

## What changes were proposed in this PR?

Just filled out the return tags for javadoc comments in Flink. These are the only linter warnings in the flink module, so that makes it officially cleaned up I guess.

## How was this patch tested?

Standard build process. There are no code changes in this PR.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
