### PR TITLE
[SEDONA-387] Implement RS_BandIsNoData

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/raster/RasterBandAccessors.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterBandAccessors.java
@@ -180,4 +180,32 @@ public class RasterBandAccessors {
     public static String getBandType(GridCoverage2D raster){
         return getBandType(raster, 1);
     }
+
+    /**
+     * Returns true if the band is filled with only nodata values.
+     * @param raster The raster to check
+     * @param band The 1-based index of band to check
+     * @return true if the band is filled with only nodata values, false otherwise
+     */
+    public static boolean bandIsNoData(GridCoverage2D raster, int band) {
+        RasterUtils.ensureBand(raster, band);
+        Raster rasterData = RasterUtils.getRaster(raster.getRenderedImage());
+        int width = rasterData.getWidth();
+        int height = rasterData.getHeight();
+        double noDataValue = RasterUtils.getNoDataValue(raster.getSampleDimension(band - 1));
+        if (Double.isNaN(noDataValue)) {
+            return false;
+        }
+        double[] pixels = rasterData.getSamples(0, 0, width, height, band - 1, (double[]) null);
+        for (double pixel: pixels) {
+            if (Double.compare(pixel, noDataValue) != 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static boolean bandIsNoData(GridCoverage2D raster) {
+        return bandIsNoData(raster, 1);
+    }
 }

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterBandAccessorsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterBandAccessorsTest.java
@@ -362,6 +362,32 @@ public class RasterBandAccessorsTest extends RasterTestBase {
         assertEquals("Provided band index 5 is not present in the raster", exception.getMessage());
     }
 
+    @Test
+    public void testBandIsNoData() throws FactoryException {
+        String[] dataTypes = new String[]{"B", "S", "US", "I", "F", "D"};
+        int width = 3;
+        int height = 3;
+        double noDataValue = 5.0;
+        double[] band1 = new double[width * height];
+        double[] band2 = new double[width * height];
+        Arrays.fill(band1, noDataValue);
+        for (int k = 0; k < band2.length; k++) {
+            band2[k] = k;
+        }
+        for (String dataType : dataTypes) {
+            GridCoverage2D raster = RasterConstructors.makeEmptyRaster(2, dataType, 3, 3, 0, 0, 1);
+            raster = MapAlgebra.addBandFromArray(raster, band1, 1, null);
+            raster = MapAlgebra.addBandFromArray(raster, band2, 2, null);
 
+            // Currently raster does not have a nodata value, isBandNoData always returns false
+            assertFalse(RasterBandAccessors.bandIsNoData(raster, 1));
+            assertFalse(RasterBandAccessors.bandIsNoData(raster, 2));
 
+            // Set nodata value for both bands, now band 1 is filled with nodata values
+            raster = RasterBandEditors.setBandNoDataValue(raster, 1, noDataValue);
+            raster = RasterBandEditors.setBandNoDataValue(raster, 2, noDataValue);
+            assertTrue(RasterBandAccessors.bandIsNoData(raster, 1));
+            assertFalse(RasterBandAccessors.bandIsNoData(raster, 2));
+        }
+    }
 }

--- a/docs/api/sql/Raster-operators.md
+++ b/docs/api/sql/Raster-operators.md
@@ -594,6 +594,27 @@ SELECT RS_BandNoDataValue(raster, 3) from rasters;
 
 Output: `IllegalArgumentException: Provided band index 3 is not present in the raster.`
 
+### RS_BandIsNoData
+
+Returns true if the band is filled with only nodata values. Band 1 is assumed if not specified.
+
+Format: `RS_BandIsNoData(raster: Raster, band: Int = 1)`
+
+Since: `1.5.0`
+
+Spark SQL example:
+
+```sql
+WITH rast_table AS (SELECT RS_AddBandFromArray(RS_MakeEmptyRaster(1, 2, 2, 0, 0, 1), ARRAY(10d, 10d, 10d, 10d), 1, 10d) as rast)
+SELECT RS_BandIsNoData(rast) from rast_table
+```
+
+Output:
+
+```
+true
+```
+
 ### RS_BandPixelType
 
 Introduction: Returns the datatype of each pixel in the given band of the given raster in string format. The band parameter is 1-indexed. If no band is specified, band 1 is assumed.

--- a/spark/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
+++ b/spark/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
@@ -227,6 +227,7 @@ object Catalog {
     function[RS_Count](),
     function[RS_Band](),
     function[RS_SummaryStats](),
+    function[RS_BandIsNoData](),
     function[RS_ConvexHull](),
     function[RS_RasterToWorldCoordX](),
     function[RS_RasterToWorldCoordY](),

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterBandAccessors.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterBandAccessors.scala
@@ -78,3 +78,10 @@ case class RS_BandPixelType(inputExpressions: Seq[Expression]) extends InferredE
   }
 }
 
+case class RS_BandIsNoData(inputExpressions: Seq[Expression])
+  extends InferredExpression(inferrableFunction2(RasterBandAccessors.bandIsNoData),
+    inferrableFunction1(RasterBandAccessors.bandIsNoData)) {
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
+}

--- a/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
@@ -783,6 +783,15 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
       assertEquals(255.0, actual(5), 0.1d)
     }
 
+    it("Passed RS_BandIsNoData") {
+      val df = sparkSession.read.format("binaryFile").load(resourceFolder + "raster/raster_with_no_data/test5.tiff")
+        .selectExpr("RS_FromGeoTiff(content) as raster")
+      assert(!df.selectExpr("RS_BandIsNoData(raster, 1)").first().getBoolean(0))
+      val bandDf = Seq(Seq.fill(9)(10.0)).toDF("data")
+      val noDataDf = bandDf.selectExpr("RS_AddBandFromArray(RS_MakeEmptyRaster(1, 3, 3, 0, 0, 1), data, 1, 10d) as raster")
+      assert(noDataDf.selectExpr("RS_BandIsNoData(raster, 1)").first().getBoolean(0))
+    }
+
     it("Passed RS_PixelAsPoint with raster") {
       val widthInPixel = 5
       val heightInPixel = 10


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-387. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Added `RS_BandIsNoData` for testing if all pixels in a band are nodata values. This is basically a more simple version of `RS_SummaryStats`.

## How was this patch tested?

Passing newly added tests.

## Did this PR include necessary documentation updates?

- Yes, I am adding a new API. I am using the [current SNAPSHOT version number](https://github.com/apache/sedona/blob/master/pom.xml#L29) in since `vX.Y.Z` format.
