### PR TITLE
[SEDONA-318] Avoid creating an unnecessary copy of raster data when serializing rasters backed by BufferedImage

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/raster/Serde.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/Serde.java
@@ -50,7 +50,7 @@ public class Serde {
         if (renderedImage instanceof DeepCopiedRenderedImage) {
             deepCopiedRenderedImage = renderedImage;
         } else {
-            deepCopiedRenderedImage = new DeepCopiedRenderedImage(raster.getRenderedImage());
+            deepCopiedRenderedImage = new DeepCopiedRenderedImage(renderedImage);
         }
         raster = new GridCoverageFactory().create(
                 raster.getName(),


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-318. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

The current implementation of the GridCoverage2D serializer calls the `getData` method of the rendered image to obtain serializable raster data. When the rendered image object is a `BufferedImage`, it will create a hard copy of the underlying raster, which is very time-consuming. This happens when serializing rasters created by `RS_MakeEmptyRaster` or `RS_AddBandFromArray`.

This patch adds a fast path for GridCoverage2D objects backed by a `BufferedImage`. We call `getRaster` to obtain the serializable raster. This won't make a new copy of the raster data.

## How was this patch tested?

Passes existing tests.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
