### PR TITLE
[SEDONA-349] Fix performance regression for spatial join

### DIFF
--- a/python/tests/spatial_operator/test_join_base.py
+++ b/python/tests/spatial_operator/test_join_base.py
@@ -28,29 +28,18 @@ class TestJoinBase(TestBase):
     use_legacy_apis = False
 
     def create_point_rdd(self, location, splitter, num_partitions):
-        rdd = PointRDD(
-            self.sc, location, 1, splitter, False, num_partitions
-        )
-        return PointRDD(rdd.rawJvmSpatialRDD)
+        return PointRDD(self.sc, location, 1, splitter, False, num_partitions)
 
     def create_linestring_rdd(self, location, splitter, num_partitions):
-        rdd = LineStringRDD(
-            self.sc, location, splitter, True, num_partitions
-        )
-        return LineStringRDD(rdd.rawJvmSpatialRDD)
+        return LineStringRDD(self.sc, location, splitter, True, num_partitions)
 
     def create_polygon_rdd(self, location, splitter, num_partitions):
-        rdd = PolygonRDD(
-            self.sc, location, splitter, True, num_partitions
-        )
-        return PolygonRDD(rdd.rawJvmSpatialRDD)
+        return PolygonRDD(self.sc, location, splitter, True, num_partitions)
 
     def create_rectangle_rdd(self, location, splitter, num_partitions):
-        rdd = RectangleRDD(
-            self.sc, location, splitter, True, num_partitions)
-        return RectangleRDD(
-            rdd.rawJvmSpatialRDD
-        )
+        rectangle_rdd = RectangleRDD(self.sc, location, splitter, True, num_partitions)
+        rectangle_rdd.analyze()
+        return rectangle_rdd
 
     def partition_rdds(self, query_rdd: SpatialRDD, spatial_rdd: SpatialRDD, grid_type):
         spatial_rdd.spatialPartitioning(grid_type)

--- a/spark/common/src/main/java/org/apache/sedona/core/spatialRDD/SpatialRDD.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/spatialRDD/SpatialRDD.java
@@ -424,7 +424,6 @@ public class SpatialRDD<T extends Geometry>
     public void setRawSpatialRDD(JavaRDD<T> rawSpatialRDD)
     {
         this.rawSpatialRDD = rawSpatialRDD;
-        this.analyze();
     }
 
     /**

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/TraitJoinQueryExec.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/TraitJoinQueryExec.scala
@@ -82,7 +82,6 @@ trait TraitJoinQueryExec extends TraitJoinQueryBase {
           numPartitions = sedonaConf.getFallbackPartitionNum
         }
         else {
-          numPartitions = rightShapes.rawSpatialRDD.partitions.size()
           numPartitions = joinPartitionNumOptimizer(rightShapes.rawSpatialRDD.partitions.size(), leftShapes.rawSpatialRDD.partitions.size(),
             rightShapes.approximateTotalCount)
         }


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-XXX. The PR name follows the format `[SEDONA-349] my subject`.

## What changes were proposed in this PR?

https://github.com/apache/sedona/pull/954/files#diff-63577974e7e93ba53321c1c96a3e6f9db257de58a7504f39ea51641ab82cb5cfR450 added a call to `analyze` in `SpatialRDD.setRawSpatialRDD`. It makes join query using Spark SQL analyzes the dataframes 3 times (where only 1 analyze on the dominant side is needed). This patch removes redundant calls to `analyze`.

## How was this patch tested?

Passing existing tests.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
