### PR TITLE
[SEDONA-283] Upgrade maven-deploy-plugin to prevent artifacts from being deployed twice

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -342,6 +342,20 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <!-- Set version to 3.0.0 to get rid of the deploying artifacts twice problem in older versions -->
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>3.0.0</version>
+                    <executions>
+                        <execution>
+                            <id>default-deploy</id>
+                            <phase>deploy</phase>
+                            <goals>
+                                <goal>deploy</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
                     <groupId>net.alchim31.maven</groupId>
                     <artifactId>scala-maven-plugin</artifactId>
                     <version>3.2.1</version>


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-283. The PR name follows the format `[SEDONA-283] my subject`.

## What changes were proposed in this PR?

Explicitly specified the version of maven-deploy-plugin to 3.0.0 to workaround this problem. Please refer to the JIRA ticket for details.

## How was this patch tested?

Manually tested by deploying artifacts to an internal repository.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
