### PR TITLE
[SEDONA-258] Fix deserialization of Circle objects in python-adapter

### DIFF
--- a/python-adapter/src/main/scala/org.apache.sedona.python.wrapper/translation/GeometryRddConverter.scala
+++ b/python-adapter/src/main/scala/org.apache.sedona.python.wrapper/translation/GeometryRddConverter.scala
@@ -31,8 +31,7 @@ private[python] case class GeometryRddConverter[T <: Geometry](spatialRDD: JavaR
       val typeBuffer = 0.toByteArray()
       val sizeBuffer = 0.toByteArray()
       typeBuffer ++ geometrySerializer.serialize(geom) ++ sizeBuffer
-    }
-    ).toJavaRDD()
+    }).toJavaRDD()
   }
 
 }

--- a/python-adapter/src/test/scala/org/apache/sedona/python/wrapper/GeometrySample.scala
+++ b/python-adapter/src/test/scala/org/apache/sedona/python/wrapper/GeometrySample.scala
@@ -19,6 +19,7 @@
 
 package org.apache.sedona.python.wrapper
 
+import org.apache.sedona.common.geometryObjects.Circle
 import org.locationtech.jts.geom.Geometry
 
 import java.io.{FileInputStream, InputStream}
@@ -30,6 +31,8 @@ trait GeometrySample extends PythonTestSpec {
   val resourceFolder = System.getProperty("user.dir") + "/../core/src/test/resources/"
   private[python] val samplePoints: List[Geometry] =
     loadGeometriesFromResources(resourceFolder + "python/samplePoints")
+
+  private[python] val sampleCircles: List[Geometry] = samplePoints.map(new Circle(_, 1.0))
 
   private[python] val sampleLines: List[Geometry] =
     loadGeometriesFromResources(resourceFolder + "python/sampleLines")

--- a/python/tests/test_assign_raw_spatial_rdd.py
+++ b/python/tests/test_assign_raw_spatial_rdd.py
@@ -15,7 +15,7 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-from sedona.core.SpatialRDD import PointRDD
+from sedona.core.SpatialRDD import PointRDD, CircleRDD
 from tests.properties.point_properties import input_location, offset, splitter, num_partitions
 from tests.test_base import TestBase
 from pyspark import StorageLevel
@@ -43,3 +43,23 @@ class TestSpatialRddAssignment(TestBase):
 
         assert empty_point_rdd.rawSpatialRDD.map(lambda x: x.geom.area).collect()[0] == 0.0
         assert empty_point_rdd.rawSpatialRDD.take(9)[4].getUserData() == "testattribute0\ttestattribute1\ttestattribute2"
+
+    def test_raw_circle_rdd_assignment(self):
+        point_rdd = PointRDD(
+            self.sc,
+            input_location,
+            offset,
+            splitter,
+            True,
+            num_partitions,
+            StorageLevel.MEMORY_ONLY
+        )
+        circle_rdd = CircleRDD(point_rdd, 1.0)
+        circle_rdd.analyze()
+
+        circle_rdd_2 = CircleRDD(point_rdd, 2.0)
+        circle_rdd_2.rawSpatialRDD = circle_rdd.rawSpatialRDD
+        circle_rdd_2.analyze()
+
+        assert circle_rdd_2.countWithoutDuplicates() == circle_rdd.countWithoutDuplicates()
+        assert circle_rdd_2.boundaryEnvelope == circle_rdd.boundaryEnvelope


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-258. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

This PR fixes deserialization of `Circle` objects in python-adapter. It fixes problems such as not being able to assign to the `rawSpatialRDD` property of `CircleRDD` objects in Python binding, as well as other potential problems with Circle RDD.

## How was this patch tested?

Added tests in both python-adapter and python module.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
