### PR TITLE
[SEDONA-366] Fix performance issue of RS_Count

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/raster/RasterBandAccessors.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterBandAccessors.java
@@ -48,26 +48,23 @@ public class RasterBandAccessors {
     }
 
     public static long getCount(GridCoverage2D raster, int band, boolean excludeNoDataValue) {
-        int height = RasterAccessors.getHeight(raster), width = RasterAccessors.getWidth(raster);
-        if(excludeNoDataValue) {
+        Double bandNoDataValue = RasterBandAccessors.getBandNoDataValue(raster, band);
+        int width = RasterAccessors.getWidth(raster);
+        int height = RasterAccessors.getHeight(raster);
+        if (excludeNoDataValue && bandNoDataValue != null) {
             RasterUtils.ensureBand(raster, band);
+            Raster r = RasterUtils.getRaster(raster.getRenderedImage());
+            double[] pixels = r.getSamples(0, 0, width, height, band - 1, (double[]) null);
             long numberOfPixel = 0;
-            Double bandNoDataValue = RasterBandAccessors.getBandNoDataValue(raster, band);
-
-            for(int j = 0; j < height; j++){
-                for(int i = 0; i < width; i++){
-
-                    double[] bandPixelValues = raster.evaluate(new GridCoordinates2D(i, j), (double[]) null);
-                    double bandValue = bandPixelValues[band - 1];
-                    if(bandNoDataValue == null || bandValue != bandNoDataValue){
-                        numberOfPixel += 1;
-                    }
+            for (double bandValue : pixels) {
+                if (Double.compare(bandValue, bandNoDataValue) != 0) {
+                    numberOfPixel += 1;
                 }
             }
             return numberOfPixel;
         } else {
             // code for false
-            return width * height;
+            return (long) width * (long) height;
         }
     }
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-366. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

The current implementation of `RS_Count` calls `GridCoverage2D.evaluate` for each pixel, which calls `getTile` method for each pixel. This is very slow for some implementations of RenderedImage. In this patch, we get the raster of the image and iterate through the samples, which is much faster.

## How was this patch tested?

Passes existing tests.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
