### PR TITLE
[SEDONA-261] Allow distance expression in distance join to reference attributes from the right-side relation when running broadcast join.

### DIFF
--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/BroadcastIndexJoinExec.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/BroadcastIndexJoinExec.scala
@@ -257,9 +257,8 @@ case class BroadcastIndexJoinExec(
   }
 
   private def createStreamShapes(streamResultsRaw: RDD[UnsafeRow], boundStreamShape: Expression) = {
-    // If there's a distance and the objects are being broadcast, we need to build the expanded envelope on the window stream side
     distance match {
-      case Some(distanceExpression) if indexBuildSide != windowJoinSide =>
+      case Some(distanceExpression) =>
         streamResultsRaw.map(row => {
           val geom = boundStreamShape.eval(row).asInstanceOf[Array[Byte]]
           if (geom == null) {


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-261. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

BroadcastIndexJoinExec cannot run distance joins when the distance expression references attribute from the right-side relation, this patch fixed this problem.

## How was this patch tested?

Added new distance join tests where the distance expressions are not constant expressions.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
