### PR TITLE
[SEDONA-270] Remove redundant serialization for rasters

### DIFF
--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/Constructors.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/Constructors.scala
@@ -18,26 +18,24 @@
  */
 package org.apache.spark.sql.sedona_sql.expressions.raster
 
-import org.apache.sedona.common.raster.Constructors
+import org.apache.sedona.common.raster.{Constructors, Serde}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression}
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
 import org.apache.spark.sql.sedona_sql.UDT.RasterUDT
+import org.apache.spark.sql.sedona_sql.expressions.SerdeAware
 import org.apache.spark.sql.types.{AbstractDataType, BinaryType, DataType}
 import org.apache.spark.sql.sedona_sql.expressions.raster.implicits._
+import org.geotools.coverage.grid.GridCoverage2D
 
 
-case class RS_FromArcInfoAsciiGrid(inputExpressions: Seq[Expression]) extends Expression with CodegenFallback with ExpectsInputTypes {
+case class RS_FromArcInfoAsciiGrid(inputExpressions: Seq[Expression]) extends Expression with CodegenFallback
+  with ExpectsInputTypes with SerdeAware {
 
   override def nullable: Boolean = true
 
   override def eval(input: InternalRow): Any = {
-    val bytes = inputExpressions(0).eval(input).asInstanceOf[Array[Byte]]
-    if (bytes == null) {
-      null
-    } else {
-      Constructors.fromArcInfoAsciiGrid(bytes).serialize
-    }
+    Option(evalWithoutSerialization(input)).map(Serde.serialize).orNull
   }
 
   override def dataType: DataType = RasterUDT
@@ -49,19 +47,24 @@ case class RS_FromArcInfoAsciiGrid(inputExpressions: Seq[Expression]) extends Ex
   }
 
   override def inputTypes: Seq[AbstractDataType] = Seq(BinaryType)
+
+  override def evalWithoutSerialization(input: InternalRow): GridCoverage2D = {
+    val bytes = inputExpressions(0).eval(input).asInstanceOf[Array[Byte]]
+    if (bytes == null) {
+      null
+    } else {
+      Constructors.fromArcInfoAsciiGrid(bytes)
+    }
+  }
 }
 
-case class RS_FromGeoTiff(inputExpressions: Seq[Expression]) extends Expression with CodegenFallback with ExpectsInputTypes {
+case class RS_FromGeoTiff(inputExpressions: Seq[Expression]) extends Expression with CodegenFallback
+  with ExpectsInputTypes with SerdeAware {
 
   override def nullable: Boolean = true
 
   override def eval(input: InternalRow): Any = {
-    val bytes = inputExpressions(0).eval(input).asInstanceOf[Array[Byte]]
-    if (bytes == null) {
-      null
-    } else {
-      Constructors.fromGeoTiff(bytes).serialize
-    }
+    Option(evalWithoutSerialization(input)).map(Serde.serialize).orNull
   }
 
   override def dataType: DataType = RasterUDT
@@ -73,4 +76,13 @@ case class RS_FromGeoTiff(inputExpressions: Seq[Expression]) extends Expression 
   }
 
   override def inputTypes: Seq[AbstractDataType] = Seq(BinaryType)
+
+  override def evalWithoutSerialization(input: InternalRow): GridCoverage2D = {
+    val bytes = inputExpressions(0).eval(input).asInstanceOf[Array[Byte]]
+    if (bytes == null) {
+      null
+    } else {
+      Constructors.fromGeoTiff(bytes)
+    }
+  }
 }


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-270. The PR name follows the format `[SEDONA-XXX] my subject`.


## What changes were proposed in this PR?

Just like in SEDONA-231 we can remove redundant serde for chained raster functions.

## How was this patch tested?

Unit test added


## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
