### PR TITLE
[SEDONA-397] Move Map Algebra functions

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
@@ -246,9 +246,7 @@ public class MapAlgebra
      * @return a sum of the provided band values
      */
     public static double[] add(double[] band1, double[] band2) {
-        if (band1.length != band2.length) {
-            throw new IllegalArgumentException("The shape of the provided bands is not same. Please check your inputs, it should be same.");
-        }
+        ensureBandShape(band1.length, band2.length);
 
         double[] result = new double[band1.length];
         for(int i = 0; i < band1.length; i++) {
@@ -264,9 +262,7 @@ public class MapAlgebra
      * @return result of subtraction of the two bands, (band2 - band1).
      */
     public static double[] subtract(double[] band1, double[] band2) {
-        if (band1.length != band2.length) {
-            throw new IllegalArgumentException("The shape of the provided bands is not same. Please check your inputs, it should be same.");
-        }
+        ensureBandShape(band1.length, band2.length);
 
         double[] result = new double[band1.length];
         for(int i = 0; i < band1.length; i++) {
@@ -274,5 +270,32 @@ public class MapAlgebra
         }
 
         return result;
+    }
+
+    /**
+     * @param band1 band values
+     * @param band2 band values
+     * @return result of multiplication of the two bands.
+     */
+    public static double[] multiply(double[] band1, double[] band2) {
+        ensureBandShape(band1.length, band2.length);
+
+        double[] result = new double[band1.length];
+        for (int i = 0; i < band1.length; i++) {
+            result[i] = band1[i] * band2[i];
+        }
+
+        return result;
+    }
+
+    /**
+     * Throws an IllegalArgumentException if the lengths of the bands are not the same.
+     * @param band1 length of band values
+     * @param band2 length of band values
+     */
+    private static void ensureBandShape(int band1, int band2) {
+        if (band1 != band2) {
+            throw new IllegalArgumentException("The shape of the provided bands is not same. Please check your inputs, it should be same.");
+        }
     }
 }

--- a/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
@@ -560,6 +560,15 @@ public class MapAlgebra
     }
 
     /**
+     * @param band band values
+     * @param target target to count
+     * @return count of the target in the band values
+     */
+    public static int countValue(double[] band, double target) {
+        return (int) Arrays.stream(band).filter(x -> x == target).count();
+    }
+
+    /**
      * Throws an IllegalArgumentException if the lengths of the bands are not the same.
      * @param band1 length of band values
      * @param band2 length of band values

--- a/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
@@ -289,6 +289,22 @@ public class MapAlgebra
     }
 
     /**
+     * @param band1 band values
+     * @param band2 band values
+     * @return result of subtraction of the two bands, (band1 / band2).
+     */
+    public static double[] divide(double[] band1, double[] band2) {
+        ensureBandShape(band1.length, band2.length);
+
+        double[] result = new double[band1.length];
+        for (int i = 0; i < band1.length; i++) {
+            result[i] = (double) Math.round(band1[i] / band2[i] * 100) /100;
+        }
+
+        return result;
+    }
+
+    /**
      * Throws an IllegalArgumentException if the lengths of the bands are not the same.
      * @param band1 length of band values
      * @param band2 length of band values

--- a/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
@@ -398,6 +398,26 @@ public class MapAlgebra
     }
 
     /**
+     * @param band1 band values
+     * @param band2 band values
+     * @return an array; if a value at an index in band1 is not equal to 0 then band1 value will be taken otherwise band2's value
+     */
+    public static double[] logicalOver(double[] band1, double[] band2) {
+        ensureBandShape(band1.length, band2.length);
+
+        double[] result = new double[band1.length];
+        for (int i = 0; i < band1.length; i++) {
+            if (band1[i] != 0d) {
+                result[i] = band1[i];
+            } else {
+                result[i] = band2[i];
+            }
+        }
+
+        return result;
+    }
+
+    /**
      * Throws an IllegalArgumentException if the lengths of the bands are not the same.
      * @param band1 length of band values
      * @param band2 length of band values

--- a/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
@@ -35,6 +35,9 @@ import java.awt.image.RenderedImage;
 import java.awt.image.WritableRaster;
 import java.awt.image.WritableRenderedImage;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class MapAlgebra
 {
@@ -481,6 +484,29 @@ public class MapAlgebra
         }
 
         return result;
+    }
+
+    /**
+     * @param band band values
+     * @return an array with the most reoccurring value or if every value occurs once then return the provided array
+     */
+    public static double[] mode(double[] band) {
+        Map<Double, Long> frequency = Arrays.stream(band)
+                .boxed()
+                .collect(
+                        Collectors.groupingBy(Function.identity(), Collectors.counting())
+                );
+        if (frequency.values().stream().max(Long::compare).orElse(0L) == 1L) {
+            return band;
+        } else {
+            return new double[] {
+                    frequency.entrySet()
+                            .stream()
+                            .max(Map.Entry.comparingByValue())
+                            .map(Map.Entry::getKey)
+                            .orElse(null)
+            };
+        }
     }
 
     /**

--- a/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
@@ -34,6 +34,7 @@ import java.awt.image.Raster;
 import java.awt.image.RenderedImage;
 import java.awt.image.WritableRaster;
 import java.awt.image.WritableRenderedImage;
+import java.util.Arrays;
 
 public class MapAlgebra
 {
@@ -412,6 +413,21 @@ public class MapAlgebra
             } else {
                 result[i] = band2[i];
             }
+        }
+
+        return result;
+    }
+
+    /**
+     * @param band band values
+     * @return an array with normalized band values to be within [0 - 255] range
+     */
+    public static double[] normalize(double[] band) {
+        double[] result = new double[band.length];
+        double normalizer = Arrays.stream(band).max().getAsDouble() / 255d;
+
+        for (int i = 0; i < band.length; i++) {
+            result[i] = (int) (band[i] / normalizer);
         }
 
         return result;

--- a/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
@@ -378,6 +378,26 @@ public class MapAlgebra
     }
 
     /**
+     * @param band1 band values
+     * @param band2 band values
+     * @return an array; if a value at an index in band1 is different in band2 then band1 value is taken otherwise 0.
+     */
+    public static double[] logicalDifference(double[] band1, double[] band2) {
+        ensureBandShape(band1.length, band2.length);
+
+        double[] result = new double[band1.length];
+        for (int i = 0; i < band1.length; i++) {
+            if (band1[i] != band2[i]) {
+                result[i] = band1[i];
+            } else {
+                result[i] = 0d;
+            }
+        }
+
+        return result;
+    }
+
+    /**
      * Throws an IllegalArgumentException if the lengths of the bands are not the same.
      * @param band1 length of band values
      * @param band2 length of band values

--- a/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
@@ -465,6 +465,25 @@ public class MapAlgebra
     }
 
     /**
+     * @param band band values
+     * @param coordinates defines the region by minX, maxX, minY, and maxY respectively
+     * @param dimension dimensions
+     * @return an array of the specified region
+     */
+    public static double[] fetchRegion(double[] band, int[] coordinates, int[] dimension) {
+        double[] result = new double[(coordinates[2] - coordinates[0] + 1) * (coordinates[3] - coordinates[1] + 1)];
+        int k = 0;
+        for (int i = coordinates[0]; i < coordinates[2] + 1; i++) {
+            for (int j = coordinates[1]; j < coordinates[3] + 1; j++) {
+                result[k] = band[(i * dimension[0]) + j];
+                k++;
+            }
+        }
+
+        return result;
+    }
+
+    /**
      * Throws an IllegalArgumentException if the lengths of the bands are not the same.
      * @param band1 length of band values
      * @param band2 length of band values

--- a/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
@@ -346,6 +346,22 @@ public class MapAlgebra
     }
 
     /**
+     * @param band1 band values
+     * @param band2 band values
+     * @return an array, where each pixel is result of bitwise AND operator from provided 2 bands.
+     */
+    public static double[] bitwiseAnd(double[] band1, double[] band2) {
+        ensureBandShape(band1.length, band2.length);
+
+        double[] result = new double[band1.length];
+        for (int i = 0; i < band1.length; i++) {
+            result[i] = (int) band1[i] & (int) band2[i];
+        }
+
+        return result;
+    }
+
+    /**
      * Throws an IllegalArgumentException if the lengths of the bands are not the same.
      * @param band1 length of band values
      * @param band2 length of band values

--- a/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
@@ -541,6 +541,25 @@ public class MapAlgebra
     }
 
     /**
+     * @param band band values
+     * @param target target to compare
+     * @return an array; mark all band values 1 that are less than or equal to target, otherwise 0
+     */
+    public static double[] lessThanEqual(double[] band, double target) {
+        double[] result = new double[band.length];
+
+        for (int i = 0; i < band.length; i++) {
+            if (band[i] <= target) {
+                result[i] = 1;
+            } else {
+                result[i] = 0;
+            }
+        }
+
+        return result;
+    }
+
+    /**
      * Throws an IllegalArgumentException if the lengths of the bands are not the same.
      * @param band1 length of band values
      * @param band2 length of band values

--- a/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
@@ -503,6 +503,25 @@ public class MapAlgebra
     }
 
     /**
+     * @param band band values
+     * @param target target to compare
+     * @return an array; mark all band values 1 that are greater than or equal to target, otherwise 0
+     */
+    public static double[] greaterThanEqual(double[] band, double target) {
+        double[] result = new double[band.length];
+
+        for (int i = 0; i < band.length; i++) {
+            if (band[i] >= target) {
+                result[i] = 1;
+            } else {
+                result[i] = 0;
+            }
+        }
+
+        return result;
+    }
+
+    /**
      * Throws an IllegalArgumentException if the lengths of the bands are not the same.
      * @param band1 length of band values
      * @param band2 length of band values

--- a/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
@@ -522,6 +522,25 @@ public class MapAlgebra
     }
 
     /**
+     * @param band band values
+     * @param target target to compare
+     * @return an array; mark all band values 1 that are less than target, otherwise 0
+     */
+    public static double[] lessThan(double[] band, double target) {
+        double[] result = new double[band.length];
+
+        for (int i = 0; i < band.length; i++) {
+            if (band[i] < target) {
+                result[i] = 1;
+            } else {
+                result[i] = 0;
+            }
+        }
+
+        return result;
+    }
+
+    /**
      * Throws an IllegalArgumentException if the lengths of the bands are not the same.
      * @param band1 length of band values
      * @param band2 length of band values

--- a/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
@@ -362,6 +362,22 @@ public class MapAlgebra
     }
 
     /**
+     * @param band1 band values
+     * @param band2 band values
+     * @return an array, where each pixel is result of bitwise OR operator from provided 2 bands.
+     */
+    public static double[] bitwiseOr(double[] band1, double[] band2) {
+        ensureBandShape(band1.length, band2.length);
+
+        double[] result = new double[band1.length];
+        for (int i = 0; i < band1.length; i++) {
+            result[i] = (int) band1[i] | (int) band2[i];
+        }
+
+        return result;
+    }
+
+    /**
      * Throws an IllegalArgumentException if the lengths of the bands are not the same.
      * @param band1 length of band values
      * @param band2 length of band values

--- a/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
@@ -484,6 +484,25 @@ public class MapAlgebra
     }
 
     /**
+     * @param band band values
+     * @param target target to compare
+     * @return an array; mark all band values 1 that are greater than target, otherwise 0
+     */
+    public static double[] greaterThan(double[] band, double target) {
+        double[] result = new double[band.length];
+
+        for (int i = 0; i < band.length; i++) {
+            if (band[i] > target) {
+                result[i] = 1;
+            } else {
+                result[i] = 0;
+            }
+        }
+
+        return result;
+    }
+
+    /**
      * Throws an IllegalArgumentException if the lengths of the bands are not the same.
      * @param band1 length of band values
      * @param band2 length of band values

--- a/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
@@ -434,6 +434,29 @@ public class MapAlgebra
     }
 
     /**
+     * @param band1 band values
+     * @param band2 band values
+     * @return an array with the normalized difference of the provided bands
+     */
+    public static double[] normalizedDifference(double[] band1, double[] band2) {
+        ensureBandShape(band1.length, band2.length);
+
+        double[] result = new double[band1.length];
+        for (int i = 0; i < band1.length; i++) {
+            if (band1[i] == 0) {
+                band1[i] = -1;
+            }
+            if (band2[i] == 0) {
+                band2[i] = -1;
+            }
+
+            result[i] = (double) Math.round(((band2[i] - band1[i]) / (band2[i] + band1[i])) * 100) / 100;
+        }
+
+        return result;
+    }
+
+    /**
      * Throws an IllegalArgumentException if the lengths of the bands are not the same.
      * @param band1 length of band values
      * @param band2 length of band values

--- a/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
@@ -239,4 +239,22 @@ public class MapAlgebra
             throw new RuntimeException("Failed to run map algebra", e);
         }
     }
+
+    /**
+     * @param band1 band values
+     * @param band2 band values
+     * @return a sum of the provided band values
+     */
+    public static double[] add(double[] band1, double[] band2) {
+        if (band1.length != band2.length) {
+            throw new IllegalArgumentException("The shape of the provided bands is not same. Please check your inputs, it should be same.");
+        }
+
+        double[] result = new double[band1.length];
+        for(int i = 0; i < band1.length; i++) {
+            result[i] = band1[i] + band2[i];
+        }
+
+        return result;
+    }
 }

--- a/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
@@ -333,6 +333,19 @@ public class MapAlgebra
     }
 
     /**
+     * @param band band values
+     * @return an array, where each pixel has been applied square root operation.
+     */
+    public static double[] squareRoot(double[] band) {
+        double[] result = new double[band.length];
+        for (int i = 0; i < band.length; i++) {
+            result[i] = (double) Math.round(Math.sqrt(band[i]) * 100) / 100;
+        }
+
+        return result;
+    }
+
+    /**
      * Throws an IllegalArgumentException if the lengths of the bands are not the same.
      * @param band1 length of band values
      * @param band2 length of band values

--- a/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
@@ -305,6 +305,20 @@ public class MapAlgebra
     }
 
     /**
+     * @param band band values
+     * @param factor multiplying factor
+     * @return an array where all the elements has been multiplied with the factor given.
+     */
+    public static double[] multiplyFactor(double[] band, double factor) {
+        double[] result = new double[band.length];
+        for (int i = 0; i < band.length; i++) {
+            result[i] = band[i] * factor;
+        }
+
+        return result;
+    }
+
+    /**
      * Throws an IllegalArgumentException if the lengths of the bands are not the same.
      * @param band1 length of band values
      * @param band2 length of band values

--- a/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
@@ -457,6 +457,14 @@ public class MapAlgebra
     }
 
     /**
+     * @param band band values
+     * @return mean of the band values
+     */
+    public static double mean(double[] band) {
+        return (Arrays.stream(band).sum() / band.length) * 100 / 100;
+    }
+
+    /**
      * Throws an IllegalArgumentException if the lengths of the bands are not the same.
      * @param band1 length of band values
      * @param band2 length of band values

--- a/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
@@ -257,4 +257,22 @@ public class MapAlgebra
 
         return result;
     }
+
+    /**
+     * @param band1 band values
+     * @param band2 band values
+     * @return result of subtraction of the two bands, (band2 - band1).
+     */
+    public static double[] subtract(double[] band1, double[] band2) {
+        if (band1.length != band2.length) {
+            throw new IllegalArgumentException("The shape of the provided bands is not same. Please check your inputs, it should be same.");
+        }
+
+        double[] result = new double[band1.length];
+        for(int i = 0; i < band1.length; i++) {
+            result[i] = band2[i] - band1[i];
+        }
+
+        return result;
+    }
 }

--- a/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
@@ -319,6 +319,20 @@ public class MapAlgebra
     }
 
     /**
+     * @param band band values
+     * @param dividend dividend for modulo
+     * @return an array with modular remainders calculated from the given dividend
+     */
+    public static double[] modulo(double[] band, double dividend) {
+        double[] result = new double[band.length];
+        for (int i = 0; i < band.length; i++) {
+            result[i] = band[i] % dividend;
+        }
+
+        return result;
+    }
+
+    /**
      * Throws an IllegalArgumentException if the lengths of the bands are not the same.
      * @param band1 length of band values
      * @param band2 length of band values

--- a/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
@@ -331,6 +331,24 @@ public class MapAlgebraTest extends RasterTestBase
     }
 
     @Test
+    public void testMean() {
+        double[] band = new double[] {200.0, 400.0, 600.0, 200.0};
+        double actual = MapAlgebra.mean(band);
+        double expected = 350.0;
+        assertEquals(expected, actual, 0.1d);
+
+        band = new double[] {200.0, 400.0, 600.0, 700.0};
+        actual = MapAlgebra.mean(band);
+        expected = 475.0;
+        assertEquals(expected, actual, 0.1d);
+
+        band = new double[] {0.43, 0.36, 0.73, 0.56};
+        actual = MapAlgebra.mean(band);
+        expected = 0.52;
+        assertEquals(expected, actual, 0.001d);
+    }
+
+    @Test
     public void testMapAlgebra() throws FactoryException {
         Random random = new Random();
         String[] pixelTypes = {null, "b", "i", "s", "us", "f", "d"};

--- a/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
@@ -287,6 +287,15 @@ public class MapAlgebraTest extends RasterTestBase
     }
 
     @Test
+    public void testBitwiseOr() {
+        double[] band1 = new double[] {15.0, 25.0, 35.0};
+        double[] band2 = new double[] {5.0, 15.0, 25.0};
+        double[] actual = MapAlgebra.bitwiseOr(band1, band2);
+        double[] expected = new double[]{15.0, 31.0, 59.0};
+        assertArrayEquals(expected, actual, 0.1d);
+    }
+
+    @Test
     public void testMapAlgebra() throws FactoryException {
         Random random = new Random();
         String[] pixelTypes = {null, "b", "i", "s", "us", "f", "d"};

--- a/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
@@ -349,6 +349,16 @@ public class MapAlgebraTest extends RasterTestBase
     }
 
     @Test
+    public void testFetchRegion() {
+        double[] band = new double[] {100.0, 260.0, 189.0, 106.0, 230.0, 169.0, 196.0, 200.0, 460.0};
+        int[] coordinates = new int[] {0, 0, 1, 2};
+        int[] dimension = new int[] {3, 3};
+        double[] actual = MapAlgebra.fetchRegion(band, coordinates, dimension);
+        double[] expected = new double[] {100.0, 260.0, 189.0, 106.0, 230.0, 169.0};
+        assertArrayEquals(expected, actual, 0.1d);
+    }
+
+    @Test
     public void testMapAlgebra() throws FactoryException {
         Random random = new Random();
         String[] pixelTypes = {null, "b", "i", "s", "us", "f", "d"};

--- a/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
@@ -256,6 +256,20 @@ public class MapAlgebraTest extends RasterTestBase
     }
 
     @Test
+    public void testModulo() {
+        double[] band = new double[] {100.0, 260.0, 189.0, 106.0, 230.0, 169.0, 196.0};
+        double dividend = 90;
+        double[] actual = MapAlgebra.modulo(band, dividend);
+        double[] expected = new double[] {10.0, 80.0, 9.0, 16.0, 50.0, 79.0, 16.0};
+        assertArrayEquals(expected, actual, 0.1d);
+
+        band = new double[] {230.0, 345.0, 136.0, 106.0, 134.0, 105.0};
+        actual = MapAlgebra.modulo(band, dividend);
+        expected = new double[] {50.0, 75.0, 46.0, 16.0, 44.0, 15.0};
+        assertArrayEquals(expected, actual, 0.1d);
+    }
+
+    @Test
     public void testMapAlgebra() throws FactoryException {
         Random random = new Random();
         String[] pixelTypes = {null, "b", "i", "s", "us", "f", "d"};

--- a/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
@@ -401,6 +401,20 @@ public class MapAlgebraTest extends RasterTestBase
     }
 
     @Test
+    public void testLessThanEqual() {
+        double[] band = new double[] {0.42, 0.36, 0.18, 0.20, 0.21, 0.2001, 0.19};
+        double target = 0.2;
+        double[] actual = MapAlgebra.lessThanEqual(band, target);
+        double[] expected = new double[] {0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0};
+        assertArrayEquals(expected, actual, 0.1d);
+
+        band = new double[] {0.14, 0.13, 0.10, 0.86, 0.01};
+        actual = MapAlgebra.lessThanEqual(band, target);
+        expected = new double[] {1.0, 1.0, 1.0, 0.0, 1.0};
+        assertArrayEquals(expected, actual, 0.1d);
+    }
+
+    @Test
     public void testMapAlgebra() throws FactoryException {
         Random random = new Random();
         String[] pixelTypes = {null, "b", "i", "s", "us", "f", "d"};

--- a/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
@@ -387,6 +387,20 @@ public class MapAlgebraTest extends RasterTestBase
     }
 
     @Test
+    public void testLessThan() {
+        double[] band = new double[] {0.42, 0.36, 0.18, 0.20, 0.21, 0.2001, 0.19};
+        double target = 0.2;
+        double[] actual = MapAlgebra.lessThan(band, target);
+        double[] expected = new double[] {0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0};
+        assertArrayEquals(expected, actual, 0.1d);
+
+        band = new double[] {0.14, 0.13, 0.10, 0.86, 0.01};
+        actual = MapAlgebra.lessThan(band, target);
+        expected = new double[] {1.0, 1.0, 1.0, 0.0, 1.0};
+        assertArrayEquals(expected, actual, 0.1d);
+    }
+
+    @Test
     public void testMapAlgebra() throws FactoryException {
         Random random = new Random();
         String[] pixelTypes = {null, "b", "i", "s", "us", "f", "d"};

--- a/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import org.opengis.referencing.FactoryException;
 
 import java.awt.image.DataBuffer;
-import java.util.Arrays;
 import java.util.Random;
 
 import static org.junit.Assert.*;
@@ -320,6 +319,15 @@ public class MapAlgebraTest extends RasterTestBase
         double[] actual = MapAlgebra.normalize(band);
         double[] expected = new double[] {226.0, 255.0, 0.0, 72.0};
         assertArrayEquals(expected, actual, 0.1d);
+    }
+
+    @Test
+    public void testNormalizedDifference() {
+        double[] band1 = new double[] {960, 1067, 107, 20, 1868};
+        double[] band2 = new double[] {1967, 951, 622, 223, 152};
+        double[] actual = MapAlgebra.normalizedDifference(band1, band2);
+        double[] expected = new double[] {0.34, -0.06, 0.71, 0.84, -0.85};
+        assertArrayEquals(expected, actual, 0.001d);
     }
 
     @Test

--- a/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
@@ -270,6 +270,14 @@ public class MapAlgebraTest extends RasterTestBase
     }
 
     @Test
+    public void testSquareRoot() {
+        double[] band = new double[] {8.0, 16.0, 24.0};
+        double[] actual = MapAlgebra.squareRoot(band);
+        double[] expected = new double[] {2.83, 4.0, 4.9};
+        assertArrayEquals(expected, actual, 0.01d);
+    }
+
+    @Test
     public void testMapAlgebra() throws FactoryException {
         Random random = new Random();
         String[] pixelTypes = {null, "b", "i", "s", "us", "f", "d"};

--- a/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
@@ -208,6 +208,15 @@ public class MapAlgebraTest extends RasterTestBase
     }
 
     @Test
+    public void testAdd() {
+        double[] band1 = new double[] {200, 100, 145, 245};
+        double[] band2 = new double[] {55, 155, 110, 10};
+        double[] actual = MapAlgebra.add(band1, band2);
+        double[] expected = new double[] {255.0, 255.0, 255.0, 255.0};
+        assertArrayEquals(expected, actual, 0.1d);
+    }
+
+    @Test
     public void testMapAlgebra() throws FactoryException {
         Random random = new Random();
         String[] pixelTypes = {null, "b", "i", "s", "us", "f", "d"};

--- a/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.opengis.referencing.FactoryException;
 
 import java.awt.image.DataBuffer;
+import java.util.Arrays;
 import java.util.Random;
 
 import static org.junit.Assert.*;
@@ -310,6 +311,14 @@ public class MapAlgebraTest extends RasterTestBase
         double[] band2 = new double[] {40.0, 20.0, 50.0};
         double[] actual = MapAlgebra.logicalOver(band1, band2);
         double[] expected = new double[] {40.0, 20.0, 30.0};
+        assertArrayEquals(expected, actual, 0.1d);
+    }
+
+    @Test
+    public void testNormalize() {
+        double[] band = new double[] {800.0, 900.0, 0.0, 255.0};
+        double[] actual = MapAlgebra.normalize(band);
+        double[] expected = new double[] {226.0, 255.0, 0.0, 72.0};
         assertArrayEquals(expected, actual, 0.1d);
     }
 

--- a/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.opengis.referencing.FactoryException;
 
 import java.awt.image.DataBuffer;
+import java.util.Arrays;
 import java.util.Random;
 
 import static org.junit.Assert.*;
@@ -222,6 +223,21 @@ public class MapAlgebraTest extends RasterTestBase
         double[] band2 = new double[] {255.0, 255.0, 255.0, 255.0};
         double[] actual = MapAlgebra.subtract(band1, band2);
         double[] expected = new double[] {200, 100, 145, 245};
+        assertArrayEquals(expected, actual, 0.1d);
+    }
+
+    @Test
+    public void testMultiply() {
+        double[] band1 = new double[] {20.43, 40.67, 60.91};
+        double[] band2 = new double[] {2.84, 5.26, 8.97};
+        double[] actual = MapAlgebra.multiply(band1, band2);
+        double[] expected = new double[] {58.02119999999999, 213.9242, 546.3627};
+        assertArrayEquals(expected, actual, 0.00001d);
+
+        band1 = new double[] {200, 400, 500};
+        band2 = new double[] {2, 2.5, 3};
+        actual = MapAlgebra.multiply(band1, band2);
+        expected = new double[] {400.0, 1000.0, 1500.0};
         assertArrayEquals(expected, actual, 0.1d);
     }
 

--- a/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
@@ -373,6 +373,20 @@ public class MapAlgebraTest extends RasterTestBase
     }
 
     @Test
+    public void testGreaterThanEqual() {
+        double[] band = new double[] {0.42, 0.36, 0.18, 0.20, 0.21, 0.2001, 0.19};
+        double target = 0.2;
+        double[] actual = MapAlgebra.greaterThanEqual(band, target);
+        double[] expected = new double[] {1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 0.0};
+        assertArrayEquals(expected, actual, 0.1d);
+
+        band = new double[] {0.14, 0.13, 0.10, 0.86, 0.01};
+        actual = MapAlgebra.greaterThanEqual(band, target);
+        expected = new double[] {0.0, 0.0, 0.0, 1.0, 0.0};
+        assertArrayEquals(expected, actual, 0.1d);
+    }
+
+    @Test
     public void testMapAlgebra() throws FactoryException {
         Random random = new Random();
         String[] pixelTypes = {null, "b", "i", "s", "us", "f", "d"};

--- a/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
@@ -27,9 +27,7 @@ import org.opengis.referencing.FactoryException;
 import java.awt.image.DataBuffer;
 import java.util.Random;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class MapAlgebraTest extends RasterTestBase
 {
@@ -193,6 +191,20 @@ public class MapAlgebraTest extends RasterTestBase
         for (int i = 0; i < band.length; i++) {
             assertEquals(band[i], bandNew[i], 1e-9);
         }
+    }
+
+    @Test
+    public void testMultiplyFactor() {
+        double[] input = new double[] {200, 100, 145, 255};
+        double factor = 1.5;
+        double[] actual = MapAlgebra.multiplyFactor(input, factor);
+        double[] expected = new double[] {300.0, 150.0, 217.5, 382.5};
+        assertArrayEquals(expected, actual, 0.01d);
+
+        factor = 2;
+        actual = MapAlgebra.multiplyFactor(input, factor);
+        expected = new double[]{400.0, 200.0, 290.0, 510.0};
+        assertArrayEquals(expected, actual, 0.1d);
     }
 
     @Test

--- a/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
@@ -296,6 +296,15 @@ public class MapAlgebraTest extends RasterTestBase
     }
 
     @Test
+    public void testLogicalDifference() {
+        double[] band1 = new double[] {10.0, 20.0, 30.0};
+        double[] band2 = new double[] {40.0, 20.0, 50.0};
+        double[] actual = MapAlgebra.logicalDifference(band1, band2);
+        double[] expected = new double[] {10.0, 0.0, 30.0};
+        assertArrayEquals(expected, actual, 0.1d);
+    }
+
+    @Test
     public void testMapAlgebra() throws FactoryException {
         Random random = new Random();
         String[] pixelTypes = {null, "b", "i", "s", "us", "f", "d"};

--- a/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
@@ -415,6 +415,15 @@ public class MapAlgebraTest extends RasterTestBase
     }
 
     @Test
+    public void testCountValue() {
+        double[] band = new double[] {200.0, 400.0, 600.0, 200.0, 600.0, 600.0, 800.0};
+        double target = 600d;
+        int actual = MapAlgebra.countValue(band, target);
+        int expected = 3;
+        assertEquals(expected, actual);
+    }
+
+    @Test
     public void testMapAlgebra() throws FactoryException {
         Random random = new Random();
         String[] pixelTypes = {null, "b", "i", "s", "us", "f", "d"};

--- a/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import org.opengis.referencing.FactoryException;
 
 import java.awt.image.DataBuffer;
-import java.util.Arrays;
 import java.util.Random;
 
 import static org.junit.Assert.*;
@@ -239,6 +238,21 @@ public class MapAlgebraTest extends RasterTestBase
         actual = MapAlgebra.multiply(band1, band2);
         expected = new double[] {400.0, 1000.0, 1500.0};
         assertArrayEquals(expected, actual, 0.1d);
+    }
+
+    @Test
+    public void testDivide() {
+        double[] band1 = new double[] {20.43, 40.67, 60.91};
+        double[] band2 = new double[] {2.84, 5.26, 8.97};
+        double[] actual = MapAlgebra.divide(band1, band2);
+        double[] expected = new double[] {7.19, 7.73, 6.79};
+        assertArrayEquals(expected, actual, 0.001d);
+
+        band1 = new double[] {200, 400, 500};
+        band2 = new double[] {2, 2.5, 3};
+        actual = MapAlgebra.divide(band1, band2);
+        expected = new double[] {100.0, 160.0, 166.67};
+        assertArrayEquals(expected, actual, 0.01d);
     }
 
     @Test

--- a/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
@@ -305,6 +305,15 @@ public class MapAlgebraTest extends RasterTestBase
     }
 
     @Test
+    public void testLogicalOver() {
+        double[] band1 = new double[] {0.0, 0.0, 30.0};
+        double[] band2 = new double[] {40.0, 20.0, 50.0};
+        double[] actual = MapAlgebra.logicalOver(band1, band2);
+        double[] expected = new double[] {40.0, 20.0, 30.0};
+        assertArrayEquals(expected, actual, 0.1d);
+    }
+
+    @Test
     public void testMapAlgebra() throws FactoryException {
         Random random = new Random();
         String[] pixelTypes = {null, "b", "i", "s", "us", "f", "d"};

--- a/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
@@ -217,6 +217,15 @@ public class MapAlgebraTest extends RasterTestBase
     }
 
     @Test
+    public void testSubtract() {
+        double[] band1 = new double[] {55, 155, 110, 10};
+        double[] band2 = new double[] {255.0, 255.0, 255.0, 255.0};
+        double[] actual = MapAlgebra.subtract(band1, band2);
+        double[] expected = new double[] {200, 100, 145, 245};
+        assertArrayEquals(expected, actual, 0.1d);
+    }
+
+    @Test
     public void testMapAlgebra() throws FactoryException {
         Random random = new Random();
         String[] pixelTypes = {null, "b", "i", "s", "us", "f", "d"};

--- a/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
@@ -278,6 +278,15 @@ public class MapAlgebraTest extends RasterTestBase
     }
 
     @Test
+    public void testBitwiseAnd() {
+        double[] band1 = new double[] {15.0, 25.0, 35.0};
+        double[] band2 = new double[] {5.0, 15.0, 25.0};
+        double[] actual = MapAlgebra.bitwiseAnd(band1, band2);
+        double[] expected = new double[]{5.0, 9.0, 1.0};
+        assertArrayEquals(expected, actual, 0.1d);
+    }
+
+    @Test
     public void testMapAlgebra() throws FactoryException {
         Random random = new Random();
         String[] pixelTypes = {null, "b", "i", "s", "us", "f", "d"};

--- a/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
@@ -359,6 +359,20 @@ public class MapAlgebraTest extends RasterTestBase
     }
 
     @Test
+    public void testGreaterThan() {
+        double[] band = new double[] {0.42, 0.36, 0.18, 0.20, 0.21, 0.2001, 0.19};
+        double target = 0.2;
+        double[] actual = MapAlgebra.greaterThan(band, target);
+        double[] expected = new double[] {1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0};
+        assertArrayEquals(expected, actual, 0.1d);
+
+        band = new double[] {0.14, 0.13, 0.10, 0.86, 0.01};
+        actual = MapAlgebra.greaterThan(band, target);
+        expected = new double[] {0.0, 0.0, 0.0, 1.0, 0.0};
+        assertArrayEquals(expected, actual, 0.1d);
+    }
+
+    @Test
     public void testMapAlgebra() throws FactoryException {
         Random random = new Random();
         String[] pixelTypes = {null, "b", "i", "s", "us", "f", "d"};

--- a/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
@@ -349,6 +349,19 @@ public class MapAlgebraTest extends RasterTestBase
     }
 
     @Test
+    public void testMode() {
+        double[] band = new double[] {200.0, 400.0, 600.0, 200.0};
+        double[] actual = MapAlgebra.mode(band);
+        double[] expected = new double[] {200d};
+        assertArrayEquals(expected, actual, 0.1d);
+
+        band = new double[] {200.0, 400.0, 600.0, 700.0};
+        actual = MapAlgebra.mode(band);
+        expected = new double[] {200.0, 400.0, 600.0, 700.0};
+        assertArrayEquals(expected, actual, 0.1d);
+    }
+
+    @Test
     public void testFetchRegion() {
         double[] band = new double[] {100.0, 260.0, 189.0, 106.0, 230.0, 169.0, 196.0, 200.0, 460.0};
         int[] coordinates = new int[] {0, 0, 1, 2};

--- a/docs/api/sql/Raster-operators.md
+++ b/docs/api/sql/Raster-operators.md
@@ -1583,6 +1583,8 @@ This function only accepts integer as factor before `v1.5.0`.
 
 Introduction: Normalize the value in the array to [0, 255]
 
+Format: `RS_Normalize (Band: Array[Double])`
+
 Since: `v1.1.0`
 
 Spark SQL example

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
@@ -28,42 +28,7 @@ import org.apache.spark.sql.sedona_sql.expressions.{InferredExpression, UserData
 import org.apache.spark.sql.types._
 
 /// Calculate Normalized Difference between two bands
-case class RS_NormalizedDifference(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback with UserDataGeneratator {
-  // This is an expression which takes one input expressions
-  assert(inputExpressions.length == 2)
-
-  override def nullable: Boolean = false
-
-  override def eval(inputRow: InternalRow): Any = {
-    val band1 = inputExpressions(0).eval(inputRow).asInstanceOf[ArrayData].toDoubleArray()
-    val band2 = inputExpressions(1).eval(inputRow).asInstanceOf[ArrayData].toDoubleArray()
-    val ndvi = normalizeddifference(band1, band2)
-
-    new GenericArrayData(ndvi)
-  }
-  private def normalizeddifference(band1: Array[Double], band2: Array[Double]): Array[Double] = {
-
-    val result = new Array[Double](band1.length)
-    for (i <- 0 until band1.length) {
-      if (band1(i) == 0) {
-        band1(i) = -1
-      }
-      if (band2(i) == 0) {
-        band2(i) = -1
-      }
-
-      result(i) = ((band2(i) - band1(i)) / (band2(i) + band1(i))*100).round/100.toDouble
-    }
-
-    result
-
-  }
-
-  override def dataType: DataType = ArrayType(DoubleType)
-
-  override def children: Seq[Expression] = inputExpressions
-
+case class RS_NormalizedDifference(inputExpressions: Seq[Expression]) extends InferredExpression(MapAlgebra.normalizedDifference _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
@@ -420,7 +385,7 @@ case class RS_LogicalDifference(inputExpressions: Seq[Expression]) extends Infer
 
 // If a value in band 1 is not equal to 0, band1 is returned else value from band2 is returned
 case class RS_LogicalOver(inputExpressions: Seq[Expression]) extends InferredExpression(MapAlgebra.logicalOver _) {
-  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) ={
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
@@ -107,37 +107,7 @@ case class RS_LessThan(inputExpressions: Seq[Expression]) extends InferredExpres
 }
 
 // Mark all the band values with 1 which are less than or equal to a particular threshold
-case class RS_LessThanEqual(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback with UserDataGeneratator {
-  assert(inputExpressions.length == 2)
-
-  override def nullable: Boolean = false
-
-  override def eval(inputRow: InternalRow): Any = {
-    val band = inputExpressions(0).eval(inputRow).asInstanceOf[ArrayData].toDoubleArray()
-    val target = inputExpressions(1).eval(inputRow).asInstanceOf[Decimal].toDouble
-    new GenericArrayData(findLessThanEqual(band, target))
-
-  }
-
-  private def findLessThanEqual(band: Array[Double], target: Double):Array[Double] = {
-
-    val result = new Array[Double](band.length)
-    for(i<-0 until band.length) {
-      if(band(i)<=target) {
-        result(i) = 1
-      }
-      else {
-        result(i) = 0
-      }
-    }
-    result
-  }
-
-  override def dataType: DataType = ArrayType(DoubleType)
-
-  override def children: Seq[Expression] = inputExpressions
-
+case class RS_LessThanEqual(inputExpressions: Seq[Expression]) extends InferredExpression(MapAlgebra.lessThanEqual _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
@@ -35,29 +35,7 @@ case class RS_NormalizedDifference(inputExpressions: Seq[Expression]) extends In
 }
 
 // Calculate mean value for a particular band
-case class RS_Mean(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback with UserDataGeneratator {
-  // This is an expression which takes one input expressions
-  assert(inputExpressions.length == 1)
-
-  override def nullable: Boolean = false
-
-  override def eval(inputRow: InternalRow): Any = {
-    val band = inputExpressions(0).eval(inputRow).asInstanceOf[ArrayData].toDoubleArray()
-    val mean = calculateMean(band)
-    mean
-  }
-
-  private def calculateMean(band:Array[Double]):Double = {
-
-    ((band.toList.sum/band.length)*100).round/100.toDouble
-  }
-
-
-  override def dataType: DataType = DoubleType
-
-  override def children: Seq[Expression] = inputExpressions
-
+case class RS_Mean(inputExpressions: Seq[Expression]) extends InferredExpression(MapAlgebra.mean _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
@@ -42,29 +42,7 @@ case class RS_Mean(inputExpressions: Seq[Expression]) extends InferredExpression
 }
 
 // Calculate mode of a particular band
-case class RS_Mode(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback with UserDataGeneratator {
-  // This is an expression which takes one input expressions
-  assert(inputExpressions.length == 1)
-
-  override def nullable: Boolean = false
-
-  override def eval(inputRow: InternalRow): Any = {
-    var band = inputExpressions(0).eval(inputRow).asInstanceOf[ArrayData].toDoubleArray()
-    val mode = calculateMode(band)
-    new GenericArrayData(mode)
-  }
-
-  private def calculateMode(band:Array[Double]):Array[Double] = {
-    val grouped = band.toList.groupBy(x => x).mapValues(_.size)
-    val modeValue = grouped.maxBy(_._2)._2
-    val modes = grouped.filter(_._2 == modeValue).map(_._1)
-    modes.toArray
-  }
-  override def dataType: DataType = ArrayType(DoubleType)
-
-  override def children: Seq[Expression] = inputExpressions
-
+case class RS_Mode(inputExpressions: Seq[Expression]) extends InferredExpression(MapAlgebra.mode _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
@@ -398,34 +398,7 @@ case class RS_SquareRoot(inputExpressions: Seq[Expression]) extends InferredExpr
 }
 
 // Bitwise AND between two bands
-case class RS_BitwiseAnd(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback with UserDataGeneratator {
-  assert(inputExpressions.length == 2)
-
-  override def nullable: Boolean = false
-
-  override def eval(inputRow: InternalRow): Any = {
-    val band1 = inputExpressions(0).eval(inputRow).asInstanceOf[ArrayData].toDoubleArray()
-    val band2 = inputExpressions(1).eval(inputRow).asInstanceOf[ArrayData].toDoubleArray()
-    assert(band1.length == band2.length)
-
-    new GenericArrayData(bitwiseAnd(band1, band2))
-  }
-
-  private def bitwiseAnd(band1: Array[Double], band2: Array[Double]):Array[Double] = {
-
-    val result = new Array[Double](band1.length)
-    for(i<-0 until band1.length) {
-      result(i) = band1(i).toInt & band2(i).toInt
-    }
-    result
-
-  }
-
-  override def dataType: DataType = ArrayType(DoubleType)
-
-  override def children: Seq[Expression] = inputExpressions
-
+case class RS_BitwiseAnd(inputExpressions: Seq[Expression]) extends InferredExpression(MapAlgebra.bitwiseAnd _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
@@ -412,41 +412,7 @@ case class RS_BitwiseOr(inputExpressions: Seq[Expression]) extends InferredExpre
 }
 
 // if a value in band1 and band2 are different,value from band1 ins returned else return 0
-case class RS_LogicalDifference(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback with UserDataGeneratator {
-  assert(inputExpressions.length == 2)
-
-  override def nullable: Boolean = false
-
-  override def eval(inputRow: InternalRow): Any = {
-    val band1 = inputExpressions(0).eval(inputRow).asInstanceOf[ArrayData].toDoubleArray()
-    val band2 = inputExpressions(1).eval(inputRow).asInstanceOf[ArrayData].toDoubleArray()
-    assert(band1.length == band2.length)
-
-    new GenericArrayData(logicalDifference(band1, band2))
-  }
-
-  private def logicalDifference(band1: Array[Double], band2: Array[Double]):Array[Double] = {
-
-    val result = new Array[Double](band1.length)
-    for(i<-0 until band1.length) {
-      if(band1(i) != band2(i))
-      {
-        result(i) = band1(i)
-      }
-      else
-      {
-        result(i) = 0.0
-      }
-    }
-    result
-
-  }
-
-  override def dataType: DataType = ArrayType(DoubleType)
-
-  override def children: Seq[Expression] = inputExpressions
-
+case class RS_LogicalDifference(inputExpressions: Seq[Expression]) extends InferredExpression(MapAlgebra.logicalDifference _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
@@ -100,37 +100,7 @@ case class RS_GreaterThanEqual(inputExpressions: Seq[Expression]) extends Inferr
 }
 
 // Mark all the band values with 1 which are less than a particular threshold
-case class RS_LessThan(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback with UserDataGeneratator {
-  assert(inputExpressions.length == 2)
-
-  override def nullable: Boolean = false
-
-  override def eval(inputRow: InternalRow): Any = {
-    val band = inputExpressions(0).eval(inputRow).asInstanceOf[ArrayData].toDoubleArray()
-    val target = inputExpressions(1).eval(inputRow).asInstanceOf[Decimal].toDouble
-    new GenericArrayData(findLessThan(band, target))
-
-  }
-
-  private def findLessThan(band: Array[Double], target: Double):Array[Double] = {
-
-    val result = new Array[Double](band.length)
-    for(i<-0 until band.length) {
-      if(band(i)<target) {
-        result(i) = 1
-      }
-      else {
-        result(i) = 0
-      }
-    }
-    result
-  }
-
-  override def dataType: DataType = ArrayType(DoubleType)
-
-  override def children: Seq[Expression] = inputExpressions
-
+case class RS_LessThan(inputExpressions: Seq[Expression]) extends InferredExpression(MapAlgebra.lessThan _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
@@ -86,37 +86,7 @@ case class RS_FetchRegion(inputExpressions: Seq[Expression]) extends InferredExp
 }
 
 // Mark all the band values with 1 which are greater than a particular threshold
-case class RS_GreaterThan(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback with UserDataGeneratator {
-  assert(inputExpressions.length == 2)
-
-  override def nullable: Boolean = false
-
-  override def eval(inputRow: InternalRow): Any = {
-    val band = inputExpressions(0).eval(inputRow).asInstanceOf[ArrayData].toDoubleArray()
-    val target = inputExpressions(1).eval(inputRow).asInstanceOf[Decimal].toDouble
-    new GenericArrayData(findGreaterThan(band, target))
-
-  }
-
-  private def findGreaterThan(band: Array[Double], target: Double):Array[Double] = {
-
-    val result = new Array[Double](band.length)
-    for(i<-0 until band.length) {
-      if(band(i)>target) {
-        result(i) = 1
-      }
-      else {
-        result(i) = 0
-      }
-    }
-    result
-  }
-
-  override def dataType: DataType = ArrayType(DoubleType)
-
-  override def children: Seq[Expression] = inputExpressions
-
+case class RS_GreaterThan(inputExpressions: Seq[Expression]) extends InferredExpression(MapAlgebra.greaterThan _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
@@ -392,34 +392,7 @@ case class RS_Add(inputExpressions: Seq[Expression]) extends InferredExpression(
 }
 
 // Subtract two bands
-case class RS_Subtract(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback with UserDataGeneratator {
-  assert(inputExpressions.length == 2)
-
-  override def nullable: Boolean = false
-
-  override def eval(inputRow: InternalRow): Any = {
-    val band1 = inputExpressions(0).eval(inputRow).asInstanceOf[ArrayData].toDoubleArray()
-    val band2 = inputExpressions(1).eval(inputRow).asInstanceOf[ArrayData].toDoubleArray()
-    assert(band1.length == band2.length)
-
-    new GenericArrayData(subtractBands(band1, band2))
-  }
-
-  private def subtractBands(band1: Array[Double], band2: Array[Double]):Array[Double] = {
-
-    val result = new Array[Double](band1.length)
-    for(i<-0 until band1.length) {
-      result(i) = band2(i) - band1(i)
-    }
-    result
-
-  }
-
-  override def dataType: DataType = ArrayType(DoubleType)
-
-  override def children: Seq[Expression] = inputExpressions
-
+case class RS_Subtract(inputExpressions: Seq[Expression]) extends InferredExpression(MapAlgebra.subtract _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
@@ -93,37 +93,7 @@ case class RS_GreaterThan(inputExpressions: Seq[Expression]) extends InferredExp
 }
 
 // Mark all the band values with 1 which are greater than or equal to a particular threshold
-case class RS_GreaterThanEqual(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback with UserDataGeneratator {
-  assert(inputExpressions.length == 2)
-
-  override def nullable: Boolean = false
-
-  override def eval(inputRow: InternalRow): Any = {
-    val band = inputExpressions(0).eval(inputRow).asInstanceOf[ArrayData].toDoubleArray()
-    val target = inputExpressions(1).eval(inputRow).asInstanceOf[Decimal].toDouble
-    new GenericArrayData(findGreaterThanEqual(band, target))
-
-  }
-
-  private def findGreaterThanEqual(band: Array[Double], target: Double):Array[Double] = {
-
-    val result = new Array[Double](band.length)
-    for(i<-0 until band.length) {
-      if(band(i)>=target) {
-        result(i) = 1
-      }
-      else {
-        result(i) = 0
-      }
-    }
-    result
-  }
-
-  override def dataType: DataType = ArrayType(DoubleType)
-
-  override def children: Seq[Expression] = inputExpressions
-
+case class RS_GreaterThanEqual(inputExpressions: Seq[Expression]) extends InferredExpression(MapAlgebra.greaterThanEqual _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
@@ -405,34 +405,7 @@ case class RS_BitwiseAnd(inputExpressions: Seq[Expression]) extends InferredExpr
 }
 
 // Bitwise OR between two bands
-case class RS_BitwiseOr(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback with UserDataGeneratator {
-  assert(inputExpressions.length == 2)
-
-  override def nullable: Boolean = false
-
-  override def eval(inputRow: InternalRow): Any = {
-    val band1 = inputExpressions(0).eval(inputRow).asInstanceOf[ArrayData].toDoubleArray()
-    val band2 = inputExpressions(1).eval(inputRow).asInstanceOf[ArrayData].toDoubleArray()
-    assert(band1.length == band2.length)
-
-    new GenericArrayData(bitwiseOr(band1, band2))
-  }
-
-  private def bitwiseOr(band1: Array[Double], band2: Array[Double]):Array[Double] = {
-
-    val result = new Array[Double](band1.length)
-    for(i<-0 until band1.length) {
-      result(i) = band1(i).toInt | band2(i).toInt
-    }
-    result
-
-  }
-
-  override def dataType: DataType = ArrayType(DoubleType)
-
-  override def children: Seq[Expression] = inputExpressions
-
+case class RS_BitwiseOr(inputExpressions: Seq[Expression]) extends InferredExpression(MapAlgebra.bitwiseOr _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
@@ -399,34 +399,7 @@ case class RS_Subtract(inputExpressions: Seq[Expression]) extends InferredExpres
 }
 
 // Multiple two bands
-case class RS_Multiply(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback with UserDataGeneratator {
-  assert(inputExpressions.length == 2)
-
-  override def nullable: Boolean = false
-
-  override def eval(inputRow: InternalRow): Any = {
-    val band1 = inputExpressions(0).eval(inputRow).asInstanceOf[ArrayData].toDoubleArray()
-    val band2 = inputExpressions(1).eval(inputRow).asInstanceOf[ArrayData].toDoubleArray()
-    assert(band1.length == band2.length)
-
-    new GenericArrayData(multiplyBands(band1, band2))
-  }
-
-  private def multiplyBands(band1: Array[Double], band2: Array[Double]):Array[Double] = {
-
-    val result = new Array[Double](band1.length)
-    for(i<-0 until band1.length) {
-      result(i) = band1(i) * band2(i)
-    }
-    result
-
-  }
-
-  override def dataType: DataType = ArrayType(DoubleType)
-
-  override def children: Seq[Expression] = inputExpressions
-
+case class RS_Multiply(inputExpressions: Seq[Expression]) extends InferredExpression(MapAlgebra.multiply _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
@@ -20,12 +20,10 @@ package org.apache.spark.sql.sedona_sql.expressions.raster
 
 import org.apache.sedona.common.raster.MapAlgebra
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
-import org.apache.spark.sql.catalyst.expressions.{Expression, ImplicitCastInputTypes}
+import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.util.{ArrayData, GenericArrayData}
 import org.apache.spark.sql.sedona_sql.expressions.InferrableFunctionConverter._
-import org.apache.spark.sql.sedona_sql.expressions.{InferredExpression, UserDataGeneratator}
-import org.apache.spark.sql.types._
+import org.apache.spark.sql.sedona_sql.expressions.InferredExpression
 
 /// Calculate Normalized Difference between two bands
 case class RS_NormalizedDifference(inputExpressions: Seq[Expression]) extends InferredExpression(MapAlgebra.normalizedDifference _) {

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
@@ -385,34 +385,7 @@ case class RS_MultiplyFactor(inputExpressions: Seq[Expression])
 }
 
 // Add two bands
-case class RS_Add(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback with UserDataGeneratator {
-  assert(inputExpressions.length == 2)
-
-  override def nullable: Boolean = false
-
-  override def eval(inputRow: InternalRow): Any = {
-    val band1 = inputExpressions(0).eval(inputRow).asInstanceOf[ArrayData].toDoubleArray()
-    val band2 = inputExpressions(1).eval(inputRow).asInstanceOf[ArrayData].toDoubleArray()
-    assert(band1.length == band2.length)
-
-    new GenericArrayData(addBands(band1, band2))
-  }
-
-  private def addBands(band1: Array[Double], band2: Array[Double]):Array[Double] = {
-
-    val result = new Array[Double](band1.length)
-    for(i<-0 until band1.length) {
-      result(i) = band1(i) + band2(i)
-    }
-    result
-
-  }
-
-  override def dataType: DataType = ArrayType(DoubleType)
-
-  override def children: Seq[Expression] = inputExpressions
-
+case class RS_Add(inputExpressions: Seq[Expression]) extends InferredExpression(MapAlgebra.add _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
@@ -425,36 +425,7 @@ case class RS_LogicalOver(inputExpressions: Seq[Expression]) extends InferredExp
   }
 }
 
-case class RS_Normalize(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback with UserDataGeneratator {
-  assert(inputExpressions.length == 1)
-  override def nullable: Boolean = false
-
-  override def eval(inputRow: InternalRow): Any = {
-    // This is an expression which takes one input expressions
-    val band = inputExpressions(0).eval(inputRow).asInstanceOf[ArrayData].toDoubleArray()
-    val result = normalize(band)
-    new GenericArrayData(result)
-  }
-
-  // Normalize between 0 and 255
-  private def normalize(band: Array[Double]): Array[Double] = {
-
-    val result = new Array[Double](band.length)
-    val maxVal = band.toList.max
-
-    for(i<-0 until band.length) {
-      result(i) = (band(i)/(maxVal/255.0)).toInt
-    }
-
-    result
-
-  }
-
-  override def dataType: DataType = ArrayType(DoubleType)
-
-  override def children: Seq[Expression] = inputExpressions
-
+case class RS_Normalize(inputExpressions: Seq[Expression]) extends InferredExpression(MapAlgebra.normalize _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
@@ -349,36 +349,7 @@ case class RS_CountValue(inputExpressions: Seq[Expression])
 }
 
 // Multiply a factor to all values of a band
-case class RS_MultiplyFactor(inputExpressions: Seq[Expression])
-  extends Expression with ImplicitCastInputTypes with CodegenFallback with UserDataGeneratator {
-  assert(inputExpressions.length == 2)
-
-  override def nullable: Boolean = false
-
-  override def eval(inputRow: InternalRow): Any = {
-    val band = inputExpressions(0).eval(inputRow).asInstanceOf[ArrayData].toDoubleArray()
-    val factor = inputExpressions(1).eval(inputRow).asInstanceOf[Double]
-    new GenericArrayData(multiply(band, factor))
-
-  }
-
-  private def multiply(band: Array[Double], factor: Double):Array[Double] = {
-
-    var result = new Array[Double](band.length)
-    for(i<-0 until band.length) {
-
-      result(i) = band(i) * factor
-
-    }
-    result
-  }
-
-  override def inputTypes: Seq[AbstractDataType] = Seq(ArrayType(DoubleType), DoubleType)
-
-  override def dataType: DataType = ArrayType(DoubleType)
-
-  override def children: Seq[Expression] = inputExpressions
-
+case class RS_MultiplyFactor(inputExpressions: Seq[Expression]) extends InferredExpression(MapAlgebra.multiplyFactor _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
@@ -114,34 +114,7 @@ case class RS_LessThanEqual(inputExpressions: Seq[Expression]) extends InferredE
 }
 
 // Count number of occurrences of a particular value in a band
-case class RS_CountValue(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback with UserDataGeneratator {
-  assert(inputExpressions.length == 2)
-
-  override def nullable: Boolean = false
-
-  override def eval(inputRow: InternalRow): Any = {
-    val band = inputExpressions(0).eval(inputRow).asInstanceOf[ArrayData].toDoubleArray()
-    val target = inputExpressions(1).eval(inputRow).asInstanceOf[Decimal].toDouble
-    findCount(band, target)
-  }
-
-  private def findCount(band: Array[Double], target: Double):Int = {
-
-    var result = 0
-    for(i<-0 until band.length) {
-      if(band(i)==target) {
-        result+=1
-      }
-
-    }
-    result
-  }
-
-  override def dataType: DataType = IntegerType
-
-  override def children: Seq[Expression] = inputExpressions
-
+case class RS_CountValue(inputExpressions: Seq[Expression]) extends InferredExpression(MapAlgebra.countValue _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
@@ -406,34 +406,7 @@ case class RS_Multiply(inputExpressions: Seq[Expression]) extends InferredExpres
 }
 
 // Divide two bands
-case class RS_Divide(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback with UserDataGeneratator {
-  assert(inputExpressions.length == 2)
-
-  override def nullable: Boolean = false
-
-  override def eval(inputRow: InternalRow): Any = {
-    val band1 = inputExpressions(0).eval(inputRow).asInstanceOf[ArrayData].toDoubleArray()
-    val band2 = inputExpressions(1).eval(inputRow).asInstanceOf[ArrayData].toDoubleArray()
-    assert(band1.length == band2.length)
-
-    new GenericArrayData(divideBands(band1, band2))
-  }
-
-  private def divideBands(band1: Array[Double], band2: Array[Double]):Array[Double] = {
-
-    val result = new Array[Double](band1.length)
-    for(i<-0 until band1.length) {
-      result(i) = ((band1(i)/band2(i))*100).round/(100.toDouble)
-    }
-    result
-
-  }
-
-  override def dataType: DataType = ArrayType(DoubleType)
-
-  override def children: Seq[Expression] = inputExpressions
-
+case class RS_Divide(inputExpressions: Seq[Expression]) extends InferredExpression(MapAlgebra.divide _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
@@ -391,32 +391,7 @@ case class RS_Modulo(inputExpressions: Seq[Expression]) extends InferredExpressi
 }
 
 // Square root of values in a band
-case class RS_SquareRoot(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback with UserDataGeneratator {
-  assert(inputExpressions.length == 1)
-
-  override def nullable: Boolean = false
-
-  override def eval(inputRow: InternalRow): Any = {
-    val band = inputExpressions(0).eval(inputRow).asInstanceOf[ArrayData].toDoubleArray()
-    new GenericArrayData(squareRoot(band))
-
-  }
-
-  private def squareRoot(band: Array[Double]):Array[Double] = {
-
-    val result = new Array[Double](band.length)
-    for(i<-0 until band.length) {
-      result(i) = (Math.sqrt(band(i))*100).round/100.toDouble
-    }
-    result
-
-  }
-
-  override def dataType: DataType = ArrayType(DoubleType)
-
-  override def children: Seq[Expression] = inputExpressions
-
+case class RS_SquareRoot(inputExpressions: Seq[Expression]) extends InferredExpression(MapAlgebra.squareRoot _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
@@ -419,42 +419,8 @@ case class RS_LogicalDifference(inputExpressions: Seq[Expression]) extends Infer
 }
 
 // If a value in band 1 is not equal to 0, band1 is returned else value from band2 is returned
-case class RS_LogicalOver(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback with UserDataGeneratator {
-  assert(inputExpressions.length == 2)
-
-  override def nullable: Boolean = false
-
-  override def eval(inputRow: InternalRow): Any = {
-    val band1 = inputExpressions(0).eval(inputRow).asInstanceOf[ArrayData].toDoubleArray()
-    val band2 = inputExpressions(1).eval(inputRow).asInstanceOf[ArrayData].toDoubleArray()
-    assert(band1.length == band2.length)
-
-    new GenericArrayData(logicalOver(band1, band2))
-  }
-
-  private def logicalOver(band1: Array[Double], band2: Array[Double]):Array[Double] = {
-
-    val result = new Array[Double](band1.length)
-    for(i<-0 until band1.length) {
-      if(band1(i) != 0.0)
-      {
-        result(i) = band1(i)
-      }
-      else
-      {
-        result(i) = band2(i)
-      }
-    }
-    result
-
-  }
-
-  override def dataType: DataType = ArrayType(DoubleType)
-
-  override def children: Seq[Expression] = inputExpressions
-
-  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+case class RS_LogicalOver(inputExpressions: Seq[Expression]) extends InferredExpression(MapAlgebra.logicalOver _) {
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) ={
     copy(inputExpressions = newChildren)
   }
 }

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
@@ -384,33 +384,7 @@ case class RS_Divide(inputExpressions: Seq[Expression]) extends InferredExpressi
 }
 
 // Modulo of a band
-case class RS_Modulo(inputExpressions: Seq[Expression])
-  extends Expression with CodegenFallback with UserDataGeneratator {
-  assert(inputExpressions.length == 2)
-
-  override def nullable: Boolean = false
-
-  override def eval(inputRow: InternalRow): Any = {
-    val band = inputExpressions(0).eval(inputRow).asInstanceOf[ArrayData].toDoubleArray()
-    val dividend = inputExpressions(1).eval(inputRow).asInstanceOf[Decimal].toDouble
-
-    new GenericArrayData(modulo(band, dividend))
-  }
-
-  private def modulo(band: Array[Double], dividend:Double):Array[Double] = {
-
-    val result = new Array[Double](band.length)
-    for(i<-0 until band.length) {
-      result(i) = band(i) % dividend
-    }
-    result
-
-  }
-
-  override def dataType: DataType = ArrayType(DoubleType)
-
-  override def children: Seq[Expression] = inputExpressions
-
+case class RS_Modulo(inputExpressions: Seq[Expression]) extends InferredExpression(MapAlgebra.modulo _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-397. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

- Moved RS_Add, RS_Subtract, RS_Multiply, RS_Divide, RS_MultiplyFactor, RS_Modulo, RS_SquareRoot, RS_BitwiseAND, RS_BitwiseOR, RS_NormalizeDifference, RS_Mean, RS_Mode, RS_FetchRegion, RS_GreaterThan, RS_GreaterThanEqual, RS_LessThan, RS_LessThanEqual, RS_CountValue, RS_LogicalDifference, RS_LogicalOver, RS_Normalize.

## How was this patch tested?

- With the existing tests and new tests

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation update if needed.
