### PR TITLE
[SEDONA-408] Set a reasonable default size for RasterUDT

### DIFF
--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/UDT/RasterUDT.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/UDT/RasterUDT.scala
@@ -28,6 +28,10 @@ class RasterUDT extends UserDefinedType[GridCoverage2D] {
 
   override def pyUDT: String = "sedona.sql.types.RasterType"
 
+  // A reasonable size for small in-db rasters. This is used by the optimizer to decide whether to
+  // broadcast the dataframe or not.
+  override def defaultSize: Int = 512 * 1024
+
   override def serialize(raster: GridCoverage2D): Array[Byte] = Serde.serialize(raster)
 
   override def deserialize(datum: Any): GridCoverage2D = {


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-408. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Set a default size for raster values. This is used by the optimizer to decide whether to broadcast the DataFrame or not.

## How was this patch tested?

Manually tested using medium-sized datasets.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
