### PR TITLE
[SEDONA-400] pre-commit add hook to ensure that links to vcs websites…

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,6 +21,6 @@
 
 ## Did this PR include necessary documentation updates?
 
-- Yes, I am adding a new API. I am using the [current SNAPSHOT version number](https://github.com/apache/sedona/blob/master/pom.xml#L29) in since `vX.Y.Z` format.
+- Yes, I am adding a new API. I am using the [current SNAPSHOT version number](https://github.com/apache/sedona/blob/99239524f17389fc4ae9548ea88756f8ea538bb9/pom.xml#L29) in since `vX.Y.Z` format.
 - Yes, I have updated the documentation update.
 - No, this PR does not affect any public API so no need to change the docs.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
       - id: check-merge-conflict
       # - id: check-shebang-scripts-are-executable
       - id: check-toml
-      # - id: check-vcs-permalinks
+      - id: check-vcs-permalinks
       - id: check-xml
       # - id: check-yaml
       - id: detect-private-key

--- a/docs/community/publish.md
+++ b/docs/community/publish.md
@@ -42,7 +42,7 @@ Make sure the Sedona version in the following files are {{ sedona_create_release
 
 1. https://github.com/apache/sedona/blob/master/python/sedona/version.py
 2. https://github.com/apache/sedona/blob/master/R/DESCRIPTION
-3. https://github.com/apache/sedona/blob/master/R/R/dependencies.R#L42
+3. https://github.com/apache/sedona/blob/99239524f17389fc4ae9548ea88756f8ea538bb9/R/R/dependencies.R#L42
 4. https://github.com/apache/sedona/blob/master/zeppelin/package.json
 
 


### PR DESCRIPTION
… are permalinks

https://github.com/pre-commit/pre-commit-hooks#check-vcs-permalinks



## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)


## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-400. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Add another pre-commit hook to standardize the docs

## How was this patch tested?


## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
