### PR TITLE
[SEDONA-303] Port all Sedona Spark function to Sedona Flink -- ST_MinimumBoundingRadius

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/Functions.java
+++ b/common/src/main/java/org/apache/sedona/common/Functions.java
@@ -14,6 +14,8 @@
 package org.apache.sedona.common;
 
 import com.google.common.geometry.S2CellId;
+
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.sedona.common.geometryObjects.Circle;
 import org.apache.sedona.common.subDivide.GeometrySubDivider;
 import org.apache.sedona.common.utils.GeomUtils;
@@ -534,6 +536,14 @@ public class Functions {
             }
         }
         return circle;
+    }
+
+    public static Pair<Geometry, Double> minimumBoundingRadius(Geometry geometry) {
+        MinimumBoundingCircle minimumBoundingCircle = new MinimumBoundingCircle(geometry);
+        Coordinate coods = minimumBoundingCircle.getCentre();
+        double radius = minimumBoundingCircle.getRadius();
+        Point centre = GEOMETRY_FACTORY.createPoint(coods);
+        return Pair.of(centre, radius);
     }
 
     public static Geometry lineSubString(Geometry geom, double fromFraction, double toFraction) {

--- a/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
@@ -764,6 +764,21 @@ public class FunctionsTest {
     }
 
     @Test
+    public void minimumBoundingRadius() {
+        Point point = GEOMETRY_FACTORY.createPoint(new Coordinate(0, 0));
+        assertEquals("POINT (0 0)", Functions.minimumBoundingRadius(point).getLeft().toString());
+        assertEquals(0, Functions.minimumBoundingRadius(point).getRight(), 1e-6);
+
+        LineString line = GEOMETRY_FACTORY.createLineString(coordArray(0, 0, 0, 10));
+        assertEquals("POINT (0 5)", Functions.minimumBoundingRadius(line).getLeft().toString());
+        assertEquals(5, Functions.minimumBoundingRadius(line).getRight(), 1e-6);
+
+        Polygon polygon = GEOMETRY_FACTORY.createPolygon(coordArray(0, 0, 0, 10, 10, 10, 10, 0, 0, 0));
+        assertEquals("POINT (5 5)", Functions.minimumBoundingRadius(polygon).getLeft().toString());
+        assertEquals(7.071067, Functions.minimumBoundingRadius(polygon).getRight(), 1e-6);
+    }
+
+    @Test
     public void nRingsPolygonOnlyExternal() throws Exception {
         Polygon polygon = GEOMETRY_FACTORY.createPolygon(coordArray(1, 0, 1, 1, 2, 1, 2, 0, 1, 0));
         Integer expected = 1;

--- a/docs/api/flink/Function.md
+++ b/docs/api/flink/Function.md
@@ -1256,6 +1256,18 @@ Example:
 ```sql
 SELECT ST_MinimumBoundingCircle(ST_GeomFromText('POLYGON((1 1,0 0, -1 1, 1 1))'))
 
+## ST_MinimumBoundingRadius
+
+Introduction: Returns a struct containing the center point and radius of the smallest circle that contains a geometry.
+
+Format: `ST_MinimumBoundingRadius(geom: geometry)`
+
+Since: `v1.5.0`
+
+Example:
+```sql
+SELECT ST_MinimumBoundingRadius(ST_GeomFromText('POLYGON((1 1,0 0, -1 1, 1 1))'))
+```
 
 ## ST_Multi
 

--- a/flink/src/main/java/org/apache/sedona/flink/Catalog.java
+++ b/flink/src/main/java/org/apache/sedona/flink/Catalog.java
@@ -113,6 +113,7 @@ public class Catalog {
                 new Functions.ST_MakePolygon(),
                 new Functions.ST_MakeValid(),
                 new Functions.ST_MinimumBoundingCircle(),
+                new Functions.ST_MinimumBoundingRadius(),
                 new Functions.ST_Multi(),
                 new Functions.ST_StartPoint(),
                 new Functions.ST_SimplifyPreserveTopology(),

--- a/flink/src/main/java/org/apache/sedona/flink/expressions/Functions.java
+++ b/flink/src/main/java/org/apache/sedona/flink/expressions/Functions.java
@@ -13,6 +13,7 @@
  */
 package org.apache.sedona.flink.expressions;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.flink.table.annotation.DataTypeHint;
 import org.apache.flink.table.annotation.InputGroup;
 import org.apache.flink.table.functions.ScalarFunction;
@@ -712,6 +713,14 @@ public class Functions {
         public Geometry eval(@DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o) {
             Geometry geom = (Geometry) o;
             return org.apache.sedona.common.Functions.minimumBoundingCircle(geom, BufferParameters.DEFAULT_QUADRANT_SEGMENTS * 6);
+        }
+    }
+
+    public static class ST_MinimumBoundingRadius extends ScalarFunction {
+        @DataTypeHint(value = "RAW")
+        public Pair<Geometry, Double> eval(@DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o) {
+            Geometry geom = (Geometry) o;
+            return org.apache.sedona.common.Functions.minimumBoundingRadius(geom);
         }
     }
 

--- a/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
@@ -14,6 +14,7 @@
 package org.apache.sedona.flink;
 
 import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.flink.table.api.Table;
 import org.apache.sedona.flink.expressions.Functions;
 import org.geotools.referencing.CRS;
@@ -802,6 +803,15 @@ public class FunctionTest extends TestBase{
         Integer actual = result.getCoordinates().length;
         Integer expected = 2 * 4 + 1;
         assertEquals(actual, expected);
+    }
+
+    @Test 
+    public void testMinimumBoundingRadius() {
+        Table table = tableEnv.sqlQuery("SELECT ST_GeomFromWKT('LINESTRING (0 0, 1 0)') AS geom");
+        table = table.select(call(Functions.ST_MinimumBoundingRadius.class.getSimpleName(), $("geom")));
+        Pair<Geometry, Double> result = (Pair<Geometry, Double>) first(table).getField(0);
+        assertEquals("POINT (0.5 0)", result.getLeft().toString());
+        assertEquals(0.5, result.getRight(), 1e-6);
     }
 
     @Test 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)


## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-303. The PR name follows the format `[SEDONA-XXX] my subject`.


## What changes were proposed in this PR?
Port missing ST_functions including 
{ST_MinimumBoundingRadius}
to [sedona-flink](https://issues.apache.org/jira/browse/SEDONA-flink).

## How was this patch tested?
1. Integration unit tests in [sedona-flink](https://issues.apache.org/jira/browse/SEDONA-flink).


## Did this PR include necessary documentation updates?
- Yes, I have updated the documentation update.
