### PR TITLE
[SEDONA-322] Fix unstable maven build on GitHub Actions

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - '*'
+
+env:
+  MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=60
       
 jobs:
   build:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - '*'
+
+env:
+  MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=60
       
 jobs:
   build:

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - '*'
 
+env:
+  MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=60
+
 jobs:
   build:
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-322. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

The CI for Scala/Java build fails frequently. The failure was triggered by a failed maven artifact download:

```
Error:  Plugin org.apache.maven.plugins:maven-shade-plugin:3.4.1 or one of its dependencies could not be resolved: Failed to read artifact descriptor for org.apache.maven.plugins:maven-shade-plugin:jar:3.4.1: Could not transfer artifact org.apache.maven.plugins:maven-shade-plugin:pom:3.4.1 from/to central (https://repo.maven.apache.org/maven2): transfer failed for https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-shade-plugin/3.4.1/maven-shade-plugin-3.4.1.pom: Connection timed out (Read failed) -> [Help 1]
```

This is caused by a networking problem of Microsoft Azure. Please refer to https://github.com/actions/runner-images/issues/1499 for details. This patch workaround the networking problem by discarding long-living TCP connections.

## How was this patch tested?

Trigger the CI multiple times to see if the problem persists.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
