### PR TITLE
[SEDONA-259] Properly implement Adapter.toSpatialRdd to support custom field names for user data

### DIFF
--- a/python-adapter/src/main/scala/org.apache.sedona.python.wrapper/utils/PythonAdapterWrapper.scala
+++ b/python-adapter/src/main/scala/org.apache.sedona.python.wrapper/utils/PythonAdapterWrapper.scala
@@ -27,6 +27,10 @@ import org.locationtech.jts.geom.Geometry
 import scala.jdk.CollectionConverters._
 
 object PythonAdapterWrapper {
+  def toSpatialRdd(df: DataFrame, geometryColumn: String, fieldNames: java.util.List[String]): SpatialRDD[Geometry] = {
+    Adapter.toSpatialRdd(df, geometryColumn, fieldNames.asScala.toSeq)
+  }
+
   def toDf[T <: Geometry](spatialRDD: SpatialRDD[T], fieldNames: java.util.ArrayList[String], sparkSession: SparkSession): DataFrame = {
     Adapter.toDf(spatialRDD, fieldNames.asScala.toSeq, sparkSession)
   }

--- a/python/sedona/utils/adapter.py
+++ b/python/sedona/utils/adapter.py
@@ -70,7 +70,7 @@ class Adapter(metaclass=MultipleMeta):
         return spatial_rdd
 
     @classmethod
-    def toSpatialRdd(cls, dataFrame: DataFrame, fieldNames: List) -> SpatialRDD:
+    def toSpatialRdd(cls, dataFrame: DataFrame, geometryFieldName: str, fieldNames: List) -> SpatialRDD:
         """
 
         :param dataFrame:
@@ -81,7 +81,7 @@ class Adapter(metaclass=MultipleMeta):
         sc = dataFrame._sc
         jvm = sc._jvm
 
-        srdd = jvm.PythonAdapterWrapper.toSpatialRdd(dataFrame._jdf, fieldNames)
+        srdd = jvm.PythonAdapterWrapper.toSpatialRdd(dataFrame._jdf, geometryFieldName, fieldNames)
 
         spatial_rdd = SpatialRDD(sc)
         spatial_rdd.set_srdd(srdd)

--- a/python/tests/sql/test_adapter.py
+++ b/python/tests/sql/test_adapter.py
@@ -264,6 +264,24 @@ class TestAdapter(TestBase):
         assert spatial_rdd.approximateTotalCount == 121960
         assert spatial_rdd.boundaryEnvelope == Envelope(-179.147236, 179.475569, -14.548699, 71.35513400000001)
 
+    def test_to_spatial_rdd_df_with_non_geom_fields(self):
+        spatial_df = self._create_spatial_point_table()
+        spatial_df = spatial_df.withColumn("i", expr("10")).withColumn("s", expr("'20'"))
+        spatial_rdd = Adapter.toSpatialRdd(spatial_df, "geom")
+        assert spatial_rdd.fieldNames == ['i', 's']
+        spatial_rdd.analyze()
+        assert spatial_rdd.approximateTotalCount == 121960
+        assert spatial_rdd.boundaryEnvelope == Envelope(-179.147236, 179.475569, -14.548699, 71.35513400000001)
+
+    def test_to_spatial_rdd_df_with_custom_user_data_field_names(self):
+        spatial_df = self._create_spatial_point_table()
+        spatial_df = spatial_df.withColumn("i", expr("10")).withColumn("s", expr("'20'"))
+        spatial_rdd = Adapter.toSpatialRdd(spatial_df, "geom", ["i2", "s2"])
+        assert spatial_rdd.fieldNames == ['i2', 's2']
+        spatial_rdd.analyze()
+        assert spatial_rdd.approximateTotalCount == 121960
+        assert spatial_rdd.boundaryEnvelope == Envelope(-179.147236, 179.475569, -14.548699, 71.35513400000001)
+
     def test_to_spatial_rdd_df(self):
         spatial_df = self._create_spatial_point_table()
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-259. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Added a proper implementation of `sedona.utils.Adapter.toSpatialRdd` to produce spatial RDDs with custom field names for user data.

## How was this patch tested?

Added tests for this use case.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
