### PR TITLE
[SEDONA-360] Handle nodata values of raster bands in a more concise way

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
@@ -19,19 +19,14 @@
 package org.apache.sedona.common.raster;
 
 import org.apache.sedona.common.utils.RasterUtils;
-import org.geotools.coverage.Category;
 import org.geotools.coverage.GridSampleDimension;
 import org.geotools.coverage.grid.GridCoverage2D;
-import org.geotools.util.NumberRange;
-import org.opengis.util.InternationalString;
 
 import javax.media.jai.RasterFactory;
 import java.awt.*;
 import java.awt.image.Raster;
 import java.awt.image.RenderedImage;
 import java.awt.image.WritableRaster;
-import java.util.ArrayList;
-import java.util.List;
 
 public class MapAlgebra
 {
@@ -143,13 +138,8 @@ public class MapAlgebra
         GridSampleDimension[] sampleDimensions = new GridSampleDimension[numBand];
         System.arraycopy(originalSampleDimensions, 0, sampleDimensions, 0, originalSampleDimensions.length);
         if (noDataValue != null) {
-            Category noDataCategory = new Category(
-                    Category.NODATA.getName(),
-                    new Color[] {new Color(0, 0, 0, 0)},
-                    NumberRange.create(noDataValue, noDataValue));
-            Category[] categories = new Category[] {noDataCategory};
-            sampleDimensions[numBand - 1] = new GridSampleDimension("band" + numBand, categories, null);
-        }else {
+            sampleDimensions[numBand - 1] = RasterUtils.createSampleDimensionWithNoDataValue("band" + numBand, noDataValue);
+        } else {
             sampleDimensions[numBand - 1] = new GridSampleDimension("band" + numBand);
         }
         // Construct a GridCoverage2D with the copied image.
@@ -177,85 +167,17 @@ public class MapAlgebra
                 wr.setPixel(i, j, bands);
             }
         }
-        GridSampleDimension[] originalSampleDimensions = gridCoverage2D.getSampleDimensions();
-        GridSampleDimension originalBandDimension = originalSampleDimensions[bandIndex - 1];
-        List<Category> categories =  (originalBandDimension.getCategories());
-        InternationalString defaultBandName = gridCoverage2D.getName();
-        Category defaultCategory = containsDefaultBand(categories, defaultBandName);
-        InternationalString bandToReplace = defaultCategory != null ? defaultBandName : null;
-        List<Category> newCategories = new ArrayList<>();
+        GridSampleDimension[] sampleDimensions = gridCoverage2D.getSampleDimensions();
+        GridSampleDimension sampleDimension = sampleDimensions[bandIndex - 1];
         if (noDataValue == null && removeNoDataIfNull) {
-            if (originalBandDimension.getNoDataValues() != null) {
-                // remove noDataCategory
-                newCategories = createCategoryDeepCopy(categories, null, false, bandToReplace);
-            }
-        }else if (noDataValue != null) {
-            if (originalBandDimension.getNoDataValues() == null) {
-               // set a new noDataValue
-                newCategories = createCategoryDeepCopy(categories, noDataValue, true, bandToReplace);
-            }else {
-                double originalNoDataValue = originalBandDimension.getNoDataValues()[0];
-                if (originalNoDataValue != noDataValue) {
-                    //change noDataValue here
-                    newCategories = createCategoryDeepCopy(categories, noDataValue, false, bandToReplace);
-                }
-            }
+            sampleDimensions[bandIndex - 1] = RasterUtils.removeNoDataValue(sampleDimension);
+        } else if (noDataValue != null) {
+            sampleDimensions[bandIndex - 1] = RasterUtils.createSampleDimensionWithNoDataValue(sampleDimension, noDataValue);
         }
-
-        // Create a new GridCoverage2D with the copied image
-        if (!newCategories.isEmpty()) {
-            //create band with new categories altogether, no need to add default category
-            Category[] categoryArray = new Category[newCategories.size()];
-            categoryArray = newCategories.toArray(categoryArray);
-            originalSampleDimensions[bandIndex - 1] = new GridSampleDimension(originalBandDimension.getDescription(), categoryArray, null);
-            return RasterUtils.create(wr, gridCoverage2D.getGridGeometry(), originalSampleDimensions);
-        }else {
-            //Have to add default category
-            if (defaultCategory != null) {
-                //previous default category available, reuse it
-                originalSampleDimensions[bandIndex - 1] = new GridSampleDimension(originalBandDimension.getDescription(), new Category[]{defaultCategory}, null);
-                return RasterUtils.create(wr, gridCoverage2D.getGridGeometry(), originalSampleDimensions);
-            }else {
-                //default category not available, enforce its creation
-                return RasterUtils.create(wr, gridCoverage2D.getGridGeometry(), null);
-            }
-        }
+        return RasterUtils.create(wr, gridCoverage2D.getGridGeometry(), sampleDimensions);
     }
 
     private static GridCoverage2D copyRasterAndReplaceBand(GridCoverage2D gridCoverage2D, int bandIndex, double[] bandValues) {
         return copyRasterAndReplaceBand(gridCoverage2D, bandIndex, bandValues, null, false);
-    }
-
-    private static Category containsDefaultBand(List<Category> categoryNames, InternationalString defaultBandName) {
-        for (Category category: categoryNames) {
-            if (category.getName().equals(defaultBandName)) return category;
-        }
-        return null;
-    }
-
-    private static List<Category> createCategoryDeepCopy(List<Category> categories, Double noDataValue, boolean addNoData, InternationalString defaultBandName) {
-        List<Category> newCategories = new ArrayList<>();
-        for (Category originalCategory : categories) {
-            Category newCategory;
-            if (originalCategory.getName().equals(Category.NODATA.getName())) {
-                //noDataValue removal is intended, skip adding this category to new categories
-                if (noDataValue == null) continue;
-                //noDataValue modification is intended, modify only the range with new noDataValue
-                newCategory = new Category(originalCategory.getName(), originalCategory.getColors(), NumberRange.create(noDataValue, noDataValue));
-            } else {
-                if (defaultBandName != null && originalCategory.getName().equals(defaultBandName))
-                    continue; //we do not need the default band if we're adding a custom band. Default band range can mess with newly added band range
-                newCategory = new Category(originalCategory.getName(), originalCategory.getColors(), originalCategory.getRange()); // add all other categories as is
-            }
-            newCategories.add(newCategory);
-        }
-        if (addNoData) {
-            // Addition of an earlier absent noDataValue is intended, manually add a new category to newCategories
-            newCategories.add(new Category(
-                    Category.NODATA.getName(),
-                    new Color[] {new Color(0, 0, 0, 0)},
-                    NumberRange.create(noDataValue, noDataValue)));
-        }
-        return newCategories;
     }
 }

--- a/common/src/main/java/org/apache/sedona/common/raster/PixelFunctions.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/PixelFunctions.java
@@ -31,9 +31,7 @@ import java.awt.geom.Point2D;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.DoublePredicate;
 import java.util.stream.Collectors;
-import java.util.stream.DoubleStream;
 
 public class PixelFunctions
 {
@@ -59,8 +57,7 @@ public class PixelFunctions
             // Invalid band index. Return nulls.
             return geometries.stream().map(geom -> (Double) null).collect(Collectors.toList());
         }
-        double[] noDataValues = rasterGeom.getSampleDimension(band - 1).getNoDataValues();
-        DoublePredicate isNoData = d -> noDataValues != null && DoubleStream.of(noDataValues).anyMatch(noDataValue -> Double.compare(noDataValue, d) == 0);
+        double noDataValue = RasterUtils.getNoDataValue(rasterGeom.getSampleDimension(band - 1));
         double[] pixelBuffer = new double[numBands];
 
         List<Double> result = new ArrayList<>(geometries.size());
@@ -73,7 +70,7 @@ public class PixelFunctions
                 try {
                     rasterGeom.evaluate(directPosition2D, pixelBuffer);
                     double pixel = pixelBuffer[band - 1];
-                    if (isNoData.test(pixel)) {
+                    if (Double.compare(noDataValue, pixel) == 0) {
                         result.add(null);
                     } else {
                         result.add(pixel);

--- a/common/src/main/java/org/apache/sedona/common/raster/RasterBandAccessors.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterBandAccessors.java
@@ -18,6 +18,7 @@
  */
 package org.apache.sedona.common.raster;
 
+import org.apache.sedona.common.utils.RasterUtils;
 import org.geotools.coverage.GridSampleDimension;
 import org.geotools.coverage.grid.GridCoverage2D;
 
@@ -26,8 +27,12 @@ public class RasterBandAccessors {
     public static Double getBandNoDataValue(GridCoverage2D raster, int band) {
         ensureBand(raster, band);
         GridSampleDimension bandSampleDimension = raster.getSampleDimension(band - 1);
-        if (bandSampleDimension.getNoDataValues() == null) return null;
-        return raster.getSampleDimension(band - 1).getNoDataValues()[0];
+        double noDataValue = RasterUtils.getNoDataValue(bandSampleDimension);
+        if (Double.isNaN(noDataValue)) {
+            return null;
+        } else {
+            return noDataValue;
+        }
     }
 
     public static Double getBandNoDataValue(GridCoverage2D raster) {

--- a/common/src/main/java/org/apache/sedona/common/raster/RasterConstructors.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterConstructors.java
@@ -29,7 +29,6 @@ import org.opengis.referencing.datum.PixelInCell;
 import org.opengis.referencing.operation.MathTransform;
 
 import javax.media.jai.RasterFactory;
-import java.awt.image.DataBuffer;
 import java.awt.image.WritableRaster;
 import java.io.IOException;
 
@@ -138,30 +137,12 @@ public class RasterConstructors
         }
 
         // Create a new empty raster
-        WritableRaster raster = RasterFactory.createBandedRaster(getDataTypeCode(bandDataType), widthInPixel, heightInPixel, numBand, null);
+        WritableRaster raster = RasterFactory.createBandedRaster(RasterUtils.getDataTypeCode(bandDataType), widthInPixel, heightInPixel, numBand, null);
         MathTransform transform = new AffineTransform2D(scaleX, skewY, skewX, scaleY, upperLeftX, upperLeftY);
         GridGeometry2D gridGeometry = new GridGeometry2D(
                 new GridEnvelope2D(0, 0, widthInPixel, heightInPixel),
                 PixelInCell.CELL_CORNER,
                 transform, crs, null);
         return RasterUtils.create(raster, gridGeometry, null);
-    }
-
-    private static int getDataTypeCode(String s) {
-        switch (s.toLowerCase()) {
-            case "d":
-                return 5;
-            case "i":
-                return 3;
-            case "b":
-                return 0;
-            case "f":
-                return 4;
-            case "s":
-                return 2;
-            case "us":
-                return 1;
-        }
-        return 5; // defaulting to double
     }
 }

--- a/common/src/main/java/org/apache/sedona/common/utils/RasterUtils.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/RasterUtils.java
@@ -187,7 +187,7 @@ public class RasterUtils {
         Category noDataCategory = new Category(
                 Category.NODATA.getName(),
                 new Color(0, 0, 0, 0),
-                noDataValue);
+                new NumberRange<>(java.lang.Double.class, noDataValue, noDataValue));
         Category[] categories = new Category[] {noDataCategory};
         return new GridSampleDimension(description, categories, null);
     }
@@ -309,7 +309,7 @@ public class RasterUtils {
                 return 0;
             case "f":
                 return 4;
-            case "u":
+            case "s":
                 return 2;
             case "us":
                 return 1;

--- a/common/src/main/java/org/apache/sedona/common/utils/RasterUtils.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/RasterUtils.java
@@ -19,18 +19,20 @@
 package org.apache.sedona.common.utils;
 
 import com.sun.media.imageioimpl.common.BogusColorSpace;
-import org.apache.sedona.common.Functions;
+import org.geotools.coverage.Category;
 import org.geotools.coverage.CoverageFactoryFinder;
 import org.geotools.coverage.GridSampleDimension;
+import org.geotools.coverage.TypeMap;
 import org.geotools.coverage.grid.GridCoordinates2D;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.coverage.grid.GridCoverageFactory;
 import org.geotools.coverage.grid.GridGeometry2D;
 import org.geotools.geometry.DirectPosition2D;
-import org.geotools.geometry.jts.JTS;
 import org.geotools.referencing.CRS;
 import org.geotools.referencing.crs.DefaultEngineeringCRS;
 import org.geotools.referencing.operation.transform.AffineTransform2D;
+import org.geotools.util.ClassChanger;
+import org.geotools.util.NumberRange;
 import org.locationtech.jts.geom.Geometry;
 import org.opengis.geometry.DirectPosition;
 import org.opengis.metadata.spatial.PixelOrientation;
@@ -38,7 +40,9 @@ import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.opengis.referencing.operation.MathTransform;
 import org.opengis.referencing.operation.TransformException;
+import org.opengis.util.InternationalString;
 
+import java.awt.Color;
 import java.awt.Transparency;
 import java.awt.color.ColorSpace;
 import java.awt.geom.Point2D;
@@ -48,7 +52,9 @@ import java.awt.image.ComponentColorModel;
 import java.awt.image.DataBuffer;
 import java.awt.image.RenderedImage;
 import java.awt.image.WritableRaster;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * Utility functions for working with GridCoverage2D objects.
@@ -66,6 +72,17 @@ public class RasterUtils {
      * @return A new GridCoverage2D object.
      */
     public static GridCoverage2D create(WritableRaster raster, GridGeometry2D gridGeometry, GridSampleDimension[] bands) {
+        return create(raster, gridGeometry, bands, null);
+    }
+
+    /**
+     * Create a new empty raster from the given WritableRaster object.
+     * @param raster The raster object to be wrapped as an image.
+     * @param gridGeometry The grid geometry of the raster.
+     * @param bands The bands of the raster.
+     * @return A new GridCoverage2D object.
+     */
+    public static GridCoverage2D create(WritableRaster raster, GridGeometry2D gridGeometry, GridSampleDimension[] bands, Double noDataValue) {
         int numBand = raster.getNumBands();
         int rasterDataType = raster.getDataBuffer().getDataType();
 
@@ -78,8 +95,148 @@ public class RasterUtils {
         ColorModel colorModel =
                 new ComponentColorModel(cs, nBits, false, true, Transparency.OPAQUE, rasterDataType);
 
+        if (noDataValue != null) {
+            GridSampleDimension[] newBands = new GridSampleDimension[numBand];
+            for (int k = 0; k < numBand; k++) {
+                if (bands != null) {
+                    newBands[k] = createSampleDimensionWithNoDataValue(bands[k], noDataValue);
+                } else {
+                    newBands[k] = createSampleDimensionWithNoDataValue("band_" + k, noDataValue);
+                }
+            }
+            bands = newBands;
+        }
+
         final RenderedImage image = new BufferedImage(colorModel, raster, false, null);
         return gridCoverageFactory.create("genericCoverage", image, gridGeometry, bands, null, null);
+    }
+
+    public static GridCoverage2D create(RenderedImage image, GridGeometry2D gridGeometry, GridSampleDimension[] bands, Double noDataValue) {
+        int numBand = image.getSampleModel().getNumBands();
+        if (noDataValue != null) {
+            GridSampleDimension[] newBands = new GridSampleDimension[numBand];
+            for (int k = 0; k < numBand; k++) {
+                if (bands != null) {
+                    newBands[k] = createSampleDimensionWithNoDataValue(bands[k], noDataValue);
+                } else {
+                    newBands[k] = createSampleDimensionWithNoDataValue("band_" + k, noDataValue);
+                }
+            }
+            bands = newBands;
+        }
+        return gridCoverageFactory.create("genericCoverage", image, gridGeometry, bands, null, null);
+    }
+
+    /**
+     * Create a sample dimension using a given sampleDimension as template, with the give no data value.
+     * @param sampleDimension The sample dimension to be used as template.
+     * @param noDataValue The no data value.
+     * @return A new sample dimension with the given no data value.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static GridSampleDimension createSampleDimensionWithNoDataValue(GridSampleDimension sampleDimension, double noDataValue) {
+        // if noDataValues contain noDataValue, then return the original sample dimension
+        double existingNoDataValue = getNoDataValue(sampleDimension);
+        if (Double.compare(existingNoDataValue, noDataValue) == 0) {
+            return sampleDimension;
+        }
+
+        String description = sampleDimension.getDescription().toString();
+        List<Category> categories = sampleDimension.getCategories();
+        double offset = sampleDimension.getOffset();
+        double scale = sampleDimension.getScale();
+
+        // Copy existing categories. If the category contains noDataValue, split it into two categories.
+        List<Category> newCategories = new ArrayList<>(categories.size());
+        for (Category category : categories) {
+            NumberRange<? extends Number> range = category.getRange();
+            if (range.contains((Number) noDataValue)) {
+                // Split this range to two ranges, one is [min, noDataValue), the other is (noDataValue, max]
+                Number min = range.getMinValue();
+                Number max = range.getMaxValue();
+                final Class<? extends Number> clazz = ClassChanger.getWidestClass(min, max);
+                min = ClassChanger.cast(min, clazz);
+                max = ClassChanger.cast(max, clazz);
+                Number nodata = ClassChanger.cast(noDataValue, clazz);
+                if (min.doubleValue() < noDataValue) {
+                    Category leftCategory = new Category(category.getName(), category.getColors(),
+                            new NumberRange(clazz, min, range.isMinIncluded(), nodata, false));
+                    newCategories.add(leftCategory);
+                }
+                if (max.doubleValue() > noDataValue) {
+                    Category rightCategory = new Category(category.getName(), category.getColors(),
+                            new NumberRange(clazz, nodata, false, max, range.isMaxIncluded()));
+                    newCategories.add(rightCategory);
+                }
+            } else if (!category.getName().equals(Category.NODATA.getName())) {
+                // This category does not contain no data value, just keep it as is.
+                newCategories.add(category);
+            }
+        }
+
+        // Add the no data value as a new category
+        Number nodata = TypeMap.wrapSample(noDataValue, sampleDimension.getSampleDimensionType(), false);
+        newCategories.add(new Category(Category.NODATA.getName(),
+                new Color(0, 0, 0, 0),
+                new NumberRange(nodata.getClass(), nodata, nodata)));
+
+        return new GridSampleDimension(description, newCategories.toArray(new Category[0]), offset, scale);
+    }
+
+    public static GridSampleDimension createSampleDimensionWithNoDataValue(String description, double noDataValue) {
+        Category noDataCategory = new Category(
+                Category.NODATA.getName(),
+                new Color(0, 0, 0, 0),
+                noDataValue);
+        Category[] categories = new Category[] {noDataCategory};
+        return new GridSampleDimension(description, categories, null);
+    }
+
+    /**
+     * Remove no data value from the given sample dimension.
+     * @param sampleDimension The sample dimension to be processed.
+     * @return A new sample dimension without no data value, or the original sample dimension if it does not contain
+     * no data value.
+     */
+    public static GridSampleDimension removeNoDataValue(GridSampleDimension sampleDimension) {
+        String description = sampleDimension.getDescription().toString();
+        List<Category> categories = sampleDimension.getCategories();
+        List<Category> newCategories = new ArrayList<>(categories.size());
+        InternationalString noDataCategoryName = Category.NODATA.getName();
+        for (Category category : categories) {
+            if (!category.getName().equals(noDataCategoryName)) {
+                newCategories.add(category);
+            }
+        }
+
+        if (newCategories.size() == categories.size()) {
+            // Nothing changed, return the original sample dimension
+            return sampleDimension;
+        }
+
+        double offset = sampleDimension.getOffset();
+        double scale = sampleDimension.getScale();
+        return new GridSampleDimension(description, newCategories.toArray(new Category[0]), offset, scale);
+    }
+
+    /**
+     * Get the no data value from the given sample dimension. Please use this method to retrieve the no data value
+     * of a raster band, instead of {@link GridSampleDimension#getNoDataValues()}. The reason is that the latter
+     * method has a strange semantics: it treats whatever qualitative categories as no data value, which is not what
+     * we want. Additionally, the GeoTiff writer and ArcGrid writer uses the same algorithm as our method for finding
+     * no data values when writing the metadata of raster bands.
+     * @param sampleDimension The sample dimension to be processed.
+     * @return The no data value, or {@link Double#NaN} if the sample dimension does not contain no data value.
+     */
+    public static double getNoDataValue(GridSampleDimension sampleDimension) {
+        List<Category> categories = sampleDimension.getCategories();
+        InternationalString noDataCategoryName = Category.NODATA.getName();
+        for (Category category : categories) {
+            if (category.getName().equals(noDataCategoryName)) {
+                return category.getRange().getMinimum();
+            }
+        }
+        return Double.NaN;
     }
 
     /**
@@ -140,5 +297,23 @@ public class RasterUtils {
             }
         }
         return geometry;
+    }
+
+    public static int getDataTypeCode(String s) {
+        switch (s.toLowerCase()) {
+            case "d":
+                return 5;
+            case "i":
+                return 3;
+            case "b":
+                return 0;
+            case "f":
+                return 4;
+            case "u":
+                return 2;
+            case "us":
+                return 1;
+        }
+        return 5; // defaulting to double
     }
 }

--- a/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
@@ -18,14 +18,14 @@
  */
 package org.apache.sedona.common.raster;
 
+import org.apache.sedona.common.utils.RasterUtils;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.junit.Test;
 import org.opengis.referencing.FactoryException;
 
-import java.io.IOException;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class MapAlgebraTest extends RasterTestBase
 {
@@ -57,7 +57,7 @@ public class MapAlgebraTest extends RasterTestBase
         assertEquals(raster.getEnvelope(), rasterWithBand1.getEnvelope());
         assertEquals(raster.getCoordinateReferenceSystem2D(), rasterWithBand1.getCoordinateReferenceSystem2D());
         assertEquals(RasterAccessors.srid(raster), RasterAccessors.srid(rasterWithBand1));
-        assertEquals(-999, rasterWithBand1.getSampleDimension(0).getNoDataValues()[0], 1e-9);
+        assertEquals(-999, RasterUtils.getNoDataValue(rasterWithBand1.getSampleDimension(0)), 1e-9);
 
         //replace first band with a different customNoDataValue
         rasterWithBand1 = MapAlgebra.addBandFromArray(rasterWithBand1, band1, 1, -9999d);
@@ -65,7 +65,7 @@ public class MapAlgebraTest extends RasterTestBase
         assertEquals(raster.getEnvelope(), rasterWithBand1.getEnvelope());
         assertEquals(raster.getCoordinateReferenceSystem2D(), rasterWithBand1.getCoordinateReferenceSystem2D());
         assertEquals(RasterAccessors.srid(raster), RasterAccessors.srid(rasterWithBand1));
-        assertEquals(-9999, rasterWithBand1.getSampleDimension(0).getNoDataValues()[0], 1e-9);
+        assertEquals(-9999, RasterUtils.getNoDataValue(rasterWithBand1.getSampleDimension(0)), 1e-9);
 
         //remove noDataValue from the first band
         rasterWithBand1 = MapAlgebra.addBandFromArray(rasterWithBand1, band1, 1, null);
@@ -73,7 +73,7 @@ public class MapAlgebraTest extends RasterTestBase
         assertEquals(raster.getEnvelope(), rasterWithBand1.getEnvelope());
         assertEquals(raster.getCoordinateReferenceSystem2D(), rasterWithBand1.getCoordinateReferenceSystem2D());
         assertEquals(RasterAccessors.srid(raster), RasterAccessors.srid(rasterWithBand1));
-        assertNull(rasterWithBand1.getSampleDimension(0).getNoDataValues());
+        assertTrue(Double.isNaN(RasterUtils.getNoDataValue(rasterWithBand1.getSampleDimension(0))));
 
         // Append a new band with default noDataValue
         GridCoverage2D rasterWithBand2 = MapAlgebra.addBandFromArray(rasterWithBand1, band2);
@@ -81,7 +81,7 @@ public class MapAlgebraTest extends RasterTestBase
         assertEquals(raster.getEnvelope(), rasterWithBand2.getEnvelope());
         assertEquals(raster.getCoordinateReferenceSystem2D(), rasterWithBand2.getCoordinateReferenceSystem2D());
         assertEquals(RasterAccessors.srid(raster), RasterAccessors.srid(rasterWithBand2));
-        assertNull(rasterWithBand2.getSampleDimension(1).getNoDataValues());
+        assertTrue(Double.isNaN(RasterUtils.getNoDataValue(rasterWithBand2.getSampleDimension(1))));
 
         // Append a new band with custom noDataValue
         GridCoverage2D rasterWithBand3 = MapAlgebra.addBandFromArray(rasterWithBand2, band3, 3, 2d);
@@ -89,7 +89,7 @@ public class MapAlgebraTest extends RasterTestBase
         assertEquals(raster.getEnvelope(), rasterWithBand3.getEnvelope());
         assertEquals(raster.getCoordinateReferenceSystem2D(), rasterWithBand3.getCoordinateReferenceSystem2D());
         assertEquals(RasterAccessors.srid(raster), RasterAccessors.srid(rasterWithBand3));
-        assertEquals(2, rasterWithBand3.getSampleDimension(2).getNoDataValues()[0], 1e-9);
+        assertEquals(2, RasterUtils.getNoDataValue(rasterWithBand3.getSampleDimension(2)), 1e-9);
 
         // Check the value of the first band when use the raster with only one band
         double[] firstBand = MapAlgebra.bandAsArray(rasterWithBand1, 1);

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterConstructorsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterConstructorsTest.java
@@ -13,6 +13,7 @@
  */
 package org.apache.sedona.common.raster;
 
+import org.apache.sedona.common.utils.RasterUtils;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.junit.Test;
 import org.locationtech.jts.geom.Geometry;
@@ -36,7 +37,7 @@ public class RasterConstructorsTest
         assertEquals(4072345d + 30, envelope.getCentroid().getY(), 0.1);
         assertEquals(2, gridCoverage2D.getRenderedImage().getTileHeight());
         assertEquals(2, gridCoverage2D.getRenderedImage().getTileWidth());
-        assertEquals(0d, gridCoverage2D.getSampleDimension(0).getNoDataValues()[0], 0.1);
+        assertEquals(0d, RasterUtils.getNoDataValue(gridCoverage2D.getSampleDimension(0)), 0.1);
         assertEquals(3d, gridCoverage2D.getRenderedImage().getData().getPixel(1, 1, (double[])null)[0], 0.1);
     }
 

--- a/common/src/test/java/org/apache/sedona/common/utils/RasterUtilsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/utils/RasterUtilsTest.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.common.utils;
+
+import org.geotools.coverage.Category;
+import org.geotools.coverage.GridSampleDimension;
+import org.geotools.util.NumberRange;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.awt.Color;
+
+public class RasterUtilsTest {
+    @Test
+    public void testNoDataValue() {
+        GridSampleDimension band = new GridSampleDimension("test");
+        Assert.assertTrue(Double.isNaN(RasterUtils.getNoDataValue(band)));
+        band = RasterUtils.createSampleDimensionWithNoDataValue(band, 100);
+        Assert.assertEquals(100, RasterUtils.getNoDataValue(band), 1e-9);
+        band = RasterUtils.createSampleDimensionWithNoDataValue("test", 200);
+        Assert.assertEquals(200, RasterUtils.getNoDataValue(band), 1e-9);
+        band = RasterUtils.removeNoDataValue(band);
+        Assert.assertTrue(Double.isNaN(RasterUtils.getNoDataValue(band)));
+    }
+
+    @Test
+    public void testNoDataValueUsingComplexCategoryList() {
+        Category[] categories = {
+                new Category("C0", new Color(87, 154, 60, 255), 1),
+                new Category("C1", new Color(0, 0, 255, 255), 2),
+                new Category("C2", new Color(255, 255, 255, 255), 3),
+                new Category(Category.NODATA.getName(), new Color(0, 0, 0, 0), 10),
+                new Category("GrayScale", (Color) null, NumberRange.create(100, 200))
+        };
+        GridSampleDimension band = new GridSampleDimension("test", categories, null);
+        Assert.assertEquals(10, RasterUtils.getNoDataValue(band), 1e-9);
+        Assert.assertEquals(5, band.getCategories().size());
+
+        // Remove no data value from this band removes the NODATA category
+        GridSampleDimension band2 = RasterUtils.removeNoDataValue(band);
+        Assert.assertTrue(Double.isNaN(RasterUtils.getNoDataValue(band2)));
+        Assert.assertEquals(4, band2.getCategories().size());
+
+        // Create a new band with no data value from band2 adds a NODATA category back
+        GridSampleDimension band3 = RasterUtils.createSampleDimensionWithNoDataValue(band2, 20);
+        Assert.assertEquals(20, RasterUtils.getNoDataValue(band3), 1e-9);
+        Assert.assertEquals(5, band3.getCategories().size());
+
+        // Create a new band with no data value from band replaces the NODATA category
+        GridSampleDimension band4 = RasterUtils.createSampleDimensionWithNoDataValue(band, 20);
+        Assert.assertEquals(20, RasterUtils.getNoDataValue(band4), 1e-9);
+        Assert.assertEquals(5, band4.getCategories().size());
+
+        // If the new no data value falls within the range of an existing qualitative category, the category is replaced
+        // with NODATA category.
+        GridSampleDimension band5 = RasterUtils.createSampleDimensionWithNoDataValue(band, 1);
+        Assert.assertEquals(1, RasterUtils.getNoDataValue(band5), 1e-9);
+        Assert.assertEquals(4, band5.getCategories().size());
+        Assert.assertEquals(Category.NODATA.getName(), band5.getCategory(1).getName());
+        Assert.assertEquals("C1", band5.getCategory(2).getName().toString());
+        Assert.assertEquals("C2", band5.getCategory(3).getName().toString());
+        Assert.assertNull(band5.getCategory(10));
+        Assert.assertEquals("GrayScale", band5.getCategory(100).getName().toString());
+
+        // If the new no data value falls within the range of an existing quantitative category, the category is splitted
+        // into two categories.
+        GridSampleDimension band6 = RasterUtils.createSampleDimensionWithNoDataValue(band, 150);
+        Assert.assertEquals(150, RasterUtils.getNoDataValue(band6), 1e-9);
+        Assert.assertEquals(6, band6.getCategories().size());
+        Assert.assertEquals("GrayScale", band5.getCategory(100).getName().toString());
+        Assert.assertEquals("GrayScale", band5.getCategory(149).getName().toString());
+        Assert.assertEquals("GrayScale", band5.getCategory(151).getName().toString());
+        Assert.assertEquals("GrayScale", band5.getCategory(200).getName().toString());
+    }
+
+    @Test
+    public void testNoDataValueUsingQuantitativeCategory() {
+        Category[] categories = {
+                new Category(Category.NODATA.getName(), new Color(0, 0, 0, 0), 10),
+                new Category("GrayScale", (Color) null, NumberRange.create(100, 200))
+        };
+        GridSampleDimension band = new GridSampleDimension("test", categories, null);
+
+        GridSampleDimension band2 = RasterUtils.createSampleDimensionWithNoDataValue(band, 100);
+        Assert.assertEquals(100, RasterUtils.getNoDataValue(band2), 1e-9);
+        Assert.assertEquals(2, band2.getCategories().size());
+        Assert.assertEquals("GrayScale", band2.getCategory(101).getName().toString());
+        Assert.assertEquals("GrayScale", band2.getCategory(200).getName().toString());
+
+        GridSampleDimension band3 = RasterUtils.createSampleDimensionWithNoDataValue(band, 200);
+        Assert.assertEquals(200, RasterUtils.getNoDataValue(band3), 1e-9);
+        Assert.assertEquals(2, band3.getCategories().size());
+        Assert.assertEquals("GrayScale", band3.getCategory(100).getName().toString());
+        Assert.assertEquals("GrayScale", band3.getCategory(199).getName().toString());
+    }
+
+    @Test
+    public void testNoDataValueUsingFloatQuantitativeCategory() {
+        Category[] categories = {
+                new Category(Category.NODATA.getName(), new Color(0, 0, 0, 0), 10.0),
+                new Category("GrayScale", (Color) null, NumberRange.create(100.0, 200.0))
+        };
+        GridSampleDimension band = new GridSampleDimension("test", categories, null);
+
+        GridSampleDimension band2 = RasterUtils.createSampleDimensionWithNoDataValue(band, 100);
+        Assert.assertEquals(100, RasterUtils.getNoDataValue(band2), 1e-9);
+        Assert.assertEquals(2, band2.getCategories().size());
+        Assert.assertEquals("GrayScale", band2.getCategory(100.001).getName().toString());
+        Assert.assertEquals("GrayScale", band2.getCategory(200).getName().toString());
+
+        GridSampleDimension band3 = RasterUtils.createSampleDimensionWithNoDataValue(band, 200);
+        Assert.assertEquals(200, RasterUtils.getNoDataValue(band3), 1e-9);
+        Assert.assertEquals(2, band3.getCategories().size());
+        Assert.assertEquals("GrayScale", band3.getCategory(100).getName().toString());
+        Assert.assertEquals("GrayScale", band3.getCategory(199.999).getName().toString());
+    }
+}

--- a/common/src/test/java/org/apache/sedona/common/utils/RasterUtilsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/utils/RasterUtilsTest.java
@@ -33,8 +33,10 @@ public class RasterUtilsTest {
         Assert.assertTrue(Double.isNaN(RasterUtils.getNoDataValue(band)));
         band = RasterUtils.createSampleDimensionWithNoDataValue(band, 100);
         Assert.assertEquals(100, RasterUtils.getNoDataValue(band), 1e-9);
+        Assert.assertEquals(100, band.getNoDataValues()[0], 1e-9);
         band = RasterUtils.createSampleDimensionWithNoDataValue("test", 200);
         Assert.assertEquals(200, RasterUtils.getNoDataValue(band), 1e-9);
+        Assert.assertEquals(200, band.getNoDataValues()[0], 1e-9);
         band = RasterUtils.removeNoDataValue(band);
         Assert.assertTrue(Double.isNaN(RasterUtils.getNoDataValue(band)));
     }

--- a/sql/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
+++ b/sql/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
@@ -18,6 +18,7 @@
  */
 package org.apache.sedona.sql
 
+import org.apache.sedona.common.utils.RasterUtils
 import org.apache.spark.sql.functions.{collect_list, expr}
 import org.geotools.coverage.grid.GridCoverage2D
 import org.junit.Assert.{assertEquals, assertNull}
@@ -533,11 +534,11 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
       }
     }
 
-    it("Passed RS_AddBandFromArray - adding a new band with a custom no data value]") {
+    it("Passed RS_AddBandFromArray - adding a new band with a custom no data value") {
       var df = sparkSession.read.format("binaryFile").load(resourceFolder + "raster/test1.tiff")
       df = df.selectExpr("RS_FromGeoTiff(content) as raster", "RS_MultiplyFactor(RS_BandAsArray(RS_FromGeoTiff(content), 1), 2) as band")
       val raster = df.selectExpr("RS_AddBandFromArray(raster, band, 2, 2)").first().getAs[GridCoverage2D](0);
-      assertEquals(2, raster.getSampleDimension(1).getNoDataValues()(0), 1e-9)
+      assertEquals(2, RasterUtils.getNoDataValue(raster.getSampleDimension(1)), 1e-9)
     }
 
     it("Passed RS_Intersects") {


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-360. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Added a utility function `RasterUtils.getNoDataValue` for retrieving the nodata value of a band using a more concise method: we only treat the values of NODATA categories as nodata values.

## How was this patch tested?

Add unit tests and replaced all calls to `GridSampleDimension#getNoDataValue` with `RasterUtils.getNoDataValue` in existing tests.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
