### PR TITLE
[SEDONA-374] Add support for geom-raster and raster-raster relationship to RS predicates 

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -70,6 +70,10 @@
             <artifactId>jts2geojson</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.locationtech.spatial4j</groupId>
+            <artifactId>spatial4j</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.geometry</groupId>
             <artifactId>s2-geometry</artifactId>
         </dependency>

--- a/common/src/main/java/org/apache/sedona/common/raster/RasterAccessors.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterAccessors.java
@@ -21,7 +21,6 @@ package org.apache.sedona.common.raster;
 import org.apache.sedona.common.utils.RasterUtils;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.coverage.grid.GridEnvelope2D;
-import org.geotools.referencing.CRS;
 import org.geotools.referencing.crs.DefaultEngineeringCRS;
 import org.geotools.referencing.operation.transform.AffineTransform2D;
 import org.locationtech.jts.geom.Coordinate;
@@ -29,11 +28,12 @@ import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 import org.opengis.referencing.FactoryException;
+import org.opengis.referencing.ReferenceIdentifier;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.opengis.referencing.operation.TransformException;
 
 import java.util.Arrays;
-import java.util.Optional;
+import java.util.Set;
 
 public class RasterAccessors
 {
@@ -47,7 +47,16 @@ public class RasterAccessors
                 return 0;
             }
         }
-        return Optional.ofNullable(CRS.lookupEpsgCode(crs, true)).orElse(0);
+        Set<ReferenceIdentifier> crsIds = crs.getIdentifiers();
+        if (crsIds.isEmpty()) {
+            return 0;
+        }
+        for (ReferenceIdentifier crsId : crsIds) {
+            if ("EPSG".equals(crsId.getCodeSpace())) {
+                return Integer.parseInt(crsId.getCode());
+            }
+        }
+        return 0;
     }
 
     public static int numBands(GridCoverage2D raster) {

--- a/common/src/main/java/org/apache/sedona/common/raster/RasterPredicates.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterPredicates.java
@@ -71,12 +71,13 @@ public class RasterPredicates {
     }
 
     private static Pair<Geometry, Geometry> convertCRSIfNeeded(GridCoverage2D raster, Geometry queryWindow) {
-        org.opengis.geometry.Envelope rasterEnvelope = raster.getEnvelope();
-        Envelope rasterJtsEnvelope = new Envelope(
-            rasterEnvelope.getMinimum(0), rasterEnvelope.getMaximum(0),
-            rasterEnvelope.getMinimum(1), rasterEnvelope.getMaximum(1));
-        Geometry rasterGeometry = GEOMETRY_FACTORY.toGeometry(rasterJtsEnvelope);
-        CoordinateReferenceSystem rasterCRS = rasterEnvelope.getCoordinateReferenceSystem();
+        Geometry rasterGeometry;
+        try {
+            rasterGeometry = GeometryFunctions.convexHull(raster);
+        } catch (FactoryException | TransformException e) {
+            throw new RuntimeException("Failed to calculate the convex hull of the raster", e);
+        }
+        CoordinateReferenceSystem rasterCRS = raster.getCoordinateReferenceSystem();
         int queryWindowSRID = queryWindow.getSRID();
         if (rasterCRS == null || rasterCRS instanceof DefaultEngineeringCRS || queryWindowSRID <= 0) {
             // Either raster or query window does not have a defined CRS, simply use the original

--- a/common/src/main/java/org/apache/sedona/common/utils/GeomUtils.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/GeomUtils.java
@@ -13,7 +13,8 @@
  */
 package org.apache.sedona.common.utils;
 
-
+import org.geotools.geometry.jts.JTS;
+import org.geotools.referencing.CRS;
 import org.locationtech.jts.geom.*;
 import org.locationtech.jts.geom.impl.CoordinateArraySequence;
 import org.locationtech.jts.io.ByteOrderValues;
@@ -24,7 +25,12 @@ import org.locationtech.jts.operation.union.UnaryUnionOp;
 import org.locationtech.jts.algorithm.Angle;
 import org.locationtech.jts.algorithm.distance.DiscreteFrechetDistance;
 import org.locationtech.jts.algorithm.distance.DiscreteHausdorffDistance;
-
+import org.locationtech.spatial4j.context.jts.JtsSpatialContext;
+import org.locationtech.spatial4j.shape.jts.JtsGeometry;
+import org.opengis.referencing.FactoryException;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.referencing.operation.MathTransform;
+import org.opengis.referencing.operation.TransformException;
 
 import java.nio.ByteOrder;
 import java.util.*;
@@ -528,5 +534,17 @@ public class GeomUtils {
     public static Boolean isMeasuredGeometry(Geometry geom) {
         Coordinate coordinate = geom.getCoordinate();
         return !Double.isNaN(coordinate.getM());
+    }
+
+    /**
+     * Returns a geometry that does not cross the anti meridian. If the given geometry crosses the
+     * anti-meridian, it will be split up into multiple geometries.
+     *
+     * @param geom the geometry to convert
+     * @return a geometry that does not cross the anti meridian
+     */
+    public static Geometry antiMeridianSafeGeom(Geometry geom) {
+        JtsGeometry jtsGeom = new JtsGeometry(geom, JtsSpatialContext.GEO, true, true);
+        return jtsGeom.getGeom();
     }
 }

--- a/common/src/main/java/org/apache/sedona/common/utils/GeomUtils.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/GeomUtils.java
@@ -13,8 +13,6 @@
  */
 package org.apache.sedona.common.utils;
 
-import org.geotools.geometry.jts.JTS;
-import org.geotools.referencing.CRS;
 import org.locationtech.jts.geom.*;
 import org.locationtech.jts.geom.impl.CoordinateArraySequence;
 import org.locationtech.jts.io.ByteOrderValues;
@@ -27,10 +25,6 @@ import org.locationtech.jts.algorithm.distance.DiscreteFrechetDistance;
 import org.locationtech.jts.algorithm.distance.DiscreteHausdorffDistance;
 import org.locationtech.spatial4j.context.jts.JtsSpatialContext;
 import org.locationtech.spatial4j.shape.jts.JtsGeometry;
-import org.opengis.referencing.FactoryException;
-import org.opengis.referencing.crs.CoordinateReferenceSystem;
-import org.opengis.referencing.operation.MathTransform;
-import org.opengis.referencing.operation.TransformException;
 
 import java.nio.ByteOrder;
 import java.util.*;
@@ -544,7 +538,11 @@ public class GeomUtils {
      * @return a geometry that does not cross the anti meridian
      */
     public static Geometry antiMeridianSafeGeom(Geometry geom) {
-        JtsGeometry jtsGeom = new JtsGeometry(geom, JtsSpatialContext.GEO, true, true);
-        return jtsGeom.getGeom();
+        try {
+            JtsGeometry jtsGeom = new JtsGeometry(geom, JtsSpatialContext.GEO, true, true);
+            return jtsGeom.getGeom();
+        } catch (TopologyException e) {
+            return geom;
+        }
     }
 }

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterPredicatesTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterPredicatesTest.java
@@ -23,6 +23,7 @@ import org.geotools.geometry.jts.JTS;
 import org.geotools.referencing.CRS;
 import org.junit.Assert;
 import org.junit.Test;
+import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -98,6 +99,92 @@ public class RasterPredicatesTest extends RasterTestBase {
         Assert.assertTrue(result);
         queryWindow = GEOMETRY_FACTORY.toGeometry(new Envelope(10, 20, 10, 20));
         queryWindow.setSRID(4326);
+        result = RasterPredicates.rsIntersects(raster, queryWindow);
+        Assert.assertFalse(result);
+    }
+
+    @Test
+    public void testIntersectsWithTransformations2() {
+        GridCoverage2D raster = createRandomRaster(DataBuffer.TYPE_BYTE, 7741, 7871, 301485, 4106715, 30, 1, "EPSG:32654");
+
+        Geometry queryWindow = GEOMETRY_FACTORY.createPoint(new Coordinate(15676311,4350120));
+        queryWindow.setSRID(3857);
+        Assert.assertTrue(RasterPredicates.rsIntersects(raster, queryWindow));
+        queryWindow = GEOMETRY_FACTORY.createPoint(new Coordinate(15494263,4240252));
+        queryWindow.setSRID(3857);
+        Assert.assertTrue(RasterPredicates.rsIntersects(raster, queryWindow));
+        queryWindow = GEOMETRY_FACTORY.createPoint(new Coordinate(15388866,4421023));
+        queryWindow.setSRID(3857);
+        Assert.assertFalse(RasterPredicates.rsIntersects(raster, queryWindow));
+        queryWindow = GEOMETRY_FACTORY.createPoint(new Coordinate(15847500,4263886));
+        queryWindow.setSRID(3857);
+        Assert.assertFalse(RasterPredicates.rsIntersects(raster, queryWindow));
+
+        queryWindow = GEOMETRY_FACTORY.createPoint(new Coordinate(140.9834, 36.4790));
+        queryWindow.setSRID(4326);
+        Assert.assertTrue(RasterPredicates.rsIntersects(raster, queryWindow));
+        queryWindow = GEOMETRY_FACTORY.createPoint(new Coordinate(139.1070, 35.6720));
+        queryWindow.setSRID(4326);
+        Assert.assertTrue(RasterPredicates.rsIntersects(raster, queryWindow));
+        queryWindow = GEOMETRY_FACTORY.createPoint(new Coordinate(36.4790, 140.9834));
+        queryWindow.setSRID(4326);
+        Assert.assertFalse(RasterPredicates.rsIntersects(raster, queryWindow));
+        queryWindow = GEOMETRY_FACTORY.createPoint(new Coordinate(35.6720, 139.1070));
+        queryWindow.setSRID(4326);
+        Assert.assertFalse(RasterPredicates.rsIntersects(raster, queryWindow));
+        queryWindow = GEOMETRY_FACTORY.createPoint(new Coordinate(142.0449, 35.3497));
+        queryWindow.setSRID(4326);
+        Assert.assertFalse(RasterPredicates.rsIntersects(raster, queryWindow));
+
+        // NAD83
+        queryWindow = GEOMETRY_FACTORY.createPoint(new Coordinate(140.9834, 36.4790));
+        queryWindow.setSRID(4269);
+        Assert.assertTrue(RasterPredicates.rsIntersects(raster, queryWindow));
+        queryWindow = GEOMETRY_FACTORY.createPoint(new Coordinate(139.1070, 35.6720));
+        queryWindow.setSRID(4269);
+        Assert.assertTrue(RasterPredicates.rsIntersects(raster, queryWindow));
+        queryWindow = GEOMETRY_FACTORY.createPoint(new Coordinate(36.4790, 140.9834));
+        queryWindow.setSRID(4269);
+        Assert.assertFalse(RasterPredicates.rsIntersects(raster, queryWindow));
+        queryWindow = GEOMETRY_FACTORY.createPoint(new Coordinate(35.6720, 139.1070));
+        queryWindow.setSRID(4269);
+        Assert.assertFalse(RasterPredicates.rsIntersects(raster, queryWindow));
+        queryWindow = GEOMETRY_FACTORY.createPoint(new Coordinate(142.0449, 35.3497));
+        queryWindow.setSRID(4269);
+        Assert.assertFalse(RasterPredicates.rsIntersects(raster, queryWindow));
+    }
+
+    @Test
+    public void testIntersectsCrossingAntiMeridian() {
+        GridCoverage2D raster = createRandomRaster(DataBuffer.TYPE_BYTE, 4289, 4194, 306240, 7840860, 60, 1, "EPSG:32601");
+
+        // Query using points near -180 lon
+        Geometry queryWindow = GEOMETRY_FACTORY.createPoint(new Coordinate(-177.8130, 68.5886));
+        queryWindow.setSRID(4326);
+        boolean result = RasterPredicates.rsIntersects(raster, queryWindow);
+        Assert.assertTrue(result);
+        queryWindow = GEOMETRY_FACTORY.createPoint(new Coordinate(-172.230, 69.830));
+        queryWindow.setSRID(4326);
+        result = RasterPredicates.rsIntersects(raster, queryWindow);
+        Assert.assertFalse(result);
+
+        // Query using points near 180 lon
+        queryWindow = GEOMETRY_FACTORY.createPoint(new Coordinate(179.7239, 69.5221));
+        queryWindow.setSRID(4326);
+        result = RasterPredicates.rsIntersects(raster, queryWindow);
+        Assert.assertTrue(result);
+        queryWindow = GEOMETRY_FACTORY.createPoint(new Coordinate(175.7754, 68.4907));
+        queryWindow.setSRID(4326);
+        result = RasterPredicates.rsIntersects(raster, queryWindow);
+        Assert.assertFalse(result);
+
+        // Query using envelopes crossing the anti-meridian in EPSG:3413
+        queryWindow = GEOMETRY_FACTORY.toGeometry(new Envelope(-1787864,-1446256,1381532,1733816));
+        queryWindow.setSRID(3413);
+        result = RasterPredicates.rsIntersects(raster, queryWindow);
+        Assert.assertTrue(result);
+        queryWindow = GEOMETRY_FACTORY.toGeometry(new Envelope(-2041936,-1736623,1782922,2088234));
+        queryWindow.setSRID(3413);
         result = RasterPredicates.rsIntersects(raster, queryWindow);
         Assert.assertFalse(result);
     }

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterPredicatesTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterPredicatesTest.java
@@ -29,6 +29,7 @@ import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.PrecisionModel;
 import org.locationtech.jts.io.ParseException;
+import org.opengis.geometry.BoundingBox;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.operation.TransformException;
 
@@ -368,6 +369,24 @@ public class RasterPredicatesTest extends RasterTestBase {
         //raster protruding out of the geometry
         raster = RasterConstructors.makeEmptyRaster(1, 100, 100, 0, 50, 1, -1, 0, 0, 4326);
         result = RasterPredicates.rsWithin(raster, geometry);
+        Assert.assertFalse(result);
+    }
+
+    @Test
+    public void testRasterWithSkew() throws FactoryException {
+        GridCoverage2D raster = RasterConstructors.makeEmptyRaster(1, "B", 100, 100, 0, 100, 1, -1, 0.1, 0.1, 3857);
+
+        Geometry queryWindow = GEOMETRY_FACTORY.createPoint(new Coordinate(7.80, 94.82));
+        boolean result = RasterPredicates.rsContains(raster, queryWindow);
+        Assert.assertTrue(result);
+
+        // Within the envelope of the raster, but not the convex hull of the raster
+        queryWindow = GEOMETRY_FACTORY.createPoint(new Coordinate(9.91, 103.86));
+        Geometry rasterEnvelope = JTS.toGeometry((BoundingBox) raster.getEnvelope2D());
+        Assert.assertTrue(rasterEnvelope.contains(queryWindow));
+        result = RasterPredicates.rsContains(raster, queryWindow);
+        Assert.assertFalse(result);
+        result = RasterPredicates.rsIntersects(raster, queryWindow);
         Assert.assertFalse(result);
     }
 }

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterPredicatesTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterPredicatesTest.java
@@ -389,4 +389,31 @@ public class RasterPredicatesTest extends RasterTestBase {
         result = RasterPredicates.rsIntersects(raster, queryWindow);
         Assert.assertFalse(result);
     }
+
+    @Test
+    public void testRasterRasterPredicates() throws FactoryException {
+        GridCoverage2D raster1 = RasterConstructors.makeEmptyRaster(1, "B", 428, 419, 306210, 7840890, 600, -600, 0, 0, 32601);
+        GridCoverage2D raster2 = RasterConstructors.makeEmptyRaster(1, "B", 100, 100, -19999963, 11067747, 1, -1, 0, 0, 3857);
+        GridCoverage2D raster3 = RasterConstructors.makeEmptyRaster(1, "B", 100, 100, -19331028, 10889880, 1, -1, 0, 0, 3857);
+        Assert.assertTrue(RasterPredicates.rsIntersects(raster1, raster2));
+        Assert.assertTrue(RasterPredicates.rsIntersects(raster2, raster1));
+        Assert.assertFalse(RasterPredicates.rsIntersects(raster1, raster3));
+        Assert.assertFalse(RasterPredicates.rsIntersects(raster3, raster1));
+        Assert.assertTrue(RasterPredicates.rsContains(raster1, raster2));
+        Assert.assertFalse(RasterPredicates.rsContains(raster2, raster1));
+    }
+
+    @Test
+    public void testRasterRasterPredicatesNoCrs() throws FactoryException {
+        GridCoverage2D raster1 = RasterConstructors.makeEmptyRaster(1, "B", 428, 419, 306210, 7840890, 600, -600, 0, 0, 32601);
+        GridCoverage2D raster2 = RasterConstructors.makeEmptyRaster(1, "B", 500, 500, 440086, 7739672, 100);
+        GridCoverage2D raster3 = RasterConstructors.makeEmptyRaster(1, "B", 500, 500, 639680, 7670102, 600);
+        Assert.assertTrue(RasterPredicates.rsIntersects(raster1, raster2));
+        Assert.assertTrue(RasterPredicates.rsIntersects(raster2, raster1));
+        Assert.assertFalse(RasterPredicates.rsIntersects(raster1, raster3));
+        Assert.assertFalse(RasterPredicates.rsIntersects(raster3, raster1));
+        Assert.assertTrue(RasterPredicates.rsContains(raster1, raster2));
+        Assert.assertFalse(RasterPredicates.rsContains(raster2, raster1));
+        Assert.assertFalse(RasterPredicates.rsIntersects(raster2, raster3));
+    }
 }

--- a/docs/api/sql/Raster-operators.md
+++ b/docs/api/sql/Raster-operators.md
@@ -695,18 +695,14 @@ Output:
 
 ### RS_Intersects
 
-Introduction: Returns true if the convex hull of the raster intersects the given geometry or raster.
+Introduction: Returns true if raster or geometry on the left side intersects with the raster or geometry on the right side.
+The convex hull of the raster is considered in the test.
 
-Rules for testing raster-geometry relationship:
+Rules for testing spatial relationship:
 
-* If the geometry does not have a defined SRID, perform the relationship test directly.
-* If the geometry has an SRID which is the same with the EPSG code of the raster CRS, then perform the relationshiop test directly.
-* Otherwise, both the geometry and the convex hull of the raster will be transformed to CRS84 before the relationship test.
-
-Rules for testing raster-raster relationship:
-
-* If both rasters have the same CRS, perform the relationship test using the convex hull of rasters directly.
-* Otherwise, transform the convex hull of both rasters to CRS84 then perform the relationship test.
+* If the raster or geometry does not have a defined SRID, it is assumed to be in WGS84.
+* If both sides are in the same CRS, then perform the relationship test directly.
+* Otherwise, both sides will be transformed to WGS84 before the relationship test.
 
 Format: `RS_Intersects(raster: Raster, geom: Geometry)`
 
@@ -734,9 +730,10 @@ Output:
 
 ### RS_Within
 
-Introduction: Returns true if the convex hull of the raster is within the given
-geometry or raster. The rules for testing raster-geometry or raster-raster
-relationship is the same as `RS_Intersects`.
+Introduction: Returns true if the geometry or raster on the left side is within the geometry or raster on the right side.
+The convex hull of the raster is considered in the test.
+
+The rules for testing spatial relationship is the same as `RS_Intersects`.
 
 Format: `RS_Within(raster: Raster, geom: Geometry)`
 
@@ -764,9 +761,10 @@ Output:
 
 ### RS_Contains
 
-Introduction: Returns true if the convex hull of the raster contains the given
-geometry or raster. The rules for testing raster-geometry or raster-raster
-relationship is the same as `RS_Intersects`.
+Introduction: Returns true if the geometry or raster on the left side contains the geometry or raster on the right side.
+The convex hull of the raster is considered in the test.
+
+The rules for testing spatial relationship is the same as `RS_Intersects`.
 
 Format: `RS_Contains(raster: Raster, geom: Geometry)`
 

--- a/docs/api/sql/Raster-operators.md
+++ b/docs/api/sql/Raster-operators.md
@@ -695,61 +695,101 @@ Output:
 
 ### RS_Intersects
 
-Introduction: Returns true if the envelope of the raster intersects the given geometry. If the geometry does not have a
-defined SRID, it is considered to be in the same CRS with the raster. If the geometry has a defined SRID, the geometry
-will be transformed to the CRS of the raster before the intersection test.
+Introduction: Returns true if the convex hull of the raster intersects the given geometry or raster.
 
-Format: `RS_Intersects (raster: Raster, geom: Geometry)`
+Rules for testing raster-geometry relationship:
+
+* If the geometry does not have a defined SRID, perform the relationship test directly.
+* If the geometry has an SRID which is the same with the EPSG code of the raster CRS, then perform the relationshiop test directly.
+* Otherwise, both the geometry and the convex hull of the raster will be transformed to CRS84 before the relationship test.
+
+Rules for testing raster-raster relationship:
+
+* If both rasters have the same CRS, perform the relationship test using the convex hull of rasters directly.
+* Otherwise, transform the convex hull of both rasters to CRS84 then perform the relationship test.
+
+Format: `RS_Intersects(raster: Raster, geom: Geometry)`
+
+Format: `RS_Intersects(geom: Geometry, raster: Raster)`
+
+Format: `RS_Intersects(raster0: Raster, raster1: Raster)`
 
 Since: `v1.5.0`
 
 Spark SQL example:
+
 ```sql
-SELECT RS_Intersects(raster, ST_SetSRID(ST_PolygonFromEnvelope(0, 0, 10, 10), 4326)) FROM raster_table
+SELECT RS_Intersects(RS_MakeEmptyRaster(1, 20, 20, 2, 22, 1), ST_SetSRID(ST_PolygonFromEnvelope(0, 0, 10, 10), 4326)) rast_geom,
+    RS_Intersects(RS_MakeEmptyRaster(1, 20, 20, 2, 22, 1), RS_MakeEmptyRaster(1, 10, 10, 1, 11, 1)) rast_rast
 ```
 Output:
 ```
-true
++---------+---------+
+|rast_geom|rast_rast|
++---------+---------+
+|     true|     true|
++---------+---------+
+
 ```
 
 ### RS_Within
 
-Introduction: Returns true if the envelope of the raster is within the given geometry. If the geometry does not have a
-defined SRID, it is considered to be in the same CRS with the raster. If the geometry has a defined SRID, the geometry
-will be transformed to the CRS of the raster before checking the within relationship.
+Introduction: Returns true if the convex hull of the raster is within the given
+geometry or raster. The rules for testing raster-geometry or raster-raster
+relationship is the same as `RS_Intersects`.
 
 Format: `RS_Within(raster: Raster, geom: Geometry)`
+
+Format: `RS_Within(geom: Geometry, raster: Raster)`
+
+Format: `RS_Within(raster0: Raster, raster1: Raster)`
 
 Since: `1.5.0`
 
 Spark SQL example:
+
 ```sql
-SELECT RS_Within(RS_MakeEmptyRaster(1, 20, 20, 2, 22, 1), ST_GeomFromWKT('POLYGON ((0 0, 0 50, 100 50, 100 0, 0 0))'));
+SELECT RS_Within(RS_MakeEmptyRaster(1, 20, 20, 2, 22, 1), ST_GeomFromWKT('POLYGON ((0 0, 0 50, 100 50, 100 0, 0 0))')) rast_geom,
+    RS_Within(RS_MakeEmptyRaster(1, 20, 20, 2, 22, 1), RS_MakeEmptyRaster(1, 30, 30, 2, 22, 1)) rast_rast
 ```
 
 Output:
 ```
-true
++---------+---------+
+|rast_geom|rast_rast|
++---------+---------+
+|     true|     true|
++---------+---------+
 ```
 
 ### RS_Contains
 
-Introduction: Returns true if the envelope of the raster contains the given geometry. If the geometry does not have a
-defined SRID, it is considered to be in the same CRS with the raster. If the geometry has a defined SRID, the geometry
-will be transformed to the CRS of the raster before checking the contains relationship.
+Introduction: Returns true if the convex hull of the raster contains the given
+geometry or raster. The rules for testing raster-geometry or raster-raster
+relationship is the same as `RS_Intersects`.
 
 Format: `RS_Contains(raster: Raster, geom: Geometry)`
+
+Format: `RS_Contains(geom: Geometry, raster: Raster)`
+
+Format: `RS_Contains(raster0: Raster, raster1: Raster)`
 
 Since: `1.5.0`
 
 Spark SQL example:
+
 ```sql
-SELECT RS_Contains(RS_MakeEmptyRaster(1, 20, 20, 2, 22, 1), ST_GeomFromWKT('POLYGON ((5 5, 5 10, 10 10, 10 5, 5 5))'));
+SELECT RS_Contains(RS_MakeEmptyRaster(1, 20, 20, 2, 22, 1), ST_GeomFromWKT('POLYGON ((5 5, 5 10, 10 10, 10 5, 5 5))')) rast_geom,
+    RS_Contains(RS_MakeEmptyRaster(1, 20, 20, 2, 22, 1), RS_MakeEmptyRaster(1, 10, 10, 2, 22, 1)) rast_rast
 ```
 
 Output:
 ```
-true
++---------+---------+
+|rast_geom|rast_rast|
++---------+---------+
+|     true|     true|
++---------+---------+
 ```
 
 ### RS_MetaData

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
         <jackson.version>2.13.4</jackson.version>
         <jts.version>1.19.0</jts.version>
         <jts2geojson.version>0.16.1</jts2geojson.version>
+        <spatial4j.version>0.8</spatial4j.version>
 
         <jt-jiffle.version>1.1.24</jt-jiffle.version>
         <antlr-runtime.version>4.9.3</antlr-runtime.version>
@@ -149,6 +150,11 @@
                 <groupId>org.locationtech.jts</groupId>
                 <artifactId>jts-core</artifactId>
                 <version>${jts.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.locationtech.spatial4j</groupId>
+                <artifactId>spatial4j</artifactId>
+                <version>${spatial4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>edu.ucar</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -250,11 +250,7 @@
                 <version>${jt-jiffle.version}</version>
                 <exclusions>
                     <exclusion>
-                        <groupId>org.antlr</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.codehaus.janino</groupId>
+                        <groupId>*</groupId>
                         <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>

--- a/sql/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
+++ b/sql/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
@@ -563,9 +563,9 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
       val df = sparkSession.read.format("binaryFile").load(resourceFolder + "raster/test1.tiff")
         .selectExpr("path", "RS_FromGeoTiff(content) as raster")
 
-      // query window without SRID
-      assert(df.selectExpr("RS_Intersects(raster, ST_Point(-13076178,4003651))").first().getBoolean(0))
-      assert(!df.selectExpr("RS_Intersects(raster, ST_Point(-13055247,3979620))").first().getBoolean(0))
+      // query window without SRID, will be assumed to be in WGS84
+      assert(df.selectExpr("RS_Intersects(raster, ST_Point(-117.47993, 33.81798))").first().getBoolean(0))
+      assert(!df.selectExpr("RS_Intersects(raster, ST_Point(-117.27868, 33.97896))").first().getBoolean(0))
 
       // query window and raster are in the same CRS
       assert(df.selectExpr("RS_Intersects(raster, ST_SetSRID(ST_Point(-13067806,4009116), 3857))").first().getBoolean(0))
@@ -581,7 +581,8 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
 
       // raster-raster
       assert(df.selectExpr("RS_Intersects(raster, raster)").first().getBoolean(0))
-      assert(!df.selectExpr("RS_Intersects(raster, RS_MakeEmptyRaster(1, 100, 100, 0, 0, 1))").first().getBoolean(0))
+      assert(!df.selectExpr("RS_Intersects(raster, RS_MakeEmptyRaster(1, 10, 10, 0, 0, 1))").first().getBoolean(0))
+      assert(df.selectExpr("RS_Intersects(raster, RS_MakeEmptyRaster(1, 10, 10, -118, 34, 1))").first().getBoolean(0))
     }
 
     it("Passed RS_AddBandFromArray collect generated raster") {


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-374. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

### Improvements
1. RS functions can take (geom, rast) and (rast, rast) as arguments.

### Semantics Changes
1. Use convex hull of rasters for spatial relationship testing.
2. If either side of the RS predicate does not have defined its CRS, we treat them as in WGS84.
3. Transform both sides to a common CRS (WGS84) if the left and right side does not have the same CRS.

## How was this patch tested?

Add unit tests

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation update.

