### PR TITLE
[SEDONA-379] Fix bugs in RS_AsBase64

### DIFF
--- a/common/src/test/java/org/apache/sedona/common/raster/RasterOutputTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterOutputTest.java
@@ -33,6 +33,7 @@ public class RasterOutputTest
     public void testAsBase64() throws IOException {
         GridCoverage2D raster = rasterFromGeoTiff(resourceFolder + "raster/raster_with_no_data/test5.tiff");
         String resultRaw = RasterOutputs.asBase64(raster);
+        System.out.println(resultRaw);
         assertTrue(resultRaw.startsWith("iVBORw0KGgoAAAANSUhEUgAABaAAAALQCAMAAABR+ye1AAADAFBMVEXE9/W48vOq7PGa5u6L3"));
     }
 

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterOutputTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterOutputTest.java
@@ -26,13 +26,14 @@ import java.io.IOException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class RasterOutputTests extends RasterTestBase {
+public class RasterOutputTest
+        extends RasterTestBase {
 
     @Test
     public void testAsBase64() throws IOException {
-        GridCoverage2D raster = rasterFromGeoTiff(resourceFolder + "raster/test1.tiff");
+        GridCoverage2D raster = rasterFromGeoTiff(resourceFolder + "raster/raster_with_no_data/test5.tiff");
         String resultRaw = RasterOutputs.asBase64(raster);
-        assertTrue(resultRaw.contains("iVBORw0KGgoAAAANSUhEUgAAAgAAAAIFCAAAAACB3hqVAACAAElEQVR42uy9K5fkONil27Bh0oQBAwY1NDQ0NDU0NBQVFBQUFRQUFBQ1NDQ0NTT0PFtR1d/MmR9w1lnrVF8qKysjwtZ72/u9+Z9//v9f/6/96rvB9GPfz8M0jcMS/LJOxm7B2udcXHb5NGGb48rfeDM7s9jZzNO6uiX5aN28zPO62HBE/0Q7LXaa1vh5de/X8PN5r/MW3GSWeZqtd8lmH806O+esNUtI6xiPdfz/wCGZZU12Wv1qbVrn1YRgC3dicsq1zGF/nmePMT5P9ot3LnubSk4peu/K5cKz5BRnO2fr/HDXupdc8l7TlU5X9uPZzqf92mJMewmRbz1PiqkkZ8N9P257/OPXlHnP"));
+        assertTrue(resultRaw.startsWith("iVBORw0KGgoAAAANSUhEUgAABaAAAALQCAMAAABR+ye1AAADAFBMVEXE9/W48vOq7PGa5u6L3"));
     }
 
     @Test

--- a/docs/api/sql/Raster-writer.md
+++ b/docs/api/sql/Raster-writer.md
@@ -9,18 +9,18 @@ To write a Sedona Raster DataFrame to raster files, you need to (1) first conver
 
 You can use the following RS output functions (`RS_AsXXX`) to convert a Raster DataFrame to a binary DataFrame. Generally the output format of a raster can be different from the original input format. For example, you can use `RS_FromGeoTiff` to create rasters and save them using `RS_AsArcInfoAsciiGrid`.
 
-#### RS_Base64
+#### RS_AsBase64
 
-Introduction: Returns base64 encoded string of given raster.
+Introduction: Returns a base64 encoded string of the given raster. This function internally takes the first 4 bands as RGBA, and converts them to the PNG format, finally produces a base64 string. To visualize other bands, please use it together with `RS_Band`. You can take the resulting base64 string in [an online viewer](https://base64-viewer.onrender.com/) to check how the image looks like.
 
 Since: `v1.5.0`
 
-Format: `RS_Base64(raster: Raster)`
+Format: `RS_AsBase64(raster: Raster)`
 
 Spark SQL Example:
 
 ```sql
-SELECT RS_Base64(raster) from rasters
+SELECT RS_AsBase64(raster) from rasters
 ```
 
 Output:

--- a/docs/api/sql/Raster-writer.md
+++ b/docs/api/sql/Raster-writer.md
@@ -26,7 +26,7 @@ SELECT RS_Base64(raster) from rasters
 Output:
 
 ```
-data:image/png;base64,iVBORw0KGgoAAAA...
+iVBORw0KGgoAAAA...
 ```
 
 #### RS_AsGeoTiff

--- a/sql/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
+++ b/sql/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
@@ -211,7 +211,7 @@ object Catalog {
     function[RS_Intersects](),
     function[RS_AsGeoTiff](),
     function[RS_AsArcGrid](),
-    function[RS_Base64](),
+    function[RS_AsBase64](),
     function[RS_Width](),
     function[RS_Height](),
     function[RS_UpperLeftX](),

--- a/sql/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterOutputs.scala
+++ b/sql/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterOutputs.scala
@@ -39,7 +39,7 @@ case class RS_AsArcGrid(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_Base64(inputExpressions: Seq[Expression]) extends InferredExpression(RasterOutputs.asBase64 _) {
+case class RS_AsBase64(inputExpressions: Seq[Expression]) extends InferredExpression(RasterOutputs.asBase64 _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }

--- a/sql/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
+++ b/sql/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
@@ -470,9 +470,9 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
       assert(writtenBinary1.length > writtenBinary2.length)
     }
 
-    it("Passed RS_Base64") {
+    it("Passed RS_AsBase64") {
       val df = sparkSession.read.format("binaryFile").load(resourceFolder + "raster/raster_with_no_data/test5.tiff")
-      val resultRaw = df.selectExpr("RS_Base64(RS_FromGeoTiff(content)) as raster").first().getString(0)
+      val resultRaw = df.selectExpr("RS_AsBase64(RS_FromGeoTiff(content)) as raster").first().getString(0)
       assert(resultRaw.startsWith("iVBORw0KGgoAAAANSUhEUgAABaAAAALQCAMAAABR+ye1AAADAFBMVEXE9/W48vOq7PGa5u6L3"))
     }
 

--- a/sql/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
+++ b/sql/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
@@ -22,7 +22,7 @@ import org.apache.sedona.common.raster.MapAlgebra
 import org.apache.sedona.common.utils.RasterUtils
 import org.apache.spark.sql.functions.{collect_list, expr}
 import org.geotools.coverage.grid.GridCoverage2D
-import org.junit.Assert.{assertEquals, assertNull, assertTrue}
+import org.junit.Assert.{assertEquals, assertNull}
 import org.locationtech.jts.geom.{Coordinate, Geometry}
 import org.scalatest.{BeforeAndAfter, GivenWhenThen}
 
@@ -473,7 +473,7 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
     it("Passed RS_Base64") {
       val df = sparkSession.read.format("binaryFile").load(resourceFolder + "raster/raster_with_no_data/test5.tiff")
       val resultRaw = df.selectExpr("RS_Base64(RS_FromGeoTiff(content)) as raster").first().getString(0)
-      assert(resultRaw.contains("""iVBORw0KGgoAAAANSUhEUgAABaAAAALQCAMAAABR+ye1AAADAFBMVEXE9/W48vOq7PGa5u6L3+t52Odn0eVVyOJDwN4yudsisdgUqtUKpNQCn9ICnNICmdICl9ICldICk9ICkNICjtICjNICitICidIChtIChN"""))
+      assert(resultRaw.startsWith("iVBORw0KGgoAAAANSUhEUgAABaAAAALQCAMAAABR+ye1AAADAFBMVEXE9/W48vOq7PGa5u6L3"))
     }
 
     it("Passed RS_AsArcGrid") {


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-XXX. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

1. Rename the function to RS_AsBase64
2. Fix the wrong name of RasterOutputTests. This stopped JUnit from picking up the tests when run with `mvn install`
3. Use another image for the test as sometimes (for some images) Java8 and Java11 produce different base64 strings given the same input image.
4. Improve the documentation to explain how this function works. In particular, this function only visualizes the first 4 bands regardless how many bands the input raster could have.

## How was this patch tested?

Passed unit tests

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation update.