### PR TITLE
[SEDONA-361] Fix performance issues of map algebra functions and some band operators

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/raster/DeepCopiedRenderedImage.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/DeepCopiedRenderedImage.java
@@ -15,20 +15,19 @@ package org.apache.sedona.common.raster;
 
 import com.sun.media.jai.util.ImageUtil;
 import it.geosolutions.jaiext.range.NoDataContainer;
+import org.apache.sedona.common.utils.RasterUtils;
 
 import javax.media.jai.JAI;
 import javax.media.jai.PlanarImage;
 import javax.media.jai.RasterAccessor;
 import javax.media.jai.RasterFormatTag;
 import javax.media.jai.RemoteImage;
-import javax.media.jai.RenderedImageAdapter;
 import javax.media.jai.TileCache;
 import javax.media.jai.remote.SerializableState;
 import javax.media.jai.remote.SerializerFactory;
 import java.awt.Image;
 import java.awt.Point;
 import java.awt.Rectangle;
-import java.awt.image.BufferedImage;
 import java.awt.image.ColorModel;
 import java.awt.image.DataBuffer;
 import java.awt.image.Raster;
@@ -355,18 +354,7 @@ public final class DeepCopiedRenderedImage implements RenderedImage, Serializabl
         out.writeObject(SerializerFactory.getState(this.colorModel, null));
         out.writeObject(propertyTable);
         if (this.source != null) {
-            Raster serializedRaster = null;
-            RenderedImage serializedImage = this.source;
-            while (serializedImage instanceof RenderedImageAdapter) {
-                serializedImage = ((RenderedImageAdapter) serializedImage).getWrappedImage();
-            }
-            if (serializedImage instanceof BufferedImage) {
-                // This is a fast path for BufferedImage. If we call getData() directly, it will make a
-                // hard copy of the raster. We can avoid this overhead by calling getRaster().
-                serializedRaster = ((BufferedImage) serializedImage).getRaster();
-            } else {
-                serializedRaster = serializedImage.getData();
-            }
+            Raster serializedRaster = RasterUtils.getRaster(this.source);
             out.writeObject(SerializerFactory.getState(serializedRaster, null));
         } else {
             out.writeObject(SerializerFactory.getState(imageRaster, null));

--- a/common/src/main/java/org/apache/sedona/common/raster/PixelFunctionEditors.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/PixelFunctionEditors.java
@@ -36,8 +36,8 @@ public class PixelFunctionEditors {
         }
 
         RenderedImage originalImage = raster.getRenderedImage();
-        Raster rasterTemp = originalImage.getData();
-        Point location = raster.getRenderedImage().getData().getBounds().getLocation();
+        Raster rasterTemp = RasterUtils.getRaster(originalImage);
+        Point location = rasterTemp.getBounds().getLocation();
         WritableRaster wr = RasterFactory.createBandedRaster(rasterTemp.getDataBuffer().getDataType(), originalImage.getWidth(), originalImage.getHeight(), raster.getNumSampleDimensions(), location);
 
         WritableRaster rasterCopied = raster.getRenderedImage().copyData(wr);

--- a/common/src/main/java/org/apache/sedona/common/raster/RasterBandAccessors.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterBandAccessors.java
@@ -86,7 +86,7 @@ public class RasterBandAccessors {
 
     public static double[] getSummaryStats(GridCoverage2D rasterGeom, int band, boolean excludeNoDataValue) {
         RasterUtils.ensureBand(rasterGeom, band);
-        Raster raster = rasterGeom.getRenderedImage().getData();
+        Raster raster = RasterUtils.getRaster(rasterGeom.getRenderedImage());
         int height = RasterAccessors.getHeight(rasterGeom), width = RasterAccessors.getWidth(rasterGeom);
         double[] pixels = raster.getSamples(0, 0, width, height, band - 1, (double[]) null);
         double count = 0, sum = 0, mean = 0, stddev = 0, min = Double.MAX_VALUE, max = -Double.MAX_VALUE;
@@ -154,7 +154,7 @@ public class RasterBandAccessors {
         }
 
         // Get Writable Raster from the resultRaster
-        WritableRaster wr = resultRaster.getRenderedImage().getData().createCompatibleWritableRaster();
+        WritableRaster wr = RasterUtils.getRaster(resultRaster.getRenderedImage()).createCompatibleWritableRaster();
 
         GridSampleDimension[] sampleDimensionsOg = rasterGeom.getSampleDimensions();
         GridSampleDimension[] sampleDimensionsResult = resultRaster.getSampleDimensions();

--- a/common/src/main/java/org/apache/sedona/common/utils/RasterUtils.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/RasterUtils.java
@@ -43,6 +43,7 @@ import org.opengis.referencing.operation.MathTransform;
 import org.opengis.referencing.operation.TransformException;
 import org.opengis.util.InternationalString;
 
+import javax.media.jai.RenderedImageAdapter;
 import java.awt.Color;
 import java.awt.Transparency;
 import java.awt.color.ColorSpace;
@@ -51,6 +52,7 @@ import java.awt.image.BufferedImage;
 import java.awt.image.ColorModel;
 import java.awt.image.ComponentColorModel;
 import java.awt.image.DataBuffer;
+import java.awt.image.Raster;
 import java.awt.image.RenderedImage;
 import java.awt.image.WritableRaster;
 import java.util.ArrayList;
@@ -295,6 +297,19 @@ public class RasterUtils {
     public static void ensureBand(GridCoverage2D raster, int band) throws IllegalArgumentException {
         if (band < 1 || band > RasterAccessors.numBands(raster)) {
             throw new IllegalArgumentException(String.format("Provided band index %d is not present in the raster", band));
+        }
+    }
+
+    public static Raster getRaster(RenderedImage renderedImage) {
+        while (renderedImage instanceof RenderedImageAdapter) {
+            renderedImage = ((RenderedImageAdapter) renderedImage).getWrappedImage();
+        }
+        if (renderedImage instanceof BufferedImage) {
+            // This is a fast path for BufferedImage. If we call getData() directly, it will make a
+            // hard copy of the raster. We can avoid this overhead by calling getRaster().
+            return ((BufferedImage) renderedImage).getRaster();
+        } else {
+            return renderedImage.getData();
         }
     }
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-361. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

We've spotted several performance hits of map algebra functions:

1. `ImageUtils.createConstantImage` is very slow, we'd better manually create a buffered image, which is way faster.
2. The `.getData()` method on `BufferedImage` objects creates an unnecessary copy of the raster object. We've added a utility function to implement a fast path for `BufferedImage`.

## How was this patch tested?

Passing existing tests

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
