### PR TITLE
[SEDONA-275] Add raster function RS_SetSRID

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/raster/Functions.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/Functions.java
@@ -13,11 +13,15 @@
  */
 package org.apache.sedona.common.raster;
 
+import org.geotools.coverage.CoverageFactoryFinder;
 import org.geotools.coverage.grid.GridCoordinates2D;
 import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.coverage.grid.GridCoverageFactory;
 import org.geotools.coverage.grid.GridGeometry2D;
+import org.geotools.gce.geotiff.GeoTiffWriter;
 import org.geotools.geometry.DirectPosition2D;
 import org.geotools.geometry.Envelope2D;
+import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
 import org.geotools.referencing.crs.DefaultEngineeringCRS;
 import org.locationtech.jts.geom.*;
@@ -46,6 +50,18 @@ public class Functions {
 
     public static int numBands(GridCoverage2D raster) {
         return raster.getNumSampleDimensions();
+    }
+
+    public static GridCoverage2D setSrid(GridCoverage2D raster, int srid) throws FactoryException {
+        CoordinateReferenceSystem crs;
+        if (srid == 0) {
+            crs = DefaultEngineeringCRS.CARTESIAN_2D;
+        } else {
+            crs = CRS.decode("EPSG:" + srid);
+        }
+        ReferencedEnvelope referencedEnvelope = new ReferencedEnvelope(raster.getEnvelope2D(), crs);
+        GridCoverageFactory gridCoverageFactory = CoverageFactoryFinder.getGridCoverageFactory(null);
+        return gridCoverageFactory.create(raster.getName().toString(), raster.getRenderedImage(), referencedEnvelope);
     }
 
     public static int srid(GridCoverage2D raster) throws FactoryException {

--- a/common/src/test/java/org/apache/sedona/common/raster/FunctionsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/FunctionsTest.java
@@ -13,6 +13,7 @@
  */
 package org.apache.sedona.common.raster;
 
+import org.geotools.coverage.grid.GridCoverage2D;
 import org.junit.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
@@ -43,6 +44,20 @@ public class FunctionsTest extends RasterTestBase {
     public void testNumBands() {
         assertEquals(1, Functions.numBands(oneBandRaster));
         assertEquals(4, Functions.numBands(multiBandRaster));
+    }
+
+    @Test
+    public void testSetSrid() throws FactoryException {
+        assertEquals(0, Functions.srid(oneBandRaster));
+        assertEquals(4326, Functions.srid(multiBandRaster));
+
+        GridCoverage2D oneBandRasterWithUpdatedSrid = Functions.setSrid(oneBandRaster, 4326);
+        assertEquals(4326, Functions.srid(oneBandRasterWithUpdatedSrid));
+        assertEquals(4326, Functions.envelope(oneBandRasterWithUpdatedSrid).getSRID());
+        assertTrue(Functions.envelope(oneBandRasterWithUpdatedSrid).equalsTopo(Functions.envelope(oneBandRaster)));
+
+        GridCoverage2D multiBandRasterWithUpdatedSrid = Functions.setSrid(multiBandRaster, 0);
+        assertEquals(0 , Functions.srid(multiBandRasterWithUpdatedSrid));
     }
 
     @Test

--- a/docs/api/sql/Raster-operators.md
+++ b/docs/api/sql/Raster-operators.md
@@ -35,6 +35,20 @@ Output:
 4
 ```
 
+## RS_SetSRID
+
+Introduction: Sets the spatial reference system identifier (SRID) of the raster geometry.
+
+Format: `RS_SetSRID (raster: Raster, srid: Integer)`
+
+Since: `v1.4.1`
+
+Spark SQL example:
+```sql
+SELECT RS_SetSRID(raster, 4326)
+FROM raster_table
+```
+
 ### RS_SRID
 
 Introduction: Returns the spatial reference system identifier (SRID) of the raster geometry.

--- a/sql/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
+++ b/sql/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
@@ -173,6 +173,7 @@ object Catalog {
     function[RS_FromGeoTiff](),
     function[RS_Envelope](),
     function[RS_NumBands](),
+    function[RS_SetSRID](),
     function[RS_SRID](),
     function[RS_Value](1),
     function[RS_Values](1)

--- a/sql/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
+++ b/sql/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
@@ -290,6 +290,17 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
       assert(result == 1)
     }
 
+    it("Passed RS_SetSRID should handle null values") {
+      val result = sparkSession.sql("select RS_SetSRID(null, 0)").first().get(0)
+      assert(result == null)
+    }
+
+    it("Passed RS_SetSRID with raster") {
+      val df = sparkSession.read.format("binaryFile").load(resourceFolder + "raster/test1.tiff")
+      val result = df.selectExpr("RS_SRID(RS_SetSRID(RS_FromGeoTiff(content), 4326))").first().getInt(0)
+      assert(result == 4326)
+    }
+
     it("Passed RS_SRID should handle null values") {
       val result = sparkSession.sql("select RS_SRID(null)").first().get(0)
       assert(result == null)


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-275. The PR name follows the format `[SEDONA-XXX] my subject`.


## What changes were proposed in this PR?

Add RS_SetSRID - the raster version of ST_SetSRID

## How was this patch tested?

Tests added

## Did this PR include necessary documentation updates?

- Yes, I am adding a new API. I am using the [current SNAPSHOT version number](https://github.com/apache/sedona/blob/master/pom.xml#L29) in since `vX.Y.Z` format.
