### PR TITLE
[DOCS] Fix filename casing for `pom.xml`

### DIFF
--- a/docs/api/sql/Overview.md
+++ b/docs/api/sql/Overview.md
@@ -32,7 +32,7 @@ SedonaSQL supports SparkSQL query optimizer, documentation is [Here](../Optimize
 
 The detailed explanation is here [Write a SQL/DataFrame application](../../tutorial/sql.md).
 
-1. Add Sedona-core and Sedona-SQL into your project POM.xml or build.sbt
+1. Add Sedona-core and Sedona-SQL into your project pom.xml or build.sbt
 2. Create your Sedona config if you want to customize your SparkSession.
 ```scala
 import org.apache.sedona.spark.SedonaContext

--- a/docs/api/viz/sql.md
+++ b/docs/api/viz/sql.md
@@ -2,7 +2,7 @@
 
 The detailed explanation is here: [Visualize Spatial DataFrame/RDD](../../tutorial/viz.md).
 
-1. Add Sedona-core, Sedona-SQL,Sedona-Viz into your project POM.xml or build.sbt
+1. Add Sedona-core, Sedona-SQL, Sedona-Viz into your project pom.xml or build.sbt
 2. Declare your Spark Session
 ```scala
 sparkSession = SparkSession.builder().

--- a/docs/community/develop.md
+++ b/docs/community/develop.md
@@ -22,7 +22,7 @@ The IDE usually has trouble understanding the complex project structure in Sedon
 
 <img src="../../image/ide-java-4.png"/>
 
-#### Fix errors by changing POM.xml
+#### Fix errors by changing pom.xml
 
 You need to comment out the following lines in `pom.xml` at the root folder, as follows. ==Remember that you should NOT submit this change to Sedona.==
 
@@ -35,9 +35,9 @@ You need to comment out the following lines in `pom.xml` at the root folder, as 
 <!--    </parent>-->
 ```
 
-#### Reload POM.xml
+#### Reload pom.xml
 
-Make sure you reload the POM.xml or reload the maven project. The IDE will ask you to remove some modules. Please select `yes`.
+Make sure you reload the pom.xml or reload the maven project. The IDE will ask you to remove some modules. Please select `yes`.
 
 <img src="../../image/ide-java-5.png"/>
 

--- a/docs/setup/flink/install-scala.md
+++ b/docs/setup/flink/install-scala.md
@@ -2,7 +2,7 @@ Before starting the Sedona journey, you need to make sure your Apache Flink clus
 
 Then you can create a self-contained Scala / Java project. A self-contained project allows you to create multiple Scala / Java files and write complex logics in one place.
 
-To use Sedona in your self-contained Flink project, you just need to add Sedona as a dependency in your POM.xml or build.sbt.
+To use Sedona in your self-contained Flink project, you just need to add Sedona as a dependency in your pom.xml or build.sbt.
 
 1. To add Sedona as dependencies, please read [Sedona Maven Central coordinates](../../maven-coordinates)
 2. Read [Sedona Flink guide](../../../tutorial/flink/sql) and use Sedona Template project to start: [Sedona Template Project](../../../tutorial/demo/)

--- a/docs/setup/install-scala.md
+++ b/docs/setup/install-scala.md
@@ -55,7 +55,7 @@ Please see [Use Sedona in a pure SQL environment](../../tutorial/sql-pure-sql/)
 
 ## Self-contained Spark projects
 
-A self-contained project allows you to create multiple Scala / Java files and write complex logics in one place. To use Sedona in your self-contained Spark project, you just need to add Sedona as a dependency in your POM.xml or build.sbt.
+A self-contained project allows you to create multiple Scala / Java files and write complex logics in one place. To use Sedona in your self-contained Spark project, you just need to add Sedona as a dependency in your pom.xml or build.sbt.
 
 1. To add Sedona as dependencies, please read [Sedona Maven Central coordinates](maven-coordinates.md)
 2. Use Sedona Template project to start: [Sedona Template Project](../../tutorial/demo/)

--- a/docs/setup/maven-coordinates.md
+++ b/docs/setup/maven-coordinates.md
@@ -118,7 +118,7 @@ Under BSD 3-clause (compatible with Apache 2.0 license)
 
 	=== "Sedona 1.3.1+"
 
-		Add unidata repo to your POM.xml
+		Add unidata repo to your pom.xml
 
 		```
 		<repositories>
@@ -253,7 +253,7 @@ Under BSD 3-clause (compatible with Apache 2.0 license)
 
 	=== "Sedona 1.3.1+"
 
-		Add unidata repo to your POM.xml
+		Add unidata repo to your pom.xml
 
 		```
 		<repositories>
@@ -289,11 +289,11 @@ Under BSD 3-clause (compatible with Apache 2.0 license)
 ## SNAPSHOT versions
 Sometimes Sedona has a SNAPSHOT version for the upcoming release. It follows the same naming conversion but has "SNAPSHOT" as suffix in the version. For example, `{{ sedona_create_release.current_snapshot }}`
 
-In order to download SNAPSHOTs, you need to add the following repositories in your POM.XML or build.sbt
+In order to download SNAPSHOTs, you need to add the following repositories in your pom.xml or build.sbt
 ### build.sbt
 resolvers +=
   "Apache Software Foundation Snapshots" at "https://repository.apache.org/content/groups/snapshots"
-### POM.XML
+### pom.xml
 
 ```xml
 <repositories>


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- No, this is a documentation update. The PR name follows the format `[DOCS] my subject`.

## What changes were proposed in this PR?

Standardized the filename to all lowercase for `pom.xml` in Markdown files.

And a single whitespace change.

All done in the "docs" folder

## How was this patch tested?


## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
