### PR TITLE
[SEDONA-377] Sphere/Spheroid functions accepts geometries in lon/lat order 

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/sphere/Haversine.java
+++ b/common/src/main/java/org/apache/sedona/common/sphere/Haversine.java
@@ -34,8 +34,8 @@ public class Haversine
      * This is also known as the great-circle distance
      * This will produce almost identical result to PostGIS ST_DistanceSphere and
      * ST_Distance(useSpheroid=false)
-     * @param geom1 The first geometry. Each coordinate is in lat/lon order
-     * @param geom2 The second geometry. Each coordinate is in lat/lon order
+     * @param geom1 The first geometry. Each coordinate is in lon/lat order
+     * @param geom2 The second geometry. Each coordinate is in lon/lat order
      * @return
      */
     public static double distance(Geometry geom1, Geometry geom2, double AVG_EARTH_RADIUS)
@@ -43,10 +43,10 @@ public class Haversine
         Coordinate coordinate1 = geom1.getGeometryType().equals("Point")? geom1.getCoordinate():geom1.getCentroid().getCoordinate();
         Coordinate coordinate2 = geom2.getGeometryType().equals("Point")? geom2.getCoordinate():geom2.getCentroid().getCoordinate();
         // Calculate the distance between the two points
-        double lat1 = coordinate1.getX();
-        double lon1 = coordinate1.getY();
-        double lat2 = coordinate2.getX();
-        double lon2 = coordinate2.getY();
+        double lon1 = coordinate1.getX();
+        double lat1 = coordinate1.getY();
+        double lon2 = coordinate2.getX();
+        double lat2 = coordinate2.getY();
         double latDistance = toRadians(lat2 - lat1);
         double lngDistance = toRadians(lon2 - lon1);
         double a = sin(latDistance / 2) * sin(latDistance / 2)

--- a/common/src/main/java/org/apache/sedona/common/sphere/Spheroid.java
+++ b/common/src/main/java/org/apache/sedona/common/sphere/Spheroid.java
@@ -45,10 +45,10 @@ public class Spheroid
         Coordinate coordinate1 = geom1.getGeometryType().equals("Point")? geom1.getCoordinate():geom1.getCentroid().getCoordinate();
         Coordinate coordinate2 = geom2.getGeometryType().equals("Point")? geom2.getCoordinate():geom2.getCentroid().getCoordinate();
         // Calculate the distance between the two points
-        double lat1 = coordinate1.getX();
-        double lon1 = coordinate1.getY();
-        double lat2 = coordinate2.getX();
-        double lon2 = coordinate2.getY();
+        double lon1 = coordinate1.getX();
+        double lat1 = coordinate1.getY();
+        double lon2 = coordinate2.getX();
+        double lat2 = coordinate2.getY();
         GeodesicData g = Geodesic.WGS84.Inverse(lat1, lon1, lat2, lon2);
         return g.s12;
     }
@@ -61,16 +61,19 @@ public class Spheroid
      * @return
      */
     public static double length(Geometry geom) {
-        if (geom.getGeometryType().equals("Polygon") || geom.getGeometryType().equals("LineString")) {
+        String geomType = geom.getGeometryType();
+        if (geomType.equals("Polygon") || geomType.equals("LineString")) {
             PolygonArea p = new PolygonArea(Geodesic.WGS84, true);
             Coordinate[] coordinates = geom.getCoordinates();
             for (int i = 0; i < coordinates.length; i++) {
-                p.AddPoint(coordinates[i].getX(), coordinates[i].getY());
+                double lon = coordinates[i].getX();
+                double lat = coordinates[i].getY();
+                p.AddPoint(lat, lon);
             }
             PolygonResult compute = p.Compute();
             return compute.perimeter;
         }
-        else if (geom.getGeometryType().equals("MultiPolygon") || geom.getGeometryType().equals("MultiLineString") || geom.getGeometryType().equals("GeometryCollection")) {
+        else if (geomType.equals("MultiPolygon") || geomType.equals("MultiLineString") || geomType.equals("GeometryCollection")) {
             double length = 0.0;
             for (int i = 0; i < geom.getNumGeometries(); i++) {
                 length += length(geom.getGeometryN(i));
@@ -90,18 +93,21 @@ public class Spheroid
      * @return
      */
     public static double area(Geometry geom) {
-        if (geom.getGeometryType().equals("Polygon")) {
+        String geomType = geom.getGeometryType();
+        if (geomType.equals("Polygon")) {
             PolygonArea p = new PolygonArea(Geodesic.WGS84, false);
             Coordinate[] coordinates = geom.getCoordinates();
             for (int i = 0; i < coordinates.length; i++) {
-                p.AddPoint(coordinates[i].getX(), coordinates[i].getY());
+                double lon = coordinates[i].getX();
+                double lat = coordinates[i].getY();
+                p.AddPoint(lat, lon);
             }
             PolygonResult compute = p.Compute();
             // The area is negative if the polygon is oriented clockwise
             // We make sure that all area are positive
             return abs(compute.area);
         }
-        else if (geom.getGeometryType().equals("MultiPolygon") || geom.getGeometryType().equals("GeometryCollection")) {
+        else if (geomType.equals("MultiPolygon") || geomType.equals("GeometryCollection")) {
             double area = 0.0;
             for (int i = 0; i < geom.getNumGeometries(); i++) {
                 area += area(geom.getGeometryN(i));

--- a/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
@@ -627,86 +627,94 @@ public class FunctionsTest {
     @Test
     public void haversineDistance() {
         // Basic check
-        Point p1 = GEOMETRY_FACTORY.createPoint(new Coordinate(0, 90));
+        Point p1 = GEOMETRY_FACTORY.createPoint(new Coordinate(90, 0));
         Point p2 = GEOMETRY_FACTORY.createPoint(new Coordinate(0, 0));
         assertEquals(1.00075559643809E7, Haversine.distance(p1, p2), 0.1);
 
-        p1 = GEOMETRY_FACTORY.createPoint(new Coordinate(51.3168, -0.56));
-        p2 = GEOMETRY_FACTORY.createPoint(new Coordinate(55.9533, -3.1883));
+        p1 = GEOMETRY_FACTORY.createPoint(new Coordinate(-0.56, 51.3168));
+        p2 = GEOMETRY_FACTORY.createPoint(new Coordinate(-3.1883, 55.9533));
         assertEquals(543796.9506134904, Haversine.distance(p1, p2), 0.1);
 
-        p1 = GEOMETRY_FACTORY.createPoint(new Coordinate(48.353889, 11.786111));
-        p2 = GEOMETRY_FACTORY.createPoint(new Coordinate(50.033333, 8.570556));
+        p1 = GEOMETRY_FACTORY.createPoint(new Coordinate(11.786111, 48.353889));
+        p2 = GEOMETRY_FACTORY.createPoint(new Coordinate(8.570556, 50.033333));
         assertEquals(299073.03416817175, Haversine.distance(p1, p2), 0.1);
 
-        p1 = GEOMETRY_FACTORY.createPoint(new Coordinate(48.353889, 11.786111));
-        p2 = GEOMETRY_FACTORY.createPoint(new Coordinate(52.559722, 13.287778));
+        p1 = GEOMETRY_FACTORY.createPoint(new Coordinate(11.786111, 48.353889));
+        p2 = GEOMETRY_FACTORY.createPoint(new Coordinate(13.287778, 52.559722));
         assertEquals(479569.4558072244, Haversine.distance(p1, p2), 0.1);
 
         LineString l1 = GEOMETRY_FACTORY.createLineString(coordArray(0, 0, 0, 90));
         LineString l2 = GEOMETRY_FACTORY.createLineString(coordArray(0, 1, 0, 0));
         assertEquals(4948180.449055, Haversine.distance(l1, l2), 0.1);
 
+        l1 = GEOMETRY_FACTORY.createLineString(coordArray(0, 0, 90, 0));
+        l2 = GEOMETRY_FACTORY.createLineString(coordArray(1, 0, 0, 0));
+        assertEquals(4948180.449055, Haversine.distance(l1, l2), 0.1);
+
         // HK to Sydney
-        p1 = GEOMETRY_FACTORY.createPoint(new Coordinate(22.308919, 113.914603));
-        p2 = GEOMETRY_FACTORY.createPoint(new Coordinate(-33.946111, 151.177222));
+        p1 = GEOMETRY_FACTORY.createPoint(new Coordinate(113.914603, 22.308919));
+        p2 = GEOMETRY_FACTORY.createPoint(new Coordinate(151.177222, -33.946111));
         assertEquals(7393893.072901942, Haversine.distance(p1, p2), 0.1);
 
         // HK to Toronto
-        p1 = GEOMETRY_FACTORY.createPoint(new Coordinate(22.308919, 113.914603));
-        p2 = GEOMETRY_FACTORY.createPoint(new Coordinate(43.677223, -79.630556));
+        p1 = GEOMETRY_FACTORY.createPoint(new Coordinate(113.914603, 22.308919));
+        p2 = GEOMETRY_FACTORY.createPoint(new Coordinate(-79.630556, 43.677223));
         assertEquals(1.2548548944238186E7, Haversine.distance(p1, p2), 0.1);
     }
 
     @Test
     public void spheroidDistance() {
         // Basic check
-        Point p1 = GEOMETRY_FACTORY.createPoint(new Coordinate(0, 90));
+        Point p1 = GEOMETRY_FACTORY.createPoint(new Coordinate(90, 0));
         Point p2 = GEOMETRY_FACTORY.createPoint(new Coordinate(0, 0));
         assertEquals(1.0018754171394622E7, Spheroid.distance(p1, p2), 0.1);
 
-        p1 = GEOMETRY_FACTORY.createPoint(new Coordinate(51.3168, -0.56));
-        p2 = GEOMETRY_FACTORY.createPoint(new Coordinate(55.9533, -3.1883));
+        p1 = GEOMETRY_FACTORY.createPoint(new Coordinate(-0.56, 51.3168));
+        p2 = GEOMETRY_FACTORY.createPoint(new Coordinate(-3.1883, 55.9533));
         assertEquals(544430.9411996203, Spheroid.distance(p1, p2), 0.1);
 
-        p1 = GEOMETRY_FACTORY.createPoint(new Coordinate(48.353889, 11.786111));
-        p2 = GEOMETRY_FACTORY.createPoint(new Coordinate(50.033333, 8.570556));
+        p1 = GEOMETRY_FACTORY.createPoint(new Coordinate(11.786111, 48.353889));
+        p2 = GEOMETRY_FACTORY.createPoint(new Coordinate(8.570556, 50.033333));
         assertEquals(299648.07216251583, Spheroid.distance(p1, p2), 0.1);
 
-        p1 = GEOMETRY_FACTORY.createPoint(new Coordinate(48.353889, 11.786111));
-        p2 = GEOMETRY_FACTORY.createPoint(new Coordinate(52.559722, 13.287778));
+        p1 = GEOMETRY_FACTORY.createPoint(new Coordinate(11.786111, 48.353889));
+        p2 = GEOMETRY_FACTORY.createPoint(new Coordinate(13.287778, 52.559722));
         assertEquals(479817.9049528187, Spheroid.distance(p1, p2), 0.1);
 
-        LineString l1 = GEOMETRY_FACTORY.createLineString(coordArray(0, 0, 0, 90));
-        LineString l2 = GEOMETRY_FACTORY.createLineString(coordArray(0, 1, 0, 0));
+        LineString l1 = GEOMETRY_FACTORY.createLineString(coordArray(0, 0, 90, 0));
+        LineString l2 = GEOMETRY_FACTORY.createLineString(coordArray(1, 0, 0, 0));
         assertEquals(4953717.340300673, Spheroid.distance(l1, l2), 0.1);
 
         // HK to Sydney
-        p1 = GEOMETRY_FACTORY.createPoint(new Coordinate(22.308919, 113.914603));
-        p2 = GEOMETRY_FACTORY.createPoint(new Coordinate(-33.946111, 151.177222));
+        p1 = GEOMETRY_FACTORY.createPoint(new Coordinate(113.914603, 22.308919));
+        p2 = GEOMETRY_FACTORY.createPoint(new Coordinate(151.177222, -33.946111));
         assertEquals(7371809.8295041, Spheroid.distance(p1, p2), 0.1);
 
         // HK to Toronto
-        p1 = GEOMETRY_FACTORY.createPoint(new Coordinate(22.308919, 113.914603));
-        p2 = GEOMETRY_FACTORY.createPoint(new Coordinate(43.677223, -79.630556));
+        p1 = GEOMETRY_FACTORY.createPoint(new Coordinate(113.914603, 22.308919));
+        p2 = GEOMETRY_FACTORY.createPoint(new Coordinate(-79.630556, 43.677223));
         assertEquals(1.2568775317073349E7, Spheroid.distance(p1, p2), 0.1);
     }
 
     @Test
     public void spheroidArea() {
-        Point point = GEOMETRY_FACTORY.createPoint(new Coordinate(0, 90));
+        Point point = GEOMETRY_FACTORY.createPoint(new Coordinate(90, 0));
         assertEquals(0, Spheroid.area(point), 0.1);
 
         LineString line = GEOMETRY_FACTORY.createLineString(coordArray(0, 0, 0, 90));
         assertEquals(0, Spheroid.area(line), 0.1);
+        line = GEOMETRY_FACTORY.createLineString(coordArray(0, 0, 90, 0));
+        assertEquals(0, Spheroid.area(line), 0.1);
 
         Polygon polygon1 = GEOMETRY_FACTORY.createPolygon(coordArray(0, 0, 0, 90, 0, 0));
         assertEquals(0, Spheroid.area(polygon1), 0.1);
+        polygon1 = GEOMETRY_FACTORY.createPolygon(coordArray(0, 0, 90, 0, 0, 0));
+        assertEquals(0, Spheroid.area(polygon1), 0.1);
 
-        Polygon polygon2 = GEOMETRY_FACTORY.createPolygon(coordArray(35, 34, 30, 28, 34, 25, 35, 34));
+        Polygon polygon2 = GEOMETRY_FACTORY.createPolygon(coordArray(34, 35, 28, 30, 25, 34, 34, 35));
         assertEquals(2.0182485081176245E11, Spheroid.area(polygon2), 0.1);
 
-        Polygon polygon3 = GEOMETRY_FACTORY.createPolygon(coordArray(35, 34, 34, 25, 30, 28, 35, 34));
+        Polygon polygon3 = GEOMETRY_FACTORY.createPolygon(coordArray(34, 35, 25, 34, 28, 30, 34, 35));
         assertEquals(2.0182485081176245E11, Spheroid.area(polygon3), 0.1);
 
         MultiPoint multiPoint = GEOMETRY_FACTORY.createMultiPoint(new Point[] { point, point });
@@ -724,13 +732,13 @@ public class FunctionsTest {
 
     @Test
     public void spheroidLength() {
-        Point point = GEOMETRY_FACTORY.createPoint(new Coordinate(0, 90));
+        Point point = GEOMETRY_FACTORY.createPoint(new Coordinate(90, 0));
         assertEquals(0, Spheroid.length(point), 0.1);
 
-        LineString line = GEOMETRY_FACTORY.createLineString(coordArray(0, 0, 0, 90));
+        LineString line = GEOMETRY_FACTORY.createLineString(coordArray(0, 0, 90, 0));
         assertEquals(1.0018754171394622E7, Spheroid.length(line), 0.1);
 
-        Polygon polygon = GEOMETRY_FACTORY.createPolygon(coordArray(0, 0, 0, 90, 0, 0));
+        Polygon polygon = GEOMETRY_FACTORY.createPolygon(coordArray(0, 0, 90, 0, 0, 0));
         assertEquals(2.0037508342789244E7, Spheroid.length(polygon), 0.1);
 
         MultiPoint multiPoint = GEOMETRY_FACTORY.createMultiPoint(new Point[] { point, point });

--- a/docs/api/flink/Function.md
+++ b/docs/api/flink/Function.md
@@ -225,7 +225,10 @@ Output:
 
 Introduction: Return the geodesic area of A using WGS84 spheroid. Unit is meter. Works better for large geometries (country level) compared to `ST_Area` + `ST_Transform`. It is equivalent to PostGIS `ST_Area(geography, use_spheroid=true)` function and produces nearly identical results.
 
-Geometry must be in EPSG:4326 (WGS84) projection and must be in ==lat/lon== order. You can use ==ST_FlipCoordinates== to swap lat and lon.
+Geometry must be in EPSG:4326 (WGS84) projection and must be in ==lon/lat== order. You can use ==ST_FlipCoordinates== to swap lat and lon.
+
+!!!note
+    By default, this function uses lon/lat order since `v1.5.0`. Before, it used lat/lon order.
 
 Format: `ST_AreaSpheroid (A:geometry)`
 
@@ -234,7 +237,7 @@ Since: `v1.4.1`
 Example:
 
 ```sql
-SELECT ST_AreaSpheroid(ST_GeomFromWKT('Polygon ((35 34, 30 28, 34 25, 35 34))'))
+SELECT ST_AreaSpheroid(ST_GeomFromWKT('Polygon ((34 35, 28 30, 25 34, 34 35))'))
 ```
 
 Output: 
@@ -808,7 +811,10 @@ Output:
 
 Introduction: Return the haversine / great-circle distance of A using a given earth radius (default radius: 6371008.0). Unit is meter. Works better for large geometries (country level) compared to `ST_Distance` + `ST_Transform`. It is equivalent to PostGIS `ST_Distance(geography, use_spheroid=false)` and `ST_DistanceSphere` function and produces nearly identical results. It provides faster but less accurate result compared to `ST_DistanceSpheroid`.
 
-Geometry must be in EPSG:4326 (WGS84) projection and must be in lat/lon order. You can use ==ST_FlipCoordinates== to swap lat and lon. For non-point data, we first take the centroids of both geometries and then compute the distance.
+Geometry must be in EPSG:4326 (WGS84) projection and must be in ==lon/lat== order. You can use ==ST_FlipCoordinates== to swap lat and lon. For non-point data, we first take the centroids of both geometries and then compute the distance.
+
+!!!note
+    By default, this function uses lon/lat order since `v1.5.0`. Before, it used lat/lon order.
 
 Format: `ST_DistanceSphere (A:geometry)`
 
@@ -817,7 +823,7 @@ Since: `v1.4.1`
 Example 1:
 
 ```sql
-SELECT ST_DistanceSphere(ST_GeomFromWKT('POINT (51.3168 -0.56)'), ST_GeomFromWKT('POINT (55.9533 -3.1883)'))
+SELECT ST_DistanceSphere(ST_GeomFromWKT('POINT (-0.56 51.3168)'), ST_GeomFromWKT('POINT (-3.1883 55.9533)'))
 ```
 
 Output: 
@@ -829,7 +835,7 @@ Output:
 Example 2:
 
 ```sql
-SELECT ST_DistanceSphere(ST_GeomFromWKT('POINT (51.3168 -0.56)'), ST_GeomFromWKT('POINT (55.9533 -3.1883)'), 6378137.0)
+SELECT ST_DistanceSphere(ST_GeomFromWKT('POINT (-0.56 51.3168)'), ST_GeomFromWKT('POINT (-3.1883 55.9533)'), 6378137.0)
 ```
 
 Output: 
@@ -842,7 +848,10 @@ Output:
 
 Introduction: Return the geodesic distance of A using WGS84 spheroid. Unit is meter. Works better for large geometries (country level) compared to `ST_Distance` + `ST_Transform`. It is equivalent to PostGIS `ST_Distance(geography, use_spheroid=true)` and `ST_DistanceSpheroid` function and produces nearly identical results. It provides slower but more accurate result compared to `ST_DistanceSphere`.
 
-Geometry must be in EPSG:4326 (WGS84) projection and must be in ==lat/lon== order. You can use ==ST_FlipCoordinates== to swap lat and lon. For non-point data, we first take the centroids of both geometries and then compute the distance.
+Geometry must be in EPSG:4326 (WGS84) projection and must be in ==lon/lat== order. You can use ==ST_FlipCoordinates== to swap lat and lon. For non-point data, we first take the centroids of both geometries and then compute the distance.
+
+!!!note
+    By default, this function uses lon/lat order since `v1.5.0`. Before, it used lat/lon order.
 
 Format: `ST_DistanceSpheroid (A:geometry)`
 
@@ -851,7 +860,7 @@ Since: `v1.4.1`
 Example:
 
 ```sql
-SELECT ST_DistanceSpheroid(ST_GeomFromWKT('POINT (51.3168 -0.56)'), ST_GeomFromWKT('POINT (55.9533 -3.1883)'))
+SELECT ST_DistanceSpheroid(ST_GeomFromWKT('POINT (-0.56 51.3168)'), ST_GeomFromWKT('POINT (-3.1883 55.9533)'))
 ```
 
 Output: 
@@ -1452,7 +1461,10 @@ Output:
 
 Introduction: Return the geodesic perimeter of A using WGS84 spheroid. Unit is meter. Works better for large geometries (country level) compared to `ST_Length` + `ST_Transform`. It is equivalent to PostGIS `ST_Length(geography, use_spheroid=true)` and `ST_LengthSpheroid` function and produces nearly identical results.
 
-Geometry must be in EPSG:4326 (WGS84) projection and must be in ==lat/lon== order. You can use ==ST_FlipCoordinates== to swap lat and lon.
+Geometry must be in EPSG:4326 (WGS84) projection and must be in ==lon/lat== order. You can use ==ST_FlipCoordinates== to swap lat and lon.
+
+!!!note
+    By default, this function uses lon/lat order since `v1.5.0`. Before, it used lat/lon order.
 
 Format: `ST_LengthSpheroid (A:geometry)`
 
@@ -1461,7 +1473,7 @@ Since: `v1.4.1`
 Example:
 
 ```sql
-SELECT ST_LengthSpheroid(ST_GeomFromWKT('Polygon ((0 0, 0 90, 0 0))'))
+SELECT ST_LengthSpheroid(ST_GeomFromWKT('Polygon ((0 0, 90 0, 0 0))'))
 ```
 
 Output: 

--- a/docs/api/sql/Function.md
+++ b/docs/api/sql/Function.md
@@ -219,7 +219,10 @@ Output:
 
 Introduction: Return the geodesic area of A using WGS84 spheroid. Unit is square meter. Works better for large geometries (country level) compared to `ST_Area` + `ST_Transform`. It is equivalent to PostGIS `ST_Area(geography, use_spheroid=true)` function and produces nearly identical results.
 
-Geometry must be in EPSG:4326 (WGS84) projection and must be in ==lat/lon== order. You can use ==ST_FlipCoordinates== to swap lat and lon.
+Geometry must be in EPSG:4326 (WGS84) projection and must be in ==lon/lat== order. You can use ==ST_FlipCoordinates== to swap lat and lon.
+
+!!!note
+    By default, this function uses lon/lat order since `v1.5.0`. Before, it used lat/lon order.
 
 Format: `ST_AreaSpheroid (A:geometry)`
 
@@ -228,7 +231,7 @@ Since: `v1.4.1`
 Spark SQL example:
 
 ```sql
-SELECT ST_AreaSpheroid(ST_GeomFromWKT('Polygon ((35 34, 30 28, 34 25, 35 34))'))
+SELECT ST_AreaSpheroid(ST_GeomFromWKT('Polygon ((34 35, 28 30, 25 34, 34 35))'))
 ```
 
 Output: 
@@ -856,7 +859,10 @@ Output:
 
 Introduction: Return the haversine / great-circle distance of A using a given earth radius (default radius: 6371008.0). Unit is meter. Compared to `ST_Distance` + `ST_Transform`, it works better for datasets that cover large regions such as continents or the entire planet. It is equivalent to PostGIS `ST_Distance(geography, use_spheroid=false)` and `ST_DistanceSphere` function and produces nearly identical results. It provides faster but less accurate result compared to `ST_DistanceSpheroid`.
 
-Geometry must be in EPSG:4326 (WGS84) projection and must be in ==lat/lon== order. You can use ==ST_FlipCoordinates== to swap lat and lon. For non-point data, we first take the centroids of both geometries and then compute the distance.
+Geometry must be in EPSG:4326 (WGS84) projection and must be in ==lon/lat== order. You can use ==ST_FlipCoordinates== to swap lat and lon. For non-point data, we first take the centroids of both geometries and then compute the distance.
+
+!!!note
+    By default, this function uses lon/lat order since `v1.5.0`. Before, it used lat/lon order.
 
 Format: `ST_DistanceSphere (A:geometry)`
 
@@ -865,7 +871,7 @@ Since: `v1.4.1`
 Spark SQL example 1:
 
 ```sql
-SELECT ST_DistanceSphere(ST_GeomFromWKT('POINT (51.3168 -0.56)'), ST_GeomFromWKT('POINT (55.9533 -3.1883)'))
+SELECT ST_DistanceSphere(ST_GeomFromWKT('POINT (-0.56 51.3168)'), ST_GeomFromWKT('POINT (-3.1883 55.9533)'))
 ```
 
 Output: 
@@ -877,7 +883,7 @@ Output:
 Spark SQL example 2:
 
 ```sql
-SELECT ST_DistanceSphere(ST_GeomFromWKT('POINT (51.3168 -0.56)'), ST_GeomFromWKT('POINT (55.9533 -3.1883)'), 6378137.0)
+SELECT ST_DistanceSphere(ST_GeomFromWKT('POINT (-0.56 51.3168)'), ST_GeomFromWKT('POINT (-3.1883 55.9533)'), 6378137.0)
 ```
 
 Output: 
@@ -891,7 +897,10 @@ Output:
 
 Introduction: Return the geodesic distance of A using WGS84 spheroid. Unit is meter. Compared to `ST_Distance` + `ST_Transform`, it works better for datasets that cover large regions such as continents or the entire planet. It is equivalent to PostGIS `ST_Distance(geography, use_spheroid=true)` and `ST_DistanceSpheroid` function and produces nearly identical results. It provides slower but more accurate result compared to `ST_DistanceSphere`.
 
-Geometry must be in EPSG:4326 (WGS84) projection and must be in ==lat/lon== order. You can use ==ST_FlipCoordinates== to swap lat and lon. For non-point data, we first take the centroids of both geometries and then compute the distance.
+Geometry must be in EPSG:4326 (WGS84) projection and must be in ==lon/lat== order. You can use ==ST_FlipCoordinates== to swap lat and lon. For non-point data, we first take the centroids of both geometries and then compute the distance.
+
+!!!note
+    By default, this function uses lon/lat order since `v1.5.0`. Before, it used lat/lon order.
 
 Format: `ST_DistanceSpheroid (A:geometry)`
 
@@ -900,7 +909,7 @@ Since: `v1.4.1`
 Spark SQL example:
 
 ```sql
-SELECT ST_DistanceSpheroid(ST_GeomFromWKT('POINT (51.3168 -0.56)'), ST_GeomFromWKT('POINT (55.9533 -3.1883)'))
+SELECT ST_DistanceSpheroid(ST_GeomFromWKT('POINT (-0.56 51.3168)'), ST_GeomFromWKT('POINT (-3.1883 55.9533)'))
 ```
 
 Output: 
@@ -1459,7 +1468,10 @@ Output:
 
 Introduction: Return the geodesic perimeter of A using WGS84 spheroid. Unit is meter. Works better for large geometries (country level) compared to `ST_Length` + `ST_Transform`. It is equivalent to PostGIS `ST_Length(geography, use_spheroid=true)` and `ST_LengthSpheroid` function and produces nearly identical results.
 
-Geometry must be in EPSG:4326 (WGS84) projection and must be in ==lat/lon== order. You can use ==ST_FlipCoordinates== to swap lat and lon.
+Geometry must be in EPSG:4326 (WGS84) projection and must be in ==lon/lat== order. You can use ==ST_FlipCoordinates== to swap lat and lon.
+
+!!!note
+    By default, this function uses lon/lat order since `v1.5.0`. Before, it used lat/lon order.
 
 Format: `ST_LengthSpheroid (A:geometry)`
 
@@ -1468,7 +1480,7 @@ Since: `v1.4.1`
 Spark SQL example:
 
 ```sql
-SELECT ST_LengthSpheroid(ST_GeomFromWKT('Polygon ((0 0, 0 90, 0 0))'))
+SELECT ST_LengthSpheroid(ST_GeomFromWKT('Polygon ((0 0, 90 0, 0 0))'))
 ```
 
 Output: 

--- a/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
@@ -59,7 +59,7 @@ public class FunctionTest extends TestBase{
     @Test
     public void testAreaSpheroid() {
         Table tbl = tableEnv.sqlQuery(
-                "SELECT ST_AreaSpheroid(ST_GeomFromWKT('Polygon ((35 34, 30 28, 34 25, 35 34))'))");
+                "SELECT ST_AreaSpheroid(ST_GeomFromWKT('Polygon ((34 35, 28 30, 25 34, 34 35))'))");
         Double expected = 201824850811.76245;
         Double actual = (Double) first(tbl).getField(0);
         assertEquals(expected, actual, 0.1);
@@ -276,7 +276,7 @@ public class FunctionTest extends TestBase{
     @Test
     public void testDistanceSpheroid() {
         Table tbl = tableEnv.sqlQuery(
-                "SELECT ST_DistanceSpheroid(ST_GeomFromWKT('POINT (51.3168 -0.56)'), ST_GeomFromWKT('POINT (55.9533 -3.1883)'))");
+                "SELECT ST_DistanceSpheroid(ST_GeomFromWKT('POINT (-0.56 51.3168)'), ST_GeomFromWKT('POINT (-3.1883 55.9533)'))");
         Double expected = 544430.9411996207;
         Double actual = (Double) first(tbl).getField(0);
         assertEquals(expected, actual, 0.1);
@@ -285,7 +285,7 @@ public class FunctionTest extends TestBase{
     @Test
     public void testDistanceSphere() {
         Table tbl = tableEnv.sqlQuery(
-                "SELECT ST_DistanceSphere(ST_GeomFromWKT('POINT (51.3168 -0.56)'), ST_GeomFromWKT('POINT (55.9533 -3.1883)'))");
+                "SELECT ST_DistanceSphere(ST_GeomFromWKT('POINT (-0.56 51.3168)'), ST_GeomFromWKT('POINT (-3.1883 55.9533)'))");
         Double expected = 543796.9506134904;
         Double actual = (Double) first(tbl).getField(0);
         assertEquals(expected, actual, 0.1);
@@ -294,7 +294,7 @@ public class FunctionTest extends TestBase{
     @Test
     public void testDistanceSphereWithRadius() {
         Table tbl = tableEnv.sqlQuery(
-                "SELECT ST_DistanceSphere(ST_GeomFromWKT('POINT (51.3168 -0.56)'), ST_GeomFromWKT('POINT (55.9533 -3.1883)'), 6378137.0)");
+                "SELECT ST_DistanceSphere(ST_GeomFromWKT('POINT (-0.56 51.3168)'), ST_GeomFromWKT('POINT (-3.1883 55.9533)'), 6378137.0)");
         Double expected = 544405.4459192449;
         Double actual = (Double) first(tbl).getField(0);
         assertEquals(expected, actual, 0.1);
@@ -327,7 +327,7 @@ public class FunctionTest extends TestBase{
     @Test
     public void testLengthSpheroid() {
         Table tbl = tableEnv.sqlQuery(
-                "SELECT ST_LengthSpheroid(ST_GeomFromWKT('Polygon ((0 0, 0 90, 0 0))'))");
+                "SELECT ST_LengthSpheroid(ST_GeomFromWKT('Polygon ((0 0, 90 0, 0 0))'))");
         Double expected = 20037508.342789244;
         Double actual = (Double) first(tbl).getField(0);
         assertEquals(expected, actual, 0.1);

--- a/sql/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/JoinedGeometry.scala
+++ b/sql/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/JoinedGeometry.scala
@@ -51,7 +51,7 @@ object JoinedGeometry {
   private def expandEnvelope(envelope: Envelope, distance: Double, sphereRadius: Double, isGeography: Boolean): Unit = {
     if (isGeography) {
       val scaleFactor = 1.1 // 10% buffer to get rid of false negatives
-      val latRadian = Math.toRadians((envelope.getMinX + envelope.getMaxX) / 2.0)
+      val latRadian = Math.toRadians((envelope.getMinY + envelope.getMaxY) / 2.0)
       val latDeltaRadian = distance / sphereRadius;
       val latDeltaDegree = Math.toDegrees(latDeltaRadian)
       val lonDeltaRadian = Math.max(Math.abs(distance / (sphereRadius * Math.cos(latRadian + latDeltaRadian))),

--- a/sql/common/src/test/scala/org/apache/sedona/sql/BroadcastIndexJoinSuite.scala
+++ b/sql/common/src/test/scala/org/apache/sedona/sql/BroadcastIndexJoinSuite.scala
@@ -308,7 +308,7 @@ class BroadcastIndexJoinSuite extends TestBaseScala {
       val sampleCount = 50
       distanceCandidates.foreach(distance => {
         val expected = bruteForceDistanceJoinCountSpheroid(sampleCount, distance)
-        val pointDf1 = buildPointDf.limit(sampleCount).repartition(4)
+        val pointDf1 = buildPointLonLatDf.limit(sampleCount).repartition(4)
         val pointDf2 = pointDf1
         var distanceJoinDf = pointDf1.alias("pointDf1").join(
           broadcast(pointDf2).alias("pointDf2"), expr(s"ST_DistanceSpheroid(pointDf1.pointshape, pointDf2.pointshape) <= $distance"))
@@ -332,7 +332,7 @@ class BroadcastIndexJoinSuite extends TestBaseScala {
       val sampleCount = 50
       distanceCandidates.foreach(distance => {
         val expected = bruteForceDistanceJoinCountSphere(sampleCount, distance)
-        val pointDf1 = buildPointDf.limit(sampleCount).repartition(4)
+        val pointDf1 = buildPointLonLatDf.limit(sampleCount).repartition(4)
         val pointDf2 = pointDf1
         var distanceJoinDf = pointDf1.alias("pointDf1").join(
           broadcast(pointDf2).alias("pointDf2"), expr(s"ST_DistanceSphere(pointDf1.pointshape, pointDf2.pointshape) <= $distance"))

--- a/sql/common/src/test/scala/org/apache/sedona/sql/TestBaseScala.scala
+++ b/sql/common/src/test/scala/org/apache/sedona/sql/TestBaseScala.scala
@@ -93,6 +93,7 @@ trait TestBaseScala extends FunSpec with BeforeAndAfterAll {
   }
 
   lazy val buildPointDf = loadCsv(csvPointInputLocation).selectExpr("ST_Point(cast(_c0 as Decimal(24,20)),cast(_c1 as Decimal(24,20))) as pointshape")
+  lazy val buildPointLonLatDf = loadCsv(csvPointInputLocation).selectExpr("ST_Point(cast(_c1 as Decimal(24,20)),cast(_c0 as Decimal(24,20))) as pointshape")
   lazy val buildPolygonDf = loadCsv(csvPolygonInputLocation).selectExpr("ST_PolygonFromEnvelope(cast(_c0 as Decimal(24,20)),cast(_c1 as Decimal(24,20)), cast(_c2 as Decimal(24,20)), cast(_c3 as Decimal(24,20))) as polygonshape")
   lazy val buildRasterDf = loadGeoTiff(rasterDataLocation).selectExpr("RS_FromGeoTiff(content) as raster")
   lazy val buildBuildingsDf = loadCsvWithHeader(buildingDataLocation).selectExpr("ST_GeomFromWKT(geometry) as building")
@@ -112,7 +113,7 @@ trait TestBaseScala extends FunSpec with BeforeAndAfterAll {
   }
 
   protected def bruteForceDistanceJoinCountSpheroid(sampleCount:Int, distance: Double): Int = {
-    val input = buildPointDf.limit(sampleCount).collect()
+    val input = buildPointLonLatDf.limit(sampleCount).collect()
     input.map(row => {
       val point1 = row.getAs[org.locationtech.jts.geom.Point](0)
       input.map(row => {
@@ -123,7 +124,7 @@ trait TestBaseScala extends FunSpec with BeforeAndAfterAll {
   }
 
   protected def bruteForceDistanceJoinCountSphere(sampleCount: Int, distance: Double): Int = {
-    val input = buildPointDf.limit(sampleCount).collect()
+    val input = buildPointLonLatDf.limit(sampleCount).collect()
     input.map(row => {
       val point1 = row.getAs[org.locationtech.jts.geom.Point](0)
       input.map(row => {

--- a/sql/common/src/test/scala/org/apache/sedona/sql/dataFrameAPITestScala.scala
+++ b/sql/common/src/test/scala/org/apache/sedona/sql/dataFrameAPITestScala.scala
@@ -963,7 +963,7 @@ class dataFrameAPITestScala extends TestBaseScala {
     }
 
     it("Passed ST_DistanceSphere") {
-      val baseDf = sparkSession.sql("SELECT ST_GeomFromWKT('POINT (0 0)') AS geom1, ST_GeomFromWKT('POINT (0 90)') AS geom2")
+      val baseDf = sparkSession.sql("SELECT ST_GeomFromWKT('POINT (0 0)') AS geom1, ST_GeomFromWKT('POINT (90 0)') AS geom2")
       var df = baseDf.select(ST_DistanceSphere("geom1", "geom2"))
       var actualResult = df.take(1)(0).getDouble(0)
       var expectedResult = 1.00075559643809E7
@@ -976,7 +976,7 @@ class dataFrameAPITestScala extends TestBaseScala {
     }
 
     it("Passed ST_DistanceSpheroid") {
-      val baseDf = sparkSession.sql("SELECT ST_GeomFromWKT('POINT (0 0)') AS geom1, ST_GeomFromWKT('POINT (0 90)') AS geom2")
+      val baseDf = sparkSession.sql("SELECT ST_GeomFromWKT('POINT (0 0)') AS geom1, ST_GeomFromWKT('POINT (90 0)') AS geom2")
       val df = baseDf.select(ST_DistanceSpheroid("geom1", "geom2"))
       val actualResult = df.take(1)(0).getDouble(0)
       val expectedResult = 10018754.171394622
@@ -984,7 +984,7 @@ class dataFrameAPITestScala extends TestBaseScala {
     }
 
     it("Passed ST_AreaSpheroid") {
-      val baseDf = sparkSession.sql("SELECT ST_GeomFromWKT('Polygon ((35 34, 30 28, 34 25, 35 34))') AS geom")
+      val baseDf = sparkSession.sql("SELECT ST_GeomFromWKT('Polygon ((34 35, 28 30, 25 34, 34 35))') AS geom")
       val df = baseDf.select(ST_AreaSpheroid("geom"))
       val actualResult = df.take(1)(0).getDouble(0)
       val expectedResult = 201824850811.76245
@@ -992,7 +992,7 @@ class dataFrameAPITestScala extends TestBaseScala {
     }
 
     it("Passed ST_LengthSpheroid") {
-      val baseDf = sparkSession.sql("SELECT ST_GeomFromWKT('LineString (0 0, 0 90)') AS geom")
+      val baseDf = sparkSession.sql("SELECT ST_GeomFromWKT('LineString (0 0, 90 0)') AS geom")
       val df = baseDf.select(ST_LengthSpheroid("geom"))
       val actualResult = df.take(1)(0).getDouble(0)
       val expectedResult = 10018754.171394622

--- a/sql/common/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
+++ b/sql/common/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
@@ -1884,8 +1884,8 @@ class functionTestScala extends TestBaseScala with Matchers with GeometrySample 
 
   it("Should pass ST_DistanceSphere") {
     val geomTestCases = Map(
-      ("'POINT (51.3168 -0.56)'", "'POINT (55.9533 -3.1883)'") -> "543796.9506134904",
-      ("'LineString (0 0, 0 90)'", "'LineString (0 1, 0 0)'") -> "4948180.449055"
+      ("'POINT (-0.56 51.3168)'", "'POINT (-3.1883 55.9533)'") -> "543796.9506134904",
+      ("'LineString (0 0, 90 0)'", "'LineString (1 0, 0 0)'") -> "4948180.449055"
     )
     for (((geom1, geom2), expectedResult) <- geomTestCases) {
       val df = sparkSession.sql(s"SELECT ST_DistanceSphere(ST_GeomFromWKT($geom1), ST_GeomFromWKT($geom2)), " +
@@ -1896,8 +1896,8 @@ class functionTestScala extends TestBaseScala with Matchers with GeometrySample 
     }
 
     val geomTestCases2 = Map(
-      ("'POINT (51.3168 -0.56)'", "'POINT (55.9533 -3.1883)'", "6378137") -> "544405.4459192449",
-      ("'LineString (0 0, 0 90)'", "'LineString (0 1, 0 0)'", "6378137.0") -> "4953717.340300673"
+      ("'POINT (-0.56 51.3168)'", "'POINT (-3.1883 55.9533)'", "6378137") -> "544405.4459192449",
+      ("'LineString (0 0, 90 0)'", "'LineString (1 0, 0 0)'", "6378137.0") -> "4953717.340300673"
     )
     for (((geom1, geom2, radius), expectedResult) <- geomTestCases2) {
       val df = sparkSession.sql(s"SELECT ST_DistanceSphere(ST_GeomFromWKT($geom1), ST_GeomFromWKT($geom2), $radius), " +
@@ -1910,8 +1910,8 @@ class functionTestScala extends TestBaseScala with Matchers with GeometrySample 
 
   it("Should pass ST_DistanceSpheroid") {
     val geomTestCases = Map(
-      ("'POINT (51.3168 -0.56)'", "'POINT (55.9533 -3.1883)'") -> "544430.94119962039",
-      ("'LineString (0 0, 0 90)'", "'LineString (0 1, 0 0)'") -> "4953717.340300673"
+      ("'POINT (-0.56 51.3168)'", "'POINT (-3.1883 55.9533)'") -> "544430.94119962039",
+      ("'LineString (0 0, 90 0)'", "'LineString (1 0, 0 0)'") -> "4953717.340300673"
     )
     for (((geom1, geom2), expectedResult) <- geomTestCases) {
       val df = sparkSession.sql(s"SELECT ST_DistanceSpheroid(ST_GeomFromWKT($geom1), ST_GeomFromWKT($geom2)), " +
@@ -1940,9 +1940,9 @@ class functionTestScala extends TestBaseScala with Matchers with GeometrySample 
 
   it("Should pass ST_AreaSpheroid") {
     val geomTestCases = Map(
-      ("'POINT (51.3168 -0.56)'") -> "0.0",
-      ("'LineString (0 0, 0 90)'") -> "0.0",
-      ("'Polygon ((35 34, 30 28, 34 25, 35 34))'") -> "201824850811.76245"
+      ("'POINT (-0.56 51.3168)'") -> "0.0",
+      ("'LineString (0 0, 90 0)'") -> "0.0",
+      ("'Polygon ((34 35, 28 30, 25 34, 34 35))'") -> "201824850811.76245"
     )
     for (((geom1), expectedResult) <- geomTestCases) {
       val df = sparkSession.sql(s"SELECT ST_AreaSpheroid(ST_GeomFromWKT($geom1)), " +
@@ -1955,9 +1955,9 @@ class functionTestScala extends TestBaseScala with Matchers with GeometrySample 
 
   it("Should pass ST_LengthSpheroid") {
     val geomTestCases = Map(
-      ("'POINT (51.3168 -0.56)'") -> "0.0",
-      ("'LineString (0 0, 0 90)'") -> "10018754.17139462",
-      ("'Polygon ((0 0, 0 90, 0 0))'") -> "20037508.34278924"
+      ("'POINT (-0.56 51.3168)'") -> "0.0",
+      ("'LineString (0 0, 90 0)'") -> "10018754.17139462",
+      ("'Polygon ((0 0, 90 0, 0 0))'") -> "20037508.34278924"
     )
     for (((geom1), expectedResult) <- geomTestCases) {
       val df = sparkSession.sql(s"SELECT ST_LengthSpheroid(ST_GeomFromWKT($geom1)), " +

--- a/sql/common/src/test/scala/org/apache/sedona/sql/predicateJoinTestScala.scala
+++ b/sql/common/src/test/scala/org/apache/sedona/sql/predicateJoinTestScala.scala
@@ -414,7 +414,7 @@ class predicateJoinTestScala extends TestBaseScala {
       val sampleCount = 50
       distanceCandidates.foreach(distance => {
         val expected = bruteForceDistanceJoinCountSpheroid(sampleCount, distance)
-        val pointDf1 = buildPointDf.limit(sampleCount).repartition(4)
+        val pointDf1 = buildPointLonLatDf.limit(sampleCount).repartition(4)
         val pointDf2 = pointDf1
         var distanceJoinDf = pointDf1.alias("pointDf1").join(
           pointDf2.alias("pointDf2"), expr(s"ST_DistanceSpheroid(pointDf1.pointshape, pointDf2.pointshape) <= $distance"))
@@ -433,7 +433,7 @@ class predicateJoinTestScala extends TestBaseScala {
       val sampleCount = 50
       distanceCandidates.foreach(distance => {
         val expected = bruteForceDistanceJoinCountSphere(sampleCount, distance)
-        val pointDf1 = buildPointDf.limit(sampleCount).repartition(4)
+        val pointDf1 = buildPointLonLatDf.limit(sampleCount).repartition(4)
         val pointDf2 = pointDf1
         var distanceJoinDf = pointDf1.alias("pointDf1").join(
           pointDf2.alias("pointDf2"), expr(s"ST_DistanceSphere(pointDf1.pointshape, pointDf2.pointshape) <= $distance"))


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-377. The PR name follows the format `[SEDONA-XXX] my subject`.


## What changes were proposed in this PR?

This PR changes the following functions to accept geometries with WGS84 coordinates in lon/lat order:

* ST_DistanceSphere
* ST_DistanceSpheroid
* ST_AreaSpheroid
* ST_LengthSpheroid

## How was this patch tested?

Changed existing unit tests

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation update.

