### PR TITLE
[SEDONA-306] Prepare release 1.4.1

### DIFF
--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: apache.sedona
 Title: R Interface for Apache Sedona
-Version: 1.4.0.9000
+Version: 1.4.1
 Authors@R:
     c(person(family = "Apache Sedona",
              role = c("aut", "cre"),

--- a/R/R/dependencies.R
+++ b/R/R/dependencies.R
@@ -39,7 +39,7 @@ spark_dependencies <- function(spark_version, scala_version, ...) {
       paste0(
         "org.apache.sedona:sedona-",
         c("spark-shaded", "viz"),
-        sprintf("-%s_%s:1.4.0", spark_version, scala_version)
+        sprintf("-%s_%s:1.4.1", spark_version, scala_version)
       ),
       packages
     )

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -183,6 +183,14 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.scalatest</groupId>

--- a/docs/community/publish.md
+++ b/docs/community/publish.md
@@ -409,14 +409,16 @@ Then submit to CRAN using this [web form](https://xmpalantir.wu.ac.at/cransubmit
 
 ### Generate Javadoc and Scaladoc
 
-* Javadoc: Use Intellij IDEA to generate Javadoc for `core` and `viz` module, output them to `docs/api/javadoc`; or run the following script:
+Run the following script to build Javadoc and Scaladoc of sedona modules and move them to docs/api/javadoc directory.
+
 ```bash
 #!/bin/bash
+
 mvn -q clean install -DskipTests
 mv core/target/apidocs docs/api/javadoc/core
 mv viz/target/apidocs docs/api/javadoc/viz
+mv sql/common/target/site/scaladocs docs/api/javadoc/sql
 ```
-* Scaladoc: Run `scaladoc -d docs/api/javadoc/sql/ sql/common/src/main/scala/org/apache/sedona/sql/utils/*.scala`
 
 Please do not commit these generated docs to Sedona GitHub.
 

--- a/docs/community/publish.md
+++ b/docs/community/publish.md
@@ -9,7 +9,7 @@ This page is for Sedona PMC to publish Sedona releases.
 
 1. In your local Sedona Git repo under master branch, run
 ```bash
-echo "#!/bin/bash" > create-release.sh
+echo '#!/bin/bash' > create-release.sh
 chmod 777 create-release.sh
 ```
 2. Use your favourite GUI text editor to open `create-release.sh`.
@@ -61,8 +61,6 @@ Make sure the Sedona version in the following files are {{ sedona_create_release
 ```bash
 #!/bin/bash
 
-source ~/.bashrc
-
 git checkout master
 git pull
 
@@ -71,20 +69,31 @@ rm -f pom.xml.*
 
 echo "*****Step 1. Stage the Release Candidate to GitHub."
 
-mvn -q -B clean release:prepare -Dtag={{ sedona_create_release.current_git_tag }} -DreleaseVersion={{ sedona_create_release.current_version }} -DdevelopmentVersion={{ sedona_create_release.current_snapshot }} -DautoVersionSubmodules=true -Dresume=false -Darguments="-DskipTests"
-
-rm -f release.*
-rm -f pom.xml.*
+mvn -q -B clean release:prepare -Dtag={{ sedona_create_release.current_git_tag }} -DreleaseVersion={{ sedona_create_release.current_version }} -DdevelopmentVersion={{ sedona_create_release.current_snapshot }} -Dresume=false -Penable-all-submodules -Darguments="-DskipTests"
+mvn -q -B release:clean -Penable-all-submodules
 
 echo "Now the releases are staged. A tag and two commits have been created on Sedona GitHub repo"
 
 echo "*****Step 2: Upload the Release Candidate to https://repository.apache.org."
 
 # For Spark 3.0 and Scala 2.12
-mvn -q org.apache.maven.plugins:maven-release-plugin:2.3.2:perform -DconnectionUrl=scm:git:https://github.com/apache/sedona.git -Dtag={{ sedona_create_release.current_git_tag }} -DautoVersionSubmodules=true -Dresume=false -Darguments="-DskipTests -Dscala=2.12"
+mvn -q org.apache.maven.plugins:maven-release-plugin:2.3.2:perform -DconnectionUrl=scm:git:https://github.com/apache/sedona.git -Dtag={{ sedona_create_release.current_git_tag }} -Dresume=false -Darguments="-DskipTests -Dspark=3.0 -Dscala=2.12" -Dspark=3.0 -Dscala=2.12
 
 # For Spark 3.0 and Scala 2.13
-mvn -q org.apache.maven.plugins:maven-release-plugin:2.3.2:perform -DconnectionUrl=scm:git:https://github.com/apache/sedona.git -Dtag={{ sedona_create_release.current_git_tag }} -DautoVersionSubmodules=true -Dresume=false -Darguments="-DskipTests -Dscala=2.13"
+## Note that we use maven-release-plugin 2.3.2 instead of more recent version (e.g., 3.0.1) to get rid of a bug of maven-release-plugin,
+## which prevent us from cloning git repo with user specified -Dtag=<tag>.
+## Please refer to https://issues.apache.org/jira/browse/MRELEASE-933 and https://issues.apache.org/jira/browse/SCM-729 for details.
+##
+## Please also note that system properties `-Dspark` and `-Dscala` has to be specified both for release:perform and the actual build parameters
+## in `-Darguments`, because the build profiles activated for release:perform task will also affect the actual build task. It is safer to specify
+## these system properties for both tasks.
+mvn -q org.apache.maven.plugins:maven-release-plugin:2.3.2:perform -DconnectionUrl=scm:git:https://github.com/apache/sedona.git -Dtag={{ sedona_create_release.current_git_tag }} -Dresume=false -Darguments="-DskipTests -Dspark=3.0 -Dscala=2.13" -Dspark=3.0 -Dscala=2.13
+
+# For Spark 3.4 and Scala 2.12
+mvn -q org.apache.maven.plugins:maven-release-plugin:2.3.2:perform -DconnectionUrl=scm:git:https://github.com/apache/sedona.git -Dtag={{ sedona_create_release.current_git_tag }} -Dresume=false -Darguments="-DskipTests -Dspark=3.4 -Dscala=2.12" -Dspark=3.4 -Dscala=2.12
+
+# For Spark 3.4 and Scala 2.13
+mvn -q org.apache.maven.plugins:maven-release-plugin:2.3.2:perform -DconnectionUrl=scm:git:https://github.com/apache/sedona.git -Dtag={{ sedona_create_release.current_git_tag }} -Dresume=false -Darguments="-DskipTests -Dspark=3.4 -Dscala=2.13" -Dspark=3.4 -Dscala=2.13
 
 echo "*****Step 3: Upload Release Candidate on ASF SVN: https://dist.apache.org/repos/dist/dev/sedona"
 
@@ -108,19 +117,33 @@ echo "Compiling the source code..."
 
 mkdir apache-sedona-{{ sedona_create_release.current_version }}-bin
 
-cd apache-sedona-{{ sedona_create_release.current_version }}-src && mvn -q clean install -DskipTests -Dscala=2.12 && cd ..
+cd apache-sedona-{{ sedona_create_release.current_version }}-src && mvn -q clean install -DskipTests -Dspark=3.0 -Dscala=2.12 && cd ..
 cp apache-sedona-{{ sedona_create_release.current_version }}-src/common/target/sedona-*{{ sedona_create_release.current_version}}.jar apache-sedona-{{ sedona_create_release.current_version }}-bin/
 cp apache-sedona-{{ sedona_create_release.current_version }}-src/core/target/sedona-*{{ sedona_create_release.current_version}}.jar apache-sedona-{{ sedona_create_release.current_version }}-bin/
-cp apache-sedona-{{ sedona_create_release.current_version }}-src/sql/target/sedona-*{{ sedona_create_release.current_version}}.jar apache-sedona-{{ sedona_create_release.current_version }}-bin/
+cp apache-sedona-{{ sedona_create_release.current_version }}-src/sql/spark-3.0/target/sedona-*{{ sedona_create_release.current_version}}.jar apache-sedona-{{ sedona_create_release.current_version }}-bin/
 cp apache-sedona-{{ sedona_create_release.current_version }}-src/viz/target/sedona-*{{ sedona_create_release.current_version}}.jar apache-sedona-{{ sedona_create_release.current_version }}-bin/
 cp apache-sedona-{{ sedona_create_release.current_version }}-src/python-adapter/target/sedona-*{{ sedona_create_release.current_version}}.jar apache-sedona-{{ sedona_create_release.current_version }}-bin/
 cp apache-sedona-{{ sedona_create_release.current_version }}-src/spark-shaded/target/sedona-*{{ sedona_create_release.current_version}}.jar apache-sedona-{{ sedona_create_release.current_version }}-bin/
 cp apache-sedona-{{ sedona_create_release.current_version }}-src/flink/target/sedona-*{{ sedona_create_release.current_version}}.jar apache-sedona-{{ sedona_create_release.current_version }}-bin/
 cp apache-sedona-{{ sedona_create_release.current_version }}-src/flink-shaded/target/sedona-*{{ sedona_create_release.current_version}}.jar apache-sedona-{{ sedona_create_release.current_version }}-bin/
 
-cd apache-sedona-{{ sedona_create_release.current_version }}-src && mvn -q clean install -DskipTests -Dscala=2.13 && cd ..
+cd apache-sedona-{{ sedona_create_release.current_version }}-src && mvn -q clean install -DskipTests -Dspark=3.0 -Dscala=2.13 && cd ..
 cp apache-sedona-{{ sedona_create_release.current_version }}-src/core/target/sedona-*{{ sedona_create_release.current_version}}.jar apache-sedona-{{ sedona_create_release.current_version }}-bin/
-cp apache-sedona-{{ sedona_create_release.current_version }}-src/sql/target/sedona-*{{ sedona_create_release.current_version}}.jar apache-sedona-{{ sedona_create_release.current_version }}-bin/
+cp apache-sedona-{{ sedona_create_release.current_version }}-src/sql/spark-3.0/target/sedona-*{{ sedona_create_release.current_version}}.jar apache-sedona-{{ sedona_create_release.current_version }}-bin/
+cp apache-sedona-{{ sedona_create_release.current_version }}-src/viz/target/sedona-*{{ sedona_create_release.current_version}}.jar apache-sedona-{{ sedona_create_release.current_version }}-bin/
+cp apache-sedona-{{ sedona_create_release.current_version }}-src/python-adapter/target/sedona-*{{ sedona_create_release.current_version}}.jar apache-sedona-{{ sedona_create_release.current_version }}-bin/
+cp apache-sedona-{{ sedona_create_release.current_version }}-src/spark-shaded/target/sedona-*{{ sedona_create_release.current_version}}.jar apache-sedona-{{ sedona_create_release.current_version }}-bin/
+
+cd apache-sedona-{{ sedona_create_release.current_version }}-src && mvn -q clean install -DskipTests -Dspark=3.4 -Dscala=2.12 && cd ..
+cp apache-sedona-{{ sedona_create_release.current_version }}-src/core/target/sedona-*{{ sedona_create_release.current_version}}.jar apache-sedona-{{ sedona_create_release.current_version }}-bin/
+cp apache-sedona-{{ sedona_create_release.current_version }}-src/sql/spark-3.4/target/sedona-*{{ sedona_create_release.current_version}}.jar apache-sedona-{{ sedona_create_release.current_version }}-bin/
+cp apache-sedona-{{ sedona_create_release.current_version }}-src/viz/target/sedona-*{{ sedona_create_release.current_version}}.jar apache-sedona-{{ sedona_create_release.current_version }}-bin/
+cp apache-sedona-{{ sedona_create_release.current_version }}-src/python-adapter/target/sedona-*{{ sedona_create_release.current_version}}.jar apache-sedona-{{ sedona_create_release.current_version }}-bin/
+cp apache-sedona-{{ sedona_create_release.current_version }}-src/spark-shaded/target/sedona-*{{ sedona_create_release.current_version}}.jar apache-sedona-{{ sedona_create_release.current_version }}-bin/
+
+cd apache-sedona-{{ sedona_create_release.current_version }}-src && mvn -q clean install -DskipTests -Dspark=3.4 -Dscala=2.13 && cd ..
+cp apache-sedona-{{ sedona_create_release.current_version }}-src/core/target/sedona-*{{ sedona_create_release.current_version}}.jar apache-sedona-{{ sedona_create_release.current_version }}-bin/
+cp apache-sedona-{{ sedona_create_release.current_version }}-src/sql/spark-3.4/target/sedona-*{{ sedona_create_release.current_version}}.jar apache-sedona-{{ sedona_create_release.current_version }}-bin/
 cp apache-sedona-{{ sedona_create_release.current_version }}-src/viz/target/sedona-*{{ sedona_create_release.current_version}}.jar apache-sedona-{{ sedona_create_release.current_version }}-bin/
 cp apache-sedona-{{ sedona_create_release.current_version }}-src/python-adapter/target/sedona-*{{ sedona_create_release.current_version}}.jar apache-sedona-{{ sedona_create_release.current_version }}-bin/
 cp apache-sedona-{{ sedona_create_release.current_version }}-src/spark-shaded/target/sedona-*{{ sedona_create_release.current_version}}.jar apache-sedona-{{ sedona_create_release.current_version }}-bin/
@@ -312,95 +335,6 @@ rm apache-sedona-{{ sedona_create_release.current_version }}-src.tar.gz.sha512
 rm apache-sedona-{{ sedona_create_release.current_version }}-bin.tar.gz
 rm apache-sedona-{{ sedona_create_release.current_version }}-bin.tar.gz.asc
 rm apache-sedona-{{ sedona_create_release.current_version }}-bin.tar.gz.sha512
-
-echo "Re-staging releases to https://repository.apache.org"
-
-# For Spark 3.0 and Scala 2.12
-
-git pull
-
-git checkout -b {{ sedona_create_release.current_git_tag }} {{ sedona_create_release.current_git_tag }}
-
-mvn versions:set -DnewVersion={{ sedona_create_release.current_version }}-SNAPSHOT
-
-git add -A
-
-git commit -m "tmp SNAPSHOT pom"
-
-mvn clean release:prepare -DautoVersionSubmodules=true -DdryRun=true -Dresume=false -Darguments="-DskipTests" -Dtag={{ sedona_create_release.current_git_tag }} -DreleaseVersion={{ sedona_create_release.current_version }} -DdevelopmentVersion={{ sedona_create_release.next_version }}
-
-mvn versions:set -DnewVersion={{ sedona_create_release.current_version }}
-
-git add -A
-
-git commit -m "revert back to the correct pom"
-
-mvn clean release:perform -DautoVersionSubmodules=true -Dresume=false -Darguments="-DskipTests"
-
-rm -f release.*
-rm -f pom.xml.*
-
-# For Spark 3.0 and Scala 2.13
-
-mvn versions:set -DnewVersion={{ sedona_create_release.current_version }}-SNAPSHOT
-
-git add -A
-
-git commit -m "tmp SNAPSHOT pom"
-
-mvn clean release:prepare -DautoVersionSubmodules=true -DdryRun=true -Dresume=false -Darguments="-DskipTests -Dscala=2.13" -Dtag={{ sedona_create_release.current_git_tag }} -DreleaseVersion={{ sedona_create_release.current_version }} -DdevelopmentVersion={{ sedona_create_release.next_version }}
-
-mvn versions:set -DnewVersion={{ sedona_create_release.current_version }}
-
-git add -A
-
-git commit -m "revert back to the correct pom"
-
-mvn clean release:perform -DautoVersionSubmodules=true -Dresume=false -Darguments="-DskipTests -Dscala=2.13"
-
-rm -f release.*
-rm -f pom.xml.*
-
-git add -A
-
-git commit -m "cleanup the branch"
-
-git checkout master
-
-git branch -d {{ sedona_create_release.current_git_tag }}
-```
-
-### Fix signature issues
-
-Please find the Sedona staging id on https://repository.apache.org under `staging repository`.
-
-Then run the following script. Replace `admin`, `admind123` with your Apache ID username and Apache ID password. Replace `stagingid` with the correct id.
-
-```bash
-#!/bin/bash
-username=admin
-password=admin123
-stagingid=1027
-
-artifacts=(parent core-3.0_2.12 core-3.0_2.13 sql-3.0_2.12 sql-3.0_2.13 viz-3.0_2.12 viz-3.0_2.13 python-adapter-3.0_2.12 python-adapter-3.0_2.13 common flink_2.12 spark-shaded-3.0_2.12 spark-shaded-3.0_2.13 flink-shaded_2.12)
-filenames=(.pom .jar -javadoc.jar)
-
-echo "Re-uploading signatures to fix *failureMessage Invalid Signature*"
-for artifact in "${artifacts[@]}"; do
-	for filename in "${filenames[@]}"; do
-	if [ $artifact -eq 'parent' && $filename -ne '.pom' ]
-    then
-       continue
-    fi
-	wget https://repository.apache.org/service/local/repositories/orgapachesedona-$stagingid/content/org/apache/sedona/sedona-$artifact/{{ sedona_create_release.current_version }}/sedona-${artifact}-{{ sedona_create_release.current_version }}${filename}
-	gpg -ab sedona-${artifact}-{{ sedona_create_release.current_version }}${filename}
-	curl -v -u $username:$password --upload-file sedona-${artifact}-{{ sedona_create_release.current_version }}${filename}.asc https://repository.apache.org/service/local/repositories/orgapachesedona-$stagingid/content/org/apache/sedona/sedona-${artifact}/{{ sedona_create_release.current_version }}/sedona-${artifact}-{{ sedona_create_release.current_version }}${filename}.asc
-   done
-done
-
-rm *.pom
-rm *.jar
-rm *.asc
 ```
 
 ### Manually close and release the package
@@ -408,6 +342,31 @@ rm *.asc
 1. Click `Close` on the Sedona staging repo on https://repository.apache.org under `staging repository`
 2. Once the staging repo is closed, click `Release` on this repo.
 
+**NOTICE**: The staging repo will be automatically dropped after 3 days without closing. If you find the staging repo being dropped, you can re-stage the release using the following script.
+
+```bash
+#!/bin/bash
+
+echo "Re-staging releases to https://repository.apache.org"
+
+git checkout master
+git pull
+
+rm -f release.*
+rm -f pom.xml.*
+
+# For Spark 3.0 and Scala 2.12
+mvn -q org.apache.maven.plugins:maven-release-plugin:2.3.2:perform -DconnectionUrl=scm:git:https://github.com/apache/sedona.git -Dtag={{ sedona_create_release.current_git_tag }} -Dresume=false -Darguments="-DskipTests -Dspark=3.0 -Dscala=2.12" -Dspark=3.0 -Dscala=2.12
+
+# For Spark 3.0 and Scala 2.13
+mvn -q org.apache.maven.plugins:maven-release-plugin:2.3.2:perform -DconnectionUrl=scm:git:https://github.com/apache/sedona.git -Dtag={{ sedona_create_release.current_git_tag }} -Dresume=false -Darguments="-DskipTests -Dspark=3.0 -Dscala=2.13" -Dspark=3.0 -Dscala=2.13
+
+# For Spark 3.4 and Scala 2.12
+mvn -q org.apache.maven.plugins:maven-release-plugin:2.3.2:perform -DconnectionUrl=scm:git:https://github.com/apache/sedona.git -Dtag={{ sedona_create_release.current_git_tag }} -Dresume=false -Darguments="-DskipTests -Dspark=3.4 -Dscala=2.12" -Dspark=3.4 -Dscala=2.12
+
+# For Spark 3.4 and Scala 2.13
+mvn -q org.apache.maven.plugins:maven-release-plugin:2.3.2:perform -DconnectionUrl=scm:git:https://github.com/apache/sedona.git -Dtag={{ sedona_create_release.current_git_tag }} -Dresume=false -Darguments="-DskipTests -Dspark=3.4 -Dscala=2.13" -Dspark=3.4 -Dscala=2.13
+```
 
 ## 9. Release Sedona Python and Zeppelin
 
@@ -450,8 +409,14 @@ Then submit to CRAN using this [web form](https://xmpalantir.wu.ac.at/cransubmit
 
 ### Generate Javadoc and Scaladoc
 
-* Javadoc: Use Intelij IDEA to generate Javadoc for `core` and `viz` module, output them to `docs/api/javadoc`
-* Scaladoc: Run `scaladoc -d docs/api/javadoc/sql/ sql/src/main/scala/org/apache/sedona/sql/utils/*.scala`
+* Javadoc: Use Intellij IDEA to generate Javadoc for `core` and `viz` module, output them to `docs/api/javadoc`; or run the following script:
+```bash
+#!/bin/bash
+mvn -q clean install -DskipTests
+mv core/target/apidocs docs/api/javadoc/core
+mv viz/target/apidocs docs/api/javadoc/viz
+```
+* Scaladoc: Run `scaladoc -d docs/api/javadoc/sql/ sql/common/src/main/scala/org/apache/sedona/sql/utils/*.scala`
 
 Please do not commit these generated docs to Sedona GitHub.
 

--- a/docs/community/snapshot.md
+++ b/docs/community/snapshot.md
@@ -13,7 +13,7 @@ The detailed requirement is on [ASF Infra website](https://infra.apache.org/publ
 
 1. In your local Sedona Git repo under master branch, run
 ```bash
-echo " " > create-release.sh
+echo '#!/bin/bash' > create-release.sh
 chmod 777 create-release.sh
 ```
 2. Use your favourite GUI text editor to open `create-release.sh`.
@@ -28,29 +28,25 @@ In your Sedona GitHub repo, run this script:
 ```bash
 #!/bin/bash
 
-source ~/.bashrc
-
 git checkout master
 git pull
 
 rm -f release.*
 rm -f pom.xml.*
 
+# Validate the POMs and your credential setup
+mvn -q -B clean release:prepare -Dtag={{ sedona_create_release.current_git_tag }} -DreleaseVersion={{ sedona_create_release.current_version }} -DdevelopmentVersion={{ sedona_create_release.current_snapshot }} -Dresume=false -DdryRun=true -Penable-all-submodules -Darguments="-DskipTests"
+mvn -q -B release:clean -Penable-all-submodules
+
 # Spark 3.0 and Scala 2.12
-# Prepare the SNAPSHOTs
-mvn -q -B clean -Darguments="-DskipTests" release:prepare -Dtag={{ sedona_create_release.current_git_tag }} -DreleaseVersion={{ sedona_create_release.current_version }} -DdevelopmentVersion={{ sedona_create_release.current_snapshot }} -DdryRun=true -DautoVersionSubmodules=true -Dresume=false
-# Deploy the SNAPSHOTs
-mvn -q deploy -DskipTests
+mvn -q deploy -DskipTests -Dspark=3.0 -Dscala=2.12
 
-rm -f release.*
-rm -f pom.xml.*
+# Spark 3.0 and Scala 2.13
+mvn -q deploy -DskipTests -Dspark=3.0 -Dscala=2.13
 
-# Prepare for Spark 3.0 and Scala 2.13
-# Prepare the SNAPSHOTs
-mvn -q -B clean -Darguments="-DskipTests -Dscala=2.13" release:prepare  -Dtag={{ sedona_create_release.current_git_tag }} -DreleaseVersion={{ sedona_create_release.current_version }} -DdevelopmentVersion={{ sedona_create_release.current_snapshot }} -DdryRun=true -DautoVersionSubmodules=true -Dresume=false
-# Deploy the SNAPSHOTs
-mvn -q deploy -DskipTests -Dscala=2.13
+# Spark 3.4 and Scala 2.12
+mvn -q deploy -DskipTests -Dspark=3.4 -Dscala=2.12
 
-rm -f release.*
-rm -f pom.xml.*
+# Spark 3.4 and Scala 2.13
+mvn -q deploy -DskipTests -Dspark=3.4 -Dscala=2.13
 ```

--- a/docs/setup/release-notes.md
+++ b/docs/setup/release-notes.md
@@ -4,6 +4,117 @@
 !!!danger
 	Sedona Python currently only works with Shapely 1.x. If you use GeoPandas, please use <= GeoPandas `0.11.1`. GeoPandas > 0.11.1 will automatically install Shapely 2.0. If you use Shapely, please use <= `1.8.4`.
 
+## Sedona 1.4.1
+
+Sedona 1.4.1 is compiled against, Spark 3.3 / Spark 3.4 / Flink 1.12, Java 8.
+
+### Highlights
+
+* [X] **Sedona Spark** More raster functions and bridge RasterUDT and Map Algebra operators. See [Raster based operators](../../api/sql/Raster-operators/#raster-based-operators) and [Raster to Map Algebra operators](../../api/sql/Raster-operators/#raster-to-map-algebra-operators).
+* [X] **Sedona Spark & Flink** Added geodesic / geography functions:
+    * ST_DistanceSphere
+    * ST_DistanceSpheroid
+    * ST_AreaSpheroid
+    * ST_LengthSpheroid
+* [X] **Sedona Spark & Flink** Introduced `SedonaContext` to unify Sedona entry points.
+* [X] **Sedona Spark** Support Spark 3.4.
+* [X] **Sedona Spark** Added a number of new ST functions.
+* [X] **Zeppelin** Zeppelin helium plugin supports ploting geometries like linestring, polygon.
+
+### API change
+
+* **Sedona Spark & Flink** Introduced a new entry point called SedonaContext to unify all Sedona entry points in different compute engines and deprecate old Sedona register entry points. Users no longer have to register Sedona kryo serializer and import many tedious Python classes.
+    * **Sedona Spark**:
+        * Scala:
+        ```scala
+        import org.apache.sedona.spark.SedonaContext
+        val sedona = SedonaContext.create(SedonaContext.builder().master("local[*]").getOrCreate())
+        sedona.sql("SELECT ST_GeomFromWKT(XXX) FROM")
+        ```
+        * Python:
+        ```python
+        from sedona.spark import *
+
+        config = SedonaContext.builder().\
+           config('spark.jars.packages',
+               'org.apache.sedona:sedona-spark-shaded-3.0_2.12:1.4.1,'
+               'org.datasyslab:geotools-wrapper:1.4.0-28.2'). \
+           getOrCreate()
+        sedona = SedonaContext.create(config)
+        sedona.sql("SELECT ST_GeomFromWKT(XXX) FROM")
+        ```
+    * **Sedona Flink**:
+    ```java
+    import org.apache.sedona.flink.SedonaContext
+    StreamTableEnvironment sedona = SedonaContext.create(env, tableEnv);
+    sedona.sqlQuery("SELECT ST_GeomFromWKT(XXX) FROM")
+    ```
+
+### Bug
+
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/SEDONA-266'>SEDONA-266</a>] -         RS_Values throws UnsupportedOperationException for shuffled point arrays
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/SEDONA-267'>SEDONA-267</a>] -         Cannot pip install apache-sedona 1.4.0 from source distribution
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/SEDONA-273'>SEDONA-273</a>] -         Set a upper bound for Shapely, Pandas and GeoPandas
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/SEDONA-277'>SEDONA-277</a>] -         Sedona spark artifacts for scala 2.13 do not have proper POMs
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/SEDONA-283'>SEDONA-283</a>] -         Artifacts were deployed twice when running mvn clean deploy
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/SEDONA-284'>SEDONA-284</a>] -         Property values in dependency deduced POMs for shaded modules were not substituted
+</li>
+</ul>
+
+### New Feature
+
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/SEDONA-196'>SEDONA-196</a>] -         Add ST_Force3D to Sedona
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/SEDONA-239'>SEDONA-239</a>] -         Implement ST_NumPoints
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/SEDONA-264'>SEDONA-264</a>] -         zeppelin helium plugin supports ploting geometry like linestring, polygon
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/SEDONA-280'>SEDONA-280</a>] -         Add ST_GeometricMedian
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/SEDONA-281'>SEDONA-281</a>] -         Support geodesic / geography functions
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/SEDONA-286'>SEDONA-286</a>] -         Support optimized distance join on ST_DistanceSpheroid and ST_DistanceSphere
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/SEDONA-287'>SEDONA-287</a>] -         Use SedonaContext to unify Sedona entry points
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/SEDONA-292'>SEDONA-292</a>] -         Bridge Sedona Raster and Map Algebra operators
+</li>
+</ul>
+
+### Improvement
+
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/SEDONA-167'>SEDONA-167</a>] -         Add __pycache__ to Python .gitignore
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/SEDONA-265'>SEDONA-265</a>] -         Migrate all ST functions to Sedona Inferred Expressions
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/SEDONA-269'>SEDONA-269</a>] -         Add data source for writing binary files
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/SEDONA-270'>SEDONA-270</a>] -         Remove redundant serialization for rasters
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/SEDONA-271'>SEDONA-271</a>] -         Add raster function RS_SRID
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/SEDONA-274'>SEDONA-274</a>] -         Move all ST function logics to Sedona common
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/SEDONA-275'>SEDONA-275</a>] -         Add raster function RS_SetSRID
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/SEDONA-276'>SEDONA-276</a>] -         Add support for Spark 3.4
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/SEDONA-279'>SEDONA-279</a>] -         Sedona-Flink should not depend on Sedona-Spark modules
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/SEDONA-282'>SEDONA-282</a>] -         R – Add raster write function
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/SEDONA-290'>SEDONA-290</a>] -         RDD Spatial Joins should follow the iterator model
+</li>
+</ul>
+
 ## Sedona 1.4.0
 
 Sedona 1.4.0 is compiled against, Spark 3.3 / Flink 1.12, Java 8.

--- a/flink/pom.xml
+++ b/flink/pom.xml
@@ -122,12 +122,6 @@
             <version>${scala.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_${scala.compat.version}</artifactId>
-            <version>${scalatest.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-1.2-api</artifactId>
             <scope>test</scope>
@@ -145,21 +139,5 @@
             <scope>compile</scope>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>net.alchim31.maven</groupId>
-                <artifactId>scala-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.scalatest</groupId>
-                <artifactId>scalatest-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.scalastyle</groupId>
-                <artifactId>scalastyle-maven-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 </project>
   

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -131,11 +131,11 @@ extra:
     current_version: 1.4.0
     current_geotools: 1.4.0-28.2
   sedona_create_release:
-    current_version: 1.4.0
-    current_git_tag: sedona-1.4.0-rc1
-    current_rc: 1.4.0-rc1
-    current_snapshot: 1.4.1-SNAPSHOT
-    next_version: 1.4.1
+    current_version: 1.4.1
+    current_git_tag: sedona-1.4.1-rc1
+    current_rc: 1.4.1-rc1
+    current_snapshot: 1.5.0-SNAPSHOT
+    next_version: 1.5.0
 copyright: Copyright © 2023 The Apache Software Foundation
 markdown_extensions:
   - admonition

--- a/pom.xml
+++ b/pom.xml
@@ -488,15 +488,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
                 <version>3.0.1</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>deploy</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>net.nicoulaj.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -361,6 +361,18 @@
                     <version>3.4.1</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>3.0.1</version>
+                    <configuration>
+                        <autoResolveSnapshots>all</autoResolveSnapshots>
+                        <autoVersionSubmodules>true</autoVersionSubmodules>
+                        <!-- Don't enable all submodules when running the
+                             actual build using modified POMs -->
+                        <preparationProfiles>!enable-all-submodules</preparationProfiles>
+                    </configuration>
+                </plugin>
+                <plugin>
                     <groupId>net.alchim31.maven</groupId>
                     <artifactId>scala-maven-plugin</artifactId>
                     <version>3.2.1</version>

--- a/python/sedona/version.py
+++ b/python/sedona/version.py
@@ -15,4 +15,4 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-version = "1.4.0"
+version = "1.4.1"

--- a/sql/pom.xml
+++ b/sql/pom.xml
@@ -41,6 +41,18 @@
         <module>spark-${spark.compat.version}</module>
     </modules>
 
+    <!-- Add non-default submodules when running `mvn release:prepare
+         -Penable-all-submodules`, so that project versions of all submodules
+         will be substituted -->
+    <profiles>
+        <profile>
+            <id>enable-all-submodules</id>
+            <modules>
+                <module>spark-3.4</module>
+            </modules>
+        </profile>
+    </profiles>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/sql/spark-3.0/pom.xml
+++ b/sql/spark-3.0/pom.xml
@@ -25,7 +25,7 @@
         <version>1.4.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-	<artifactId>sedona-sql-${spark.compat.version}_${scala.compat.version}</artifactId>
+	<artifactId>sedona-sql-3.0_${scala.compat.version}</artifactId>
 
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>A cluster computing system for processing large-scale spatial data: SQL API for Spark 3.0 - 3.3.</description>

--- a/sql/spark-3.4/pom.xml
+++ b/sql/spark-3.4/pom.xml
@@ -25,7 +25,7 @@
         <version>1.4.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-	<artifactId>sedona-sql-${spark.compat.version}_${scala.compat.version}</artifactId>
+	<artifactId>sedona-sql-3.4_${scala.compat.version}</artifactId>
 
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>A cluster computing system for processing large-scale spatial data: SQL API for Spark 3.4.</description>

--- a/viz/pom.xml
+++ b/viz/pom.xml
@@ -155,6 +155,14 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.scalatest</groupId>

--- a/zeppelin/package.json
+++ b/zeppelin/package.json
@@ -2,7 +2,7 @@
   "name": "apache-sedona",
   "description": "Zeppelin visualization support for Sedona",
   "author": "Apache Sedona, original authors are listed on https://github.com/myuwono/zeppelin-leaflet",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-306. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Due to the changes made to the project structure since Sedona 1.4.0, the release process of Sedona 1.4.1 changed a lot. We'll update the docs and address all the issues introduced to the release process. Notable changes are:

1. Added an `enable-all-submodules` profile for `release:prepare` to substitute versions of all submodules.
2. Don't generate and publish scala docs when building `sedona-core`, `sedona-viz` and `sedona-flink`. We'll publish java docs for these modules. This also gets rid of conflicts caused by deploying javadocs.jar twice.
3. Don't run gpg-sign in the deploy phase. Now the signatures generated by gpg-sign in verify phase are all correct, and there's no need to fix signature issues manually.

We'll also submit release notes for 1.4.1 in the same pull request, as well as other trivial version changes. Experienced contributors can help check if these changes were made correctly.

## How was this patch tested?

We've set up a local nexus repository and tested the release process. The release process to actually publish artifacts to repository.apache.org may be a little bit different.

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation update.

