### PR TITLE
[SEDONA-319] Make result of RS_BandAsArray serializable

### DIFF
--- a/sql/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
+++ b/sql/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
@@ -452,5 +452,12 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
       assert(df.selectExpr("RS_Intersects(raster, ST_SetSRID(ST_Point(33.81798,-117.47993), 4326))").first().getBoolean(0))
       assert(!df.selectExpr("RS_Intersects(raster, ST_SetSRID(ST_Point(33.97896,-117.27868), 4326))").first().getBoolean(0))
     }
+
+    it("Passed RS_AddBandFromArray 2") {
+      var df = sparkSession.read.format("binaryFile").load(resourceFolder + "raster/test3.tif")
+      df = df.selectExpr("RS_FromGeoTiff(content) as raster", "RS_BandAsArray(RS_FromGeoTiff(content), 1) as band")
+      df = df.selectExpr("RS_AddBandFromArray(raster, band, 2)")
+      df.collect()
+    }
   }
 }

--- a/sql/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
+++ b/sql/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
@@ -453,11 +453,15 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
       assert(!df.selectExpr("RS_Intersects(raster, ST_SetSRID(ST_Point(33.97896,-117.27868), 4326))").first().getBoolean(0))
     }
 
-    it("Passed RS_AddBandFromArray 2") {
-      var df = sparkSession.read.format("binaryFile").load(resourceFolder + "raster/test3.tif")
+    it("Passed RS_AddBandFromArray collect generated raster") {
+      var df = sparkSession.read.format("binaryFile").load(resourceFolder + "raster/test1.tiff")
       df = df.selectExpr("RS_FromGeoTiff(content) as raster", "RS_BandAsArray(RS_FromGeoTiff(content), 1) as band")
-      df = df.selectExpr("RS_AddBandFromArray(raster, band, 2)")
-      df.collect()
+      df = df.selectExpr("RS_AddBandFromArray(raster, band, 1) as raster", "band")
+      var raster = df.collect().head.getAs[GridCoverage2D](0)
+      assert(raster.getNumSampleDimensions == 1)
+      df = df.selectExpr("RS_AddBandFromArray(raster, band, 2) as raster", "band")
+      raster = df.collect().head.getAs[GridCoverage2D](0)
+      assert(raster.getNumSampleDimensions == 2)
     }
   }
 }


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-319. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Manually construct the `BufferedImage` object with a serializable color model when building the resulting GridCoverage2D object, so that the resulting raster could be successfully serialized.

## How was this patch tested?

Added a new test case for it.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
