### PR TITLE
[SEDONA-386] Fixed CRS deserialization when cache was not hit

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/raster/CRSSerializer.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/CRSSerializer.java
@@ -29,8 +29,8 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.nio.ByteBuffer;
-import java.util.zip.DeflaterInputStream;
 import java.util.zip.DeflaterOutputStream;
+import java.util.zip.InflaterInputStream;
 
 /**
  * There won't be too many distinct CRSes in a typical application, so we can cache the serialized form
@@ -99,11 +99,17 @@ public class CRSSerializer {
     private static CoordinateReferenceSystem doDeserializeCRS(ByteBuffer byteBuffer) throws IOException, ClassNotFoundException {
         byte[] bytes = byteBuffer.array();
         try (ByteArrayInputStream bis = new ByteArrayInputStream(bytes);
-             DeflaterInputStream dis = new DeflaterInputStream(bis);
+             InflaterInputStream dis = new InflaterInputStream(bis);
              ObjectInputStream ois = new ObjectInputStream(dis)) {
             CoordinateReferenceSystem crs = (CoordinateReferenceSystem) ois.readObject();
             crsSerializationCache.put(new CRSKey(crs), bytes);
             return crs;
         }
+    }
+
+    // This method is only used in tests
+    public static void invalidateCache() {
+        crsSerializationCache.invalidateAll();
+        crsDeserializationCache.invalidateAll();
     }
 }

--- a/common/src/test/java/org/apache/sedona/common/raster/CRSSerializerTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/CRSSerializerTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.common.raster;
+
+import org.geotools.referencing.CRS;
+import org.junit.Assert;
+import org.junit.Test;
+import org.opengis.referencing.FactoryException;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+
+public class CRSSerializerTest {
+    @Test
+    public void testCRSSerializer() throws FactoryException {
+        CoordinateReferenceSystem crs = CRS.decode("EPSG:32607");
+        byte[] serializedCRS = CRSSerializer.serialize(crs);
+        CoordinateReferenceSystem deserializedCRS = CRSSerializer.deserialize(serializedCRS);
+        Assert.assertTrue(CRS.equalsIgnoreMetadata(crs, deserializedCRS));
+    }
+
+    @Test
+    public void testCRSSerializerWithoutCache() throws FactoryException {
+        CoordinateReferenceSystem crs = CRS.decode("EPSG:32607");
+        byte[] serializedCRS = CRSSerializer.serialize(crs);
+        CRSSerializer.invalidateCache();
+        CoordinateReferenceSystem deserializedCRS = CRSSerializer.deserialize(serializedCRS);
+        Assert.assertTrue(CRS.equalsIgnoreMetadata(crs, deserializedCRS));
+    }
+}


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-386. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Fix a silly mistake in CRS deserialization code: we should use `InflaterInputStream` instead of `DeflaterInputStream` to decompress the stream.

## How was this patch tested?

Added test to cover the case where cache was not hit when deserializing CRS objects.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
