### PR TITLE
[SEDONA-321] Implement RS_Intersects(rast, geom)

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/raster/RasterPredicates.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterPredicates.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.common.raster;
+
+import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.geometry.Envelope2D;
+import org.geotools.geometry.jts.JTS;
+import org.geotools.referencing.CRS;
+import org.geotools.referencing.crs.DefaultEngineeringCRS;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.opengis.referencing.FactoryException;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.referencing.operation.MathTransform;
+import org.opengis.referencing.operation.TransformException;
+
+public class RasterPredicates {
+    private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory();
+
+    /**
+     * Test if a raster intersects a query window. If both the raster and the query window have a
+     * CRS, the query window will be transformed to the CRS of the raster before testing for intersection.
+     * Please note that the CRS transformation will be lenient, which means that the transformation may
+     * not be accurate.
+     * @param raster the raster
+     * @param queryWindow the query window
+     * @return true if the raster intersects the query window
+     */
+    public static boolean rsIntersects(GridCoverage2D raster, Geometry queryWindow) {
+        Envelope2D rasterEnvelope2D = raster.getEnvelope2D();
+        CoordinateReferenceSystem rasterCRS = rasterEnvelope2D.getCoordinateReferenceSystem();
+        int queryWindowSRID = queryWindow.getSRID();
+        if (rasterCRS != null && !(rasterCRS instanceof DefaultEngineeringCRS) && queryWindowSRID > 0) {
+            try {
+                CoordinateReferenceSystem queryWindowCRS = CRS.decode("EPSG:" + queryWindowSRID);
+                if (!CRS.equalsIgnoreMetadata(rasterCRS, queryWindowCRS)) {
+                    MathTransform transform = CRS.findMathTransform(queryWindowCRS, rasterCRS, true);
+                    queryWindow = JTS.transform(queryWindow, transform);
+                }
+            } catch (FactoryException | TransformException e) {
+                throw new RuntimeException("Cannot transform CRS of query window", e);
+            }
+        }
+        Envelope rasterEnvelope = JTS.toEnvelope(rasterEnvelope2D);
+        Geometry rasterGeometry = GEOMETRY_FACTORY.toGeometry(rasterEnvelope);
+        return rasterGeometry.intersects(queryWindow);
+    }
+}

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterPredicatesTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterPredicatesTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.common.raster;
+
+import org.geotools.coverage.grid.GridCoverage2D;
+import org.junit.Assert;
+import org.junit.Test;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+
+import java.awt.image.DataBuffer;
+
+public class RasterPredicatesTest extends RasterTestBase {
+    private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory();
+    @Test
+    public void testIntersectsNoCrs() {
+        Geometry queryWindow = GEOMETRY_FACTORY.toGeometry(new Envelope(0, 10, 0, 10));
+        GridCoverage2D raster = createRandomRaster(DataBuffer.TYPE_BYTE, 100, 100, 0, 100, 1, 1, null);
+        boolean result = RasterPredicates.rsIntersects(raster, queryWindow);
+        Assert.assertTrue(result);
+        queryWindow = GEOMETRY_FACTORY.toGeometry(new Envelope(1000, 1010, 1000, 1010));
+        result = RasterPredicates.rsIntersects(raster, queryWindow);
+        Assert.assertFalse(result);
+    }
+
+    @Test
+    public void testIntersectsQueryWindowNoCrs() {
+        Geometry queryWindow = GEOMETRY_FACTORY.toGeometry(new Envelope(0, 10, 0, 10));
+        GridCoverage2D raster = createRandomRaster(DataBuffer.TYPE_BYTE, 100, 100, 0, 100, 1, 1, "EPSG:3857");
+        boolean result = RasterPredicates.rsIntersects(raster, queryWindow);
+        Assert.assertTrue(result);
+        queryWindow = GEOMETRY_FACTORY.toGeometry(new Envelope(1000, 1010, 1000, 1010));
+        result = RasterPredicates.rsIntersects(raster, queryWindow);
+        Assert.assertFalse(result);
+    }
+
+    @Test
+    public void testIntersectsRasterNoCrs() {
+        Geometry queryWindow = GEOMETRY_FACTORY.toGeometry(new Envelope(0, 10, 0, 10));
+        queryWindow.setSRID(3857);
+        GridCoverage2D raster = createRandomRaster(DataBuffer.TYPE_BYTE, 100, 100, 0, 100, 1, 1, null);
+        boolean result = RasterPredicates.rsIntersects(raster, queryWindow);
+        Assert.assertTrue(result);
+        queryWindow = GEOMETRY_FACTORY.toGeometry(new Envelope(1000, 1010, 1000, 1010));
+        queryWindow.setSRID(3857);
+        result = RasterPredicates.rsIntersects(raster, queryWindow);
+        Assert.assertFalse(result);
+    }
+
+    @Test
+    public void testIntersectsSameCrs() {
+        Geometry queryWindow = GEOMETRY_FACTORY.toGeometry(new Envelope(0, 10, 0, 10));
+        queryWindow.setSRID(3857);
+        GridCoverage2D raster = createRandomRaster(DataBuffer.TYPE_BYTE, 100, 100, 0, 100, 1, 1, "EPSG:3857");
+        boolean result = RasterPredicates.rsIntersects(raster, queryWindow);
+        Assert.assertTrue(result);
+        queryWindow = GEOMETRY_FACTORY.toGeometry(new Envelope(10, 20, 10, 20));
+        queryWindow.setSRID(3857);
+        result = RasterPredicates.rsIntersects(raster, queryWindow);
+        Assert.assertTrue(result);
+        queryWindow = GEOMETRY_FACTORY.toGeometry(new Envelope(1000, 1010, 1000, 1010));
+        queryWindow.setSRID(3857);
+        result = RasterPredicates.rsIntersects(raster, queryWindow);
+        Assert.assertFalse(result);
+    }
+
+    @Test
+    public void testIntersectsWithTransformations() {
+        Geometry queryWindow = GEOMETRY_FACTORY.toGeometry(new Envelope(0, 10, 0, 10));
+        queryWindow.setSRID(4326);
+        GridCoverage2D raster = createRandomRaster(DataBuffer.TYPE_BYTE, 100, 100, 0, 100, 1, 1, "EPSG:3857");
+        boolean result = RasterPredicates.rsIntersects(raster, queryWindow);
+        Assert.assertTrue(result);
+        queryWindow = GEOMETRY_FACTORY.toGeometry(new Envelope(10, 20, 10, 20));
+        queryWindow.setSRID(4326);
+        result = RasterPredicates.rsIntersects(raster, queryWindow);
+        Assert.assertFalse(result);
+    }
+}

--- a/docs/api/sql/Raster-operators.md
+++ b/docs/api/sql/Raster-operators.md
@@ -17,6 +17,25 @@ Output:
 POLYGON((0 0,20 0,20 60,0 60,0 0))
 ```
 
+### RS_Intersects
+
+Introduction: Returns true if the envelope of the raster intersects the given geometry. If the geometry does not have a
+defined SRID, it is considered to be in the same CRS with the raster. If the geometry has a defined SRID, the geometry
+will be transformed to the CRS of the raster before the intersection test.
+
+Format: `RS_Intersects (raster: Raster, geom: Geometry)`
+
+Since: `v1.5.0`
+
+Spark SQL example:
+```sql
+SELECT RS_Intersects(raster, ST_SetSRID(ST_PolygonFromEnvelope(0, 0, 10, 10), 4326)) FROM raster_table
+```
+Output:
+```
+true
+```
+
 ### RS_MetaData
 
 Introduction: Returns the metadata of the raster as an array of double. The array contains the following values:

--- a/sql/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
+++ b/sql/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
@@ -200,6 +200,7 @@ object Catalog {
     function[RS_SRID](),
     function[RS_Value](1),
     function[RS_Values](1),
+    function[RS_Intersects](),
     function[RS_AsGeoTiff](),
     function[RS_AsArcGrid]()
   )

--- a/sql/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterPredicates.scala
+++ b/sql/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterPredicates.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.spark.sql.sedona_sql.expressions.raster
+
+import org.apache.sedona.common.raster.RasterPredicates
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression}
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.sedona_sql.UDT.{GeometryUDT, RasterUDT}
+import org.apache.spark.sql.sedona_sql.expressions.implicits.InputExpressionEnhancer
+import org.apache.spark.sql.sedona_sql.expressions.raster.implicits.RasterInputExpressionEnhancer
+import org.apache.spark.sql.types.{AbstractDataType, BooleanType, DataType}
+
+case class RS_Intersects(inputExpressions: Seq[Expression]) extends Expression with CodegenFallback with ExpectsInputTypes {
+
+  override def eval(input: InternalRow): Any = {
+    val raster = inputExpressions.head.toRaster(input)
+    val geom = inputExpressions(1).toGeometry(input)
+    if (raster == null || geom == null) {
+      null
+    } else {
+      RasterPredicates.rsIntersects(raster, geom)
+    }
+  }
+
+  override def nullable: Boolean = true
+  override def dataType: DataType = BooleanType
+  override def inputTypes: Seq[AbstractDataType] = Seq(RasterUDT, GeometryUDT)
+  override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
+}


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-321. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Added a function `RS_Intersects(rast, geom)` for testing if the envelope of `rast` intersects with `geom`. This function performs implicit CRS transformations before the intersection testing.

## How was this patch tested?

Added new test cases.

## Did this PR include necessary documentation updates?

- Yes, I am adding a new API. I am using the [current SNAPSHOT version number](https://github.com/apache/sedona/blob/master/pom.xml#L29) in since `vX.Y.Z` format.
