### PR TITLE
[SEDONA-338] Don't change the geo-referencing data when setting the SRID of rasters.

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/raster/RasterEditors.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterEditors.java
@@ -21,11 +21,14 @@ package org.apache.sedona.common.raster;
 import org.geotools.coverage.CoverageFactoryFinder;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.coverage.grid.GridCoverageFactory;
-import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
 import org.geotools.referencing.crs.DefaultEngineeringCRS;
+import org.opengis.coverage.grid.GridCoverage;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.referencing.operation.MathTransform2D;
+
+import java.util.Map;
 
 public class RasterEditors
 {
@@ -37,8 +40,11 @@ public class RasterEditors
         } else {
             crs = CRS.decode("EPSG:" + srid);
         }
-        ReferencedEnvelope referencedEnvelope = new ReferencedEnvelope(raster.getEnvelope2D(), crs);
+
         GridCoverageFactory gridCoverageFactory = CoverageFactoryFinder.getGridCoverageFactory(null);
-        return gridCoverageFactory.create(raster.getName().toString(), raster.getRenderedImage(), referencedEnvelope);
+        MathTransform2D transform = raster.getGridGeometry().getGridToCRS2D();
+        Map<?, ?> properties = raster.getProperties();
+        GridCoverage[] sources = raster.getSources().toArray(new GridCoverage[0]);
+        return gridCoverageFactory.create(raster.getName().toString(), raster.getRenderedImage(), crs, transform, raster.getSampleDimensions(), sources, properties);
     }
 }

--- a/common/src/test/java/org/apache/sedona/common/raster/FunctionsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/FunctionsTest.java
@@ -13,7 +13,10 @@
  */
 package org.apache.sedona.common.raster;
 
+import org.apache.sedona.common.utils.RasterUtils;
 import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.referencing.operation.transform.AffineTransform2D;
+import org.junit.Assert;
 import org.junit.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
@@ -41,8 +44,16 @@ public class FunctionsTest extends RasterTestBase {
         assertEquals(4326, GeometryFunctions.envelope(oneBandRasterWithUpdatedSrid).getSRID());
         assertTrue(GeometryFunctions.envelope(oneBandRasterWithUpdatedSrid).equalsTopo(GeometryFunctions.envelope(oneBandRaster)));
 
+        AffineTransform2D oneBandAffine = RasterUtils.getGDALAffineTransform(oneBandRaster);
+        AffineTransform2D oneBandUpdatedAffine = RasterUtils.getGDALAffineTransform(oneBandRasterWithUpdatedSrid);
+        Assert.assertEquals(oneBandAffine, oneBandUpdatedAffine);
+
         GridCoverage2D multiBandRasterWithUpdatedSrid = RasterEditors.setSrid(multiBandRaster, 0);
         assertEquals(0 , RasterAccessors.srid(multiBandRasterWithUpdatedSrid));
+
+        AffineTransform2D multiBandAffine = RasterUtils.getGDALAffineTransform(multiBandRaster);
+        AffineTransform2D multiBandUpdatedAffine = RasterUtils.getGDALAffineTransform(multiBandRasterWithUpdatedSrid);
+        Assert.assertEquals(multiBandAffine, multiBandUpdatedAffine);
     }
 
     @Test

--- a/sql/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
+++ b/sql/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
@@ -304,8 +304,22 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
 
     it("Passed RS_SetSRID with raster") {
       val df = sparkSession.read.format("binaryFile").load(resourceFolder + "raster/test1.tiff")
-      val result = df.selectExpr("RS_SRID(RS_SetSRID(RS_FromGeoTiff(content), 4326))").first().getInt(0)
-      assert(result == 4326)
+      val dfRaster = df.selectExpr("RS_FromGeoTiff(content) as rast", "RS_SetSRID(RS_FromGeoTiff(content), 4326) as rast_4326")
+      val dfResult = dfRaster.selectExpr("RS_SRID(rast_4326) as srid_4326", "RS_Metadata(rast) as metadata", "RS_Metadata(rast_4326) as metadata_4326")
+      val result = dfResult.first()
+      assert(result.getInt(0) == 4326)
+      val metadata = result.getSeq[Double](1)
+      val metadata4326 = result.getSeq[Double](2)
+      assert(metadata4326(8) == 4326)
+      assert(metadata(0) == metadata4326(0))
+      assert(metadata(1) == metadata4326(1))
+      assert(metadata(2) == metadata4326(2))
+      assert(metadata(3) == metadata4326(3))
+      assert(metadata(4) == metadata4326(4))
+      assert(metadata(5) == metadata4326(5))
+      assert(metadata(6) == metadata4326(6))
+      assert(metadata(7) == metadata4326(7))
+      assert(metadata(9) == metadata4326(9))
     }
 
     it("Passed RS_SRID should handle null values") {


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-338. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Use the original geo-referencing information to construct rasters with new SRIDs, instead of using referenced envelopes to construct new rasters.

## How was this patch tested?

Add assertions for geo-referencing data of result rasters.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
