### PR TITLE
[SEDONA-398] Add RS_AddBand

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
@@ -21,12 +21,10 @@ package org.apache.sedona.common.raster;
 import it.geosolutions.jaiext.jiffle.JiffleBuilder;
 import it.geosolutions.jaiext.jiffle.runtime.JiffleDirectRuntime;
 import org.apache.sedona.common.utils.RasterUtils;
-import org.geotools.coverage.GridSampleDimension;
 import org.geotools.coverage.grid.GridCoverage2D;
 
 import javax.media.jai.PlanarImage;
 import javax.media.jai.RasterFactory;
-import java.awt.Point;
 import java.awt.image.BufferedImage;
 import java.awt.image.ColorModel;
 import java.awt.image.DataBuffer;
@@ -34,6 +32,7 @@ import java.awt.image.Raster;
 import java.awt.image.RenderedImage;
 import java.awt.image.WritableRaster;
 import java.awt.image.WritableRenderedImage;
+import java.util.Arrays;
 
 public class MapAlgebra
 {
@@ -74,11 +73,12 @@ public class MapAlgebra
             throw new IllegalArgumentException("Band index is out of bounds. Must be between 1 and " + (numBands + 1) + ")");
         }
 
+        Double[] bandValuesClass = Arrays.stream(bandValues).boxed().toArray(Double[]::new);
         if (bandIndex == numBands + 1) {
-            return copyRasterAndAppendBand(rasterGeom, bandValues, noDataValue);
+            return RasterUtils.copyRasterAndAppendBand(rasterGeom, bandValuesClass, noDataValue);
         }
         else {
-            return copyRasterAndReplaceBand(rasterGeom, bandIndex, bandValues, noDataValue, true);
+            return RasterUtils.copyRasterAndReplaceBand(rasterGeom, bandIndex, bandValuesClass, noDataValue, true);
         }
     }
 
@@ -89,11 +89,12 @@ public class MapAlgebra
             throw new IllegalArgumentException("Band index is out of bounds. Must be between 1 and " + (numBands + 1) + ")");
         }
 
+        Double[] bandValuesClass = Arrays.stream(bandValues).boxed().toArray(Double[]::new);
         if (bandIndex == numBands + 1) {
-            return copyRasterAndAppendBand(rasterGeom, bandValues);
+            return RasterUtils.copyRasterAndAppendBand(rasterGeom, bandValuesClass);
         }
         else {
-            return copyRasterAndReplaceBand(rasterGeom, bandIndex, bandValues);
+            return RasterUtils.copyRasterAndReplaceBand(rasterGeom, bandIndex, bandValuesClass);
         }
     }
 
@@ -106,78 +107,6 @@ public class MapAlgebra
      */
     public static GridCoverage2D addBandFromArray(GridCoverage2D rasterGeom, double[] bandValues) {
         return addBandFromArray(rasterGeom, bandValues, rasterGeom.getNumSampleDimensions() + 1);
-    }
-
-    /**
-     * This is an experimental method as it does not copy the original raster properties (e.g. color model, sample model, etc.)
-     * TODO: Copy the original raster properties
-     * @param gridCoverage2D
-     * @param bandValues
-     * @return
-     */
-    private static GridCoverage2D copyRasterAndAppendBand(GridCoverage2D gridCoverage2D, double[] bandValues, Double noDataValue) {
-        // Get the original image and its properties
-        RenderedImage originalImage = gridCoverage2D.getRenderedImage();
-        Raster raster = RasterUtils.getRaster(originalImage);
-        Point location = raster.getBounds().getLocation();
-        WritableRaster wr = RasterFactory.createBandedRaster(raster.getDataBuffer().getDataType(), originalImage.getWidth(), originalImage.getHeight(), gridCoverage2D.getNumSampleDimensions() + 1, location);
-        // Copy the raster data and append the new band values
-        for (int i = 0; i < raster.getWidth(); i++) {
-            for (int j = 0; j < raster.getHeight(); j++) {
-                double[] pixels = raster.getPixel(i, j, (double[]) null);
-                double[] copiedPixels = new double[pixels.length + 1];
-                System.arraycopy(pixels, 0, copiedPixels, 0, pixels.length);
-                copiedPixels[pixels.length] = bandValues[j * raster.getWidth() + i];
-                wr.setPixel(i, j, copiedPixels);
-            }
-        }
-        // Add a sample dimension for newly added band
-        int numBand = wr.getNumBands();
-        GridSampleDimension[] originalSampleDimensions = gridCoverage2D.getSampleDimensions();
-        GridSampleDimension[] sampleDimensions = new GridSampleDimension[numBand];
-        System.arraycopy(originalSampleDimensions, 0, sampleDimensions, 0, originalSampleDimensions.length);
-        if (noDataValue != null) {
-            sampleDimensions[numBand - 1] = RasterUtils.createSampleDimensionWithNoDataValue("band" + numBand, noDataValue);
-        } else {
-            sampleDimensions[numBand - 1] = new GridSampleDimension("band" + numBand);
-        }
-        // Construct a GridCoverage2D with the copied image.
-        return RasterUtils.create(wr, gridCoverage2D.getGridGeometry(), sampleDimensions);
-    }
-
-    private static GridCoverage2D copyRasterAndAppendBand(GridCoverage2D gridCoverage2D, double[] bandValues) {
-        return copyRasterAndAppendBand(gridCoverage2D, bandValues, null);
-    }
-
-    private static GridCoverage2D copyRasterAndReplaceBand(GridCoverage2D gridCoverage2D, int bandIndex, double[] bandValues, Double noDataValue, boolean removeNoDataIfNull) {
-        // Do not allow the band index to be out of bounds
-        if (bandIndex < 1 || bandIndex > gridCoverage2D.getNumSampleDimensions()) {
-            throw new IllegalArgumentException("Band index is out of bounds. Must be between 1 and " + gridCoverage2D.getNumSampleDimensions() + ")");
-        }
-        // Get the original image and its properties
-        RenderedImage originalImage = gridCoverage2D.getRenderedImage();
-        Raster raster = RasterUtils.getRaster(originalImage);
-        WritableRaster wr = raster.createCompatibleWritableRaster();
-        // Copy the raster data and replace the band values
-        for (int i = 0; i < raster.getWidth(); i++) {
-            for (int j = 0; j < raster.getHeight(); j++) {
-                double[] bands = raster.getPixel(i, j, (double[]) null);
-                bands[bandIndex - 1] = bandValues[j * raster.getWidth() + i];
-                wr.setPixel(i, j, bands);
-            }
-        }
-        GridSampleDimension[] sampleDimensions = gridCoverage2D.getSampleDimensions();
-        GridSampleDimension sampleDimension = sampleDimensions[bandIndex - 1];
-        if (noDataValue == null && removeNoDataIfNull) {
-            sampleDimensions[bandIndex - 1] = RasterUtils.removeNoDataValue(sampleDimension);
-        } else if (noDataValue != null) {
-            sampleDimensions[bandIndex - 1] = RasterUtils.createSampleDimensionWithNoDataValue(sampleDimension, noDataValue);
-        }
-        return RasterUtils.create(wr, gridCoverage2D.getGridGeometry(), sampleDimensions);
-    }
-
-    private static GridCoverage2D copyRasterAndReplaceBand(GridCoverage2D gridCoverage2D, int bandIndex, double[] bandValues) {
-        return copyRasterAndReplaceBand(gridCoverage2D, bandIndex, bandValues, null, false);
     }
 
     private static final ThreadLocal<String> previousScript = new ThreadLocal<>();

--- a/common/src/main/java/org/apache/sedona/common/raster/RasterBandEditors.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterBandEditors.java
@@ -26,6 +26,9 @@ import org.geotools.coverage.grid.GridGeometry2D;
 import org.geotools.referencing.operation.transform.AffineTransform2D;
 import org.opengis.metadata.spatial.PixelOrientation;
 
+import java.awt.image.Raster;
+import java.util.Arrays;
+
 public class RasterBandEditors {
     public static GridCoverage2D setBandNoDataValue(GridCoverage2D raster, int bandIndex, double noDataValue) {
         RasterUtils.ensureBand(raster, bandIndex);
@@ -49,5 +52,92 @@ public class RasterBandEditors {
 
     public static GridCoverage2D setBandNoDataValue(GridCoverage2D raster, double noDataValue) {
         return setBandNoDataValue(raster, 1, noDataValue);
+    }
+
+    /**
+     * @param toRaster Raster to add the band
+     * @param fromRaster Raster from the band will be copied
+     * @param fromBand Index of Raster band that will be copied
+     * @param toRasterIndex Index of Raster where the copied band will be changed
+     * @return A raster with either replacing a band or adding a new band at the end the toRaster, with the specified band values extracted from the fromRaster at given band
+     */
+    public static GridCoverage2D addBand(GridCoverage2D toRaster, GridCoverage2D fromRaster, int fromBand, int toRasterIndex) {
+        RasterUtils.ensureBand(fromRaster, fromBand);
+        ensureBandAppend(toRaster, toRasterIndex);
+        isRasterSameShape(toRaster, fromRaster);
+
+        int width = RasterAccessors.getWidth(toRaster), height = RasterAccessors.getHeight(toRaster);
+
+        Raster rasterData = RasterUtils.getRaster(fromRaster.getRenderedImage());
+
+        // get datatype of toRaster to preserve data type
+        int dataTypeCode = RasterUtils.getRaster(toRaster.getRenderedImage()).getDataBuffer().getDataType();
+        int numBands = RasterAccessors.numBands(toRaster);
+        Double noDataValue = RasterBandAccessors.getBandNoDataValue(fromRaster, fromBand);
+
+        if (RasterUtils.isDataTypeIntegral(dataTypeCode)) {
+            int[] bandValues = rasterData.getSamples(0, 0, width, height, fromBand - 1, (int[]) null);
+            if (numBands + 1 == toRasterIndex) {
+                return RasterUtils.copyRasterAndAppendBand(toRaster, Arrays.stream(bandValues).boxed().toArray(Integer[]::new), noDataValue);
+            } else {
+                return RasterUtils.copyRasterAndReplaceBand(toRaster, fromBand, Arrays.stream(bandValues).boxed().toArray(Integer[]::new), noDataValue, false);
+            }
+        } else {
+            double[] bandValues = rasterData.getSamples(0, 0, width, height, fromBand - 1, (double[]) null);
+            if (numBands + 1 == toRasterIndex) {
+                return RasterUtils.copyRasterAndAppendBand(toRaster, Arrays.stream(bandValues).boxed().toArray(Double[]::new), noDataValue);
+            } else {
+                return RasterUtils.copyRasterAndReplaceBand(toRaster, fromBand, Arrays.stream(bandValues).boxed().toArray(Double[]::new), noDataValue, false);
+            }
+        }
+    }
+
+    /**
+     * The new band will be added to the end of the toRaster
+     * @param toRaster Raster to add the band
+     * @param fromRaster Raster from the band will be copied
+     * @param fromBand Index of Raster band that will be copied
+     * @return A raster with either replacing a band or adding a new band at the end the toRaster, with the specified band values extracted from the fromRaster at given band
+     */
+    public static GridCoverage2D addBand(GridCoverage2D toRaster, GridCoverage2D fromRaster, int fromBand) {
+        int endBand = RasterAccessors.numBands(toRaster) + 1;
+        return addBand(toRaster, fromRaster, fromBand, endBand);
+    }
+
+    /**
+     * Index of fromRaster will be taken as 1 and will be copied at the end of the toRaster
+     * @param toRaster Raster to add the band
+     * @param fromRaster Raster from the band will be copied
+     * @return A raster with either replacing a band or adding a new band at the end the toRaster, with the specified band values extracted from the fromRaster at given band
+     */
+    public static GridCoverage2D addBand(GridCoverage2D toRaster, GridCoverage2D fromRaster) {
+        return addBand(toRaster, fromRaster, 1);
+    }
+
+    /**
+     * Check if the band index is either present or at the end of the raster
+     * @param raster Raster to check
+     * @param band Band index to append to the raster
+     */
+    private static void ensureBandAppend(GridCoverage2D raster, int band) {
+        if (band < 1 || band > RasterAccessors.numBands(raster) + 1) {
+            throw new IllegalArgumentException(String.format("Provided band index %d is not present in the raster", band));
+        }
+    }
+
+    /**
+     * Check if the two rasters are of the same shape
+     * @param raster1
+     * @param raster2
+     */
+    private static void isRasterSameShape(GridCoverage2D raster1, GridCoverage2D raster2) {
+        int width1 = RasterAccessors.getWidth(raster1), height1 = RasterAccessors.getHeight(raster1);
+        int width2 = RasterAccessors.getWidth(raster2), height2 = RasterAccessors.getHeight(raster2);
+
+        if (width1 != width2 && height1 != height2) {
+            throw new IllegalArgumentException(String.format("Provided rasters are not of same shape. \n" +
+                    "First raster having width of %d and height of %d. \n" +
+                    "Second raster having width of %d and height of %d", width1, height1, width2, height2));
+        }
     }
 }

--- a/common/src/main/java/org/apache/sedona/common/utils/RasterUtils.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/RasterUtils.java
@@ -45,7 +45,9 @@ import org.opengis.util.InternationalString;
 
 import javax.media.jai.RasterFactory;
 import javax.media.jai.RenderedImageAdapter;
-import java.awt.*;
+import java.awt.Color;
+import java.awt.Point;
+import java.awt.Transparency;
 import java.awt.color.ColorSpace;
 import java.awt.geom.Point2D;
 import java.awt.image.BufferedImage;

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterBandEditorsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterBandEditorsTest.java
@@ -25,6 +25,7 @@ import org.opengis.referencing.FactoryException;
 import java.io.IOException;
 import java.util.Arrays;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 public class RasterBandEditorsTest extends RasterTestBase{
@@ -67,4 +68,106 @@ public class RasterBandEditorsTest extends RasterTestBase{
         assertEquals(-9999, (double) RasterBandAccessors.getBandNoDataValue(grid), 0.1d);
         assertEquals(444, (double) RasterBandAccessors.getBandNoDataValue(grid, 2), 0.1d);
     }
+
+    @Test
+    public void testAddBandWithEmptyRaster() throws FactoryException {
+        double[][] rasterData1 = new double[][] {
+                {13, 80, 49, 15, 4, 46, 47, 94, 58, 37, 6, 22, 98, 26, 78, 66, 86, 79, 5, 65, 7, 12, 89, 67},
+                {37, 4, 5, 15, 60, 83, 24, 19, 23, 87, 98, 89, 59, 71, 42, 46, 0, 80, 27, 73, 66, 100, 78, 64},
+                {73, 39, 50, 13, 45, 21, 87, 38, 63, 22, 44, 6, 8, 24, 19, 10, 89, 3, 48, 28, 0, 71, 59, 11}
+        };
+        GridCoverage2D toRaster = RasterConstructors.makeNonEmptyRaster(3, "i", 4, 6, 1, -1, 1, 1, 0, 0, 0, rasterData1);
+
+        // fromRaster's data type is Double to test the preservation of data type
+        double[][] rasterData2 = new double[][] {
+                {35, 68, 56, 87, 49, 20, 73, 90, 45, 96, 52, 98, 2, 82, 88, 74, 77, 60, 5, 61, 81, 32, 9, 15},
+                {55, 49, 72, 10, 63, 94, 100, 83, 61, 47, 20, 15, 34, 46, 52, 11, 23, 98, 70, 67, 18, 39, 53, 91}
+        };
+        GridCoverage2D fromRaster = RasterConstructors.makeNonEmptyRaster(2, "d", 4, 6, 10, -10, 1, -1, 0, 0, 0, rasterData2);
+
+        // test 4 parameter variant
+        testAddBand4Param(fromRaster, toRaster);
+
+        // test 3 parameter variant
+        testAddBand3Param(fromRaster, toRaster);
+
+        // test 2 parameter variant
+        testAddBand2Param(fromRaster, toRaster);
+    }
+
+    public static void testAddBand4Param(GridCoverage2D fromRaster, GridCoverage2D toRaster) throws FactoryException {
+        GridCoverage2D actualRaster = RasterBandEditors.addBand(toRaster, fromRaster, 1, 4);
+
+        // test numBands
+        int actualNumBands = RasterAccessors.numBands(actualRaster);
+        int expectedNumBands = 4;
+        assertEquals(expectedNumBands, actualNumBands);
+
+        // test data type preservation
+        String actualDataType = RasterBandAccessors.getBandType(actualRaster);
+        String expectedDataType = "SIGNED_32BITS";
+        assertEquals(expectedDataType, actualDataType);
+
+        // test new band values in the resultant raster
+        double[] actualBandValues = MapAlgebra.bandAsArray(actualRaster, 4);
+        double[] expectedBandValues = MapAlgebra.bandAsArray(fromRaster, 1);
+        assertArrayEquals(expectedBandValues, actualBandValues, 0.1d);
+
+        // test preservation of original raster
+        // remove last index as that's number of bands and they wouldn't be equal
+        double[] actualMetadata = Arrays.stream(RasterAccessors.metadata(actualRaster), 0, 9).toArray();
+        double[] expectedMetadata = Arrays.stream(RasterAccessors.metadata(toRaster), 0, 9).toArray();
+        assertArrayEquals(expectedMetadata, actualMetadata, 0.1d);
+    }
+
+    public static void testAddBand3Param(GridCoverage2D fromRaster, GridCoverage2D toRaster) throws FactoryException {
+        GridCoverage2D actualRaster = RasterBandEditors.addBand(toRaster, fromRaster, 2);
+
+        // test numBands
+        int actualNumBands = RasterAccessors.numBands(actualRaster);
+        int expectedNumBands = 4;
+        assertEquals(expectedNumBands, actualNumBands);
+
+        // test data type preservation
+        String actualDataType = RasterBandAccessors.getBandType(actualRaster);
+        String expectedDataType = "SIGNED_32BITS";
+        assertEquals(expectedDataType, actualDataType);
+
+        // test new band values in the resultant raster
+        double[] actualBandValues = MapAlgebra.bandAsArray(actualRaster, 4);
+        double[] expectedBandValues = MapAlgebra.bandAsArray(fromRaster, 2);
+        assertArrayEquals(expectedBandValues, actualBandValues, 0.1d);
+
+        // test preservation of original raster
+        // remove last index as that's number of bands and they wouldn't be equal
+        double[] actualMetadata = Arrays.stream(RasterAccessors.metadata(actualRaster), 0, 9).toArray();
+        double[] expectedMetadata = Arrays.stream(RasterAccessors.metadata(toRaster), 0, 9).toArray();
+        assertArrayEquals(expectedMetadata, actualMetadata, 0.1d);
+    }
+
+    public static void testAddBand2Param(GridCoverage2D fromRaster, GridCoverage2D toRaster) throws FactoryException {
+        GridCoverage2D actualRaster = RasterBandEditors.addBand(toRaster, fromRaster);
+
+        // test numBands
+        int actualNumBands = RasterAccessors.numBands(actualRaster);
+        int expectedNumBands = 4;
+        assertEquals(expectedNumBands, actualNumBands);
+
+        // test data type preservation
+        String actualDataType = RasterBandAccessors.getBandType(actualRaster);
+        String expectedDataType = "SIGNED_32BITS";
+        assertEquals(expectedDataType, actualDataType);
+
+        // test new band values in the resultant raster
+        double[] actualBandValues = MapAlgebra.bandAsArray(actualRaster, 4);
+        double[] expectedBandValues = MapAlgebra.bandAsArray(fromRaster, 1);
+        assertArrayEquals(expectedBandValues, actualBandValues, 0.1d);
+
+        // test preservation of original raster
+        // remove last index as that's number of bands and they wouldn't be equal
+        double[] actualMetadata = Arrays.stream(RasterAccessors.metadata(actualRaster), 0, 9).toArray();
+        double[] expectedMetadata = Arrays.stream(RasterAccessors.metadata(toRaster), 0, 9).toArray();
+        assertArrayEquals(expectedMetadata, actualMetadata, 0.1d);
+    }
+
 }

--- a/docs/api/sql/Raster-operators.md
+++ b/docs/api/sql/Raster-operators.md
@@ -745,6 +745,46 @@ Output:
 
 ## Raster based operators
 
+### RS_AddBand
+
+Introduction: Adds a new band to a raster `toRaster` at a specified index `toRasterIndex`. The new band's values are copied from `fromRaster` at a specified band index `fromBand`. 
+If no `toRasterIndex` is provided, the new band is appended to the end of `toRaster`. If no `fromBand` is specified, band `1` from `fromRaster` is copied by default.
+
+!!!Note
+    IllegalArgumentException will be thrown in these cases:
+
+    - The provided Rasters, `toRaster` & `fromRaster` don't have same shape.
+    - The provided `fromBand` is not in `fromRaster`.
+    - The provided `toRasterIndex` is not in or at end of `toRaster`. 
+
+Format: 
+
+```
+RS_AddBand(toRaster: Raster, fromRaster: Raster, fromBand: Integer = 1, toRasterIndex: Integer = at_end)
+```
+
+```
+RS_AddBand(toRaster: Raster, fromRaster: Raster, fromBand: Integer = 1)
+```
+
+```
+RS_AddBand(toRaster: Raster, fromRaster: Raster)
+```
+
+Since: `v1.5.0`
+
+Spark SQL Example:
+
+```sql
+SELECT RS_AddBand(raster1, raster2, 2, 1) FROM rasters
+```
+
+Output:
+
+```
+GridCoverage2D["g...
+```
+
 ### RS_Contains
 
 Introduction: Returns true if the geometry or raster on the left side contains the geometry or raster on the right side.

--- a/docs/api/sql/Raster-operators.md
+++ b/docs/api/sql/Raster-operators.md
@@ -745,6 +745,37 @@ Output:
 
 ## Raster based operators
 
+### RS_Contains
+
+Introduction: Returns true if the geometry or raster on the left side contains the geometry or raster on the right side.
+The convex hull of the raster is considered in the test.
+
+The rules for testing spatial relationship is the same as `RS_Intersects`.
+
+Format: `RS_Contains(raster: Raster, geom: Geometry)`
+
+Format: `RS_Contains(geom: Geometry, raster: Raster)`
+
+Format: `RS_Contains(raster0: Raster, raster1: Raster)`
+
+Since: `1.5.0`
+
+Spark SQL example:
+
+```sql
+SELECT RS_Contains(RS_MakeEmptyRaster(1, 20, 20, 2, 22, 1), ST_GeomFromWKT('POLYGON ((5 5, 5 10, 10 10, 10 5, 5 5))')) rast_geom,
+    RS_Contains(RS_MakeEmptyRaster(1, 20, 20, 2, 22, 1), RS_MakeEmptyRaster(1, 10, 10, 2, 22, 1)) rast_rast
+```
+
+Output:
+```
++---------+---------+
+|rast_geom|rast_rast|
++---------+---------+
+|     true|     true|
++---------+---------+
+```
+
 ### RS_Intersects
 
 Introduction: Returns true if raster or geometry on the left side intersects with the raster or geometry on the right side.
@@ -778,68 +809,6 @@ Output:
 |     true|     true|
 +---------+---------+
 
-```
-
-### RS_Within
-
-Introduction: Returns true if the geometry or raster on the left side is within the geometry or raster on the right side.
-The convex hull of the raster is considered in the test.
-
-The rules for testing spatial relationship is the same as `RS_Intersects`.
-
-Format: `RS_Within(raster: Raster, geom: Geometry)`
-
-Format: `RS_Within(geom: Geometry, raster: Raster)`
-
-Format: `RS_Within(raster0: Raster, raster1: Raster)`
-
-Since: `1.5.0`
-
-Spark SQL example:
-
-```sql
-SELECT RS_Within(RS_MakeEmptyRaster(1, 20, 20, 2, 22, 1), ST_GeomFromWKT('POLYGON ((0 0, 0 50, 100 50, 100 0, 0 0))')) rast_geom,
-    RS_Within(RS_MakeEmptyRaster(1, 20, 20, 2, 22, 1), RS_MakeEmptyRaster(1, 30, 30, 2, 22, 1)) rast_rast
-```
-
-Output:
-```
-+---------+---------+
-|rast_geom|rast_rast|
-+---------+---------+
-|     true|     true|
-+---------+---------+
-```
-
-### RS_Contains
-
-Introduction: Returns true if the geometry or raster on the left side contains the geometry or raster on the right side.
-The convex hull of the raster is considered in the test.
-
-The rules for testing spatial relationship is the same as `RS_Intersects`.
-
-Format: `RS_Contains(raster: Raster, geom: Geometry)`
-
-Format: `RS_Contains(geom: Geometry, raster: Raster)`
-
-Format: `RS_Contains(raster0: Raster, raster1: Raster)`
-
-Since: `1.5.0`
-
-Spark SQL example:
-
-```sql
-SELECT RS_Contains(RS_MakeEmptyRaster(1, 20, 20, 2, 22, 1), ST_GeomFromWKT('POLYGON ((5 5, 5 10, 10 10, 10 5, 5 5))')) rast_geom,
-    RS_Contains(RS_MakeEmptyRaster(1, 20, 20, 2, 22, 1), RS_MakeEmptyRaster(1, 10, 10, 2, 22, 1)) rast_rast
-```
-
-Output:
-```
-+---------+---------+
-|rast_geom|rast_rast|
-+---------+---------+
-|     true|     true|
-+---------+---------+
 ```
 
 ### RS_MetaData
@@ -1224,6 +1193,36 @@ Output:
 +----+------------+-------+
 ```
 
+### RS_Within
+
+Introduction: Returns true if the geometry or raster on the left side is within the geometry or raster on the right side.
+The convex hull of the raster is considered in the test.
+
+The rules for testing spatial relationship is the same as `RS_Intersects`.
+
+Format: `RS_Within(raster: Raster, geom: Geometry)`
+
+Format: `RS_Within(geom: Geometry, raster: Raster)`
+
+Format: `RS_Within(raster0: Raster, raster1: Raster)`
+
+Since: `1.5.0`
+
+Spark SQL example:
+
+```sql
+SELECT RS_Within(RS_MakeEmptyRaster(1, 20, 20, 2, 22, 1), ST_GeomFromWKT('POLYGON ((0 0, 0 50, 100 50, 100 0, 0 0))')) rast_geom,
+    RS_Within(RS_MakeEmptyRaster(1, 20, 20, 2, 22, 1), RS_MakeEmptyRaster(1, 30, 30, 2, 22, 1)) rast_rast
+```
+
+Output:
+```
++---------+---------+
+|rast_geom|rast_rast|
++---------+---------+
+|     true|     true|
++---------+---------+
+```
 
 ## Raster to Map Algebra operators
 

--- a/spark/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
+++ b/spark/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
@@ -227,6 +227,7 @@ object Catalog {
     function[RS_PixelAsCentroid](),
     function[RS_Count](),
     function[RS_Band](),
+    function[RS_AddBand](),
     function[RS_SummaryStats](),
     function[RS_BandIsNoData](),
     function[RS_ConvexHull](),

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterBandEditors.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterBandEditors.scala
@@ -31,3 +31,13 @@ case class RS_SetBandNoDataValue(inputExpressions: Seq[Expression]) extends Infe
     copy(inputExpressions = newChildren)
   }
 }
+
+case class RS_AddBand(inputExpressions: Seq[Expression]) extends InferredExpression(
+  inferrableFunction4(RasterBandEditors.addBand),
+  inferrableFunction3(RasterBandEditors.addBand),
+  inferrableFunction2(RasterBandEditors.addBand)
+) {
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
+}


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-398. The PR name follows the format `[SEDONA-XXX] my subject`.


## What changes were proposed in this PR?

- Add RS_AddBand
- Add Number[] instead of double[] to support generics that are numeric
- Move copyRasterAndAppendBand & copyRasterAndReplaceBand to RasterUtils
- Reorder subsection 'Raster based operators' in Raster-operations.md

## How was this patch tested?

- Passed existing and new tests

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation update.
