### PR TITLE
[SEDONA-424] Specify jt-jiffle as a provided dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -256,6 +256,7 @@
                 <groupId>it.geosolutions.jaiext.jiffle</groupId>
                 <artifactId>jt-jiffle-language</artifactId>
                 <version>${jt-jiffle.version}</version>
+                <scope>${geotools.scope}</scope>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>

--- a/spark/common/pom.xml
+++ b/spark/common/pom.xml
@@ -135,6 +135,10 @@
             <artifactId>gt-arcgrid</artifactId>
         </dependency>
         <dependency>
+            <groupId>it.geosolutions.jaiext.jiffle</groupId>
+            <artifactId>jt-jiffle-language</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.locationtech.jts</groupId>
             <artifactId>jts-core</artifactId>
         </dependency>


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-424. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

It is better to mark non-central dependencies as provided. jt-jiffle will be bundled in geotools-wrapper in the next release (1.5.1).

Please follow this thread in the sedona mailing list for why this change is necessary: https://lists.apache.org/thread/o4sf32tm1761f32hfckh1x70tl5clc0t

## How was this patch tested?

Passing existing tests

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
