### PR TITLE
[SEDONA-273] Explicitly bound Pandas, GeoPandas and Shapely versions

### DIFF
--- a/python/Pipfile
+++ b/python/Pipfile
@@ -12,7 +12,7 @@ pytest-cov = "*"
 
 [packages]
 shapely="==1.8.5"
-pandas="*"
+pandas="==1.5.3"
 geopandas="==0.10.2"
 pyspark=">=2.3.0"
 attrs="*"

--- a/python/Pipfile
+++ b/python/Pipfile
@@ -11,9 +11,9 @@ mkdocs="*"
 pytest-cov = "*"
 
 [packages]
-shapely="==1.8.5"
-pandas="==1.3.5"
-geopandas="==0.10.2"
+shapely="<=1.8.5"
+pandas="<=1.3.5"
+geopandas="<=0.10.2"
 pyspark=">=2.3.0"
 attrs="*"
 pyarrow="*"

--- a/python/Pipfile
+++ b/python/Pipfile
@@ -12,7 +12,7 @@ pytest-cov = "*"
 
 [packages]
 shapely="==1.8.5"
-pandas="==1.5.3"
+pandas="==1.3.5"
 geopandas="==0.10.2"
 pyspark=">=2.3.0"
 attrs="*"


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-XXX. The PR name follows the format `[SEDONA-XXX] my subject`.


## What changes were proposed in this PR?

Limit 3 Python dependencies to the versions that work for Python 3.7, 3.8 and 3.9. Note: this only affects people who want to do Sedona Dataframe toPandas or pandas to Sedona DataFrame


If you are using Python ==3.7:

Shapely <= 1.8.5.post1

Pandas <= 1.3.5

GeoPandas <= 0.10.2

 

If you are using Python >=3.8:

Shapely <=1.8.5.post1

Pandas <= 1.5.3

GeoPandas <= 0.11.1

## How was this patch tested?

Passed CI

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
