### PR TITLE
[SEDONA-313] Remove redundant ST_Affine entry from the Spark SQL catalog

### DIFF
--- a/sql/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
+++ b/sql/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
@@ -156,7 +156,6 @@ object Catalog {
     function[ST_NRings](),
     function[ST_Translate](0.0),
     function[ST_FrechetDistance](),
-    function[ST_Affine](null, null, null, null, null, null),
     function[ST_Affine](),
     function[ST_BoundingDiagonal](),
     function[ST_Angle](),


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-313. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

A redundant UDF catalog entry for `ST_Affine` was removed.

## How was this patch tested?

Passed existing tests.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
