### PR TITLE
[SEDONA-389] Pin pipenv version to 2023.9.1, since 2023.9.7 introduces a bug that broke our build

### DIFF
--- a/.github/workflows/python-extension.yml
+++ b/.github/workflows/python-extension.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
     - name: Install pipenv
-      run: pip install -U pipenv
+      run: pip install -U pipenv==2023.9.1
     - name: Install dependencies
       run: |
         cd python

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -86,7 +86,7 @@ jobs:
     - run: sudo pip3 install -U setuptools
     - run: sudo pip3 install -U wheel
     - run: sudo pip3 install -U virtualenvwrapper
-    - run: python3 -m pip install pipenv
+    - run: python3 -m pip install pipenv==2023.9.1
     - run: cd python; python3 setup.py build_ext --inplace
     - env:
         SPARK_VERSION: ${{ matrix.spark }}


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-389. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Please refer to https://github.com/pypa/pipenv/issues/5924 for details. We'll temporarily pin the version of pipenv to 2023.9.1 to resolve this issue.

## How was this patch tested?

Passing CI.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
