### PR TITLE
[SEDONA-351] Support XYZM coordinate

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/utils/GeomUtils.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/GeomUtils.java
@@ -171,15 +171,14 @@ public class GeomUtils {
         if (srid != 0) {
             sridString = "SRID=" + String.valueOf(srid) + ";";
         }
-
-        return sridString + new WKTWriter(GeomUtils.getDimension(geometry)).write(geometry);
+        return sridString + new WKTWriter(4).write(geometry);
     }
 
     public static String getWKT(Geometry geometry) {
         if (geometry == null) {
             return null;
         }
-        return new WKTWriter(GeomUtils.getDimension(geometry)).write(geometry);
+        return new WKTWriter(4).write(geometry);
     }
 
     public static byte[] getEWKB(Geometry geometry) {
@@ -254,17 +253,7 @@ public class GeomUtils {
     }
 
     public static int getDimension(Geometry geometry) {
-        int dimension = 2;
-        if (geometry.getCoordinate() == null) {
-            return dimension;
-        }
-        if(!java.lang.Double.isNaN(geometry.getCoordinate().getZ())){
-            dimension = 3;
-        }
-        if(!java.lang.Double.isNaN(geometry.getCoordinate().getM())){
-            dimension = 4;
-        }
-        return dimension;
+        return geometry.getCoordinate() != null && !java.lang.Double.isNaN(geometry.getCoordinate().getZ()) ? 3 : 2;
     }
 
     /**

--- a/common/src/main/java/org/apache/sedona/common/utils/GeomUtils.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/GeomUtils.java
@@ -254,7 +254,17 @@ public class GeomUtils {
     }
 
     public static int getDimension(Geometry geometry) {
-        return geometry.getCoordinate() != null && !java.lang.Double.isNaN(geometry.getCoordinate().getZ()) ? 3 : 2;
+        int dimension = 2;
+        if (geometry.getCoordinate() == null) {
+            return dimension;
+        }
+        if(!java.lang.Double.isNaN(geometry.getCoordinate().getZ())){
+            dimension = 3;
+        }
+        if(!java.lang.Double.isNaN(geometry.getCoordinate().getM())){
+            dimension = 4;
+        }
+        return dimension;
     }
 
     /**

--- a/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
@@ -67,51 +67,80 @@ public class FunctionsTest {
     }
 
     @Test
-    public void asEWKT() {
+    public void asEWKT() throws Exception{
         Geometry geometry = GEOMETRY_FACTORY.createPoint(new Coordinate(1.0, 2.0));
         String actualResult = Functions.asEWKT(geometry);
         String expectedResult = "POINT (1 2)";
+        Geometry expected = Constructors.geomFromEWKT(expectedResult);
+        assertEquals(expected, geometry);
         assertEquals(actualResult, expectedResult);
 
         geometry = GEOMETRY_FACTORY.createPoint(new Coordinate(1.0, 2.0, 3.0));
         actualResult = Functions.asEWKT(geometry);
         expectedResult = "POINT Z(1 2 3)";
+        expected = Constructors.geomFromEWKT(expectedResult);
+        assertEquals(expected, geometry);
         assertEquals(actualResult, expectedResult);
         
         geometry = GEOMETRY_FACTORY.createPoint(new CoordinateXYM(1.0, 2.0, 3.0));
         actualResult = Functions.asEWKT(geometry);
         expectedResult = "POINT M(1 2 3)";
+        expected = Constructors.geomFromEWKT(expectedResult);
+        assertEquals(expected, geometry);
         assertEquals(actualResult, expectedResult);
 
         geometry = GEOMETRY_FACTORY.createPoint(new CoordinateXYZM(1.0, 2.0, 3.0, 4.0));
         actualResult = Functions.asEWKT(geometry);
         expectedResult = "POINT ZM(1 2 3 4)";
+        expected = Constructors.geomFromEWKT(expectedResult);
+        assertEquals(expected, geometry);
         assertEquals(actualResult, expectedResult);
     }
 
     @Test
-    public void asWKT() {
+    public void asWKT() throws Exception {
         Geometry geometry = GEOMETRY_FACTORY.createPoint(new Coordinate(1.0, 2.0));
         String actualResult = Functions.asWKT(geometry);
         String expectedResult = "POINT (1 2)";
+        Geometry expected = Constructors.geomFromEWKT(expectedResult);
+        assertEquals(expected, geometry);
         assertEquals(actualResult, expectedResult);
 
         geometry = GEOMETRY_FACTORY.createPoint(new Coordinate(1.0, 2.0, 3.0));
         actualResult = Functions.asWKT(geometry);
         expectedResult = "POINT Z(1 2 3)";
+        expected = Constructors.geomFromEWKT(expectedResult);
+        assertEquals(expected, geometry);
         assertEquals(actualResult, expectedResult);
         
         geometry = GEOMETRY_FACTORY.createPoint(new CoordinateXYM(1.0, 2.0, 3.0));
         actualResult = Functions.asWKT(geometry);
         expectedResult = "POINT M(1 2 3)";
+        expected = Constructors.geomFromEWKT(expectedResult);
+        assertEquals(expected, geometry);
         assertEquals(actualResult, expectedResult);
         
         geometry = GEOMETRY_FACTORY.createPoint(new CoordinateXYZM(1.0, 2.0, 3.0, 4.0));
         actualResult = Functions.asWKT(geometry);
         expectedResult = "POINT ZM(1 2 3 4)";
+        expected = Constructors.geomFromEWKT(expectedResult);
+        assertEquals(expected, geometry);
         assertEquals(actualResult, expectedResult);
     }
 
+    @Test
+    public void asWKB() throws Exception{
+        Geometry geometry = GEOMETRY_FACTORY.createPoint(new Coordinate(1.0, 2.0));
+        byte[] actualResult = Functions.asWKB(geometry);
+        Geometry expected = Constructors.geomFromWKB(actualResult);
+        assertEquals(expected, geometry);
+
+        geometry = GEOMETRY_FACTORY.createPoint(new Coordinate(1.0, 2.0, 3.0));
+        actualResult = Functions.asWKB(geometry);
+        expected = Constructors.geomFromWKB(actualResult);
+        assertEquals(expected, geometry);
+    }
+    
     @Test
     public void splitLineStringByMultipoint() {
         LineString lineString = GEOMETRY_FACTORY.createLineString(coordArray(0.0, 0.0, 1.5, 1.5, 2.0, 2.0));

--- a/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
@@ -67,6 +67,52 @@ public class FunctionsTest {
     }
 
     @Test
+    public void asEWKT() {
+        Geometry geometry = GEOMETRY_FACTORY.createPoint(new Coordinate(1.0, 2.0));
+        String actualResult = Functions.asEWKT(geometry);
+        String expectedResult = "POINT (1 2)";
+        assertEquals(actualResult, expectedResult);
+
+        geometry = GEOMETRY_FACTORY.createPoint(new Coordinate(1.0, 2.0, 3.0));
+        actualResult = Functions.asEWKT(geometry);
+        expectedResult = "POINT Z(1 2 3)";
+        assertEquals(actualResult, expectedResult);
+        
+        geometry = GEOMETRY_FACTORY.createPoint(new CoordinateXYM(1.0, 2.0, 3.0));
+        actualResult = Functions.asEWKT(geometry);
+        expectedResult = "POINT M(1 2 3)";
+        assertEquals(actualResult, expectedResult);
+
+        geometry = GEOMETRY_FACTORY.createPoint(new CoordinateXYZM(1.0, 2.0, 3.0, 4.0));
+        actualResult = Functions.asEWKT(geometry);
+        expectedResult = "POINT ZM(1 2 3 4)";
+        assertEquals(actualResult, expectedResult);
+    }
+
+    @Test
+    public void asWKT() {
+        Geometry geometry = GEOMETRY_FACTORY.createPoint(new Coordinate(1.0, 2.0));
+        String actualResult = Functions.asWKT(geometry);
+        String expectedResult = "POINT (1 2)";
+        assertEquals(actualResult, expectedResult);
+
+        geometry = GEOMETRY_FACTORY.createPoint(new Coordinate(1.0, 2.0, 3.0));
+        actualResult = Functions.asWKT(geometry);
+        expectedResult = "POINT Z(1 2 3)";
+        assertEquals(actualResult, expectedResult);
+        
+        geometry = GEOMETRY_FACTORY.createPoint(new CoordinateXYM(1.0, 2.0, 3.0));
+        actualResult = Functions.asWKT(geometry);
+        expectedResult = "POINT M(1 2 3)";
+        assertEquals(actualResult, expectedResult);
+        
+        geometry = GEOMETRY_FACTORY.createPoint(new CoordinateXYZM(1.0, 2.0, 3.0, 4.0));
+        actualResult = Functions.asWKT(geometry);
+        expectedResult = "POINT ZM(1 2 3 4)";
+        assertEquals(actualResult, expectedResult);
+    }
+
+    @Test
     public void splitLineStringByMultipoint() {
         LineString lineString = GEOMETRY_FACTORY.createLineString(coordArray(0.0, 0.0, 1.5, 1.5, 2.0, 2.0));
         MultiPoint multiPoint = GEOMETRY_FACTORY.createMultiPointFromCoords(coordArray(0.5, 0.5, 1.0, 1.0));

--- a/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
@@ -68,33 +68,34 @@ public class FunctionsTest {
 
     @Test
     public void asEWKT() throws Exception{
-        Geometry geometry = GEOMETRY_FACTORY.createPoint(new Coordinate(1.0, 2.0));
+        GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4236);
+        Geometry geometry = geometryFactory.createPoint(new Coordinate(1.0, 2.0));
         String actualResult = Functions.asEWKT(geometry);
-        String expectedResult = "POINT (1 2)";
-        Geometry expected = Constructors.geomFromEWKT(expectedResult);
-        assertEquals(expected, geometry);
-        assertEquals(actualResult, expectedResult);
+        String expectedResult = "SRID=4236;POINT (1 2)";
+        Geometry acutal = Constructors.geomFromEWKT(expectedResult);
+        assertEquals(geometry, acutal);
+        assertEquals(expectedResult, actualResult);
 
-        geometry = GEOMETRY_FACTORY.createPoint(new Coordinate(1.0, 2.0, 3.0));
+        geometry = geometryFactory.createPoint(new Coordinate(1.0, 2.0, 3.0));
         actualResult = Functions.asEWKT(geometry);
-        expectedResult = "POINT Z(1 2 3)";
-        expected = Constructors.geomFromEWKT(expectedResult);
-        assertEquals(expected, geometry);
-        assertEquals(actualResult, expectedResult);
+        expectedResult = "SRID=4236;POINT Z(1 2 3)";
+        acutal = Constructors.geomFromEWKT(expectedResult);
+        assertEquals(geometry, acutal);
+        assertEquals(expectedResult, actualResult);
         
-        geometry = GEOMETRY_FACTORY.createPoint(new CoordinateXYM(1.0, 2.0, 3.0));
+        geometry = geometryFactory.createPoint(new CoordinateXYM(1.0, 2.0, 3.0));
         actualResult = Functions.asEWKT(geometry);
-        expectedResult = "POINT M(1 2 3)";
-        expected = Constructors.geomFromEWKT(expectedResult);
-        assertEquals(expected, geometry);
-        assertEquals(actualResult, expectedResult);
+        expectedResult = "SRID=4236;POINT M(1 2 3)";
+        acutal = Constructors.geomFromEWKT(expectedResult);
+        assertEquals(geometry, acutal);
+        assertEquals(expectedResult, actualResult);
 
-        geometry = GEOMETRY_FACTORY.createPoint(new CoordinateXYZM(1.0, 2.0, 3.0, 4.0));
+        geometry = geometryFactory.createPoint(new CoordinateXYZM(1.0, 2.0, 3.0, 4.0));
         actualResult = Functions.asEWKT(geometry);
-        expectedResult = "POINT ZM(1 2 3 4)";
-        expected = Constructors.geomFromEWKT(expectedResult);
-        assertEquals(expected, geometry);
-        assertEquals(actualResult, expectedResult);
+        expectedResult = "SRID=4236;POINT ZM(1 2 3 4)";
+        acutal = Constructors.geomFromEWKT(expectedResult);
+        assertEquals(geometry, acutal);
+        assertEquals(expectedResult, actualResult);
     }
 
     @Test
@@ -102,30 +103,30 @@ public class FunctionsTest {
         Geometry geometry = GEOMETRY_FACTORY.createPoint(new Coordinate(1.0, 2.0));
         String actualResult = Functions.asWKT(geometry);
         String expectedResult = "POINT (1 2)";
-        Geometry expected = Constructors.geomFromEWKT(expectedResult);
-        assertEquals(expected, geometry);
-        assertEquals(actualResult, expectedResult);
+        Geometry acutal = Constructors.geomFromEWKT(expectedResult);
+        assertEquals(geometry, acutal);
+        assertEquals(expectedResult, actualResult);
 
         geometry = GEOMETRY_FACTORY.createPoint(new Coordinate(1.0, 2.0, 3.0));
         actualResult = Functions.asWKT(geometry);
         expectedResult = "POINT Z(1 2 3)";
-        expected = Constructors.geomFromEWKT(expectedResult);
-        assertEquals(expected, geometry);
-        assertEquals(actualResult, expectedResult);
+        acutal = Constructors.geomFromEWKT(expectedResult);
+        assertEquals(geometry, acutal);
+        assertEquals(expectedResult, actualResult);
         
         geometry = GEOMETRY_FACTORY.createPoint(new CoordinateXYM(1.0, 2.0, 3.0));
         actualResult = Functions.asWKT(geometry);
         expectedResult = "POINT M(1 2 3)";
-        expected = Constructors.geomFromEWKT(expectedResult);
-        assertEquals(expected, geometry);
-        assertEquals(actualResult, expectedResult);
+        acutal = Constructors.geomFromEWKT(expectedResult);
+        assertEquals(geometry, acutal);
+        assertEquals(expectedResult, actualResult);
         
         geometry = GEOMETRY_FACTORY.createPoint(new CoordinateXYZM(1.0, 2.0, 3.0, 4.0));
         actualResult = Functions.asWKT(geometry);
         expectedResult = "POINT ZM(1 2 3 4)";
-        expected = Constructors.geomFromEWKT(expectedResult);
-        assertEquals(expected, geometry);
-        assertEquals(actualResult, expectedResult);
+        acutal = Constructors.geomFromEWKT(expectedResult);
+        assertEquals(geometry, acutal);
+        assertEquals(expectedResult, actualResult);
     }
 
     @Test

--- a/docs/api/flink/Function.md
+++ b/docs/api/flink/Function.md
@@ -269,6 +269,7 @@ Introduction: Return the Extended Well-Known Binary representation of a geometry
 EWKB is an extended version of WKB which includes the SRID of the geometry.
 The format originated in PostGIS but is supported by many GIS tools.
 If the geometry is lacking SRID a WKB format is produced.
+It will ignore the M coordinate if present.
 
 Format: `ST_AsEWKB (A:geometry)`
 
@@ -293,6 +294,7 @@ EWKT is an extended version of WKT which includes the SRID of the geometry.
 The format originated in PostGIS but is supported by many GIS tools.
 If the geometry is lacking SRID a WKT format is produced.
 [See ST_SetSRID](#ST_SetSRID)
+It will support M coodinate if present since v1.5.0.
 
 Format: `ST_AsEWKT (A:geometry)`
 
@@ -307,6 +309,30 @@ Output:
 
 ```
 SRID=4326;POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))
+```
+
+Example:
+
+```sql
+SELECT ST_AsEWKT(ST_MakePointM(1.0, 1.0, 1.0))
+```
+
+Output:
+
+```
+POINT M(1 1 1)
+```
+
+Example:
+
+```sql
+SELECT ST_AsEWKT(ST_MakePoint(1.0, 1.0, 1.0, 1.0))
+```
+
+Output:
+
+```
+POINT ZM(1 1 1 1)
 ```
 
 ## ST_AsGeoJSON
@@ -379,7 +405,8 @@ Output:
 
 ## ST_AsText
 
-Introduction: Return the Well-Known Text string representation of a geometry
+Introduction: Return the Well-Known Text string representation of a geometry.
+It will support M coodinate if present since v1.5.0.
 
 Format: `ST_AsText (A:geometry)`
 
@@ -395,6 +422,30 @@ Output:
 
 ```
 POINT (1 1)
+```
+
+Example:
+
+```sql
+SELECT ST_AsText(ST_MakePointM(1.0, 1.0, 1.0))
+```
+
+Output:
+
+```
+POINT M(1 1 1)
+```
+
+Example:
+
+```sql
+SELECT ST_AsText(ST_MakePoint(1.0, 1.0, 1.0, 1.0))
+```
+
+Output:
+
+```
+POINT ZM(1 1 1 1)
 ```
 
 ## ST_Azimuth

--- a/docs/api/sql/Function.md
+++ b/docs/api/sql/Function.md
@@ -264,6 +264,7 @@ EWKB is an extended version of WKB which includes the SRID of the geometry.
 The format originated in PostGIS but is supported by many GIS tools.
 If the geometry is lacking SRID a WKB format is produced.
 [Se ST_SetSRID](#ST_SetSRID)
+It will ignore the M coordinate if present.
 
 Format: `ST_AsEWKB (A:geometry)`
 
@@ -288,6 +289,7 @@ EWKT is an extended version of WKT which includes the SRID of the geometry.
 The format originated in PostGIS but is supported by many GIS tools.
 If the geometry is lacking SRID a WKT format is produced.
 [See ST_SetSRID](#ST_SetSRID)
+It will support M coodinate if present since v1.5.0.
 
 Format: `ST_AsEWKT (A:geometry)`
 
@@ -303,6 +305,30 @@ Output:
 
 ```
 SRID=4326;POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))
+```
+
+Example:
+
+```sql
+SELECT ST_AsEWKT(ST_MakePointM(1.0, 1.0, 1.0))
+```
+
+Output:
+
+```
+POINT M(1 1 1)
+```
+
+Example:
+
+```sql
+SELECT ST_AsEWKT(ST_MakePoint(1.0, 1.0, 1.0, 1.0))
+```
+
+Output:
+
+```
+POINT ZM(1 1 1 1)
 ```
 
 ## ST_AsGeoJSON
@@ -376,7 +402,8 @@ Output:
 
 ## ST_AsText
 
-Introduction: Return the Well-Known Text string representation of a geometry
+Introduction: Return the Well-Known Text string representation of a geometry.
+It will support M coodinate if present since v1.5.0.
 
 Format: `ST_AsText (A:geometry)`
 
@@ -392,6 +419,30 @@ Output:
 
 ```
 POINT (1 1)
+```
+
+Example:
+
+```sql
+SELECT ST_AsText(ST_MakePointM(1.0, 1.0, 1.0))
+```
+
+Output:
+
+```
+POINT M(1 1 1)
+```
+
+Example:
+
+```sql
+SELECT ST_AsText(ST_MakePoint(1.0, 1.0, 1.0, 1.0))
+```
+
+Output:
+
+```
+POINT ZM(1 1 1 1)
 ```
 
 ## ST_Azimuth

--- a/flink/src/main/java/org/apache/sedona/flink/expressions/Functions.java
+++ b/flink/src/main/java/org/apache/sedona/flink/expressions/Functions.java
@@ -455,7 +455,7 @@ public class Functions {
         @DataTypeHint("String")
         public String eval(@DataTypeHint(value = "RAW", bridgedTo = org.locationtech.jts.geom.Geometry.class) Object o) {
             Geometry geom = (Geometry) o;
-            return org.apache.sedona.common.Functions.asEWKT(geom);
+            return org.apache.sedona.common.Functions.asWKT(geom);
         }
     }
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)


## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket will be https://issues.apache.org/jira/browse/SEDONA-348. The PR name follows the format `[SEDONA-XXX] my subject`.


## What changes were proposed in this PR?

GetDimension will support 2D and 3D, which will lead functions like ST_AsWKT ignore the M coordinate. After this PR is merged, M coordinate will be available in WKT format.

In short, current status of Sedona Input and Output ST functions are follows:

1. ST_AsEWKT: SRID + XYZM WKT
2. ST_AsText: XYZM WKT
3. ST_GeomFromWKT: accepts EWKT and WKT format, with XYZM
4. ST_GeomFromWKB: accepts EWKB format, with XYZM but M is ignored.
5. ST_AsWKB will print EWKB without M

Sedona Jvm serializer will carry XYZM + SRID. So any ST functions in Sedona can access XYZM in the geometry type.
Shapely serializer does not support M so when deal with data created by Shapely, M is ignored.


## How was this patch tested?

Comprehensive unit tests in [sedona-common](https://issues.apache.org/jira/browse/SEDONA-common)


## Did this PR include necessary documentation updates?
- Yes, I have updated the documentation update.
