### PR TITLE
[SEDONA-406] Add a dummy implementation of UDT RasterType to get rid of errors when representing pyspark dataframes containing raster fields.

### DIFF
--- a/python/sedona/spark/__init__.py
+++ b/python/sedona/spark/__init__.py
@@ -34,6 +34,7 @@ from sedona.core.enums import IndexType
 from sedona.core.enums import GridType
 from sedona.core.enums import FileDataSplitter
 from sedona.sql.types import GeometryType
+from sedona.sql.types import RasterType
 from sedona.utils.adapter import Adapter
 from sedona.utils import KryoSerializer
 from sedona.utils import SedonaKryoRegistrator

--- a/python/sedona/sql/types.py
+++ b/python/sedona/sql/types.py
@@ -43,3 +43,27 @@ class GeometryType(UserDefinedType):
     @classmethod
     def scalaUDT(cls):
         return "org.apache.spark.sql.sedona_sql.UDT.GeometryUDT"
+
+
+class RasterType(UserDefinedType):
+
+    @classmethod
+    def sqlType(cls):
+        return BinaryType()
+
+    def serialize(self, obj):
+        raise NotImplementedError("RasterType.serialize is not implemented yet")
+
+    def deserialize(self, datum):
+        raise NotImplementedError("RasterType.deserialize is not implemented yet")
+
+    @classmethod
+    def module(cls):
+        return "sedona.sql.types"
+
+    def needConversion(self):
+        return True
+
+    @classmethod
+    def scalaUDT(cls):
+        return "org.apache.spark.sql.sedona_sql.UDT.RasterUDT"

--- a/python/tests/sql/test_raster.py
+++ b/python/tests/sql/test_raster.py
@@ -1,0 +1,30 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+import pytest
+from tests.test_base import TestBase
+
+
+class TestRaster(TestBase):
+
+    def test_raster_df_repr(self):
+        """DataFrame containing raster columns should be represented without
+        exception.
+
+        """
+        raster_df = self.spark.sql("SELECT RS_MakeEmptyRaster(1, 10, 10, 0, 0, 1) rast")
+        assert "rast: udt" in repr(raster_df)

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/UDT/RasterUDT.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/UDT/RasterUDT.scala
@@ -26,6 +26,8 @@ import org.geotools.coverage.grid.GridCoverage2D
 class RasterUDT extends UserDefinedType[GridCoverage2D] {
   override def sqlType: DataType = BinaryType
 
+  override def pyUDT: String = "sedona.sql.types.RasterType"
+
   override def serialize(raster: GridCoverage2D): Array[Byte] = Serde.serialize(raster)
 
   override def deserialize(datum: Any): GridCoverage2D = {


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes. https://issues.apache.org/jira/browse/SEDONA-406

## What changes were proposed in this PR?

`RasterUDT` does not have a corresponding PySpark implementation, which will lead to errors when printing pyspark dataframes. For example, if we run `df` to print the pyspark dataframe in jupyter notebook, it will raise an exception:

```
File /opt/spark/python/pyspark/sql/dataframe.py:2022, in DataFrame.dtypes(self)
   2001 @property
   2002 def dtypes(self) -> List[Tuple[str, str]]:
   2003     """Returns all column names and their data types as a list.
   2004 
   2005     .. versionadded:: 1.3.0
   (...)
   2020     [('age', 'bigint'), ('name', 'string')]
   2021     """
-> 2022     return [(str(f.name), f.dataType.simpleString()) for f in self.schema.fields]

File /opt/spark/python/pyspark/sql/dataframe.py:573, in DataFrame.schema(self)
    569         self._schema = cast(
    570             StructType, _parse_datatype_json_string(self._jdf.schema().json())
    571         )
    572     except Exception as e:
--> 573         raise ValueError("Unable to parse datatype from schema. %s" % e) from e
    574 return self._schema

ValueError: Unable to parse datatype from schema. No module named 'Non'
```

This is because RasterUDT does not have a PySpark implementation. This patch adds a dummy PySpark implementation for RasterUDT to suppress this error.

It is hard to implement a functioning RasterType in python because some components of the rasters were serialized using Java serializer. We'll switch to customized kryo serializer for easier implementation of RasterType.

## How was this patch tested?

After applying this patch, evaluating `df` in jupyter notebook yields this output:

```
DataFrame[name: string, length: bigint, rast: udt]
```

We've also added a unit test for it.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
