### PR TITLE
[SEDONA-266] RS_Values throws UnsupportedOperationException for shuff…

### DIFF
--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/Functions.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/Functions.scala
@@ -894,9 +894,8 @@ case class RS_Values(inputExpressions: Seq[Expression]) extends Expression with 
     if (raster == null || serializedGeometries == null) {
       null
     } else {
-      val geometries = serializedGeometries.array.map {
-        case b: Array[Byte] => GeometrySerializer.deserialize(b)
-        case _ => null
+      val geometries = (0 until serializedGeometries.numElements()).map {
+        i => Option(serializedGeometries.getBinary(i)).map(GeometrySerializer.deserialize).orNull
       }
       new GenericArrayData(Functions.values(raster, java.util.Arrays.asList(geometries:_*), band).toArray)
     }


### PR DESCRIPTION
…led point arrays



## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-266. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Avoid using the array mehtod on ArrayData in RS_Values. The method is not supported by all ArrayData implementations.

## How was this patch tested?

Unit test added

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
