### PR TITLE
[SEDONA-303] Port all Sedona Spark functions to Sedona Flink -- Step 1

### DIFF
--- a/docs/api/flink/Function.md
+++ b/docs/api/flink/Function.md
@@ -431,6 +431,60 @@ Input: `MULTILINESTRING((0 0, 10 0, 10 10, 0 10, 0 0),(10 10, 20 10, 20 20, 10 2
 
 Output: `MULTIPOLYGON(((0 0,0 10,10 10,10 0,0 0)),((10 10,10 20,20 20,20 10,10 10)))`
 
+## ST_Centroid
+
+Introduction: Return the centroid point of A
+
+Format: `ST_Centroid (A:geometry)`
+
+Since: `v1.0.0`
+
+Spark SQL example:
+```sql
+SELECT ST_Centroid(polygondf.countyshape)
+FROM polygondf
+```
+
+## ST_CollectionExtract
+
+Introduction: Returns a homogeneous multi-geometry from a given geometry collection.
+
+The type numbers are:
+1. POINT
+2. LINESTRING
+3. POLYGON
+
+If the type parameter is omitted a multi-geometry of the highest dimension is returned.
+
+Format: `ST_CollectionExtract (A:geometry)`
+
+Format: `ST_CollectionExtract (A:geometry, type:Int)`
+
+Since: `v1.2.1`
+
+Example:
+
+```sql
+WITH test_data as (
+    ST_GeomFromText(
+        'GEOMETRYCOLLECTION(POINT(40 10), POLYGON((0 0, 0 5, 5 5, 5 0, 0 0)))'
+    ) as geom
+)
+SELECT ST_CollectionExtract(geom) as c1, ST_CollectionExtract(geom, 1) as c2
+FROM test_data
+
+```
+
+Result:
+
+```
++----------------------------------------------------------------------------+
+|c1                                        |c2                               |
++----------------------------------------------------------------------------+
+|MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0))) |MULTIPOINT(40 10)                |              |
++----------------------------------------------------------------------------+
+```
+
 ## ST_ConcaveHull
 
 Introduction: Return the Concave Hull of polgyon A, with alpha set to pctConvex[0, 1] in the Delaunay Triangulation method, the concave hull will not contain a hole unless allowHoles is set to true
@@ -451,6 +505,20 @@ FROM polygondf
 Input: `Polygon ((0 0, 1 2, 2 2, 3 2, 5 0, 4 0, 3 1, 2 1, 1 0, 0 0))`
 
 Output: `POLYGON ((1 2, 2 2, 3 2, 5 0, 4 0, 1 0, 0 0, 1 2))`
+
+## ST_ConvexHull
+
+Introduction: Return the Convex Hull of polgyon A
+
+Format: `ST_ConvexHull (A:geometry)`
+
+Since: `v1.0.0`
+
+Spark SQL example:
+```sql
+SELECT ST_ConvexHull(polygondf.countyshape)
+FROM polygondf
+```
 
 ## ST_Dimension
 
@@ -545,6 +613,42 @@ SELECT ST_Degrees(0.19739555984988044)
 ```
 
 Output: 11.309932474020195
+
+## ST_Difference
+
+Introduction: Return the difference between geometry A and B (return part of geometry A that does not intersect geometry B)
+
+Format: `ST_Difference (A:geometry, B:geometry)`
+
+Since: `v1.2.0`
+
+Example:
+
+```sql
+SELECT ST_Difference(ST_GeomFromWKT('POLYGON ((-3 -3, 3 -3, 3 3, -3 3, -3 -3))'), ST_GeomFromWKT('POLYGON ((0 -4, 4 -4, 4 4, 0 4, 0 -4))'))
+```
+
+Result:
+
+```
+POLYGON ((0 -3, -3 -3, -3 3, 0 3, 0 -3))
+```
+
+## ST_Dump
+
+Introduction: It expands the geometries. If the geometry is simple (Point, Polygon Linestring etc.) it returns the geometry
+itself, if the geometry is collection or multi it returns record for each of collection components.
+
+Format: `ST_Dump(geom: geometry)`
+
+Since: `v1.0.0`
+
+SQL example:
+```sql
+SELECT ST_Dump(ST_GeomFromText('MULTIPOINT ((10 40), (40 30), (20 20), (30 10))'))
+```
+
+Output: `[POINT (10 40), POINT (40 30), POINT (20 20), POINT (30 10)]`
 
 ## ST_Envelope
 

--- a/docs/api/flink/Function.md
+++ b/docs/api/flink/Function.md
@@ -437,9 +437,9 @@ Introduction: Return the centroid point of A
 
 Format: `ST_Centroid (A:geometry)`
 
-Since: `v1.0.0`
+Since: `v1.5.0`
 
-Spark SQL example:
+Example:
 ```sql
 SELECT ST_Centroid(polygondf.countyshape)
 FROM polygondf
@@ -460,7 +460,7 @@ Format: `ST_CollectionExtract (A:geometry)`
 
 Format: `ST_CollectionExtract (A:geometry, type:Int)`
 
-Since: `v1.2.1`
+Since: `v1.5.0`
 
 Example:
 
@@ -512,9 +512,9 @@ Introduction: Return the Convex Hull of polgyon A
 
 Format: `ST_ConvexHull (A:geometry)`
 
-Since: `v1.0.0`
+Since: `v1.5.0`
 
-Spark SQL example:
+Example:
 ```sql
 SELECT ST_ConvexHull(polygondf.countyshape)
 FROM polygondf
@@ -620,7 +620,7 @@ Introduction: Return the difference between geometry A and B (return part of geo
 
 Format: `ST_Difference (A:geometry, B:geometry)`
 
-Since: `v1.2.0`
+Since: `v1.5.0`
 
 Example:
 
@@ -641,7 +641,7 @@ itself, if the geometry is collection or multi it returns record for each of col
 
 Format: `ST_Dump(geom: geometry)`
 
-Since: `v1.0.0`
+Since: `v1.5.0`
 
 SQL example:
 ```sql

--- a/flink/src/main/java/org/apache/sedona/flink/Catalog.java
+++ b/flink/src/main/java/org/apache/sedona/flink/Catalog.java
@@ -47,6 +47,7 @@ public class Catalog {
                 new Functions.ST_Centroid(),
                 new Functions.ST_CollectionExtract(),
                 new Functions.ST_ConcaveHull(),
+                new Functions.ST_ConvexHull(),
                 new Functions.ST_Envelope(),
                 new Functions.ST_Difference(),
                 new Functions.ST_Dimension(),

--- a/flink/src/main/java/org/apache/sedona/flink/Catalog.java
+++ b/flink/src/main/java/org/apache/sedona/flink/Catalog.java
@@ -16,6 +16,8 @@ package org.apache.sedona.flink;
 import org.apache.flink.table.functions.UserDefinedFunction;
 import org.apache.sedona.flink.expressions.*;
 
+import scala.Function;
+
 public class Catalog {
     public static UserDefinedFunction[] getFuncs() {
         return new UserDefinedFunction[]{
@@ -42,13 +44,17 @@ public class Catalog {
                 new Functions.ST_Azimuth(),
                 new Functions.ST_Boundary(),
                 new Functions.ST_Buffer(),
+                new Functions.ST_Centroid(),
+                new Functions.ST_CollectionExtract(),
                 new Functions.ST_ConcaveHull(),
                 new Functions.ST_Envelope(),
+                new Functions.ST_Difference(),
                 new Functions.ST_Dimension(),
                 new Functions.ST_Distance(),
                 new Functions.ST_DistanceSphere(),
                 new Functions.ST_DistanceSpheroid(),
                 new Functions.ST_3DDistance(),
+                new Functions.ST_Dump(),
                 new Functions.ST_Length(),
                 new Functions.ST_LengthSpheroid(),
                 new Functions.ST_Transform(),

--- a/flink/src/main/java/org/apache/sedona/flink/expressions/Functions.java
+++ b/flink/src/main/java/org/apache/sedona/flink/expressions/Functions.java
@@ -136,11 +136,11 @@ public class Functions {
 
     public static class ST_Difference extends ScalarFunction {
         @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class)
-        public Double eval(@DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o1,
+        public Geometry eval(@DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o1,
                            @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o2) {
             Geometry geom1 = (Geometry) o1;
             Geometry geom2 = (Geometry) o2;
-            return org.apache.sedona.common.Functions.azimuth(geom1, geom2);
+            return org.apache.sedona.common.Functions.difference(geom1, geom2);
         }
     }
 

--- a/flink/src/main/java/org/apache/sedona/flink/expressions/Functions.java
+++ b/flink/src/main/java/org/apache/sedona/flink/expressions/Functions.java
@@ -71,6 +71,29 @@ public class Functions {
         }
     }
 
+    public static class ST_Centroid extends ScalarFunction {
+        @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class)
+        public Geometry eval(@DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o) {
+            Geometry geom = (Geometry) o;
+            return org.apache.sedona.common.Functions.getCentroid(geom);
+        }
+    }
+    
+    public static class ST_CollectionExtract extends ScalarFunction {
+        @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class)
+        public Geometry eval(@DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o) {
+            Geometry geom = (Geometry) o;
+            return org.apache.sedona.common.Functions.collectionExtract(geom);
+        }
+
+        @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class)
+        public Geometry eval(@DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o,
+                             @DataTypeHint("Integer") Integer geoType) {
+            Geometry geom = (Geometry) o;
+            return org.apache.sedona.common.Functions.collectionExtract(geom, geoType);
+        }
+    }
+
     public static class ST_ConcaveHull extends ScalarFunction {
         @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class)
         public Geometry eval(@DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o,
@@ -101,7 +124,16 @@ public class Functions {
             Geometry geom = (Geometry) o;
             return org.apache.sedona.common.Functions.dimension(geom);
         }
+    }
 
+    public static class ST_Difference extends ScalarFunction {
+        @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class)
+        public Double eval(@DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o1,
+                           @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o2) {
+            Geometry geom1 = (Geometry) o1;
+            Geometry geom2 = (Geometry) o2;
+            return org.apache.sedona.common.Functions.azimuth(geom1, geom2);
+        }
     }
 
     public static class ST_Distance extends ScalarFunction {
@@ -152,6 +184,14 @@ public class Functions {
         }
     }
 
+    public static class ST_Dump extends ScalarFunction {
+        @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry[].class)
+        public Geometry[] eval(@DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o) {
+            Geometry geom1 = (Geometry) o;
+            return org.apache.sedona.common.Functions.dump(geom1);
+        }
+    }
+    
     public static class ST_Length extends ScalarFunction {
         @DataTypeHint("Double")
         public Double eval(@DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o) {

--- a/flink/src/main/java/org/apache/sedona/flink/expressions/Functions.java
+++ b/flink/src/main/java/org/apache/sedona/flink/expressions/Functions.java
@@ -110,6 +110,14 @@ public class Functions {
         }
     }
 
+    public static class ST_ConvexHull extends ScalarFunction {
+        @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class)
+        public Geometry eval(@DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o) {
+            Geometry geom = (Geometry) o;
+            return org.apache.sedona.common.Functions.convexHull(geom);
+        }
+    }
+
     public static class ST_Envelope extends ScalarFunction {
         @DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class)
         public Geometry eval(@DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o) {

--- a/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
@@ -131,9 +131,11 @@ public class FunctionTest extends TestBase{
 
     @Test
     public void testDump() {
-        Table table = tableEnv.sqlQuery("SELECT ST_AsText((ST_Dump(ST_GeomFromText('POINT (0 0)'))).geom)");
-        String result = (String) first(table).getField(0).toString();
-        assertEquals("POINT (0 0)", result);
+        Table table = tableEnv.sqlQuery("SELECT ST_GeomFromWKT('MULTIPOINT ((0 0), (1 1))') AS geom");
+        table = table.select(call(Functions.ST_Dump.class.getSimpleName(), $("geom")));
+        Geometry[] result = (Geometry[]) first(table).getField(0);
+        assertEquals("POINT (0 0)", result[0].toString());
+        assertEquals("POINT (1 1)", result[1].toString());
     }
 
     @Test

--- a/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
@@ -85,6 +85,22 @@ public class FunctionTest extends TestBase{
     }
 
     @Test
+    public void testCentroid() {
+        Table polygonTable = tableEnv.sqlQuery("SELECT ST_GeomFromWKT('POLYGON ((2 2, 0 0, 2 0, 0 2))') AS geom");
+        Table boundaryTable = polygonTable.select(call(Functions.ST_Centroid.class.getSimpleName(), $("geom")));
+        Geometry result = (Geometry) first(boundaryTable).getField(0);
+        assertEquals("POINT (1 1)", result.toString());
+    }
+
+    @Test
+    public void testCollectionExtract() {
+        Table collectionTable = tableEnv.sqlQuery("SELECT ST_GeomFromWKT('GEOMETRYCOLLECTION(POINT(0 0), LINESTRING(1 1, 2 2))') AS collection");
+        Table resultTable = collectionTable.select(call(Functions.ST_CollectionExtract.class.getSimpleName(), $("collection")));
+        Geometry result = (Point) first(resultTable).getField(0);
+        assertEquals("MULTILINESTRING ((1 1, 2 2))", result.toString());
+    }
+
+    @Test
     public void testConcaveHull() {
         Table polygonTable = tableEnv.sqlQuery("SELECT ST_GeomFromWKT('Polygon ((0 0, 1 2, 2 2, 3 2, 5 0, 4 0, 3 1, 2 1, 1 0, 0 0))') as geom");
         Table concaveHullPolygonTable = polygonTable.select(call(Functions.ST_ConcaveHull.class.getSimpleName(), $("geom"), 1.0, true));
@@ -95,6 +111,20 @@ public class FunctionTest extends TestBase{
         Table concaveHullPolygonTable2 = polygonTable2.select(call(Functions.ST_ConcaveHull.class.getSimpleName(), $("geom"), 1.0));
         Geometry result2 = (Geometry) first(concaveHullPolygonTable2).getField(0);
         assertEquals("POLYGON ((0 0, 1 1, 1 0, 0 0))", result2.toString());
+    }
+
+    @Test
+    public void testDifference() {
+        Table table = tableEnv.sqlQuery("SELECT ST_Difference(ST_GeomFromWKT('LINESTRING(50 100, 50 200)'), ST_GeomFromWKT('LINESTRING(50 50, 50 150)'))");
+        Geometry result = (Geometry) first(table).getField(0);
+        assertEquals("LINESTRING (50 150, 50 200)", result.toString());
+    }
+
+    @Test
+    public void testDump() {
+        Table table = tableEnv.sqlQuery("SELECT ST_AsText((ST_Dump(ST_GeomFromText('POINT (0 0)'))).geom)");
+        Geometry result = (Geometry) first(table).getField(0);
+        assertEquals("POINT (0 0)", result.toString());
     }
 
     @Test

--- a/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
@@ -118,7 +118,7 @@ public class FunctionTest extends TestBase{
         Table polygonTable = tableEnv.sqlQuery("SELECT ST_GeomFromWKT('Polygon ((0 0, 1 2, 2 2, 3 2, 5 0, 4 0, 3 1, 2 1, 1 0, 0 0))') as geom");
         Table concaveHullPolygonTable = polygonTable.select(call(Functions.ST_ConvexHull.class.getSimpleName(), $("geom")));
         Geometry result = (Geometry) first(concaveHullPolygonTable).getField(0);
-        assertEquals("POLYGON ((0 0, 1 2, 3 2, 5 0, 0 0)", result.toString());
+        assertEquals("POLYGON ((0 0, 1 2, 3 2, 5 0, 0 0))", result.toString());
     }
 
     @Test
@@ -132,8 +132,8 @@ public class FunctionTest extends TestBase{
     @Test
     public void testDump() {
         Table table = tableEnv.sqlQuery("SELECT ST_AsText((ST_Dump(ST_GeomFromText('POINT (0 0)'))).geom)");
-        Geometry result = (Geometry) first(table).getField(0);
-        assertEquals("POINT (0 0)", result.toString());
+        String result = (String) first(table).getField(0).toString();
+        assertEquals("POINT (0 0)", result);
     }
 
     @Test

--- a/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
@@ -86,17 +86,17 @@ public class FunctionTest extends TestBase{
 
     @Test
     public void testCentroid() {
-        Table polygonTable = tableEnv.sqlQuery("SELECT ST_GeomFromWKT('POLYGON ((2 2, 0 0, 2 0, 0 2))') AS geom");
-        Table boundaryTable = polygonTable.select(call(Functions.ST_Centroid.class.getSimpleName(), $("geom")));
-        Geometry result = (Geometry) first(boundaryTable).getField(0);
+        Table polygonTable = tableEnv.sqlQuery("SELECT ST_GeomFromText('POLYGON ((2 2, 0 0, 2 0, 0 2, 2 2))') as geom");
+        Table resultTable = polygonTable.select(call(Functions.ST_Centroid.class.getSimpleName(), $("geom")));
+        Geometry result = (Geometry) first(resultTable).getField(0);
         assertEquals("POINT (1 1)", result.toString());
     }
 
     @Test
     public void testCollectionExtract() {
-        Table collectionTable = tableEnv.sqlQuery("SELECT ST_GeomFromWKT('GEOMETRYCOLLECTION(POINT(0 0), LINESTRING(1 1, 2 2))') AS collection");
+        Table collectionTable = tableEnv.sqlQuery("SELECT ST_GeomFromText('GEOMETRYCOLLECTION(POINT(0 0), LINESTRING(1 1, 2 2))') as collection");
         Table resultTable = collectionTable.select(call(Functions.ST_CollectionExtract.class.getSimpleName(), $("collection")));
-        Geometry result = (Point) first(resultTable).getField(0);
+        Geometry result = (Geometry) first(resultTable).getField(0);
         assertEquals("MULTILINESTRING ((1 1, 2 2))", result.toString());
     }
 
@@ -114,9 +114,18 @@ public class FunctionTest extends TestBase{
     }
 
     @Test
+    public void testConvexHull() {
+        Table polygonTable = tableEnv.sqlQuery("SELECT ST_GeomFromWKT('Polygon ((0 0, 1 2, 2 2, 3 2, 5 0, 4 0, 3 1, 2 1, 1 0, 0 0))') as geom");
+        Table concaveHullPolygonTable = polygonTable.select(call(Functions.ST_ConvexHull.class.getSimpleName(), $("geom")));
+        Geometry result = (Geometry) first(concaveHullPolygonTable).getField(0);
+        assertEquals("POLYGON ((0 0, 1 2, 3 2, 5 0, 0 0)", result.toString());
+    }
+
+    @Test
     public void testDifference() {
-        Table table = tableEnv.sqlQuery("SELECT ST_Difference(ST_GeomFromWKT('LINESTRING(50 100, 50 200)'), ST_GeomFromWKT('LINESTRING(50 50, 50 150)'))");
-        Geometry result = (Geometry) first(table).getField(0);
+        Table lineTable = tableEnv.sqlQuery("SELECT ST_GeomFromWKT('LINESTRING(50 100, 50 200)') AS g1, ST_GeomFromWKT('LINESTRING(50 50, 50 150)') as g2");
+        Table resultTable = lineTable.select(call(Functions.ST_Difference.class.getSimpleName(), $("g1"), $("g2")));
+        Geometry result = (Geometry) first(resultTable).getField(0);
         assertEquals("LINESTRING (50 150, 50 200)", result.toString());
     }
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)


## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-303. The PR name follows the format `[SEDONA-XXX] my subject`.


## What changes were proposed in this PR?
Port missing ST_functions including {ST_Centroid, ST_CollectionExtract, ST_ConvexHull, ST_Difference, ST_Dump} to [sedona-flink](https://issues.apache.org/jira/browse/SEDONA-flink).

## How was this patch tested?
1. Integration unit tests in [sedona-flink](https://issues.apache.org/jira/browse/SEDONA-flink).


## Did this PR include necessary documentation updates?
- Yes, I have updated the documentation update.
