### PR TITLE
[SEDONA-326] Improve raster algebra functions: RS_Array and RS_MultiplyFactor

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/Constructors.java
+++ b/common/src/main/java/org/apache/sedona/common/Constructors.java
@@ -148,8 +148,6 @@ public class Constructors {
     }
 
     public static Geometry geomFromGeoHash(String geoHash, Integer precision) {
-        System.out.println(geoHash);
-        System.out.println(precision);
         try {
             return GeoHashDecoder.decode(geoHash, precision);
         } catch (GeoHashDecoder.InvalidGeoHashException e) {

--- a/docs/api/sql/Raster-loader.md
+++ b/docs/api/sql/Raster-loader.md
@@ -191,7 +191,7 @@ Output:
 
 Introduction: Create an array that is filled by the given value
 
-Format: `RS_Array(length:Int, value: Decimal)`
+Format: `RS_Array(length:Int, value: Double)`
 
 Since: `v1.1.0`
 

--- a/docs/api/sql/Raster-operators.md
+++ b/docs/api/sql/Raster-operators.md
@@ -517,7 +517,7 @@ val multiplyDF = spark.sql("select RS_Multiply(band1, band2) as multiplyBands fr
 
 Introduction: Multiply a factor to a spectral band in a geotiff image
 
-Format: `RS_MultiplyFactor (Band1: Array[Double], Factor: Int)`
+Format: `RS_MultiplyFactor (Band1: Array[Double], Factor: Double)`
 
 Since: `v1.1.0`
 
@@ -527,6 +527,8 @@ Spark SQL example:
 val multiplyFactorDF = spark.sql("select RS_MultiplyFactor(band1, 2) as multiplyfactor from dataframe")
 
 ```
+
+This function only accepts integer as factor before `v1.5.0`.
 
 ### RS_Normalize
 

--- a/sql/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/IO.scala
+++ b/sql/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/IO.scala
@@ -22,6 +22,7 @@ package org.apache.spark.sql.sedona_sql.expressions.raster
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
 import org.apache.spark.sql.catalyst.expressions.{Expression, UnsafeArrayData}
+import org.apache.spark.sql.catalyst.expressions.ImplicitCastInputTypes
 import org.apache.spark.sql.catalyst.util.{ArrayData, GenericArrayData}
 import org.apache.spark.sql.sedona_sql.expressions.UserDataGeneratator
 import org.apache.spark.sql.types._
@@ -126,14 +127,14 @@ case class RS_GetBand(inputExpressions: Seq[Expression])
 }
 
 case class RS_Array(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback with UserDataGeneratator {
+  extends Expression with ImplicitCastInputTypes with CodegenFallback with UserDataGeneratator {
   override def nullable: Boolean = false
 
   override def eval(inputRow: InternalRow): Any = {
     // This is an expression which takes one input expressions
     assert(inputExpressions.length == 2)
     val len =inputExpressions(0).eval(inputRow).asInstanceOf[Int]
-    val num = inputExpressions(1).eval(inputRow).asInstanceOf[Decimal].toDouble
+    val num = inputExpressions(1).eval(inputRow).asInstanceOf[Double]
     val result = createarray(len, num)
     new GenericArrayData(result)
   }
@@ -147,6 +148,8 @@ case class RS_Array(inputExpressions: Seq[Expression])
     }
     result
   }
+
+  override def inputTypes: Seq[AbstractDataType] = Seq(IntegerType, DoubleType)
 
   override def dataType: DataType = ArrayType(DoubleType)
 

--- a/sql/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
+++ b/sql/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
@@ -71,6 +71,12 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
       assert(inputDf.first().getAs[mutable.WrappedArray[Double]](0) == expectedDF.first().getAs[mutable.WrappedArray[Double]](0))
     }
 
+    it("Passed RS_MultiplyFactor with double factor") {
+      val inputDf = Seq((Seq(200.0, 400.0, 600.0))).toDF("Band")
+      val expectedDF = Seq((Seq(20.0, 40.0, 60.0))).toDF("multiply")
+      val actualDF = inputDf.selectExpr("RS_MultiplyFactor(Band, 0.1) as multiply")
+      assert(actualDF.first().getAs[mutable.WrappedArray[Double]](0) == expectedDF.first().getAs[mutable.WrappedArray[Double]](0))
+    }
   }
 
   describe("Should pass basic statistical tests") {
@@ -201,6 +207,13 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
       var df = Seq((Seq(800.0, 900.0, 0.0, 255.0)), (Seq(100.0, 200.0, 700.0, 900.0))).toDF("Band")
       df = df.selectExpr("RS_Normalize(Band) as normalizedBand")
       assert(df.first().getAs[mutable.WrappedArray[Double]](0)(1) == 255)
+    }
+
+    it("should pass RS_Array") {
+      val df = sparkSession.sql("SELECT RS_Array(6, 1e-6) as band")
+      val result = df.first().getAs[mutable.WrappedArray[Double]](0)
+      assert(result.length == 6)
+      assert(result sameElements Array.fill[Double](6)(1e-6))
     }
   }
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

Yes, [SEDONA-326](https://issues.apache.org/jira/browse/SEDONA-326)

## What changes were proposed in this PR?

Make `RS_Array` and `RS_MultiplyFactor` easier to use.

* `RS_Array` automatically casts the initial value to double. Now we can safe guard `RS_Divide` using
  ```sql
  RS_Divide(band_nir, RS_LogicalOver(band_red, RS_Array(array_size(band_red), 1e-12)))
  ```
* `RS_MultiplyFactor` takes double factors.

## How was this patch tested?

Added new unit tests.

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation update.
