### PR TITLE
[SEDONA-274] transplant FormatUtils to sedona-common

### DIFF
--- a/R/R/dependencies.R
+++ b/R/R/dependencies.R
@@ -84,7 +84,7 @@ sedona_initialize_spark_connection <- function(sc) {
     "semicolon"
   )) {
     sc$state$enums$delimiter[[x]] <- invoke_static(
-      sc, "org.apache.sedona.core.enums.FileDataSplitter", toupper(x)
+      sc, "org.apache.sedona.common.enums.FileDataSplitter", toupper(x)
     )
   }
   for (x in c(
@@ -99,7 +99,7 @@ sedona_initialize_spark_connection <- function(sc) {
     "rectangle"
   )) {
     sc$state$enums$geometry_type[[x]] <- invoke_static(
-      sc, "org.apache.sedona.core.enums.GeometryType", toupper(x)
+      sc, "org.apache.sedona.common.enums.GeometryType", toupper(x)
     )
   }
   for (x in c("quadtree", "rtree")) {

--- a/common/src/main/java/org/apache/sedona/common/Constructors.java
+++ b/common/src/main/java/org/apache/sedona/common/Constructors.java
@@ -13,6 +13,9 @@
  */
 package org.apache.sedona.common;
 
+import org.apache.sedona.common.enums.FileDataSplitter;
+import org.apache.sedona.common.enums.GeometryType;
+import org.apache.sedona.common.utils.FormatUtils;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -77,5 +80,24 @@ public class Constructors {
     public static Geometry pointZ(double x, double y, double z, int srid) {
         GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), srid);
         return geometryFactory.createPoint(new Coordinate(x, y, z));
+    }
+
+    public static Geometry geomFromText(String geomString, String geomFormat, GeometryType geometryType) {
+        FileDataSplitter fileDataSplitter = FileDataSplitter.getFileDataSplitter(geomFormat);
+        FormatUtils<Geometry> formatMapper = new FormatUtils<>(fileDataSplitter, false, geometryType);
+        try {
+            return formatMapper.readGeometry(geomString);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static Geometry geomFromText(String geomString, FileDataSplitter fileDataSplitter) {
+        FormatUtils<Geometry> formatMapper = new FormatUtils<>(fileDataSplitter, false);
+        try {
+            return formatMapper.readGeometry(geomString);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/common/src/main/java/org/apache/sedona/common/enums/FileDataSplitter.java
+++ b/common/src/main/java/org/apache/sedona/common/enums/FileDataSplitter.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.sedona.core.enums;
+package org.apache.sedona.common.enums;
 
 import java.io.Serializable;
 import java.util.HashMap;

--- a/common/src/main/java/org/apache/sedona/common/enums/GeometryType.java
+++ b/common/src/main/java/org/apache/sedona/common/enums/GeometryType.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.sedona.core.enums;
+package org.apache.sedona.common.enums;
 
 import java.io.Serializable;
 

--- a/common/src/main/java/org/apache/sedona/common/utils/FormatUtils.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/FormatUtils.java
@@ -11,16 +11,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.sedona.core.formatMapper;
+package org.apache.sedona.common.utils;
 
-import org.apache.log4j.Logger;
-import org.apache.sedona.core.enums.FileDataSplitter;
-import org.apache.sedona.core.enums.GeometryType;
+
+import org.apache.sedona.common.enums.FileDataSplitter;
+import org.apache.sedona.common.enums.GeometryType;
 import org.locationtech.jts.geom.*;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKBReader;
 import org.locationtech.jts.io.WKTReader;
 import org.locationtech.jts.operation.valid.IsValidOp;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.wololo.geojson.Feature;
 import org.wololo.geojson.GeoJSONFactory;
 import org.wololo.jts2geojson.GeoJSONReader;
@@ -34,7 +36,7 @@ import java.util.*;
  * This format mapper is isolated on purpose for the sake of sharing across Spark and Flink
  */
 public class FormatUtils<T extends Geometry> implements Serializable {
-    final static Logger logger = Logger.getLogger(FormatUtils.class);
+    final static Logger logger = LoggerFactory.getLogger(FormatUtils.class);
     /**
      * The start offset.
      */

--- a/common/src/main/java/org/apache/sedona/common/utils/FormatUtils.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/FormatUtils.java
@@ -68,12 +68,12 @@ public class FormatUtils<T extends Geometry> implements Serializable {
     /**
      * Allow mapping of invalid geometries.
      */
-    boolean allowTopologicallyInvalidGeometries;
+    public boolean allowTopologicallyInvalidGeometries;
     // For some unknown reasons, the wkb reader cannot be used in transient variable like the wkt reader.
     /**
      * Crash on syntactically invalid geometries or skip them.
      */
-    boolean skipSyntacticallyInvalidGeometries;
+    public boolean skipSyntacticallyInvalidGeometries;
 
     /**
      * Instantiates a new format mapper.

--- a/core/src/main/java/org/apache/sedona/core/formatMapper/FormatMapper.java
+++ b/core/src/main/java/org/apache/sedona/core/formatMapper/FormatMapper.java
@@ -19,8 +19,9 @@
 
 package org.apache.sedona.core.formatMapper;
 
-import org.apache.sedona.core.enums.FileDataSplitter;
-import org.apache.sedona.core.enums.GeometryType;
+import org.apache.sedona.common.enums.FileDataSplitter;
+import org.apache.sedona.common.enums.GeometryType;
+import org.apache.sedona.common.utils.FormatUtils;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.locationtech.jts.geom.Geometry;
 

--- a/core/src/main/java/org/apache/sedona/core/formatMapper/GeoJsonReader.java
+++ b/core/src/main/java/org/apache/sedona/core/formatMapper/GeoJsonReader.java
@@ -19,7 +19,7 @@
 
 package org.apache.sedona.core.formatMapper;
 
-import org.apache.sedona.core.enums.FileDataSplitter;
+import org.apache.sedona.common.enums.FileDataSplitter;
 import org.apache.sedona.core.spatialRDD.SpatialRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;

--- a/core/src/main/java/org/apache/sedona/core/formatMapper/LineStringFormatMapper.java
+++ b/core/src/main/java/org/apache/sedona/core/formatMapper/LineStringFormatMapper.java
@@ -19,8 +19,8 @@
 
 package org.apache.sedona.core.formatMapper;
 
-import org.apache.sedona.core.enums.FileDataSplitter;
-import org.apache.sedona.core.enums.GeometryType;
+import org.apache.sedona.common.enums.FileDataSplitter;
+import org.apache.sedona.common.enums.GeometryType;
 
 public class LineStringFormatMapper
         extends FormatMapper

--- a/core/src/main/java/org/apache/sedona/core/formatMapper/PointFormatMapper.java
+++ b/core/src/main/java/org/apache/sedona/core/formatMapper/PointFormatMapper.java
@@ -19,8 +19,8 @@
 
 package org.apache.sedona.core.formatMapper;
 
-import org.apache.sedona.core.enums.FileDataSplitter;
-import org.apache.sedona.core.enums.GeometryType;
+import org.apache.sedona.common.enums.FileDataSplitter;
+import org.apache.sedona.common.enums.GeometryType;
 
 public class PointFormatMapper
         extends FormatMapper

--- a/core/src/main/java/org/apache/sedona/core/formatMapper/PolygonFormatMapper.java
+++ b/core/src/main/java/org/apache/sedona/core/formatMapper/PolygonFormatMapper.java
@@ -19,8 +19,8 @@
 
 package org.apache.sedona.core.formatMapper;
 
-import org.apache.sedona.core.enums.FileDataSplitter;
-import org.apache.sedona.core.enums.GeometryType;
+import org.apache.sedona.common.enums.FileDataSplitter;
+import org.apache.sedona.common.enums.GeometryType;
 
 public class PolygonFormatMapper
         extends FormatMapper

--- a/core/src/main/java/org/apache/sedona/core/formatMapper/RectangleFormatMapper.java
+++ b/core/src/main/java/org/apache/sedona/core/formatMapper/RectangleFormatMapper.java
@@ -19,8 +19,8 @@
 
 package org.apache.sedona.core.formatMapper;
 
-import org.apache.sedona.core.enums.FileDataSplitter;
-import org.apache.sedona.core.enums.GeometryType;
+import org.apache.sedona.common.enums.FileDataSplitter;
+import org.apache.sedona.common.enums.GeometryType;
 
 public class RectangleFormatMapper
         extends FormatMapper

--- a/core/src/main/java/org/apache/sedona/core/formatMapper/WkbReader.java
+++ b/core/src/main/java/org/apache/sedona/core/formatMapper/WkbReader.java
@@ -19,7 +19,7 @@
 
 package org.apache.sedona.core.formatMapper;
 
-import org.apache.sedona.core.enums.FileDataSplitter;
+import org.apache.sedona.common.enums.FileDataSplitter;
 import org.apache.sedona.core.spatialRDD.SpatialRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;

--- a/core/src/main/java/org/apache/sedona/core/formatMapper/WktReader.java
+++ b/core/src/main/java/org/apache/sedona/core/formatMapper/WktReader.java
@@ -19,7 +19,7 @@
 
 package org.apache.sedona.core.formatMapper;
 
-import org.apache.sedona.core.enums.FileDataSplitter;
+import org.apache.sedona.common.enums.FileDataSplitter;
 import org.apache.sedona.core.spatialRDD.SpatialRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;

--- a/core/src/main/java/org/apache/sedona/core/showcase/EarthdataMapperRunnableExample.java
+++ b/core/src/main/java/org/apache/sedona/core/showcase/EarthdataMapperRunnableExample.java
@@ -21,7 +21,7 @@ package org.apache.sedona.core.showcase;
 
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.apache.sedona.core.enums.FileDataSplitter;
+import org.apache.sedona.common.enums.FileDataSplitter;
 import org.apache.sedona.core.enums.IndexType;
 import org.apache.sedona.core.formatMapper.EarthdataHDFPointMapper;
 import org.apache.sedona.core.serde.SedonaKryoRegistrator;

--- a/core/src/main/java/org/apache/sedona/core/showcase/Example.java
+++ b/core/src/main/java/org/apache/sedona/core/showcase/Example.java
@@ -21,7 +21,7 @@ package org.apache.sedona.core.showcase;
 
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.apache.sedona.core.enums.FileDataSplitter;
+import org.apache.sedona.common.enums.FileDataSplitter;
 import org.apache.sedona.core.enums.GridType;
 import org.apache.sedona.core.enums.IndexType;
 import org.apache.sedona.core.formatMapper.shapefileParser.ShapefileRDD;

--- a/core/src/main/java/org/apache/sedona/core/spatialRDD/LineStringRDD.java
+++ b/core/src/main/java/org/apache/sedona/core/spatialRDD/LineStringRDD.java
@@ -19,7 +19,7 @@
 
 package org.apache.sedona.core.spatialRDD;
 
-import org.apache.sedona.core.enums.FileDataSplitter;
+import org.apache.sedona.common.enums.FileDataSplitter;
 import org.apache.sedona.core.formatMapper.FormatMapper;
 import org.apache.sedona.core.formatMapper.LineStringFormatMapper;
 import org.apache.spark.api.java.JavaRDD;

--- a/core/src/main/java/org/apache/sedona/core/spatialRDD/PointRDD.java
+++ b/core/src/main/java/org/apache/sedona/core/spatialRDD/PointRDD.java
@@ -19,7 +19,7 @@
 
 package org.apache.sedona.core.spatialRDD;
 
-import org.apache.sedona.core.enums.FileDataSplitter;
+import org.apache.sedona.common.enums.FileDataSplitter;
 import org.apache.sedona.core.formatMapper.FormatMapper;
 import org.apache.sedona.core.formatMapper.PointFormatMapper;
 import org.apache.spark.api.java.JavaRDD;

--- a/core/src/main/java/org/apache/sedona/core/spatialRDD/PolygonRDD.java
+++ b/core/src/main/java/org/apache/sedona/core/spatialRDD/PolygonRDD.java
@@ -19,7 +19,7 @@
 
 package org.apache.sedona.core.spatialRDD;
 
-import org.apache.sedona.core.enums.FileDataSplitter;
+import org.apache.sedona.common.enums.FileDataSplitter;
 import org.apache.sedona.core.formatMapper.FormatMapper;
 import org.apache.sedona.core.formatMapper.PolygonFormatMapper;
 import org.apache.spark.api.java.JavaRDD;

--- a/core/src/main/java/org/apache/sedona/core/spatialRDD/RectangleRDD.java
+++ b/core/src/main/java/org/apache/sedona/core/spatialRDD/RectangleRDD.java
@@ -19,7 +19,7 @@
 
 package org.apache.sedona.core.spatialRDD;
 
-import org.apache.sedona.core.enums.FileDataSplitter;
+import org.apache.sedona.common.enums.FileDataSplitter;
 import org.apache.sedona.core.formatMapper.RectangleFormatMapper;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;

--- a/core/src/main/scala/org/apache/sedona/core/showcase/ScalaEarthdataMapperRunnableExample.scala
+++ b/core/src/main/scala/org/apache/sedona/core/showcase/ScalaEarthdataMapperRunnableExample.scala
@@ -20,7 +20,8 @@
 package org.apache.sedona.core.showcase
 
 import org.apache.log4j.{Level, Logger}
-import org.apache.sedona.core.enums.{FileDataSplitter, IndexType}
+import org.apache.sedona.common.enums.FileDataSplitter
+import org.apache.sedona.core.enums.IndexType
 import org.apache.sedona.core.formatMapper.EarthdataHDFPointMapper
 import org.apache.sedona.core.spatialOperator.RangeQuery
 import org.apache.sedona.core.spatialOperator.SpatialPredicate

--- a/core/src/main/scala/org/apache/sedona/core/showcase/ScalaExample.scala
+++ b/core/src/main/scala/org/apache/sedona/core/showcase/ScalaExample.scala
@@ -20,7 +20,8 @@
 package org.apache.sedona.core.showcase
 
 import org.apache.log4j.{Level, Logger}
-import org.apache.sedona.core.enums.{FileDataSplitter, GridType, IndexType}
+import org.apache.sedona.common.enums.FileDataSplitter
+import org.apache.sedona.core.enums.{GridType, IndexType}
 import org.apache.sedona.core.formatMapper.shapefileParser.ShapefileRDD
 import org.apache.sedona.core.serde.SedonaKryoRegistrator
 import org.apache.sedona.core.spatialOperator.SpatialPredicate

--- a/core/src/test/java/org/apache/sedona/core/io/EarthdataHDFTest.java
+++ b/core/src/test/java/org/apache/sedona/core/io/EarthdataHDFTest.java
@@ -20,7 +20,7 @@ package org.apache.sedona.core.io;
 
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.apache.sedona.core.enums.FileDataSplitter;
+import org.apache.sedona.common.enums.FileDataSplitter;
 import org.apache.sedona.core.enums.IndexType;
 import org.apache.sedona.core.formatMapper.EarthdataHDFPointMapper;
 import org.apache.sedona.core.spatialOperator.RangeQuery;
@@ -31,7 +31,6 @@ import org.apache.spark.storage.StorageLevel;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
-import org.junit.Test;
 import org.locationtech.jts.geom.Envelope;
 
 // TODO: Auto-generated Javadoc

--- a/core/src/test/java/org/apache/sedona/core/spatialOperator/JoinTestBase.java
+++ b/core/src/test/java/org/apache/sedona/core/spatialOperator/JoinTestBase.java
@@ -19,7 +19,7 @@
 package org.apache.sedona.core.spatialOperator;
 
 import org.apache.sedona.core.TestBase;
-import org.apache.sedona.core.enums.FileDataSplitter;
+import org.apache.sedona.common.enums.FileDataSplitter;
 import org.apache.sedona.core.enums.GridType;
 import org.apache.sedona.core.enums.IndexType;
 import org.apache.sedona.core.spatialRDD.LineStringRDD;

--- a/core/src/test/java/org/apache/sedona/core/spatialOperator/LineStringKnnTest.java
+++ b/core/src/test/java/org/apache/sedona/core/spatialOperator/LineStringKnnTest.java
@@ -20,7 +20,7 @@ package org.apache.sedona.core.spatialOperator;
 
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.apache.sedona.core.enums.FileDataSplitter;
+import org.apache.sedona.common.enums.FileDataSplitter;
 import org.apache.sedona.core.enums.IndexType;
 import org.apache.sedona.core.spatialRDD.LineStringRDD;
 import org.apache.spark.SparkConf;

--- a/core/src/test/java/org/apache/sedona/core/spatialOperator/LineStringRangeTest.java
+++ b/core/src/test/java/org/apache/sedona/core/spatialOperator/LineStringRangeTest.java
@@ -20,7 +20,7 @@ package org.apache.sedona.core.spatialOperator;
 
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.apache.sedona.core.enums.FileDataSplitter;
+import org.apache.sedona.common.enums.FileDataSplitter;
 import org.apache.sedona.core.enums.IndexType;
 import org.apache.sedona.core.spatialRDD.LineStringRDD;
 import org.apache.sedona.core.spatialRDD.LineStringRDDTest;

--- a/core/src/test/java/org/apache/sedona/core/spatialOperator/PointKnnTest.java
+++ b/core/src/test/java/org/apache/sedona/core/spatialOperator/PointKnnTest.java
@@ -20,7 +20,7 @@ package org.apache.sedona.core.spatialOperator;
 
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.apache.sedona.core.enums.FileDataSplitter;
+import org.apache.sedona.common.enums.FileDataSplitter;
 import org.apache.sedona.core.enums.IndexType;
 import org.apache.sedona.core.knnJudgement.GeometryDistanceComparator;
 import org.apache.sedona.core.spatialRDD.PointRDD;

--- a/core/src/test/java/org/apache/sedona/core/spatialOperator/PointRangeTest.java
+++ b/core/src/test/java/org/apache/sedona/core/spatialOperator/PointRangeTest.java
@@ -20,7 +20,7 @@ package org.apache.sedona.core.spatialOperator;
 
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.apache.sedona.core.enums.FileDataSplitter;
+import org.apache.sedona.common.enums.FileDataSplitter;
 import org.apache.sedona.core.enums.IndexType;
 import org.apache.sedona.core.spatialRDD.PointRDD;
 import org.apache.spark.SparkConf;

--- a/core/src/test/java/org/apache/sedona/core/spatialOperator/PolygonKnnTest.java
+++ b/core/src/test/java/org/apache/sedona/core/spatialOperator/PolygonKnnTest.java
@@ -20,7 +20,7 @@ package org.apache.sedona.core.spatialOperator;
 
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.apache.sedona.core.enums.FileDataSplitter;
+import org.apache.sedona.common.enums.FileDataSplitter;
 import org.apache.sedona.core.enums.IndexType;
 import org.apache.sedona.core.knnJudgement.GeometryDistanceComparator;
 import org.apache.sedona.core.spatialRDD.PolygonRDD;

--- a/core/src/test/java/org/apache/sedona/core/spatialOperator/PolygonRangeTest.java
+++ b/core/src/test/java/org/apache/sedona/core/spatialOperator/PolygonRangeTest.java
@@ -20,7 +20,7 @@ package org.apache.sedona.core.spatialOperator;
 
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.apache.sedona.core.enums.FileDataSplitter;
+import org.apache.sedona.common.enums.FileDataSplitter;
 import org.apache.sedona.core.enums.IndexType;
 import org.apache.sedona.core.spatialRDD.PolygonRDD;
 import org.apache.spark.SparkConf;

--- a/core/src/test/java/org/apache/sedona/core/spatialOperator/RectangleKnnTest.java
+++ b/core/src/test/java/org/apache/sedona/core/spatialOperator/RectangleKnnTest.java
@@ -20,7 +20,7 @@ package org.apache.sedona.core.spatialOperator;
 
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.apache.sedona.core.enums.FileDataSplitter;
+import org.apache.sedona.common.enums.FileDataSplitter;
 import org.apache.sedona.core.enums.IndexType;
 import org.apache.sedona.core.knnJudgement.GeometryDistanceComparator;
 import org.apache.sedona.core.spatialRDD.RectangleRDD;

--- a/core/src/test/java/org/apache/sedona/core/spatialOperator/RectangleRangeTest.java
+++ b/core/src/test/java/org/apache/sedona/core/spatialOperator/RectangleRangeTest.java
@@ -20,7 +20,7 @@ package org.apache.sedona.core.spatialOperator;
 
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.apache.sedona.core.enums.FileDataSplitter;
+import org.apache.sedona.common.enums.FileDataSplitter;
 import org.apache.sedona.core.enums.IndexType;
 import org.apache.sedona.core.rangeJudgement.RangeFilter;
 import org.apache.sedona.core.rangeJudgement.RangeFilterUsingIndex;

--- a/core/src/test/java/org/apache/sedona/core/spatialRDD/PolygonRDDTest.java
+++ b/core/src/test/java/org/apache/sedona/core/spatialRDD/PolygonRDDTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.sedona.core.spatialRDD;
 
-import org.apache.sedona.core.enums.FileDataSplitter;
+import org.apache.sedona.common.enums.FileDataSplitter;
 import org.apache.sedona.core.enums.IndexType;
 import org.apache.spark.storage.StorageLevel;
 import org.junit.AfterClass;

--- a/core/src/test/java/org/apache/sedona/core/spatialRDD/SpatialRDDTestBase.java
+++ b/core/src/test/java/org/apache/sedona/core/spatialRDD/SpatialRDDTestBase.java
@@ -19,7 +19,7 @@
 package org.apache.sedona.core.spatialRDD;
 
 import org.apache.sedona.core.TestBase;
-import org.apache.sedona.core.enums.FileDataSplitter;
+import org.apache.sedona.common.enums.FileDataSplitter;
 import org.apache.sedona.core.enums.GridType;
 import org.apache.sedona.core.enums.IndexType;
 import org.locationtech.jts.geom.Envelope;

--- a/core/src/test/java/org/apache/sedona/core/spatialRDD/SpatialRDDWriterTest.java
+++ b/core/src/test/java/org/apache/sedona/core/spatialRDD/SpatialRDDWriterTest.java
@@ -22,7 +22,7 @@ package org.apache.sedona.core.spatialRDD;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.NullArgumentException;
 import org.apache.sedona.common.utils.GeomUtils;
-import org.apache.sedona.core.enums.FileDataSplitter;
+import org.apache.sedona.common.enums.FileDataSplitter;
 import org.apache.spark.storage.StorageLevel;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;

--- a/core/src/test/java/org/apache/sedona/core/utils/CRSTransformationTest.java
+++ b/core/src/test/java/org/apache/sedona/core/utils/CRSTransformationTest.java
@@ -20,7 +20,7 @@ package org.apache.sedona.core.utils;
 
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.apache.sedona.core.enums.FileDataSplitter;
+import org.apache.sedona.common.enums.FileDataSplitter;
 import org.apache.sedona.core.enums.GridType;
 import org.apache.sedona.core.enums.IndexType;
 import org.apache.sedona.core.knnJudgement.GeometryDistanceComparator;

--- a/core/src/test/scala/org/apache/sedona/core/scalaTest.scala
+++ b/core/src/test/scala/org/apache/sedona/core/scalaTest.scala
@@ -19,7 +19,8 @@
 
 package org.apache.sedona.core
 
-import org.apache.sedona.core.enums.{FileDataSplitter, GridType, IndexType, JoinBuildSide}
+import org.apache.sedona.common.enums.FileDataSplitter
+import org.apache.sedona.core.enums.{GridType, IndexType, JoinBuildSide}
 import org.apache.sedona.core.formatMapper.EarthdataHDFPointMapper
 import org.apache.sedona.core.spatialOperator.JoinQuery.JoinParams
 import org.apache.sedona.core.spatialOperator.SpatialPredicate

--- a/docs/tutorial/flink/sql.md
+++ b/docs/tutorial/flink/sql.md
@@ -396,7 +396,7 @@ The output will be
 * Create a Geometry from a WKT string
 
 ```java
-import org.apache.sedona.core.formatMapper.FormatUtils;
+import org.apache.sedona.common.utils.FormatUtils;
 import org.locationtech.jts.geom.Geometry;
 
 DataStream<Geometry> geometries = text.map(new MapFunction<String, Geometry>() {
@@ -412,7 +412,7 @@ DataStream<Geometry> geometries = text.map(new MapFunction<String, Geometry>() {
 * Create a Point from a String `1.1, 2.2`. Use `,` as the delimiter.
 
 ```java
-import org.apache.sedona.core.formatMapper.FormatUtils;
+import org.apache.sedona.common.utils.FormatUtils;
 import org.locationtech.jts.geom.Geometry;
 
 DataStream<Geometry> geometries = text.map(new MapFunction<String, Geometry>() {
@@ -428,7 +428,7 @@ DataStream<Geometry> geometries = text.map(new MapFunction<String, Geometry>() {
 * Create a Polygon from a String `1.1, 1.1, 10.1, 10.1`. This is a rectangle with (1.1, 1.1) and (10.1, 10.1) as their min/max corners.
 
 ```java
-import org.apache.sedona.core.formatMapper.FormatUtils;
+import org.apache.sedona.common.utils.FormatUtils;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Geometry;
 
@@ -455,7 +455,7 @@ DataStream<Geometry> geometries = text.map(new MapFunction<String, Geometry>() {
 Put a geometry in a Flink Row to a `geomStream`. Note that you can put other attributes in Row as well. This example uses a constant value `myName` for all geometries.
 
 ```java
-import org.apache.sedona.core.formatMapper.FormatUtils;
+import org.apache.sedona.common.utils.FormatUtils;
 import org.locationtech.jts.geom.Geometry;
 import org.apache.flink.types.Row;
 

--- a/flink/src/main/java/org/apache/sedona/flink/expressions/Constructors.java
+++ b/flink/src/main/java/org/apache/sedona/flink/expressions/Constructors.java
@@ -15,9 +15,9 @@ package org.apache.sedona.flink.expressions;
 
 import org.apache.flink.table.annotation.DataTypeHint;
 import org.apache.flink.table.functions.ScalarFunction;
-import org.apache.sedona.core.enums.FileDataSplitter;
-import org.apache.sedona.core.enums.GeometryType;
-import org.apache.sedona.core.formatMapper.FormatUtils;
+import org.apache.sedona.common.enums.FileDataSplitter;
+import org.apache.sedona.common.enums.GeometryType;
+import org.apache.sedona.common.utils.FormatUtils;
 import org.apache.spark.sql.sedona_sql.expressions.geohash.GeoHashDecoder;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;

--- a/python/sedona/register/java_libs.py
+++ b/python/sedona/register/java_libs.py
@@ -33,7 +33,7 @@ class SedonaJvmLib(Enum):
     LineStringRDD = "org.apache.sedona.core.spatialRDD.LineStringRDD"
     RectangleRDD = "org.apache.sedona.core.spatialRDD.RectangleRDD"
     SpatialRDD = "org.apache.sedona.core.spatialRDD.SpatialRDD"
-    FileDataSplitter = "org.apache.sedona.core.enums.FileDataSplitter"
+    FileDataSplitter = "org.apache.sedona.common.enums.FileDataSplitter"
     GeoJsonReader = "org.apache.sedona.core.formatMapper.GeoJsonReader"
     ShapeFileReader = "org.apache.sedona.core.formatMapper.shapefileParser.ShapefileReader"
     SedonaSQLRegistrator = "org.apache.sedona.sql.utils.SedonaSQLRegistrator"

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Constructors.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Constructors.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.sedona_sql.expressions
 
 import org.apache.sedona.common.Constructors
 import org.apache.sedona.common.enums.{FileDataSplitter, GeometryType}
-import org.apache.sedona.core.formatMapper.FormatMapper
 import org.apache.sedona.sql.utils.GeometrySerializer
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Expression, ImplicitCastInputTypes}

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Constructors.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Constructors.scala
@@ -18,25 +18,22 @@
  */
 package org.apache.spark.sql.sedona_sql.expressions
 
-import org.apache.sedona.core.enums.{FileDataSplitter, GeometryType}
+import org.apache.sedona.common.Constructors
+import org.apache.sedona.common.enums.{FileDataSplitter, GeometryType}
 import org.apache.sedona.core.formatMapper.FormatMapper
 import org.apache.sedona.sql.utils.GeometrySerializer
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.{Expression, ImplicitCastInputTypes}
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
-import org.apache.spark.sql.catalyst.util.GenericArrayData
 import org.apache.spark.sql.sedona_sql.UDT.GeometryUDT
 import org.apache.spark.sql.sedona_sql.expressions.geohash.GeoHashDecoder
 import org.apache.spark.sql.sedona_sql.expressions.implicits.GeometryEnhancer
-import org.apache.spark.sql.types.{AbstractDataType, DataType, DoubleType, IntegerType, StringType, TypeCollection}
+import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 import org.locationtech.jts.geom.{Coordinate, GeometryFactory}
 import org.locationtech.jts.io.WKBReader
 import org.locationtech.jts.io.gml2.GMLReader
 import org.locationtech.jts.io.kml.KMLReader
-import org.apache.spark.sql.catalyst.expressions.ImplicitCastInputTypes
-import org.apache.sedona.common.Constructors
-import org.apache.spark.sql.types.BinaryType
 
 /**
   * Return a point from a string. The string must be plain string and each coordinate must be separated by a delimiter.
@@ -54,9 +51,7 @@ case class ST_PointFromText(inputExpressions: Seq[Expression])
   override def eval(inputRow: InternalRow): Any = {
     val geomString = inputExpressions(0).eval(inputRow).asInstanceOf[UTF8String].toString
     val geomFormat = inputExpressions(1).eval(inputRow).asInstanceOf[UTF8String].toString
-    var fileDataSplitter = FileDataSplitter.getFileDataSplitter(geomFormat)
-    var formatMapper = new FormatMapper(fileDataSplitter, false, GeometryType.POINT)
-    var geometry = formatMapper.readGeometry(geomString)
+    val geometry = Constructors.geomFromText(geomString, geomFormat, GeometryType.POINT)
     GeometrySerializer.serialize(geometry)
   }
 
@@ -87,9 +82,7 @@ case class ST_PolygonFromText(inputExpressions: Seq[Expression])
     val geomString = inputExpressions(0).eval(inputRow).asInstanceOf[UTF8String].toString
     val geomFormat = inputExpressions(1).eval(inputRow).asInstanceOf[UTF8String].toString
 
-    var fileDataSplitter = FileDataSplitter.getFileDataSplitter(geomFormat)
-    var formatMapper = new FormatMapper(fileDataSplitter, false, GeometryType.POLYGON)
-    var geometry = formatMapper.readGeometry(geomString)
+    var geometry = Constructors.geomFromText(geomString, geomFormat, GeometryType.POLYGON)
     GeometrySerializer.serialize(geometry)
   }
 
@@ -119,9 +112,8 @@ case class ST_LineFromText(inputExpressions: Seq[Expression])
   override def eval(inputRow: InternalRow): Any = {
     val lineString = inputExpressions(0).eval(inputRow).asInstanceOf[UTF8String].toString
 
-    var fileDataSplitter = FileDataSplitter.WKT
-    var formatMapper = new FormatMapper(fileDataSplitter, false)
-    var geometry = formatMapper.readGeometry(lineString)
+    val fileDataSplitter = FileDataSplitter.WKT
+    val geometry = Constructors.geomFromText(lineString, fileDataSplitter)
     if(geometry.getGeometryType.contains("LineString")) {
       GeometrySerializer.serialize(geometry)
     } else {
@@ -156,9 +148,7 @@ case class ST_LineStringFromText(inputExpressions: Seq[Expression])
     val geomString = inputExpressions(0).eval(inputRow).asInstanceOf[UTF8String].toString
     val geomFormat = inputExpressions(1).eval(inputRow).asInstanceOf[UTF8String].toString
 
-    var fileDataSplitter = FileDataSplitter.getFileDataSplitter(geomFormat)
-    var formatMapper = new FormatMapper(fileDataSplitter, false, GeometryType.LINESTRING)
-    var geometry = formatMapper.readGeometry(geomString)
+    val geometry = Constructors.geomFromText(geomString, geomFormat, GeometryType.LINESTRING)
 
     GeometrySerializer.serialize(geometry)
   }
@@ -219,9 +209,7 @@ case class ST_GeomFromWKB(inputExpressions: Seq[Expression])
     (inputExpressions.head.eval(inputRow)) match {
       case (geomString: UTF8String) => {
         // Parse UTF-8 encoded wkb string
-        val fileDataSplitter = FileDataSplitter.WKB
-        val formatMapper = new FormatMapper(fileDataSplitter, false)
-        formatMapper.readGeometry(geomString.toString).toGenericArrayData
+        Constructors.geomFromText(geomString.toString, FileDataSplitter.WKB).toGenericArrayData
       }
       case (wkb: Array[Byte]) => {
         // convert raw wkb byte array to geometry
@@ -257,10 +245,7 @@ case class ST_GeomFromGeoJSON(inputExpressions: Seq[Expression])
 
   override def eval(inputRow: InternalRow): Any = {
     val geomString = inputExpressions.head.eval(inputRow).asInstanceOf[UTF8String].toString
-
-    var fileDataSplitter = FileDataSplitter.GEOJSON
-    var formatMapper = new FormatMapper(fileDataSplitter, false)
-    var geometry = formatMapper.readGeometry(geomString)
+    val geometry = Constructors.geomFromText(geomString, FileDataSplitter.GEOJSON)
     // If the user specify a bunch of attributes to go with each geometry, we need to store all of them in this geometry
     if (inputExpressions.length > 1) {
       geometry.setUserData(generateUserData(minInputLength, inputExpressions, inputRow))

--- a/sql/src/test/scala/org/apache/sedona/sql/adapterTestScala.scala
+++ b/sql/src/test/scala/org/apache/sedona/sql/adapterTestScala.scala
@@ -19,7 +19,8 @@
 
 package org.apache.sedona.sql
 
-import org.apache.sedona.core.enums.{FileDataSplitter, GridType, IndexType}
+import org.apache.sedona.common.enums.FileDataSplitter
+import org.apache.sedona.core.enums.{GridType, IndexType}
 import org.apache.sedona.core.formatMapper.EarthdataHDFPointMapper
 import org.apache.sedona.core.formatMapper.shapefileParser.ShapefileReader
 import org.apache.sedona.core.spatialOperator.JoinQuery

--- a/viz/src/main/java/org/apache/sedona/viz/showcase/Example.java
+++ b/viz/src/main/java/org/apache/sedona/viz/showcase/Example.java
@@ -20,7 +20,7 @@ package org.apache.sedona.viz.showcase;
 
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.apache.sedona.core.enums.FileDataSplitter;
+import org.apache.sedona.common.enums.FileDataSplitter;
 import org.apache.sedona.core.enums.GridType;
 import org.apache.sedona.core.enums.IndexType;
 import org.apache.sedona.core.formatMapper.EarthdataHDFPointMapper;

--- a/viz/src/main/scala/org/apache/sedona/viz/showcase/ScalaExample.scala
+++ b/viz/src/main/scala/org/apache/sedona/viz/showcase/ScalaExample.scala
@@ -23,7 +23,8 @@ import java.io.FileInputStream
 import java.util.Properties
 
 import org.apache.log4j.{Level, Logger}
-import org.apache.sedona.core.enums.{FileDataSplitter, GridType, IndexType}
+import org.apache.sedona.common.enums.FileDataSplitter
+import org.apache.sedona.core.enums.{GridType, IndexType}
 import org.apache.sedona.core.formatMapper.EarthdataHDFPointMapper
 import org.apache.sedona.core.spatialOperator.JoinQuery
 import org.apache.sedona.core.spatialRDD.{PointRDD, PolygonRDD, RectangleRDD}

--- a/viz/src/test/java/org/apache/sedona/viz/NYCTripTest.java
+++ b/viz/src/test/java/org/apache/sedona/viz/NYCTripTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.sedona.viz;
 
-import org.apache.sedona.core.enums.FileDataSplitter;
+import org.apache.sedona.common.enums.FileDataSplitter;
 import org.apache.sedona.core.spatialRDD.PointRDD;
 import org.apache.sedona.viz.core.ImageGenerator;
 import org.apache.sedona.viz.extension.visualizationEffect.HeatMap;

--- a/viz/src/test/java/org/apache/sedona/viz/VizTestBase.java
+++ b/viz/src/test/java/org/apache/sedona/viz/VizTestBase.java
@@ -18,7 +18,7 @@
  */
 package org.apache.sedona.viz;
 
-import org.apache.sedona.core.enums.FileDataSplitter;
+import org.apache.sedona.common.enums.FileDataSplitter;
 import org.apache.sedona.viz.core.Serde.SedonaVizKryoRegistrator;
 import org.locationtech.jts.geom.Envelope;
 import org.apache.log4j.Level;

--- a/viz/src/test/scala/org/apache/sedona/viz/rdd/scalaTest.scala
+++ b/viz/src/test/scala/org/apache/sedona/viz/rdd/scalaTest.scala
@@ -24,7 +24,8 @@ import java.util.Properties
 
 import org.locationtech.jts.geom.Envelope
 import org.apache.log4j.{Level, Logger}
-import org.apache.sedona.core.enums.{FileDataSplitter, GridType, IndexType}
+import org.apache.sedona.common.enums.FileDataSplitter
+import org.apache.sedona.core.enums.{GridType, IndexType}
 import org.apache.sedona.core.formatMapper.EarthdataHDFPointMapper
 import org.apache.sedona.core.spatialOperator.JoinQuery
 import org.apache.sedona.core.spatialRDD.{PointRDD, PolygonRDD, RectangleRDD}


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-274 The PR name follows the format `[SEDONA-XXX] my subject`.


## What changes were proposed in this PR?
Transplant the sedona-core FormatUtils class and corresponding enum classes to sedona-common. To enable us move some sql ST constructor functions implementation to sedona-common package. This will allow us to add on the ST functions to other computation engine easily

## How was this patch tested?
Update the existing test cases to execute based on the java implementation

## Did this PR include necessary documentation updates?
- No, this PR does not affect any public API so no need to change the docs.
