### PR TITLE
[SEDONA-371] Fix a bug handling geometries with northing-easting CRS in raster-geometry join

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/FunctionsGeoTools.java
+++ b/common/src/main/java/org/apache/sedona/common/FunctionsGeoTools.java
@@ -84,6 +84,19 @@ public class FunctionsGeoTools {
         else return geometry;
     }
 
+    /**
+     * Decode SRID to CRS, forcing axis order to be lon/lat
+     * @param srid SRID
+     * @return CoordinateReferenceSystem object
+     */
+    public static CoordinateReferenceSystem sridToCRS(int srid) {
+        try {
+            return CRS.decode("EPSG:" + srid, true);
+        } catch (FactoryException e) {
+            throw new IllegalArgumentException("Cannot decode SRID " + srid, e);
+        }
+    }
+
     private static CoordinateReferenceSystem parseCRSString(String CRSString)
             throws FactoryException
     {

--- a/common/src/main/java/org/apache/sedona/common/raster/RasterConstructors.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterConstructors.java
@@ -13,6 +13,7 @@
  */
 package org.apache.sedona.common.raster;
 
+import org.apache.sedona.common.FunctionsGeoTools;
 import org.apache.sedona.common.raster.inputstream.ByteArrayImageInputStream;
 import org.apache.sedona.common.utils.RasterUtils;
 import org.geotools.coverage.grid.GridCoverage2D;
@@ -20,7 +21,6 @@ import org.geotools.coverage.grid.GridEnvelope2D;
 import org.geotools.coverage.grid.GridGeometry2D;
 import org.geotools.gce.arcgrid.ArcGridReader;
 import org.geotools.gce.geotiff.GeoTiffReader;
-import org.geotools.referencing.CRS;
 import org.geotools.referencing.crs.DefaultEngineeringCRS;
 import org.geotools.referencing.operation.transform.AffineTransform2D;
 import org.geotools.util.factory.Hints;
@@ -136,7 +136,7 @@ public class RasterConstructors
         } else {
             // Create the CRS from the srid
             // Longitude first, Latitude second
-            crs = CRS.decode("EPSG:" + srid, true);
+            crs = FunctionsGeoTools.sridToCRS(srid);
         }
 
         // Create a new empty raster

--- a/common/src/main/java/org/apache/sedona/common/raster/RasterEditors.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterEditors.java
@@ -18,18 +18,17 @@
  */
 package org.apache.sedona.common.raster;
 
+import org.apache.sedona.common.FunctionsGeoTools;
 import org.apache.sedona.common.utils.RasterUtils;
 import org.geotools.coverage.CoverageFactoryFinder;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.coverage.grid.GridCoverageFactory;
 import org.geotools.coverage.grid.GridEnvelope2D;
 import org.geotools.coverage.grid.GridGeometry2D;
-import org.geotools.referencing.CRS;
 import org.geotools.referencing.crs.DefaultEngineeringCRS;
 import org.geotools.referencing.operation.transform.AffineTransform2D;
 import org.opengis.coverage.grid.GridCoverage;
 import org.opengis.metadata.spatial.PixelOrientation;
-import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.opengis.referencing.operation.MathTransform2D;
 
@@ -37,13 +36,13 @@ import java.util.Map;
 
 public class RasterEditors
 {
-    public static GridCoverage2D setSrid(GridCoverage2D raster, int srid) throws FactoryException
+    public static GridCoverage2D setSrid(GridCoverage2D raster, int srid)
     {
         CoordinateReferenceSystem crs;
         if (srid == 0) {
             crs = DefaultEngineeringCRS.GENERIC_2D;
         } else {
-            crs = CRS.decode("EPSG:" + srid, true);
+            crs = FunctionsGeoTools.sridToCRS(srid);
         }
 
         GridCoverageFactory gridCoverageFactory = CoverageFactoryFinder.getGridCoverageFactory(null);

--- a/common/src/main/java/org/apache/sedona/common/raster/RasterPredicates.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterPredicates.java
@@ -21,6 +21,7 @@ package org.apache.sedona.common.raster;
 import java.util.Set;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.sedona.common.FunctionsGeoTools;
 import org.apache.sedona.common.utils.GeomUtils;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.geometry.jts.JTS;
@@ -109,11 +110,7 @@ public class RasterPredicates {
         // CRS of the query window. We'll transform both sides to a common CRS (WGS84) before
         // testing for relationship.
         CoordinateReferenceSystem queryWindowCRS;
-        try {
-            queryWindowCRS = CRS.decode("EPSG:" + queryWindowSRID, true);
-        } catch (FactoryException e) {
-            throw new RuntimeException("Cannot decode SRID of geometry to CRS. SRID=" + queryWindowSRID, e);
-        }
+        queryWindowCRS = FunctionsGeoTools.sridToCRS(queryWindowSRID);
         Geometry transformedQueryWindow = transformGeometryToWGS84(queryWindow, queryWindowCRS);
 
         // Transform the raster envelope. Here we don't use the envelope transformation method

--- a/sql/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/JoinedGeometryRaster.scala
+++ b/sql/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/JoinedGeometryRaster.scala
@@ -18,6 +18,7 @@
  */
 package org.apache.spark.sql.sedona_sql.strategy.join
 
+import org.apache.sedona.common.FunctionsGeoTools
 import org.apache.sedona.common.utils.GeomUtils
 import org.geotools.coverage.grid.GridCoverage2D
 import org.geotools.geometry.Envelope2D
@@ -58,7 +59,7 @@ object JoinedGeometryRaster {
     } else {
       val env = geom.getEnvelopeInternal
       val envelope = new Envelope2D(null, env.getMinX, env.getMinY, env.getWidth, env.getHeight)
-      val crs = CRS.decode("EPSG:" + srid)
+      val crs = FunctionsGeoTools.sridToCRS(srid)
       transformToWGS84Envelope(envelope, crs)
     }
   }

--- a/sql/common/src/test/scala/org/apache/sedona/sql/RasterJoinSuite.scala
+++ b/sql/common/src/test/scala/org/apache/sedona/sql/RasterJoinSuite.scala
@@ -38,6 +38,8 @@ class RasterJoinSuite extends TestBaseScala with TableDrivenPropertyChecks {
     makeRaster(751, 742, 332385,4258815, 300, 32610),
     // China
     makeRaster(1098, 1098, 399960, 4100040, 100, 32649),
+    // Europe
+    makeRaster(100, 100, 5418900, 4440600, 1000, 3035),
     // Crossing the anti-meridian
     makeRaster(428, 419, 306210, 7840890, 600, 32601),
     // Covering the north pole
@@ -78,6 +80,11 @@ class RasterJoinSuite extends TestBaseScala with TableDrivenPropertyChecks {
         |460336.44393422664143145 4039658.63395863398909569,
         |365263.47518765379209071 4063668.33383210469037294))
         |""".stripMargin, 32649),
+
+    // Within the raster in Europe. EPSG:3035 is in northing/easting axis order.
+    makeGeometry("POINT (5484765 4366950)", 3035),
+    // The same point in WGS84 lon/lat order
+    makeGeometry("POINT (31.69291306160833 60.778101471493095)", 0),
 
     // Intersects with the raster crossing the anti-meridian
     makeGeometry(


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-371. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

There is a problem when generating envelopes for raster-geometry join: we did not enforce lon-lat axis order when retrieving the CRS of geometries. This makes the join produce incorrect results when there are geometries in CRS with northing-easting axis order, such as EPSG:3035.

We've also replaced calls to `CRS.decode` scattered in the code base with `FunctionsGeoTools.sridToCRS`, which handles axis order uniformly.

## How was this patch tested?

Add new data to `RasterJoinSuite` to fail the test without this patch.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
