### PR TITLE
[SEDONA-419] Remove SedonaKepler and SedonaPyDeck from `sedona.spark import *`

### DIFF
--- a/python/sedona/spark/__init__.py
+++ b/python/sedona/spark/__init__.py
@@ -40,6 +40,4 @@ from sedona.utils import KryoSerializer
 from sedona.utils import SedonaKryoRegistrator
 from sedona.register import SedonaRegistrator
 from sedona.spark.SedonaContext import SedonaContext
-from sedona.maps.SedonaKepler import SedonaKepler
-from sedona.maps.SedonaPyDeck import SedonaPyDeck
 from sedona.raster_utils.SedonaUtils import SedonaUtils


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-419. The PR name follows the format `[SEDONA-419] my subject`.


## What changes were proposed in this PR?

Remove SedonaKepler and SedonaPyDeck from the `__init__.py` file.

Users who use `from sedona.spark import *` to do SedonaKepler/SedonaPyDeck visualization will need to explicitly import

```
from sedona.maps.SedonaKepler import SedonaKepler
from sedona.maps.SedonaPyDeck import SedonaPyDeck
```

## How was this patch tested?

Passed all unit tests

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
