### PR TITLE
[SEDONA-260] Don't swap the left and right relations of spatial joins

### DIFF
--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/BroadcastIndexJoinExec.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/BroadcastIndexJoinExec.scala
@@ -257,9 +257,8 @@ case class BroadcastIndexJoinExec(
   }
 
   private def createStreamShapes(streamResultsRaw: RDD[UnsafeRow], boundStreamShape: Expression) = {
-    // If there's a distance and the objects are being broadcast, we need to build the expanded envelope on the window stream side
     distance match {
-      case Some(distanceExpression) if indexBuildSide != windowJoinSide =>
+      case Some(distanceExpression) =>
         streamResultsRaw.map(row => {
           val geom = boundStreamShape.eval(row).asInstanceOf[Array[Byte]]
           if (geom == null) {

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/RangeJoinExec.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/RangeJoinExec.scala
@@ -33,7 +33,6 @@ import org.apache.spark.sql.sedona_sql.execution.SedonaBinaryExecNode
   * @param right      right side of the join
   * @param leftShape  expression for the first argument of spatialPredicate
   * @param rightShape expression for the second argument of spatialPredicate
-  * @param swappedLeftAndRight boolean indicating whether left and right plans were swapped
   * @param spatialPredicate spatial predicate as join condition
   * @param extraCondition extra join condition other than spatialPredicate
   */
@@ -41,7 +40,6 @@ case class RangeJoinExec(left: SparkPlan,
                          right: SparkPlan,
                          leftShape: Expression,
                          rightShape: Expression,
-                         swappedLeftAndRight: Boolean,
                          spatialPredicate: SpatialPredicate,
                          extraCondition: Option[Expression] = None)
   extends SedonaBinaryExecNode

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/TraitJoinQueryExec.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/TraitJoinQueryExec.scala
@@ -37,13 +37,10 @@ trait TraitJoinQueryExec extends TraitJoinQueryBase {
   val right: SparkPlan
   val leftShape: Expression
   val rightShape: Expression
-  val swappedLeftAndRight: Boolean
   val spatialPredicate: SpatialPredicate
   val extraCondition: Option[Expression]
 
-  override def output: Seq[Attribute] = {
-    if (!swappedLeftAndRight) left.output ++ right.output else right.output ++ left.output
-  }
+  override def output: Seq[Attribute] = left.output ++ right.output
 
   override protected def doExecute(): RDD[InternalRow] = {
     val boundLeftShape = BindReferences.bindReference(leftShape, left.output)
@@ -125,12 +122,9 @@ trait TraitJoinQueryExec extends TraitJoinQueryBase {
     logDebug(s"Join result has ${matchesRDD.count()} rows")
 
     matchesRDD.mapPartitions { iter =>
-      val joinRow = if (!swappedLeftAndRight) {
+      val joinRow = {
         val joiner = GenerateUnsafeRowJoiner.create(left.schema, right.schema)
         (l: UnsafeRow, r: UnsafeRow) => joiner.join(l, r)
-      } else {
-        val joiner = GenerateUnsafeRowJoiner.create(right.schema, left.schema)
-        (l: UnsafeRow, r: UnsafeRow) => joiner.join(r, l)
       }
 
       val joined = iter.map { case (l, r) =>


### PR DESCRIPTION
## Notice

This patch depends on https://github.com/apache/sedona/pull/796.

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-260. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Do not automatically swap the left and right relations when doing spatial joins, since it may cause confusion when the user wants to configure the partition and index-build side of the join.

## How was this patch tested?

Tested using existing tests in SpatialJoinSuite.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
