### PR TITLE
[SEDONA-338] Fix `RS_MakeEmptyRaster` and make affine transformation parameters compliant with the GDAL/PostGIS convention

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
@@ -18,25 +18,15 @@
  */
 package org.apache.sedona.common.raster;
 
-import com.sun.media.imageioimpl.common.BogusColorSpace;
-import org.geotools.coverage.CoverageFactoryFinder;
+import org.apache.sedona.common.utils.RasterUtils;
 import org.geotools.coverage.GridSampleDimension;
 import org.geotools.coverage.grid.GridCoverage2D;
-import org.geotools.coverage.grid.GridCoverageFactory;
 
 import javax.media.jai.RasterFactory;
-
 import java.awt.Point;
-import java.awt.Transparency;
-import java.awt.color.ColorSpace;
-import java.awt.image.BufferedImage;
-import java.awt.image.ColorModel;
-import java.awt.image.ComponentColorModel;
-import java.awt.image.DataBuffer;
 import java.awt.image.Raster;
 import java.awt.image.RenderedImage;
 import java.awt.image.WritableRaster;
-import java.util.Arrays;
 
 public class MapAlgebra
 {
@@ -134,7 +124,7 @@ public class MapAlgebra
         System.arraycopy(originalSampleDimensions, 0, sampleDimensions, 0, originalSampleDimensions.length);
         sampleDimensions[numBand - 1] = new GridSampleDimension("band" + numBand);
         // Construct a GridCoverage2D with the copied image.
-        return createCompatibleGridCoverage2D(gridCoverage2D, wr, sampleDimensions);
+        return RasterUtils.create(wr, gridCoverage2D.getGridGeometry(), sampleDimensions);
     }
 
     private static GridCoverage2D copyRasterAndReplaceBand(GridCoverage2D gridCoverage2D, int bandIndex, double[] bandValues) {
@@ -155,20 +145,6 @@ public class MapAlgebra
             }
         }
         // Create a new GridCoverage2D with the copied image
-        return createCompatibleGridCoverage2D(gridCoverage2D, wr, gridCoverage2D.getSampleDimensions());
-    }
-
-    private static GridCoverage2D createCompatibleGridCoverage2D(GridCoverage2D gridCoverage2D, WritableRaster wr, GridSampleDimension[] bands) {
-        int rasterDataType = wr.getDataBuffer().getDataType();
-        int numBand = wr.getNumBands();
-        final ColorSpace cs = new BogusColorSpace(numBand);
-        final int[] nBits = new int[numBand];
-        Arrays.fill(nBits, DataBuffer.getDataTypeSize(rasterDataType));
-        ColorModel colorModel =
-                new ComponentColorModel(cs, nBits, false, true, Transparency.OPAQUE, rasterDataType);
-        final RenderedImage image = new BufferedImage(colorModel, wr, false, null);
-        GridCoverageFactory gridCoverageFactory = CoverageFactoryFinder.getGridCoverageFactory(null);
-        return gridCoverageFactory.create(gridCoverage2D.getName(), image, gridCoverage2D.getCoordinateReferenceSystem(),
-                gridCoverage2D.getGridGeometry().getGridToCRS(), bands, null, null);
+        return RasterUtils.create(wr, gridCoverage2D.getGridGeometry(), gridCoverage2D.getSampleDimensions());
     }
 }

--- a/common/src/main/java/org/apache/sedona/common/utils/RasterUtils.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/RasterUtils.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.common.utils;
+
+import com.sun.media.imageioimpl.common.BogusColorSpace;
+import org.geotools.coverage.CoverageFactoryFinder;
+import org.geotools.coverage.GridSampleDimension;
+import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.coverage.grid.GridCoverageFactory;
+import org.geotools.coverage.grid.GridGeometry2D;
+import org.geotools.referencing.operation.transform.AffineTransform2D;
+import org.opengis.metadata.spatial.PixelOrientation;
+import org.opengis.referencing.operation.MathTransform;
+
+import java.awt.Transparency;
+import java.awt.color.ColorSpace;
+import java.awt.image.BufferedImage;
+import java.awt.image.ColorModel;
+import java.awt.image.ComponentColorModel;
+import java.awt.image.DataBuffer;
+import java.awt.image.RenderedImage;
+import java.awt.image.WritableRaster;
+import java.util.Arrays;
+
+/**
+ * Utility functions for working with GridCoverage2D objects.
+ */
+public class RasterUtils {
+    private RasterUtils() {}
+
+    private static final GridCoverageFactory gridCoverageFactory = CoverageFactoryFinder.getGridCoverageFactory(null);
+
+    /**
+     * Create a new empty raster from the given WritableRaster object.
+     * @param raster The raster object to be wrapped as an image.
+     * @param gridGeometry The grid geometry of the raster.
+     * @param bands The bands of the raster.
+     * @return A new GridCoverage2D object.
+     */
+    public static GridCoverage2D create(WritableRaster raster, GridGeometry2D gridGeometry, GridSampleDimension[] bands) {
+        int numBand = raster.getNumBands();
+        int rasterDataType = raster.getDataBuffer().getDataType();
+
+        // Construct a color model for the rendered image. This color model should be able to be serialized and
+        // deserialized. The color model object automatically constructed by grid coverage factory may not be
+        // serializable, please refer to https://issues.apache.org/jira/browse/SEDONA-319 for more details.
+        final ColorSpace cs = new BogusColorSpace(numBand);
+        final int[] nBits = new int[numBand];
+        Arrays.fill(nBits, DataBuffer.getDataTypeSize(rasterDataType));
+        ColorModel colorModel =
+                new ComponentColorModel(cs, nBits, false, true, Transparency.OPAQUE, rasterDataType);
+
+        final RenderedImage image = new BufferedImage(colorModel, raster, false, null);
+        return gridCoverageFactory.create("genericCoverage", image, gridGeometry, bands, null, null);
+    }
+
+    /**
+     * Get a GDAL-compliant affine transform from the given raster, where the grid coordinate indicates the upper left
+     * corner of the pixel. PostGIS also follows GDAL convention.
+     * @param raster The raster to get the affine transform from.
+     * @return The affine transform.
+     */
+    public static AffineTransform2D getGDALAffineTransform(GridCoverage2D raster) {
+        return getAffineTransform(raster, PixelOrientation.UPPER_LEFT);
+    }
+
+    public static AffineTransform2D getAffineTransform(GridCoverage2D raster, PixelOrientation orientation) throws UnsupportedOperationException {
+        GridGeometry2D gridGeometry2D = raster.getGridGeometry();
+        MathTransform crsTransform = gridGeometry2D.getGridToCRS2D(orientation);
+        if (!(crsTransform instanceof AffineTransform2D)) {
+            throw new UnsupportedOperationException("Only AffineTransform2D is supported");
+        }
+        return (AffineTransform2D) crsTransform;
+    }
+}

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterAccessorsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterAccessorsTest.java
@@ -20,6 +20,7 @@ package org.apache.sedona.common.raster;
 
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.junit.Test;
+import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.opengis.referencing.FactoryException;
 
@@ -34,8 +35,30 @@ public class RasterAccessorsTest extends RasterTestBase
         assertEquals(3600.0d, envelope.getArea(), 0.1d);
         assertEquals(378922.0d + 30.0d, envelope.getCentroid().getX(), 0.1d);
         assertEquals(4072345.0d + 30.0d, envelope.getCentroid().getY(), 0.1d);
-
         assertEquals(4326, RasterAccessors.envelope(multiBandRaster).getSRID());
+    }
+
+    @Test
+    public void testEnvelopeUsingSkewedRaster() throws FactoryException {
+        GridCoverage2D raster = RasterConstructors.makeEmptyRaster(1, 100, 100, 5, 4, 3, -2, 0.1, 0.15, 3857);
+        Geometry envelope = RasterAccessors.envelope(raster);
+        Envelope env = envelope.getEnvelopeInternal();
+        // The expected values were obtained by running the following query in PostGIS:
+        // SELECT ST_AsText(ST_Envelope(ST_MakeEmptyRaster(100, 100, 5, 4, 3, -2, 0.1, 0.15, 3857)));
+        assertEquals(5, env.getMinX(), 1e-9);
+        assertEquals(315, env.getMaxX(), 1e-9);
+        assertEquals(-196, env.getMinY(), 1e-9);
+        assertEquals(19, env.getMaxY(), 1e-9);
+
+        raster = RasterConstructors.makeEmptyRaster(1, 800, 700, 5, 4, 0.3, -0.2, -0.1, -0.15, 3857);
+        envelope = RasterAccessors.envelope(raster);
+        env = envelope.getEnvelopeInternal();
+        // The expected values were obtained by running the following query in PostGIS:
+        // SELECT ST_AsText(ST_Envelope(ST_MakeEmptyRaster(800, 700, 5, 4, 0.3, -0.2, -0.1, -0.15, 3857)));
+        assertEquals(-65, env.getMinX(), 1e-9);
+        assertEquals(245, env.getMaxX(), 1e-9);
+        assertEquals(-256, env.getMinY(), 1e-9);
+        assertEquals(4, env.getMaxY(), 1e-9);
     }
 
     @Test
@@ -75,18 +98,18 @@ public class RasterAccessorsTest extends RasterTestBase
 
         gridCoverage2D = RasterConstructors.makeEmptyRaster(10, 7, 8, 5, 6, 9);
         upperLeftY = RasterAccessors.getUpperLeftY(gridCoverage2D);
-        assertEquals(6, upperLeftY, 0.1d);    
+        assertEquals(6, upperLeftY, 0.1d);
     }
 
     @Test
     public void testScaleX() throws UnsupportedOperationException, FactoryException {
-        GridCoverage2D emptyRaster = RasterConstructors.makeEmptyRaster(2, 10, 15, 0, 0, 1, 2, 0, 0, 0);
+        GridCoverage2D emptyRaster = RasterConstructors.makeEmptyRaster(2, 10, 15, 0, 0, 1, -2, 0, 0, 0);
         assertEquals(1, RasterAccessors.getScaleX(emptyRaster), 1e-9);
     }
 
     @Test
     public void testScaleY() throws UnsupportedOperationException, FactoryException {
-        GridCoverage2D emptyRaster = RasterConstructors.makeEmptyRaster(2, 10, 15, 0, 0, 1, 2, 0, 0, 0);
+        GridCoverage2D emptyRaster = RasterConstructors.makeEmptyRaster(2, 10, 15, 0, 0, 1, -2, 0, 0, 0);
         assertEquals(-2, RasterAccessors.getScaleY(emptyRaster), 1e-9);
     }
 
@@ -103,16 +126,16 @@ public class RasterAccessorsTest extends RasterTestBase
 
         GridCoverage2D gridCoverage2D = RasterConstructors.makeEmptyRaster(numBands, widthInPixel, heightInPixel, upperLeftX, upperLeftY, pixelSize);
         double[] metadata = RasterAccessors.metadata(gridCoverage2D);
-        assertEquals(upperLeftX, metadata[0], 0.1d);
-        assertEquals(upperLeftY, metadata[1], 0.1d);
-        assertEquals(widthInPixel, metadata[2], 0.1d);
-        assertEquals(heightInPixel, metadata[3], 0.1d);
-        assertEquals(pixelSize, metadata[4], 0.1d);
-        assertEquals(-1 * pixelSize, metadata[5], 0.1d);
-        assertEquals(0, metadata[6], 0.1d);
-        assertEquals(0, metadata[7], 0.1d);
-        assertEquals(0, metadata[8], 0.1d);
-        assertEquals(numBands, metadata[9], 0.1d);
+        assertEquals(upperLeftX, metadata[0], 1e-9);
+        assertEquals(upperLeftY, metadata[1], 1e-9);
+        assertEquals(widthInPixel, metadata[2], 1e-9);
+        assertEquals(heightInPixel, metadata[3], 1e-9);
+        assertEquals(pixelSize, metadata[4], 1e-9);
+        assertEquals(-1 * pixelSize, metadata[5], 1e-9);
+        assertEquals(0, metadata[6], 1e-9);
+        assertEquals(0, metadata[7], 1e-9);
+        assertEquals(0, metadata[8], 1e-9);
+        assertEquals(numBands, metadata[9], 1e-9);
         assertEquals(10, metadata.length);
 
         upperLeftX = 5;
@@ -126,17 +149,44 @@ public class RasterAccessorsTest extends RasterTestBase
 
         metadata = RasterAccessors.metadata(gridCoverage2D);
 
-        assertEquals(upperLeftX, metadata[0], 0.1d);
-        assertEquals(upperLeftY, metadata[1], 0.1d);
-        assertEquals(widthInPixel, metadata[2], 0.1d);
-        assertEquals(heightInPixel, metadata[3], 0.1d);
-        assertEquals(pixelSize, metadata[4], 0.1d);
-        assertEquals(-1 * pixelSize, metadata[5], 0.1d);
-        assertEquals(0, metadata[6], 0.1d);
-        assertEquals(0, metadata[7], 0.1d);
-        assertEquals(0, metadata[8], 0.1d);
-        assertEquals(numBands, metadata[9], 0.1d);
+        assertEquals(upperLeftX, metadata[0], 1e-9);
+        assertEquals(upperLeftY, metadata[1], 1e-9);
+        assertEquals(widthInPixel, metadata[2], 1e-9);
+        assertEquals(heightInPixel, metadata[3], 1e-9);
+        assertEquals(pixelSize, metadata[4], 1e-9);
+        assertEquals(-1 * pixelSize, metadata[5], 1e-9);
+        assertEquals(0, metadata[6], 1e-9);
+        assertEquals(0, metadata[7], 1e-9);
+        assertEquals(0, metadata[8], 1e-9);
+        assertEquals(numBands, metadata[9], 1e-9);
 
+        assertEquals(10, metadata.length);
+    }
+
+    @Test
+    public void testMetaDataUsingSkewedRaster() throws FactoryException {
+        int widthInPixel = 3;
+        int heightInPixel = 4;
+        double upperLeftX = 100.0;
+        double upperLeftY = 200.0;
+        double scaleX = 2.0;
+        double scaleY = -3.0;
+        double skewX = 0.1;
+        double skewY = 0.2;
+        int numBands = 1;
+
+        GridCoverage2D gridCoverage2D = RasterConstructors.makeEmptyRaster(numBands, widthInPixel, heightInPixel, upperLeftX, upperLeftY, scaleX, scaleY, skewX, skewY, 3857);
+        double[] metadata = RasterAccessors.metadata(gridCoverage2D);
+        assertEquals(upperLeftX, metadata[0], 1e-9);
+        assertEquals(upperLeftY, metadata[1], 1e-9);
+        assertEquals(widthInPixel, metadata[2], 1e-9);
+        assertEquals(heightInPixel, metadata[3], 1e-9);
+        assertEquals(scaleX, metadata[4], 1e-9);
+        assertEquals(scaleY, metadata[5], 1e-9);
+        assertEquals(skewX, metadata[6], 1e-9);
+        assertEquals(skewY, metadata[7], 1e-9);
+        assertEquals(3857, metadata[8], 1e-9);
+        assertEquals(numBands, metadata[9], 1e-9);
         assertEquals(10, metadata.length);
     }
 }

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterConstructorsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterConstructorsTest.java
@@ -80,12 +80,11 @@ public class RasterConstructorsTest
         assertEquals(0d, gridCoverage2D.getRenderedImage().getData().getPixel(0, 0, (double[])null)[0], 0.001);
         assertEquals(1, gridCoverage2D.getNumSampleDimensions());
 
-        gridCoverage2D = RasterConstructors.makeEmptyRaster(numBands, widthInPixel, heightInPixel, upperLeftX, upperLeftY, pixelSize, pixelSize + 1, 0, 0, 0);
+        gridCoverage2D = RasterConstructors.makeEmptyRaster(numBands, widthInPixel, heightInPixel, upperLeftX, upperLeftY, pixelSize, -pixelSize - 1, 0, 0, 0);
         envelope = RasterAccessors.envelope(gridCoverage2D);
         assertEquals(upperLeftX, envelope.getEnvelopeInternal().getMinX(), 0.001);
         assertEquals(upperLeftX + widthInPixel * pixelSize, envelope.getEnvelopeInternal().getMaxX(), 0.001);
         assertEquals(upperLeftY - heightInPixel * (pixelSize + 1), envelope.getEnvelopeInternal().getMinY(), 0.001);
         assertEquals(upperLeftY, envelope.getEnvelopeInternal().getMaxY(), 0.001);
-
     }
 }

--- a/docs/api/sql/Raster-loader.md
+++ b/docs/api/sql/Raster-loader.md
@@ -80,7 +80,7 @@ Format: `RS_MakeEmptyRaster(numBands:Int, width: Int, height: Int, upperleftX: D
 SQL example 1 (with 2 bands):
 
 ```sql
-SELECT RS_MakeEmptyRaster(2, 10, 10, 0.0, 0.0, 1.0) as raster
+SELECT RS_MakeEmptyRaster(2, 10, 10, 0.0, 0.0, 1.0)
 ```
 
 Output:
@@ -95,16 +95,16 @@ Output:
 SQL example 1 (with 2 bands, scale, skew, and SRID):
 
 ```sql
-SELECT RS_MakeEmptyRaster(2, 10, 10, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 4326) as raster
+SELECT RS_MakeEmptyRaster(2, 10, 10, 0.0, 0.0, 1.0, -1.0, 0.0, 0.0, 4326)
 ```
 
 Output:
 ```
-+--------------------------------------------------------------+
-|rs_makeemptyraster(2, 10, 10, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0)|
-+--------------------------------------------------------------+
-|                                          GridCoverage2D["g...|
-+--------------------------------------------------------------+
++------------------------------------------------------------------+
+|rs_makeemptyraster(2, 10, 10, 0.0, 0.0, 1.0, -1.0, 0.0, 0.0, 4326)|
++------------------------------------------------------------------+
+|                                              GridCoverage2D["g...|
++------------------------------------------------------------------+
 ```
 
 ## Load GeoTiff to Array[Double] format

--- a/docs/api/sql/Raster-operators.md
+++ b/docs/api/sql/Raster-operators.md
@@ -164,12 +164,12 @@ true
 
 Introduction: Returns the metadata of the raster as an array of double. The array contains the following values:
 
-- 0: upper left x coordinate of the raster, in terms of CRS units (the minimum x coordinate)
-- 1: upper left y coordinate of the raster, in terms of CRS units (the maximum y coordinate)
+- 0: upper left x coordinate of the raster, in terms of CRS units
+- 1: upper left y coordinate of the raster, in terms of CRS units
 - 2: width of the raster, in terms of pixels
 - 3: height of the raster, in terms of pixels
 - 4: width of a pixel, in terms of CRS units (scaleX)
-- 5: height of a pixel, in terms of CRS units (scaleY)
+- 5: height of a pixel, in terms of CRS units (scaleY), may be negative
 - 6: skew in x direction (rotation x)
 - 7: skew in y direction (rotation y)
 - 8: srid of the raster

--- a/sql/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
+++ b/sql/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
@@ -445,7 +445,7 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
       val skewX = 0.0
       val skewY = 0.0
       val srid = 0
-      result = sparkSession.sql(s"SELECT RS_Metadata(RS_MakeEmptyRaster($numBands, $widthInPixel, $heightInPixel, $upperLeftX, $upperLeftY, $cellSize, $cellSize, $skewX, $skewY, $srid))").first().getSeq(0)
+      result = sparkSession.sql(s"SELECT RS_Metadata(RS_MakeEmptyRaster($numBands, $widthInPixel, $heightInPixel, $upperLeftX, $upperLeftY, $cellSize, -$cellSize, $skewX, $skewY, $srid))").first().getSeq(0)
       assertEquals(numBands, result(9), 0.001)
     }
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-338. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

1. Make `RS_MakeEmptyRaster` work correctly by constructing the GridCoverage2D object directly from the affine transformation. Please refer to [SEDONA-338](https://issues.apache.org/jira/browse/SEDONA-338) for details.
2. Grid coordinates are consistently treated as the upper-left corner of the grid cells. This behavior follows the GDAL/PostGIS convention.

## How was this patch tested?

Add unit tests for geo-referencing related functions.

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation update.
