### PR TITLE
[SEDONA-227] Enable building python wheels for ARM64

### DIFF
--- a/.github/workflows/python-wheel.yml
+++ b/.github/workflows/python-wheel.yml
@@ -21,11 +21,18 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Set up QEMU
+      if: runner.os == 'Linux'
+      uses: docker/setup-qemu-action@v2
+      with:
+        platforms: all
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.12.0
       env:
         CIBW_SKIP: 'pp* *musl*'
-        CIBW_ARCHS: 'auto64'
+        CIBW_ARCHS_LINUX: 'x86_64 aarch64'
+        CIBW_ARCHS_WINDOWS: 'AMD64 ARM64'
+        CIBW_ARCHS_MACOS: 'x86_64 arm64'
       with:
         package-dir: python
     - uses: actions/upload-artifact@v3


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-227. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Build python wheels for ARM64.

## How was this patch tested?

Tested manually by installing the wheels on Linux aarch64 and macOS arm64. Windows ARM64 was left untested.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
