### PR TITLE
[SEDONA-267] Fix missing header files in the python sdist package

### DIFF
--- a/.github/workflows/python-extension.yml
+++ b/.github/workflows/python-extension.yml
@@ -53,3 +53,8 @@ jobs:
         cd python
         pipenv install shapely~=1.7
         pipenv run pytest tests/utils/test_geomserde_speedup.py
+    - name: Install from sdist
+      run: |
+        cd python
+        pipenv run python setup.py sdist
+        pipenv run python -m pip install dist/apache-sedona-*.tar.gz

--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -1,0 +1,1 @@
+global-include *.h


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-267. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Added header files to the source distribution package by adding a MANIFEST.in file, following the practice recommended by https://github.com/pypa/packaging-problems/issues/84.

## How was this patch tested?

We've added a step to install apache-sedona from source distribution package.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
