### PR TITLE
[SEDONA-327] Refactored raster UDFs to extend InferredExpression

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/raster/RasterConstructors.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterConstructors.java
@@ -93,15 +93,9 @@ public class RasterConstructors
         } else {
             crs = CRS.decode("EPSG:" + srid);
         }
-        // If scaleY is not defined, use scaleX
-        // MAX_VALUE is used to indicate that the scaleY is not defined
-        double actualScaleY = scaleY;
-        if (scaleY == Integer.MAX_VALUE) {
-            actualScaleY = scaleX;
-        }
         // Create a new empty raster
         WritableRaster raster = RasterFactory.createBandedRaster(DataBuffer.TYPE_DOUBLE, widthInPixel, heightInPixel, numBand, null);
-        MathTransform transform = new AffineTransform2D(scaleX, skewY, skewX, -actualScaleY, upperLeftX + scaleX / 2, upperLeftY - actualScaleY / 2);
+        MathTransform transform = new AffineTransform2D(scaleX, skewY, skewX, -scaleY, upperLeftX + scaleX / 2, upperLeftY - scaleY / 2);
         GridGeometry2D gridGeometry = new GridGeometry2D(new GridEnvelope2D(0, 0, widthInPixel, heightInPixel), transform, crs);
         ReferencedEnvelope referencedEnvelope = new ReferencedEnvelope(gridGeometry.getEnvelope2D());
         // Create a new coverage

--- a/common/src/main/java/org/apache/sedona/common/raster/RasterOutputs.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterOutputs.java
@@ -35,7 +35,7 @@ import java.io.IOException;
 
 public class RasterOutputs
 {
-    public static byte[] asGeoTiff(GridCoverage2D raster, String compressionType, float compressionQuality) {
+    public static byte[] asGeoTiff(GridCoverage2D raster, String compressionType, double compressionQuality) {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         GridCoverageWriter writer;
         try {
@@ -52,7 +52,7 @@ public class RasterOutputs
             params.setCompressionType(compressionType);
             // Should be a value between 0 and 1
             // 0 means max compression, 1 means no compression
-            params.setCompressionQuality(compressionQuality);
+            params.setCompressionQuality((float) compressionQuality);
             defaultParams.parameter(AbstractGridFormat.GEOTOOLS_WRITE_PARAMS.getName().toString()).setValue(params);
         }
         GeneralParameterValue[] wps = defaultParams.values().toArray(new GeneralParameterValue[0]);
@@ -65,6 +65,10 @@ public class RasterOutputs
             throw new RuntimeException(e);
         }
         return out.toByteArray();
+    }
+
+    public static byte[] asGeoTiff(GridCoverage2D raster) {
+        return asGeoTiff(raster, null, -1);
     }
 
     public static byte[] asArcGrid(GridCoverage2D raster, int sourceBand) {
@@ -92,5 +96,9 @@ public class RasterOutputs
             throw new RuntimeException(e);
         }
         return out.toByteArray();
+    }
+
+    public static byte[] asArcGrid(GridCoverage2D raster) {
+        return asArcGrid(raster, -1);
     }
 }

--- a/python-adapter/pom.xml
+++ b/python-adapter/pom.xml
@@ -112,6 +112,10 @@
             <artifactId>gt-epsg-hsql</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-coverage</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
             <version>${scala.version}</version>

--- a/sql/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
+++ b/sql/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
@@ -192,7 +192,7 @@ object Catalog {
     function[RS_BandAsArray](),
     function[RS_FromArcInfoAsciiGrid](),
     function[RS_FromGeoTiff](),
-    function[RS_MakeEmptyRaster](java.lang.Integer.MAX_VALUE, 0.0, 0.0, 0),
+    function[RS_MakeEmptyRaster](),
     function[RS_Envelope](),
     function[RS_NumBands](),
     function[RS_Metadata](),

--- a/sql/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterAccessors.scala
+++ b/sql/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterAccessors.scala
@@ -19,103 +19,30 @@
 package org.apache.spark.sql.sedona_sql.expressions.raster
 
 import org.apache.sedona.common.raster.RasterAccessors
-import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression}
-import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
-import org.apache.spark.sql.catalyst.util.GenericArrayData
-import org.apache.spark.sql.sedona_sql.UDT.{GeometryUDT, RasterUDT}
-import org.apache.spark.sql.sedona_sql.expressions.implicits.GeometryEnhancer
-import org.apache.spark.sql.sedona_sql.expressions.raster.implicits.RasterInputExpressionEnhancer
-import org.apache.spark.sql.types.{AbstractDataType, ArrayType, DataType, DoubleType, IntegerType}
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.sedona_sql.expressions.InferrableFunctionConverter._
+import org.apache.spark.sql.sedona_sql.expressions.InferredExpression
 
-case class RS_Envelope(inputExpressions: Seq[Expression]) extends Expression with CodegenFallback with ExpectsInputTypes {
-  override def nullable: Boolean = true
-
-  override def eval(input: InternalRow): Any = {
-    val raster = inputExpressions(0).toRaster(input)
-    if (raster == null) {
-      null
-    } else {
-      RasterAccessors.envelope(raster).toGenericArrayData
-    }
-  }
-
-  override def dataType: DataType = GeometryUDT
-
-  override def children: Seq[Expression] = inputExpressions
-
+case class RS_Envelope(inputExpressions: Seq[Expression]) extends InferredExpression(RasterAccessors.envelope _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
-
-  override def inputTypes: Seq[AbstractDataType] = Seq(RasterUDT)
 }
 
-case class RS_NumBands(inputExpressions: Seq[Expression]) extends Expression with CodegenFallback with ExpectsInputTypes {
-  override def nullable: Boolean = true
-
-  override def eval(input: InternalRow): Any = {
-    val raster = inputExpressions(0).toRaster(input)
-    if (raster == null) {
-      null
-    } else {
-      RasterAccessors.numBands(raster)
-    }
-  }
-
-  override def dataType: DataType = IntegerType
-
-  override def children: Seq[Expression] = inputExpressions
-
+case class RS_NumBands(inputExpressions: Seq[Expression]) extends InferredExpression(RasterAccessors.numBands _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
-
-  override def inputTypes: Seq[AbstractDataType] = Seq(RasterUDT)
 }
 
-case class RS_SRID(inputExpressions: Seq[Expression]) extends Expression with CodegenFallback with ExpectsInputTypes {
-  override def nullable: Boolean = true
-
-  override def eval(input: InternalRow): Any = {
-    val raster = inputExpressions(0).toRaster(input)
-    if (raster == null) {
-      null
-    } else {
-      RasterAccessors.srid(raster)
-    }
-  }
-
-  override def dataType: DataType = IntegerType
-
-  override def children: Seq[Expression] = inputExpressions
-
+case class RS_SRID(inputExpressions: Seq[Expression]) extends InferredExpression(RasterAccessors.srid _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
-
-  override def inputTypes: Seq[AbstractDataType] = Seq(RasterUDT)
 }
 
-case class RS_Metadata(inputExpressions: Seq[Expression]) extends Expression with CodegenFallback with ExpectsInputTypes {
-  override def nullable: Boolean = true
-
-  override def eval(input: InternalRow): Any = {
-    val raster = inputExpressions(0).toRaster(input)
-    if (raster == null) {
-      null
-    } else {
-      new GenericArrayData(RasterAccessors.metadata(raster))
-    }
-  }
-
-  override def dataType: DataType = ArrayType(DoubleType)
-
-  override def children: Seq[Expression] = inputExpressions
-
+case class RS_Metadata(inputExpressions: Seq[Expression]) extends InferredExpression(RasterAccessors.metadata _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
-
-  override def inputTypes: Seq[AbstractDataType] = Seq(RasterUDT)
 }

--- a/sql/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterConstructors.scala
+++ b/sql/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterConstructors.scala
@@ -18,105 +18,38 @@
  */
 package org.apache.spark.sql.sedona_sql.expressions.raster
 
-import org.apache.sedona.common.raster.{RasterConstructors, Serde}
-import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
-import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression, ImplicitCastInputTypes}
-import org.apache.spark.sql.sedona_sql.UDT.RasterUDT
-import org.apache.spark.sql.sedona_sql.expressions.SerdeAware
-import org.apache.spark.sql.sedona_sql.expressions.raster.implicits._
-import org.apache.spark.sql.types._
-import org.geotools.coverage.grid.GridCoverage2D
+import org.apache.sedona.common.raster.RasterConstructors
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.sedona_sql.expressions.InferrableFunctionConverter._
+import org.apache.spark.sql.sedona_sql.expressions.InferredExpression
 
-
-case class RS_FromArcInfoAsciiGrid(inputExpressions: Seq[Expression]) extends Expression with CodegenFallback
-  with ExpectsInputTypes with SerdeAware {
-
-  override def nullable: Boolean = true
-
-  override def eval(input: InternalRow): Any = {
-    Option(evalWithoutSerialization(input)).map(Serde.serialize).orNull
-  }
-
-  override def dataType: DataType = RasterUDT
-
-  override def children: Seq[Expression] = inputExpressions
+case class RS_FromArcInfoAsciiGrid(inputExpressions: Seq[Expression])
+  extends InferredExpression(RasterConstructors.fromArcInfoAsciiGrid _) {
+  override def foldable: Boolean = false
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
-  }
-
-  override def inputTypes: Seq[AbstractDataType] = Seq(BinaryType)
-
-  override def evalWithoutSerialization(input: InternalRow): GridCoverage2D = {
-    val bytes = inputExpressions(0).eval(input).asInstanceOf[Array[Byte]]
-    if (bytes == null) {
-      null
-    } else {
-      RasterConstructors.fromArcInfoAsciiGrid(bytes)
-    }
   }
 }
 
-case class RS_FromGeoTiff(inputExpressions: Seq[Expression]) extends Expression with CodegenFallback
-  with ExpectsInputTypes with SerdeAware {
+case class RS_FromGeoTiff(inputExpressions: Seq[Expression])
+  extends InferredExpression(RasterConstructors.fromGeoTiff _) {
 
-  override def nullable: Boolean = true
-
-  override def eval(input: InternalRow): Any = {
-    Option(evalWithoutSerialization(input)).map(Serde.serialize).orNull
-  }
-
-  override def dataType: DataType = RasterUDT
-
-  override def children: Seq[Expression] = inputExpressions
+  override def foldable: Boolean = false
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
-  }
-
-  override def inputTypes: Seq[AbstractDataType] = Seq(BinaryType)
-
-  override def evalWithoutSerialization(input: InternalRow): GridCoverage2D = {
-    val bytes = inputExpressions(0).eval(input).asInstanceOf[Array[Byte]]
-    if (bytes == null) {
-      null
-    } else {
-      RasterConstructors.fromGeoTiff(bytes)
-    }
   }
 }
 
-case class RS_MakeEmptyRaster(inputExpressions: Seq[Expression]) extends Expression with CodegenFallback
-  with ImplicitCastInputTypes with SerdeAware {
+case class RS_MakeEmptyRaster(inputExpressions: Seq[Expression])
+  extends InferredExpression(
+    inferrableFunction6(RasterConstructors.makeEmptyRaster),
+    inferrableFunction10(RasterConstructors.makeEmptyRaster)) {
 
-  override def nullable: Boolean = true
-
-  override def eval(input: InternalRow): Any = {
-    Option(evalWithoutSerialization(input)).map(Serde.serialize).orNull
-  }
-
-  override def dataType: DataType = RasterUDT
-
-  override def children: Seq[Expression] = inputExpressions
+  override def foldable: Boolean = false
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
-  }
-
-  override def inputTypes: Seq[AbstractDataType] = Seq(IntegerType, IntegerType, IntegerType, DecimalType, DecimalType, DecimalType, DecimalType, DecimalType, DecimalType, IntegerType)
-
-  override def evalWithoutSerialization(input: InternalRow): GridCoverage2D = {
-    val numBands = inputExpressions(0).eval(input).asInstanceOf[Int]
-    val widthInPixels = inputExpressions(1).eval(input).asInstanceOf[Int]
-    val heightInPixel = inputExpressions(2).eval(input).asInstanceOf[Int]
-    val upperLeftX = inputExpressions(3).eval(input).asInstanceOf[Decimal].toDouble
-    val upperLeftY = inputExpressions(4).eval(input).asInstanceOf[Decimal].toDouble
-    val pixelSizeX = inputExpressions(5).eval(input).asInstanceOf[Decimal].toDouble
-    val pixelSizeY = inputExpressions(6).eval(input).asInstanceOf[Decimal].toDouble
-    val skewX = inputExpressions(7).eval(input).asInstanceOf[Decimal].toDouble
-    val skewY = inputExpressions(8).eval(input).asInstanceOf[Decimal].toDouble
-    val srid = inputExpressions(9).eval(input).asInstanceOf[Int]
-    RasterConstructors.makeEmptyRaster(numBands, widthInPixels, heightInPixel, upperLeftX, upperLeftY, pixelSizeX, pixelSizeY, skewX, skewY, srid)
   }
 }

--- a/sql/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterEditors.scala
+++ b/sql/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterEditors.scala
@@ -18,40 +18,13 @@
  */
 package org.apache.spark.sql.sedona_sql.expressions.raster
 
-import org.apache.sedona.common.raster.{RasterEditors, Serde}
-import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression}
-import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
-import org.apache.spark.sql.sedona_sql.UDT.RasterUDT
-import org.apache.spark.sql.sedona_sql.expressions.SerdeAware
-import org.apache.spark.sql.sedona_sql.expressions.raster.implicits.RasterInputExpressionEnhancer
-import org.apache.spark.sql.types.{AbstractDataType, DataType, IntegerType}
-import org.geotools.coverage.grid.GridCoverage2D
+import org.apache.sedona.common.raster.RasterEditors
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.sedona_sql.expressions.InferrableFunctionConverter._
+import org.apache.spark.sql.sedona_sql.expressions.InferredExpression
 
-case class RS_SetSRID(inputExpressions: Seq[Expression]) extends Expression with CodegenFallback with ExpectsInputTypes with SerdeAware {
-  override def nullable: Boolean = true
-
-  override def eval(input: InternalRow): Any = {
-    Option(evalWithoutSerialization(input)).map(Serde.serialize).orNull
-  }
-
-  override def evalWithoutSerialization(input: InternalRow): GridCoverage2D = {
-    val raster = inputExpressions(0).toRaster(input)
-    val srid = inputExpressions(1).eval(input).asInstanceOf[Int]
-    if (raster == null) {
-      null
-    } else {
-      RasterEditors.setSrid(raster, srid)
-    }
-  }
-
-  override def dataType: DataType = RasterUDT
-
-  override def children: Seq[Expression] = inputExpressions
-
+case class RS_SetSRID(inputExpressions: Seq[Expression]) extends InferredExpression(RasterEditors.setSrid _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
-
-  override def inputTypes: Seq[AbstractDataType] = Seq(RasterUDT, IntegerType)
 }

--- a/sql/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterOutputs.scala
+++ b/sql/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterOutputs.scala
@@ -19,59 +19,21 @@
 package org.apache.spark.sql.sedona_sql.expressions.raster
 
 import org.apache.sedona.common.raster.RasterOutputs
-import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Expression
-import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
-import org.apache.spark.sql.sedona_sql.expressions.raster.implicits.RasterInputExpressionEnhancer
-import org.apache.spark.sql.types._
-import org.apache.spark.unsafe.types.UTF8String
+import org.apache.spark.sql.sedona_sql.expressions.InferrableFunctionConverter._
+import org.apache.spark.sql.sedona_sql.expressions.InferredExpression
 
-// Expected Types (RasterUDT, StringType, IntegerType) or (RasterUDT, StringType, DecimalType)
-case class RS_AsGeoTiff(inputExpressions: Seq[Expression]) extends Expression with CodegenFallback {
-
-  override def nullable: Boolean = true
-
-  override def eval(input: InternalRow): Any = {
-    val raster = inputExpressions(0).toRaster(input)
-    if (raster == null) return null
-    // If there are more than one input expressions, the additional ones are used as parameters
-    if (inputExpressions.length > 1) {
-      RasterOutputs.asGeoTiff(raster, inputExpressions(1).eval(input).asInstanceOf[UTF8String].toString, inputExpressions(2).eval(input).toString.toFloat)
-    }
-    else {
-      RasterOutputs.asGeoTiff(raster, null, -1)
-    }
-  }
-
-  override def dataType: DataType = BinaryType
-
-  override def children: Seq[Expression] = inputExpressions
-
+case class RS_AsGeoTiff(inputExpressions: Seq[Expression])
+  extends InferredExpression(inferrableFunction3(RasterOutputs.asGeoTiff),
+    inferrableFunction1(RasterOutputs.asGeoTiff)) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_AsArcGrid(inputExpressions: Seq[Expression]) extends Expression with CodegenFallback {
-
-  override def nullable: Boolean = true
-
-  override def eval(input: InternalRow): Any = {
-    val raster = inputExpressions(0).toRaster(input)
-    if (raster == null) return null
-    // If there are more than one input expressions, the additional ones are used as parameters
-    if (inputExpressions.length > 1) {
-      RasterOutputs.asArcGrid(raster, inputExpressions(1).eval(input).asInstanceOf[Int])
-    }
-    else {
-      RasterOutputs.asArcGrid(raster, -1)
-    }
-  }
-
-  override def dataType: DataType = BinaryType
-
-  override def children: Seq[Expression] = inputExpressions
-
+case class RS_AsArcGrid(inputExpressions: Seq[Expression])
+  extends InferredExpression(inferrableFunction2(RasterOutputs.asArcGrid),
+    inferrableFunction1(RasterOutputs.asArcGrid)) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }

--- a/sql/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterPredicates.scala
+++ b/sql/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterPredicates.scala
@@ -19,31 +19,11 @@
 package org.apache.spark.sql.sedona_sql.expressions.raster
 
 import org.apache.sedona.common.raster.RasterPredicates
-import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression}
-import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
-import org.apache.spark.sql.sedona_sql.UDT.{GeometryUDT, RasterUDT}
-import org.apache.spark.sql.sedona_sql.expressions.implicits.InputExpressionEnhancer
-import org.apache.spark.sql.sedona_sql.expressions.raster.implicits.RasterInputExpressionEnhancer
-import org.apache.spark.sql.types.{AbstractDataType, BooleanType, DataType}
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.sedona_sql.expressions.InferrableFunctionConverter._
+import org.apache.spark.sql.sedona_sql.expressions.InferredExpression
 
-case class RS_Intersects(inputExpressions: Seq[Expression]) extends Expression with CodegenFallback with ExpectsInputTypes {
-
-  override def eval(input: InternalRow): Any = {
-    val raster = inputExpressions.head.toRaster(input)
-    val geom = inputExpressions(1).toGeometry(input)
-    if (raster == null || geom == null) {
-      null
-    } else {
-      RasterPredicates.rsIntersects(raster, geom)
-    }
-  }
-
-  override def nullable: Boolean = true
-  override def dataType: DataType = BooleanType
-  override def inputTypes: Seq[AbstractDataType] = Seq(RasterUDT, GeometryUDT)
-  override def children: Seq[Expression] = inputExpressions
-
+case class RS_Intersects(inputExpressions: Seq[Expression]) extends InferredExpression(RasterPredicates.rsIntersects _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }

--- a/viz/pom.xml
+++ b/viz/pom.xml
@@ -116,6 +116,10 @@
             <artifactId>gt-epsg-hsql</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-coverage</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
             <version>${scala.version}</version>


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-327. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Added support for `GridCoverage2D` to `InferredExpression`, and refactored many raster functions to extend `InferredExpression`.

Please note that this patch will make `gt-coverage` a mandatory dependency.

## How was this patch tested?

Passing existing tests.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
