### PR TITLE
[SEDONA-362] Fix bandAsArray to preserve float/double band values

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
@@ -50,15 +50,7 @@ public class MapAlgebra
 
         // Array to hold the band values
         double[] bandValues = new double[width * height];
-
-        // Iterate over each pixel
-        for (int y = 0; y < height; y++) {
-            for (int x = 0; x < width; x++) {
-                // Get the value and store it in the 1D array
-                bandValues[y * width + x] = raster.getSample(x, y, bandIndex - 1);
-            }
-        }
-        return bandValues;
+        return raster.getSamples(0, 0, width, height, bandIndex - 1, bandValues);
     }
 
     /**

--- a/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
@@ -182,12 +182,12 @@ public class MapAlgebraTest extends RasterTestBase
         }
         // Now set the value of the first band and check again
         for (int i = 0; i < band.length; i++) {
-            band[i] = i;
+            band[i] = i * 0.1;
         }
         double[] bandNew = MapAlgebra.bandAsArray(MapAlgebra.addBandFromArray(raster, band, 1), 1);
         assertEquals(band.length, bandNew.length);
         for (int i = 0; i < band.length; i++) {
-            assertEquals(band[i], bandNew[i], 0.1);
+            assertEquals(band[i], bandNew[i], 1e-9);
         }
     }
 }

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterBandAccessorsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterBandAccessorsTest.java
@@ -84,7 +84,7 @@ public class RasterBandAccessorsTest extends RasterTestBase {
         assertEquals("REAL_64BITS", RasterBandAccessors.getBandType(emptyRaster));
         assertEquals("REAL_64BITS", RasterBandAccessors.getBandType(emptyRaster, 2));
         double[] bandValues = MapAlgebra.bandAsArray(emptyRaster, 1);
-        double[] expectedBandValuesD = new double[]{1, 1, 32, 43};
+        double[] expectedBandValuesD = new double[]{1.2, 1.1, 32.2, 43.2};
         for (int i = 0; i < bandValues.length; i++) {
             assertEquals(expectedBandValuesD[i], bandValues[i], 1e-9);
         }
@@ -94,7 +94,7 @@ public class RasterBandAccessorsTest extends RasterTestBase {
         assertEquals("REAL_32BITS", RasterBandAccessors.getBandType(emptyRaster));
         assertEquals("REAL_32BITS", RasterBandAccessors.getBandType(emptyRaster, 2));
         bandValues = MapAlgebra.bandAsArray(emptyRaster, 1);
-        float[] expectedBandValuesF = new float[]{1, 1, 32, 43};
+        float[] expectedBandValuesF = new float[]{1.2f, 1.1f, 32.2f, 43.2f};
         for (int i = 0; i < bandValues.length; i++) {
             assertEquals(expectedBandValuesF[i], bandValues[i], 1e-9);
         }


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-362 The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Fixed `RS_BandAsArray` to not truncate the decimal part of float/double pixel values.

## How was this patch tested?

Updated some test cases to verify that the problem was fixed.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
