### PR TITLE
[SEDONA-265] Migrate all ST functions to Sedona Inferred Expressions

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/Functions.java
+++ b/common/src/main/java/org/apache/sedona/common/Functions.java
@@ -14,11 +14,8 @@
 package org.apache.sedona.common;
 
 import com.google.common.geometry.S2CellId;
-import com.google.common.geometry.S2Point;
-import com.google.common.geometry.S2Region;
-import com.google.common.geometry.S2RegionCoverer;
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.sedona.common.geometryObjects.Circle;
+import org.apache.sedona.common.subDivide.GeometrySubDivider;
 import org.apache.sedona.common.utils.GeomUtils;
 import org.apache.sedona.common.utils.GeometryGeoHashEncoder;
 import org.apache.sedona.common.utils.GeometrySplitter;
@@ -37,6 +34,7 @@ import org.locationtech.jts.operation.linemerge.LineMerger;
 import org.locationtech.jts.operation.valid.IsSimpleOp;
 import org.locationtech.jts.operation.valid.IsValidOp;
 import org.locationtech.jts.precision.GeometryPrecisionReducer;
+import org.locationtech.jts.simplify.TopologyPreservingSimplifier;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.NoSuchAuthorityCodeException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
@@ -48,7 +46,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 
@@ -574,5 +571,99 @@ public class Functions {
             }
         }
         return S2Utils.roundCellsToSameLevel(new ArrayList<>(cellIds), level).stream().map(S2CellId::id).collect(Collectors.toList()).toArray(new Long[cellIds.size()]);
+    }
+
+
+    // create static function named simplifyPreserveTopology
+    public static Geometry simplifyPreserveTopology(Geometry geometry, double distanceTolerance) {
+        return TopologyPreservingSimplifier.simplify(geometry, distanceTolerance);
+    }
+
+    public static String geometryType(Geometry geometry) {
+        return "ST_" + geometry.getGeometryType();
+    }
+
+    public static Geometry startPoint(Geometry geometry) {
+        if (geometry instanceof LineString) {
+            LineString line = (LineString) geometry;
+            return line.getStartPoint();
+        }
+        return null;
+    }
+
+    public static Geometry endPoint(Geometry geometry) {
+        if (geometry instanceof LineString) {
+            LineString line = (LineString) geometry;
+            return line.getEndPoint();
+        }
+        return null;
+    }
+
+    public static Geometry[] dump(Geometry geometry) {
+        int numGeom = geometry.getNumGeometries();
+        if (geometry instanceof GeometryCollection) {
+            Geometry[] geoms = new Geometry[geometry.getNumGeometries()];
+            for (int i = 0; i < numGeom; i++) {
+                geoms[i] = geometry.getGeometryN(i);
+            }
+            return geoms;
+        } else {
+            return new Geometry[] {geometry};
+        }
+    }
+
+    public static Geometry[] dumpPoints(Geometry geometry) {
+        return Arrays.stream(geometry.getCoordinates()).map(GEOMETRY_FACTORY::createPoint).toArray(Point[]::new);
+    }
+
+    public static Geometry symDifference(Geometry leftGeom, Geometry rightGeom) {
+        return leftGeom.symDifference(rightGeom);
+    }
+
+    public static Geometry union(Geometry leftGeom, Geometry rightGeom) {
+        return leftGeom.union(rightGeom);
+    }
+
+    public static Geometry createMultiGeometryFromOneElement(Geometry geometry) {
+        if (geometry instanceof Circle) {
+            return GEOMETRY_FACTORY.createGeometryCollection(new Circle[] {(Circle) geometry});
+        } else if (geometry instanceof GeometryCollection) {
+            return geometry;
+        } else if (geometry instanceof  LineString) {
+            return GEOMETRY_FACTORY.createMultiLineString(new LineString[]{(LineString) geometry});
+        } else if (geometry instanceof Point) {
+            return GEOMETRY_FACTORY.createMultiPoint(new Point[] {(Point) geometry});
+        } else if (geometry instanceof Polygon) {
+            return GEOMETRY_FACTORY.createMultiPolygon(new Polygon[] {(Polygon) geometry});
+        } else {
+            return GEOMETRY_FACTORY.createGeometryCollection();
+        }
+    }
+
+    public static Geometry[] subDivide(Geometry geometry, int maxVertices) {
+        return GeometrySubDivider.subDivide(geometry, maxVertices);
+    }
+
+    public static Geometry makePolygon(Geometry shell, Geometry[] holes) {
+        if (holes != null) {
+            LinearRing[] interiorRings =  Arrays.stream(holes).filter(
+                    h -> h != null && !h.isEmpty() && h instanceof LineString && ((LineString) h).isClosed()
+            ).map(
+                    h -> GEOMETRY_FACTORY.createLinearRing(h.getCoordinates())
+            ).toArray(LinearRing[]::new);
+            if (interiorRings.length != 0) {
+                return GEOMETRY_FACTORY.createPolygon(
+                        GEOMETRY_FACTORY.createLinearRing(shell.getCoordinates()),
+                        Arrays.stream(holes).filter(
+                                h -> h != null && !h.isEmpty() && h instanceof LineString && ((LineString) h).isClosed()
+                        ).map(
+                                h -> GEOMETRY_FACTORY.createLinearRing(h.getCoordinates())
+                        ).toArray(LinearRing[]::new)
+                );
+            }
+        }
+        return GEOMETRY_FACTORY.createPolygon(
+                GEOMETRY_FACTORY.createLinearRing(shell.getCoordinates())
+        );
     }
 }

--- a/common/src/main/java/org/apache/sedona/common/Functions.java
+++ b/common/src/main/java/org/apache/sedona/common/Functions.java
@@ -645,25 +645,29 @@ public class Functions {
     }
 
     public static Geometry makePolygon(Geometry shell, Geometry[] holes) {
-        if (holes != null) {
-            LinearRing[] interiorRings =  Arrays.stream(holes).filter(
-                    h -> h != null && !h.isEmpty() && h instanceof LineString && ((LineString) h).isClosed()
-            ).map(
-                    h -> GEOMETRY_FACTORY.createLinearRing(h.getCoordinates())
-            ).toArray(LinearRing[]::new);
-            if (interiorRings.length != 0) {
-                return GEOMETRY_FACTORY.createPolygon(
-                        GEOMETRY_FACTORY.createLinearRing(shell.getCoordinates()),
-                        Arrays.stream(holes).filter(
-                                h -> h != null && !h.isEmpty() && h instanceof LineString && ((LineString) h).isClosed()
-                        ).map(
-                                h -> GEOMETRY_FACTORY.createLinearRing(h.getCoordinates())
-                        ).toArray(LinearRing[]::new)
-                );
+        try {
+            if (holes != null) {
+                LinearRing[] interiorRings =  Arrays.stream(holes).filter(
+                        h -> h != null && !h.isEmpty() && h instanceof LineString && ((LineString) h).isClosed()
+                ).map(
+                        h -> GEOMETRY_FACTORY.createLinearRing(h.getCoordinates())
+                ).toArray(LinearRing[]::new);
+                if (interiorRings.length != 0) {
+                    return GEOMETRY_FACTORY.createPolygon(
+                            GEOMETRY_FACTORY.createLinearRing(shell.getCoordinates()),
+                            Arrays.stream(holes).filter(
+                                    h -> h != null && !h.isEmpty() && h instanceof LineString && ((LineString) h).isClosed()
+                            ).map(
+                                    h -> GEOMETRY_FACTORY.createLinearRing(h.getCoordinates())
+                            ).toArray(LinearRing[]::new)
+                    );
+                }
             }
+            return GEOMETRY_FACTORY.createPolygon(
+                    GEOMETRY_FACTORY.createLinearRing(shell.getCoordinates())
+            );
+        } catch (IllegalArgumentException e) {
+            return null;
         }
-        return GEOMETRY_FACTORY.createPolygon(
-                GEOMETRY_FACTORY.createLinearRing(shell.getCoordinates())
-        );
     }
 }

--- a/common/src/main/java/org/apache/sedona/common/Predicates.java
+++ b/common/src/main/java/org/apache/sedona/common/Predicates.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sedona.common;
+
+import org.locationtech.jts.geom.Geometry;
+
+public class Predicates {
+    public static boolean contains(Geometry leftGeometry, Geometry rightGeometry) {
+        return leftGeometry.contains(rightGeometry);
+    }
+    public static boolean intersects(Geometry leftGeometry, Geometry rightGeometry) {
+        return leftGeometry.intersects(rightGeometry);
+    }
+    public static boolean within(Geometry leftGeometry, Geometry rightGeometry) {
+        return leftGeometry.within(rightGeometry);
+    }
+    public static boolean covers(Geometry leftGeometry, Geometry rightGeometry) {
+        return leftGeometry.covers(rightGeometry);
+    }
+    public static boolean coveredBy(Geometry leftGeometry, Geometry rightGeometry) {
+        return leftGeometry.coveredBy(rightGeometry);
+    }
+    public static boolean crosses(Geometry leftGeometry, Geometry rightGeometry) {
+        return leftGeometry.crosses(rightGeometry);
+    }
+    public static boolean overlaps(Geometry leftGeometry, Geometry rightGeometry) {
+        return leftGeometry.overlaps(rightGeometry);
+    }
+    public static boolean touches(Geometry leftGeometry, Geometry rightGeometry) {
+        return leftGeometry.touches(rightGeometry);
+    }
+    public static boolean equals(Geometry leftGeometry, Geometry rightGeometry) {
+        return leftGeometry.symDifference(rightGeometry).isEmpty();
+    }
+    public static boolean disjoint(Geometry leftGeometry, Geometry rightGeometry) {
+        return leftGeometry.disjoint(rightGeometry);
+    }
+    public static boolean orderingEquals(Geometry leftGeometry, Geometry rightGeometry) {
+        return leftGeometry.equalsExact(rightGeometry);
+    }
+}

--- a/common/src/main/java/org/apache/sedona/common/utils/GeoHashDecoder.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/GeoHashDecoder.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sedona.common.utils;
+
+import org.locationtech.jts.geom.Geometry;
+
+public class GeoHashDecoder {
+    private static final int[] bits = new int[] {16, 8, 4, 2, 1};
+    private static final String base32 = "0123456789bcdefghjkmnpqrstuvwxyz";
+
+    public static class InvalidGeoHashException extends Exception {
+        public InvalidGeoHashException(String message) {
+            super(message);
+        }
+    }
+
+    public static Geometry decode(String geohash, Integer precision) throws InvalidGeoHashException {
+        return decodeGeoHashBBox(geohash, precision).getBbox().toPolygon();
+    }
+
+    private static class LatLon {
+        public Double[] lons;
+
+        public Double[] lats;
+
+        public LatLon(Double[] lons, Double[] lats) {
+            this.lons = lons;
+            this.lats = lats;
+        }
+
+        BBox getBbox() {
+            return new BBox(
+                    lons[0],
+                    lons[1],
+                    lats[0],
+                    lats[1]
+            );
+        }
+    }
+
+    private static LatLon decodeGeoHashBBox(String geohash, Integer precision) throws InvalidGeoHashException {
+        LatLon latLon = new LatLon(new Double[] {-180.0, 180.0}, new Double[] {-90.0, 90.0});
+        String geoHashLowered = geohash.toLowerCase();
+        int geoHashLength = geohash.length();
+        int targetPrecision = geoHashLength;
+        if (precision != null) {
+            if (precision < 0) throw new InvalidGeoHashException("Precision can not be negative");
+            else targetPrecision = Math.min(geoHashLength, precision);
+        }
+        boolean isEven = true;
+
+        for (int i = 0; i < targetPrecision ; i++){
+            char c = geoHashLowered.charAt(i);
+            byte cd = (byte) base32.indexOf(c);
+            if (cd == -1){
+                throw new InvalidGeoHashException(String.format("Invalid character '%s' found at index %d", c, i));
+            }
+            for (int j = 0;j < 5; j++){
+                byte mask = (byte) bits[j];
+                int index = (mask & cd) == 0 ? 1 : 0;
+                if (isEven){
+                    latLon.lons[index] = (latLon.lons[0] + latLon.lons[1]) / 2;
+                }
+                else {
+                    latLon.lats[index] = (latLon.lats[0] + latLon.lats[1]) / 2;
+                }
+                isEven = !isEven;
+            }
+        }
+        return latLon;
+    }
+
+}

--- a/sql/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
+++ b/sql/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
@@ -117,7 +117,7 @@ object Catalog {
     function[ST_LineInterpolatePoint](),
     function[ST_SubDivideExplode](),
     function[ST_SubDivide](),
-    function[ST_MakePolygon](),
+    function[ST_MakePolygon](null),
     function[ST_GeoHash](),
     function[ST_GeomFromGeoHash](null),
     function[ST_Collect](),

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Constructors.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Constructors.scala
@@ -19,20 +19,15 @@
 package org.apache.spark.sql.sedona_sql.expressions
 
 import org.apache.sedona.common.Constructors
-import org.apache.sedona.common.enums.{FileDataSplitter, GeometryType}
+import org.apache.sedona.common.enums.FileDataSplitter
 import org.apache.sedona.sql.utils.GeometrySerializer
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Expression, ImplicitCastInputTypes}
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.catalyst.expressions.{Expression, ImplicitCastInputTypes}
 import org.apache.spark.sql.sedona_sql.UDT.GeometryUDT
-import org.apache.spark.sql.sedona_sql.expressions.geohash.GeoHashDecoder
 import org.apache.spark.sql.sedona_sql.expressions.implicits.GeometryEnhancer
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
-import org.locationtech.jts.geom.{Coordinate, GeometryFactory}
-import org.locationtech.jts.io.WKBReader
-import org.locationtech.jts.io.gml2.GMLReader
-import org.locationtech.jts.io.kml.KMLReader
 
 /**
   * Return a point from a string. The string must be plain string and each coordinate must be separated by a delimiter.
@@ -41,25 +36,7 @@ import org.locationtech.jts.io.kml.KMLReader
   *                         string, the second parameter is the delimiter. String format should be similar to CSV/TSV
   */
 case class ST_PointFromText(inputExpressions: Seq[Expression])
-  extends Expression with FoldableExpression with ImplicitCastInputTypes with CodegenFallback with UserDataGeneratator {
-  // This is an expression which takes two input expressions.
-  assert(inputExpressions.length == 2)
-
-  override def nullable: Boolean = false
-
-  override def eval(inputRow: InternalRow): Any = {
-    val geomString = inputExpressions(0).eval(inputRow).asInstanceOf[UTF8String].toString
-    val geomFormat = inputExpressions(1).eval(inputRow).asInstanceOf[UTF8String].toString
-    val geometry = Constructors.geomFromText(geomString, geomFormat, GeometryType.POINT)
-    GeometrySerializer.serialize(geometry)
-  }
-
-  override def dataType: DataType = GeometryUDT
-
-  override def inputTypes: Seq[AbstractDataType] = Seq(StringType, StringType)
-
-  override def children: Seq[Expression] = inputExpressions
-
+  extends InferredBinaryExpression(Constructors.pointFromText) with FoldableExpression {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
@@ -71,26 +48,7 @@ case class ST_PointFromText(inputExpressions: Seq[Expression])
   * @param inputExpressions
   */
 case class ST_PolygonFromText(inputExpressions: Seq[Expression])
-  extends Expression with FoldableExpression with ImplicitCastInputTypes with CodegenFallback with UserDataGeneratator {
-  // This is an expression which takes two input expressions.
-  assert(inputExpressions.length == 2)
-
-  override def nullable: Boolean = false
-
-  override def eval(inputRow: InternalRow): Any = {
-    val geomString = inputExpressions(0).eval(inputRow).asInstanceOf[UTF8String].toString
-    val geomFormat = inputExpressions(1).eval(inputRow).asInstanceOf[UTF8String].toString
-
-    var geometry = Constructors.geomFromText(geomString, geomFormat, GeometryType.POLYGON)
-    GeometrySerializer.serialize(geometry)
-  }
-
-  override def dataType: DataType = GeometryUDT
-
-  override def inputTypes: Seq[AbstractDataType] = Seq(StringType, StringType)
-
-  override def children: Seq[Expression] = inputExpressions
-
+  extends InferredBinaryExpression(Constructors.polygonFromText) with FoldableExpression {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
@@ -102,67 +60,22 @@ case class ST_PolygonFromText(inputExpressions: Seq[Expression])
   * @param inputExpressions
   */
 case class ST_LineFromText(inputExpressions: Seq[Expression])
-  extends Expression with FoldableExpression with ImplicitCastInputTypes with CodegenFallback with UserDataGeneratator {
-  // This is an expression which takes one input expressions.
-  assert(inputExpressions.length == 1)
-
-  override def nullable: Boolean = true
-
-  override def eval(inputRow: InternalRow): Any = {
-    val lineString = inputExpressions(0).eval(inputRow).asInstanceOf[UTF8String].toString
-
-    val fileDataSplitter = FileDataSplitter.WKT
-    val geometry = Constructors.geomFromText(lineString, fileDataSplitter)
-    if(geometry.getGeometryType.contains("LineString")) {
-      GeometrySerializer.serialize(geometry)
-    } else {
-      null
-    }
-  }
-
-  override def dataType: DataType = GeometryUDT
-
-  override def inputTypes: Seq[AbstractDataType] = Seq(StringType)
-
-  override def children: Seq[Expression] = inputExpressions
-
+  extends InferredUnaryExpression(Constructors.lineFromText) with FoldableExpression {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
-
 /**
   * Return a linestring from a string. The string must be plain string and each coordinate must be separated by a delimiter.
   *
   * @param inputExpressions
   */
 case class ST_LineStringFromText(inputExpressions: Seq[Expression])
-  extends Expression with FoldableExpression with ImplicitCastInputTypes with CodegenFallback with UserDataGeneratator {
-  // This is an expression which takes two input expressions.
-  assert(inputExpressions.length == 2)
-
-  override def nullable: Boolean = false
-
-  override def eval(inputRow: InternalRow): Any = {
-    val geomString = inputExpressions(0).eval(inputRow).asInstanceOf[UTF8String].toString
-    val geomFormat = inputExpressions(1).eval(inputRow).asInstanceOf[UTF8String].toString
-
-    val geometry = Constructors.geomFromText(geomString, geomFormat, GeometryType.LINESTRING)
-
-    GeometrySerializer.serialize(geometry)
-  }
-
-  override def dataType: DataType = GeometryUDT
-
-  override def inputTypes: Seq[AbstractDataType] = Seq(StringType, StringType)
-
-  override def children: Seq[Expression] = inputExpressions
-
+  extends InferredBinaryExpression(Constructors.lineStringFromText) with FoldableExpression {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
-
 
 /**
   * Return a Geometry from a WKT string
@@ -212,7 +125,7 @@ case class ST_GeomFromWKB(inputExpressions: Seq[Expression])
       }
       case (wkb: Array[Byte]) => {
         // convert raw wkb byte array to geometry
-        new WKBReader().read(wkb).toGenericArrayData
+        Constructors.geomFromWKB(wkb).toGenericArrayData
       }
       case null => null
     }
@@ -294,32 +207,7 @@ case class ST_PointZ(inputExpressions: Seq[Expression])
   * @param inputExpressions
   */
 case class ST_PolygonFromEnvelope(inputExpressions: Seq[Expression])
-  extends Expression with FoldableExpression with ImplicitCastInputTypes with CodegenFallback with UserDataGeneratator {
-  assert(inputExpressions.length == 4)
-
-  override def nullable: Boolean = false
-
-  override def eval(input: InternalRow): Any = {
-    val minX = inputExpressions(0).eval(input).asInstanceOf[Double]
-    val minY = inputExpressions(1).eval(input).asInstanceOf[Double]
-    val maxX = inputExpressions(2).eval(input).asInstanceOf[Double]
-    val maxY = inputExpressions(3).eval(input).asInstanceOf[Double]
-    var coordinates = new Array[Coordinate](5)
-    coordinates(0) = new Coordinate(minX, minY)
-    coordinates(1) = new Coordinate(minX, maxY)
-    coordinates(2) = new Coordinate(maxX, maxY)
-    coordinates(3) = new Coordinate(maxX, minY)
-    coordinates(4) = coordinates(0)
-    val geometryFactory = new GeometryFactory()
-    val polygon = geometryFactory.createPolygon(coordinates)
-    GeometrySerializer.serialize(polygon)
-  }
-
-  override def dataType: DataType = GeometryUDT
-
-  override def inputTypes: Seq[AbstractDataType] = Seq(DoubleType, DoubleType, DoubleType, DoubleType)
-
-  override def children: Seq[Expression] = inputExpressions
+  extends InferredQuarternaryExpression(Constructors.polygonFromEnvelope) with FoldableExpression {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
@@ -337,81 +225,23 @@ trait UserDataGeneratator {
   }
 }
 
-
 case class ST_GeomFromGeoHash(inputExpressions: Seq[Expression])
-  extends Expression with FoldableExpression with ImplicitCastInputTypes with CodegenFallback {
-  override def nullable: Boolean = true
-
-  override def eval(input: InternalRow): Any = {
-    val geoHash = Option(inputExpressions.head.eval(input))
-      .map(_.asInstanceOf[UTF8String].toString)
-    val precision = Option(inputExpressions(1).eval(input)).map(_.asInstanceOf[Int])
-
-    try {
-      geoHash match {
-        case Some(value) => GeoHashDecoder.decode(value, precision).toGenericArrayData
-        case None => null
-      }
-    }
-    catch {
-      case e: Exception => null
-    }
-  }
-
-  override def dataType: DataType = GeometryUDT
-
-  override def inputTypes: Seq[AbstractDataType] = Seq(StringType, IntegerType)
-
-  override def children: Seq[Expression] = inputExpressions
-
+  extends InferredBinaryExpression(Constructors.geomFromGeoHash) with FoldableExpression {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
+  override def allowRightNull: Boolean = true
 }
 
 case class ST_GeomFromGML(inputExpressions: Seq[Expression])
-  extends Expression with FoldableExpression with ImplicitCastInputTypes with CodegenFallback {
-  assert(inputExpressions.length == 1)
-  override def nullable: Boolean = true
-
-  override def eval(inputRow: InternalRow): Any = {
-    (inputExpressions(0).eval(inputRow)) match {
-      case geomString: UTF8String =>
-        new GMLReader().read(geomString.toString, new GeometryFactory()).toGenericArrayData
-      case _ => null
-    }
-  }
-
-  override def dataType: DataType = GeometryUDT
-
-  override def inputTypes: Seq[AbstractDataType] = Seq(StringType)
-
-  override def children: Seq[Expression] = inputExpressions
-
+  extends InferredUnaryExpression(Constructors.geomFromGML) with FoldableExpression {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
 case class ST_GeomFromKML(inputExpressions: Seq[Expression])
-  extends Expression with FoldableExpression with ImplicitCastInputTypes with CodegenFallback {
-  assert(inputExpressions.length == 1)
-  override def nullable: Boolean = true
-
-  override def eval(inputRow: InternalRow): Any = {
-    inputExpressions(0).eval(inputRow) match {
-      case geomString: UTF8String =>
-        new KMLReader().read(geomString.toString).toGenericArrayData
-      case _ => null
-    }
-  }
-
-  override def dataType: DataType = GeometryUDT
-
-  override def inputTypes: Seq[AbstractDataType] = Seq(StringType)
-
-  override def children: Seq[Expression] = inputExpressions
-
+  extends InferredUnaryExpression(Constructors.geomFromKML) with FoldableExpression {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Predicates.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Predicates.scala
@@ -18,15 +18,14 @@
  */
 package org.apache.spark.sql.sedona_sql.expressions
 
+import org.apache.sedona.common.Predicates
 import org.apache.sedona.sql.utils.GeometrySerializer
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression, NullIntolerant}
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
-import org.apache.spark.sql.catalyst.util.ArrayData
-import org.apache.spark.sql.types.{BooleanType, DataType}
-import org.locationtech.jts.geom.Geometry
-import org.apache.spark.sql.types.AbstractDataType
+import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression, NullIntolerant}
 import org.apache.spark.sql.sedona_sql.UDT.GeometryUDT
+import org.apache.spark.sql.types.{AbstractDataType, BooleanType, DataType}
+import org.locationtech.jts.geom.Geometry
 
 abstract class ST_Predicate extends Expression
   with FoldableExpression
@@ -73,7 +72,7 @@ case class ST_Contains(inputExpressions: Seq[Expression])
   extends ST_Predicate with CodegenFallback {
 
   override def evalGeom(leftGeometry: Geometry, rightGeometry: Geometry): Boolean = {
-    leftGeometry.contains(rightGeometry)
+    Predicates.contains(leftGeometry, rightGeometry)
   }
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -90,7 +89,7 @@ case class ST_Intersects(inputExpressions: Seq[Expression])
   extends ST_Predicate with CodegenFallback {
 
   override def evalGeom(leftGeometry: Geometry, rightGeometry: Geometry): Boolean = {
-    leftGeometry.intersects(rightGeometry)
+    Predicates.intersects(leftGeometry, rightGeometry)
   }
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -107,7 +106,7 @@ case class ST_Within(inputExpressions: Seq[Expression])
   extends ST_Predicate with CodegenFallback {
 
   override def evalGeom(leftGeometry: Geometry, rightGeometry: Geometry): Boolean = {
-    leftGeometry.within(rightGeometry)
+    Predicates.within(leftGeometry, rightGeometry)
   }
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -124,7 +123,7 @@ case class ST_Covers(inputExpressions: Seq[Expression])
   extends ST_Predicate with CodegenFallback {
 
   override def evalGeom(leftGeometry: Geometry, rightGeometry: Geometry): Boolean = {
-    leftGeometry.covers(rightGeometry)
+    Predicates.covers(leftGeometry, rightGeometry)
   }
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -141,7 +140,7 @@ case class ST_CoveredBy(inputExpressions: Seq[Expression])
   extends ST_Predicate with CodegenFallback {
 
   override def evalGeom(leftGeometry: Geometry, rightGeometry: Geometry): Boolean = {
-    leftGeometry.coveredBy(rightGeometry)
+    Predicates.coveredBy(leftGeometry, rightGeometry)
   }
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -158,7 +157,7 @@ case class ST_Crosses(inputExpressions: Seq[Expression])
   extends ST_Predicate with CodegenFallback {
 
   override def evalGeom(leftGeometry: Geometry, rightGeometry: Geometry): Boolean = {
-    leftGeometry.crosses(rightGeometry)
+    Predicates.crosses(leftGeometry, rightGeometry)
   }
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -176,7 +175,7 @@ case class ST_Overlaps(inputExpressions: Seq[Expression])
   extends ST_Predicate with CodegenFallback {
 
   override def evalGeom(leftGeometry: Geometry, rightGeometry: Geometry): Boolean = {
-    leftGeometry.overlaps(rightGeometry)
+    Predicates.overlaps(leftGeometry, rightGeometry)
   }
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -193,7 +192,7 @@ case class ST_Touches(inputExpressions: Seq[Expression])
   extends ST_Predicate with CodegenFallback {
 
   override def evalGeom(leftGeometry: Geometry, rightGeometry: Geometry): Boolean = {
-    leftGeometry.touches(rightGeometry)
+    Predicates.touches(leftGeometry, rightGeometry)
   }
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -211,8 +210,7 @@ case class ST_Equals(inputExpressions: Seq[Expression])
 
   override def evalGeom(leftGeometry: Geometry, rightGeometry: Geometry): Boolean = {
     // Returns GeometryCollection object
-    val symDifference = leftGeometry.symDifference(rightGeometry)
-    symDifference.isEmpty
+    Predicates.equals(leftGeometry, rightGeometry)
   }
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -229,7 +227,7 @@ case class ST_Disjoint(inputExpressions: Seq[Expression])
   extends ST_Predicate with CodegenFallback {
 
   override def evalGeom(leftGeometry: Geometry, rightGeometry: Geometry): Boolean = {
-    leftGeometry.disjoint(rightGeometry)
+    Predicates.disjoint(leftGeometry, rightGeometry)
   }
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -246,7 +244,7 @@ case class ST_OrderingEquals(inputExpressions: Seq[Expression])
   extends ST_Predicate with CodegenFallback {
 
   override def evalGeom(leftGeometry: Geometry, rightGeometry: Geometry): Boolean = {
-    leftGeometry.equalsExact(rightGeometry)
+    Predicates.orderingEquals(leftGeometry, rightGeometry)
   }
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/implicits.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/implicits.scala
@@ -42,15 +42,20 @@ object implicits {
     }
 
     def toGeometryArray(input: InternalRow): Array[Geometry] = {
-      inputExpression.eval(input).asInstanceOf[ArrayData] match {
-        case arrayData: ArrayData =>
-          val length = arrayData.numElements()
-          val geometries = new Array[Geometry](length)
-          for (i <- 0 until length) {
-            geometries(i) = arrayData.getBinary(i).toGeometry
+      inputExpression match {
+        case aware: SerdeAware =>
+          aware.evalWithoutSerialization(input).asInstanceOf[Array[Geometry]]
+        case _ =>
+          inputExpression.eval(input).asInstanceOf[ArrayData] match {
+            case arrayData: ArrayData =>
+              val length = arrayData.numElements()
+              val geometries = new Array[Geometry](length)
+              for (i <- 0 until length) {
+                geometries(i) = arrayData.getBinary(i).toGeometry
+              }
+              geometries
+            case _ => null
           }
-          geometries
-        case _ => null
       }
     }
 

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/implicits.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/implicits.scala
@@ -23,6 +23,7 @@ import org.apache.sedona.sql.utils.GeometrySerializer
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.util.{ArrayData, GenericArrayData}
+import org.apache.spark.sql.types.{ByteType, DataTypes}
 import org.apache.spark.unsafe.types.UTF8String
 import org.locationtech.jts.geom.{Geometry, GeometryFactory, Point}
 
@@ -37,6 +38,19 @@ object implicits {
           case binary: Array[Byte] => GeometrySerializer.deserialize(binary)
           case _ => null
         }
+      }
+    }
+
+    def toGeometryArray(input: InternalRow): Array[Geometry] = {
+      inputExpression.eval(input).asInstanceOf[ArrayData] match {
+        case arrayData: ArrayData =>
+          val length = arrayData.numElements()
+          val geometries = new Array[Geometry](length)
+          for (i <- 0 until length) {
+            geometries(i) = arrayData.getBinary(i).toGeometry
+          }
+          geometries
+        case _ => null
       }
     }
 

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/st_constructors.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/st_constructors.scala
@@ -25,6 +25,10 @@ object st_constructors extends DataFrameAPI {
   def ST_GeomFromGeoHash(geohash: Column, precision: Column): Column = wrapExpression[ST_GeomFromGeoHash](geohash, precision)
   def ST_GeomFromGeoHash(geohash: String, precision: Int): Column = wrapExpression[ST_GeomFromGeoHash](geohash, precision)
 
+  def ST_GeomFromGeoHash(geohash: Column): Column = wrapExpression[ST_GeomFromGeoHash](geohash, null)
+
+  def ST_GeomFromGeoHash(geohash: String): Column = wrapExpression[ST_GeomFromGeoHash](geohash, null)
+
   def ST_GeomFromGeoJSON(geojsonString: Column): Column = wrapExpression[ST_GeomFromGeoJSON](geojsonString)
   def ST_GeomFromGeoJSON(geojsonString: String): Column = wrapExpression[ST_GeomFromGeoJSON](geojsonString)
 

--- a/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/st_functions.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/st_functions.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.sedona_sql.expressions
 
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.sedona_sql.expressions.collect.{ST_Collect, ST_CollectionExtract}
+import org.locationtech.jts.geom.Geometry
 import org.locationtech.jts.operation.buffer.BufferParameters
 
 object st_functions extends DataFrameAPI {
@@ -159,8 +160,8 @@ object st_functions extends DataFrameAPI {
   def ST_LineSubstring(lineString: Column, startFraction: Column, endFraction: Column): Column = wrapExpression[ST_LineSubstring](lineString, startFraction, endFraction)
   def ST_LineSubstring(lineString: String, startFraction: Double, endFraction: Double): Column = wrapExpression[ST_LineSubstring](lineString, startFraction, endFraction)
 
-  def ST_MakePolygon(lineString: Column): Column = wrapExpression[ST_MakePolygon](lineString)
-  def ST_MakePolygon(lineString: String): Column = wrapExpression[ST_MakePolygon](lineString)
+  def ST_MakePolygon(lineString: Column): Column = wrapExpression[ST_MakePolygon](lineString, null)
+  def ST_MakePolygon(lineString: String): Column = wrapExpression[ST_MakePolygon](lineString, null)
   def ST_MakePolygon(lineString: Column, holes: Column): Column = wrapExpression[ST_MakePolygon](lineString, holes)
   def ST_MakePolygon(lineString: String, holes: String): Column = wrapExpression[ST_MakePolygon](lineString, holes)
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-274 The PR name follows the format `[SEDONA-XXX] my subject`.


## What changes were proposed in this PR?
Transplant all the sql st funcions' implementation to sedona-common to allow added to flink and other computation engines.
Migrate the expressions to inferred typed expressions. Except following

- ST_SubDivideExplode    <==    explode method 1 -> N
- ST_MinimumBoundingRadius    <==    result in 2 columns
- St_geomfromwkb    <==    accept 2 types of argument, require overloading
- Predicates    <==    spatial join detector requires implementation of ST_Predicate class


## How was this patch tested?
Update the existing test cases to execute based on the java implementation

## Did this PR include necessary documentation updates?
- No, this PR does not affect any public API so no need to change the docs.
