### PR TITLE
[DOCS] Add example outputs to all Sedona functions - 4

### DIFF
--- a/docs/api/flink/Function.md
+++ b/docs/api/flink/Function.md
@@ -1133,8 +1133,16 @@ Since: `v1.5.0`
 Example:
 
 ```sql
-SELECT ST_Intersection(polygondf.countyshape, polygondf.countyshape)
-FROM polygondf
+SELECT ST_Intersection(
+    ST_GeomFromWTK("POLYGON((1 1, 8 1, 8 8, 1 8, 1 1))"),
+    ST_GeomFromWTK("POLYGON((2 2, 9 2, 9 9, 2 9, 2 2))")
+    )
+```
+
+Output:
+
+```
+POLYGON ((2 8, 8 8, 8 2, 2 2, 2 8))
 ```
 
 ## ST_IsClosed

--- a/docs/api/flink/Function.md
+++ b/docs/api/flink/Function.md
@@ -1352,17 +1352,14 @@ Format: `ST_LineInterpolatePoint (geom: geometry, fraction: Double)`
 Since: `v1.5.0`
 
 Example:
+
 ```sql
-SELECT ST_LineInterpolatePoint(ST_GeomFromWKT('LINESTRING(25 50, 100 125, 150 190)'), 0.2) as Interpolated
+SELECT ST_LineInterpolatePoint(ST_GeomFromWKT('LINESTRING(25 50, 100 125, 150 190)'), 0.2)
 ```
 
 Output:
 ```
-+-----------------------------------------+
-|Interpolated                             |
-+-----------------------------------------+
-|POINT (51.5974135047432 76.5974135047432)|
-+-----------------------------------------+
+POINT (51.5974135047432 76.5974135047432)
 ```
 
 ## ST_LineMerge

--- a/docs/api/flink/Function.md
+++ b/docs/api/flink/Function.md
@@ -1134,8 +1134,8 @@ Example:
 
 ```sql
 SELECT ST_Intersection(
-    ST_GeomFromWTK("POLYGON((1 1, 8 1, 8 8, 1 8, 1 1))"),
-    ST_GeomFromWTK("POLYGON((2 2, 9 2, 9 9, 2 9, 2 2))")
+    ST_GeomFromWKT("POLYGON((1 1, 8 1, 8 8, 1 8, 1 1))"),
+    ST_GeomFromWKT("POLYGON((2 2, 9 2, 9 9, 2 9, 2 2))")
     )
 ```
 
@@ -1252,7 +1252,7 @@ Since: `v1.3.0`
 Example:
 
 ```sql
-SELECT ST_IsSimple(ST_GeomFromWTK('POLYGON((1 1, 3 1, 3 3, 1 3, 1 1))'))
+SELECT ST_IsSimple(ST_GeomFromWKT('POLYGON((1 1, 3 1, 3 3, 1 3, 1 1))'))
 ```
 
 Output:

--- a/docs/api/flink/Function.md
+++ b/docs/api/flink/Function.md
@@ -1183,7 +1183,11 @@ Example:
 SELECT ST_IsCollection(ST_GeomFromText('MULTIPOINT(0 0), (6 6)'))
 ```
 
-Output: `true`
+Output: 
+
+```
+true
+```
 
 Example:
 
@@ -1191,7 +1195,11 @@ Example:
 SELECT ST_IsCollection(ST_GeomFromText('POINT(5 5)'))
 ```
 
-Output: `false`
+Output: 
+
+```
+false
+```
 
 ## ST_IsEmpty
 

--- a/docs/api/flink/Function.md
+++ b/docs/api/flink/Function.md
@@ -1159,6 +1159,12 @@ Example:
 SELECT ST_IsClosed(ST_GeomFromText('LINESTRING(0 0, 1 1, 1 0)'))
 ```
 
+Output:
+
+```
+false
+```
+
 ## ST_IsCollection
 
 Introduction: Returns `TRUE` if the geometry type of the input is a geometry collection type. 

--- a/docs/api/flink/Function.md
+++ b/docs/api/flink/Function.md
@@ -1292,8 +1292,13 @@ Since: `v1.3.0`
 Example:
 
 ```sql
-SELECT ST_Length(polygondf.countyshape)
-FROM polygondf
+SELECT ST_Length(ST_GeomFromWKT('LINESTRING(38 16,38 50,65 50,66 16,38 16)'))
+```
+
+Output:
+
+```
+123.0147027033899
 ```
 
 ## ST_LengthSpheroid

--- a/docs/api/flink/Function.md
+++ b/docs/api/flink/Function.md
@@ -1272,8 +1272,13 @@ Since: `v1.3.0`
 Example:
 
 ```sql
-SELECT ST_IsValid(polygondf.countyshape)
-FROM polygondf
+SELECT ST_IsValid(ST_GeomFromWKT('POLYGON((0 0, 10 0, 10 10, 0 10, 0 0), (15 15, 15 20, 20 20, 20 15, 15 15))'))
+```
+
+Output:
+
+```
+false
 ```
 
 ## ST_Length

--- a/docs/api/flink/Function.md
+++ b/docs/api/flink/Function.md
@@ -1111,11 +1111,16 @@ Format: `ST_InteriorRingN(geom: geometry, n: Int)`
 Since: `v1.3.0`
 
 Example:
+
 ```sql
 SELECT ST_InteriorRingN(ST_GeomFromText('POLYGON((0 0, 0 5, 5 5, 5 0, 0 0), (1 1, 2 1, 2 2, 1 2, 1 1), (1 3, 2 3, 2 4, 1 4, 1 3), (3 3, 4 3, 4 4, 3 4, 3 3))'), 0)
 ```
 
-Output: `LINEARRING (1 1, 2 1, 2 2, 1 2, 1 1)`
+Output: 
+
+```
+LINEARRING (1 1, 2 1, 2 2, 1 2, 1 1)
+```
 
 ## ST_Intersection
 

--- a/docs/api/flink/Function.md
+++ b/docs/api/flink/Function.md
@@ -1312,11 +1312,16 @@ Format: `ST_LengthSpheroid (A:geometry)`
 Since: `v1.4.1`
 
 Example:
+
 ```sql
 SELECT ST_LengthSpheroid(ST_GeomFromWKT('Polygon ((0 0, 0 90, 0 0))'))
 ```
 
-Output: `20037508.342789244`
+Output: 
+
+```
+20037508.342789244
+```
 
 ## ST_LineFromMultiPoint
 

--- a/docs/api/flink/Function.md
+++ b/docs/api/flink/Function.md
@@ -1235,7 +1235,11 @@ Example:
 SELECT ST_IsRing(ST_GeomFromText("LINESTRING(0 0, 0 1, 1 1, 1 0, 0 0)"))
 ```
 
-Output: `true`
+Output: 
+
+```
+true
+```
 
 ## ST_IsSimple
 

--- a/docs/api/flink/Function.md
+++ b/docs/api/flink/Function.md
@@ -1334,13 +1334,14 @@ Since: `v1.3.0`
 Example:
 
 ```sql
-SELECT ST_LineFromMultiPoint(df.geometry) AS geom
-FROM df
+SELECT ST_LineFromMultiPoint(ST_GeomFromText('MULTIPOINT((10 40), (40 30), (20 20), (30 10))'))
 ```
 
-Input: `MULTIPOINT((10 40), (40 30), (20 20), (30 10))`
+Output:
 
-Output: `LINESTRING (10 40, 40 30, 20 20, 30 10)`
+```
+LINESTRING (10 40, 40 30, 20 20, 30 10)
+```
 
 ## ST_LineInterpolatePoint
 

--- a/docs/api/flink/Function.md
+++ b/docs/api/flink/Function.md
@@ -1252,8 +1252,13 @@ Since: `v1.3.0`
 Example:
 
 ```sql
-SELECT ST_IsSimple(polygondf.countyshape)
-FROM polygondf
+SELECT ST_IsSimple(ST_GeomFromWTK('POLYGON((1 1, 3 1, 3 3, 1 3, 1 1))'))
+```
+
+Output:
+
+```
+true
 ```
 
 ## ST_IsValid

--- a/docs/api/flink/Function.md
+++ b/docs/api/flink/Function.md
@@ -1209,11 +1209,16 @@ Format: `ST_IsEmpty (A:geometry)`
 
 Since: `v1.2.1`
 
-Spark SQL example:
+Example:
 
 ```sql
-SELECT ST_IsEmpty(polygondf.countyshape)
-FROM polygondf
+SELECT ST_IsEmpty(ST_GeomFromWKT('POLYGON((0 0,0 1,1 1,1 0,0 0))'))
+```
+
+Output:
+
+```
+false
 ```
 
 ## ST_IsRing

--- a/docs/api/sql/Function.md
+++ b/docs/api/sql/Function.md
@@ -1181,14 +1181,23 @@ Example:
 SELECT ST_IsCollection(ST_GeomFromText('MULTIPOINT(0 0), (6 6)'))
 ```
 
-Output: `true`
+Output: 
+
+```
+true
+```
 
 Example:
+
 ```sql
 SELECT ST_IsCollection(ST_GeomFromText('POINT(5 5)'))
 ```
 
-Output: `false`
+Output: 
+
+```
+false
+```
 
 ## ST_IsEmpty
 

--- a/docs/api/sql/Function.md
+++ b/docs/api/sql/Function.md
@@ -1132,8 +1132,8 @@ Spark SQL example:
 
 ```sql
 SELECT ST_Intersection(
-    ST_GeomFromWTK("POLYGON((1 1, 8 1, 8 8, 1 8, 1 1))"),
-    ST_GeomFromWTK("POLYGON((2 2, 9 2, 9 9, 2 9, 2 2))")
+    ST_GeomFromWKT("POLYGON((1 1, 8 1, 8 8, 1 8, 1 1))"),
+    ST_GeomFromWKT("POLYGON((2 2, 9 2, 9 9, 2 9, 2 2))")
     )
 ```
 
@@ -1250,7 +1250,7 @@ Since: `v1.0.0`
 Spark SQL example:
 
 ```sql
-SELECT ST_IsSimple(ST_GeomFromWTK('POLYGON((1 1, 3 1, 3 3, 1 3, 1 1))'))
+SELECT ST_IsSimple(ST_GeomFromWKT('POLYGON((1 1, 3 1, 3 3, 1 3, 1 1))'))
 ```
 
 Output:

--- a/docs/api/sql/Function.md
+++ b/docs/api/sql/Function.md
@@ -1152,11 +1152,16 @@ Format: `ST_IsClosed(geom: geometry)`
 Since: `v1.0.0`
 
 Spark SQL example:
+
 ```sql
 SELECT ST_IsClosed(ST_GeomFromText('LINESTRING(0 0, 1 1, 1 0)'))
 ```
 
-Output: `false`
+Output: 
+
+```
+false
+```
 
 ## ST_IsCollection
 

--- a/docs/api/sql/Function.md
+++ b/docs/api/sql/Function.md
@@ -1332,19 +1332,13 @@ Since: `v1.3.0`
 Example:
 
 ```sql
-SELECT ST_AsText(
-    ST_LineFromMultiPoint(ST_GeomFromText('MULTIPOINT((10 40), (40 30), (20 20), (30 10))'))
-) AS geom
+SELECT ST_LineFromMultiPoint(ST_GeomFromText('MULTIPOINT((10 40), (40 30), (20 20), (30 10))'))
 ```
 
-Result:
+Output:
 
 ```
-+---------------------------------------------------------------+
-|geom                                                           |
-+---------------------------------------------------------------+
-|LINESTRING (10 40, 40 30, 20 20, 30 10)                        |
-+---------------------------------------------------------------+
+LINESTRING (10 40, 40 30, 20 20, 30 10)
 ```
 
 ## ST_LineInterpolatePoint

--- a/docs/api/sql/Function.md
+++ b/docs/api/sql/Function.md
@@ -1310,11 +1310,16 @@ Format: `ST_LengthSpheroid (A:geometry)`
 Since: `v1.4.1`
 
 Spark SQL example:
+
 ```sql
 SELECT ST_LengthSpheroid(ST_GeomFromWKT('Polygon ((0 0, 0 90, 0 0))'))
 ```
 
-Output: `20037508.342789244`
+Output: 
+
+```
+20037508.342789244
+```
 
 ## ST_LineFromMultiPoint
 

--- a/docs/api/sql/Function.md
+++ b/docs/api/sql/Function.md
@@ -1250,8 +1250,13 @@ Since: `v1.0.0`
 Spark SQL example:
 
 ```sql
-SELECT ST_IsSimple(polygondf.countyshape)
-FROM polygondf
+SELECT ST_IsSimple(ST_GeomFromWTK('POLYGON((1 1, 3 1, 3 3, 1 3, 1 1))'))
+```
+
+Output:
+
+```
+true
 ```
 
 ## ST_IsValid

--- a/docs/api/sql/Function.md
+++ b/docs/api/sql/Function.md
@@ -1350,17 +1350,14 @@ Format: `ST_LineInterpolatePoint (geom: geometry, fraction: Double)`
 Since: `v1.0.1`
 
 Spark SQL example:
+
 ```sql
-SELECT ST_LineInterpolatePoint(ST_GeomFromWKT('LINESTRING(25 50, 100 125, 150 190)'), 0.2) as Interpolated
+SELECT ST_LineInterpolatePoint(ST_GeomFromWKT('LINESTRING(25 50, 100 125, 150 190)'), 0.2)
 ```
 
 Output:
 ```
-+-----------------------------------------+
-|Interpolated                             |
-+-----------------------------------------+
-|POINT (51.5974135047432 76.5974135047432)|
-+-----------------------------------------+
+POINT (51.5974135047432 76.5974135047432)
 ```
 
 ## ST_LineMerge

--- a/docs/api/sql/Function.md
+++ b/docs/api/sql/Function.md
@@ -1131,8 +1131,16 @@ Since: `v1.0.0`
 Spark SQL example:
 
 ```sql
-SELECT ST_Intersection(polygondf.countyshape, polygondf.countyshape)
-FROM polygondf
+SELECT ST_Intersection(
+    ST_GeomFromWTK("POLYGON((1 1, 8 1, 8 8, 1 8, 1 1))"),
+    ST_GeomFromWTK("POLYGON((2 2, 9 2, 9 9, 2 9, 2 2))")
+    )
+```
+
+Output:
+
+```
+POLYGON ((2 8, 8 8, 8 2, 2 2, 2 8))
 ```
 
 ## ST_IsClosed

--- a/docs/api/sql/Function.md
+++ b/docs/api/sql/Function.md
@@ -1270,8 +1270,13 @@ Since: `v1.0.0`
 Spark SQL example:
 
 ```sql
-SELECT ST_IsValid(polygondf.countyshape)
-FROM polygondf
+SELECT ST_IsValid(ST_GeomFromWKT('POLYGON((0 0, 10 0, 10 10, 0 10, 0 0), (15 15, 15 20, 20 20, 20 15, 15 15))'))
+```
+
+Output:
+
+```
+false
 ```
 
 ## ST_Length

--- a/docs/api/sql/Function.md
+++ b/docs/api/sql/Function.md
@@ -1228,11 +1228,16 @@ Format: `ST_IsRing(geom: geometry)`
 Since: `v1.0.0`
 
 Spark SQL example:
+
 ```sql
 SELECT ST_IsRing(ST_GeomFromText("LINESTRING(0 0, 0 1, 1 1, 1 0, 0 0)"))
 ```
 
-Output: `true`
+Output: 
+
+```
+true
+```
 
 ## ST_IsSimple
 

--- a/docs/api/sql/Function.md
+++ b/docs/api/sql/Function.md
@@ -1109,11 +1109,16 @@ Format: `ST_InteriorRingN(geom: geometry, n: Int)`
 Since: `v1.0.0`
 
 Spark SQL example:
+
 ```sql
 SELECT ST_InteriorRingN(ST_GeomFromText('POLYGON((0 0, 0 5, 5 5, 5 0, 0 0), (1 1, 2 1, 2 2, 1 2, 1 1), (1 3, 2 3, 2 4, 1 4, 1 3), (3 3, 4 3, 4 4, 3 4, 3 3))'), 0)
 ```
 
-Output: `LINESTRING (1 1, 2 1, 2 2, 1 2, 1 1)`
+Output: 
+
+```
+LINESTRING (1 1, 2 1, 2 2, 1 2, 1 1)
+```
 
 ## ST_Intersection
 

--- a/docs/api/sql/Function.md
+++ b/docs/api/sql/Function.md
@@ -1210,8 +1210,13 @@ Since: `v1.2.1`
 Spark SQL example:
 
 ```sql
-SELECT ST_IsEmpty(polygondf.countyshape)
-FROM polygondf
+SELECT ST_IsEmpty(ST_GeomFromWKT('POLYGON((0 0,0 1,1 1,1 0,0 0))'))
+```
+
+Output:
+
+```
+false
 ```
 
 ## ST_IsRing

--- a/docs/api/sql/Function.md
+++ b/docs/api/sql/Function.md
@@ -1288,9 +1288,15 @@ Format: ST_Length (A:geometry)
 Since: `v1.0.0`
 
 Spark SQL example:
+
 ```sql
-SELECT ST_Length(polygondf.countyshape)
-FROM polygondf
+SELECT ST_Length(ST_GeomFromWKT('LINESTRING(38 16,38 50,65 50,66 16,38 16)'))
+```
+
+Output:
+
+```
+123.0147027033899
 ```
 
 ## ST_LengthSpheroid


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- No, this is a documentation update. The PR name follows the format `[DOCS] my subject`.

## What changes were proposed in this PR?

The following functions' docs were edited both in Spark and Flink:

ST_InteriorRingN, ST_Intersection, ST_IsClosed, ST_IsCollection, ST_IsEmpty, ST_IsRing, ST_IsSimple, ST_IsValid, ST_Length, ST_LengthSpheroid, ST_LineFromMultiPoint, and ST_LineInterpolatePoint.

## How was this patch tested?

On my local Ubuntu VM.

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation update.
