### PR TITLE
[SEDONA-431] Add RS_PixelAsPoints

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -114,6 +114,14 @@
             <version>${janino-version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-catalyst_2.12</artifactId>
+        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.apache.spark</groupId>-->
+<!--            <artifactId>spark-catalyst_2.13</artifactId>-->
+<!--        </dependency>-->
     </dependencies>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/docs/api/sql/Raster-operators.md
+++ b/docs/api/sql/Raster-operators.md
@@ -56,6 +56,26 @@ Output:
 IndexOutOfBoundsException: Specified pixel coordinates (6, 2) do not lie in the raster
 ```
 
+### RS_PixelAsPoints
+Introduction: Returns an array of Row objects for a given raster band. 
+Each Row object encapsulates the geometry of the pixel's upper-left corner, the pixel value, and its x and y coordinates within the raster. 
+This function provides a detailed pixel-level analysis of the raster data.
+
+Format: `RS_PixelAsPoints(raster: Raster, band: Integer)`
+
+Since: `v1.5.1`
+
+Spark SQL Example:
+```sql
+SELECT ST_AsText(RS_PixelAsPoints(raster, 1)) from rasters
+```
+
+Output:
+```
+[[POINT (-13065223 4021262.75),148.0,0,0], [POINT (-13065150 4021262.75),123.0,0,1], [POINT (-13065078 4021262.75),99.0,1,0], [POINT (-13065006 4021262.75),140.0,1,1]]
+```
+
+
 ### RS_PixelAsPolygon
 
 Introduction: Returns a polygon geometry that bounds the specified pixel.

--- a/pom.xml
+++ b/pom.xml
@@ -202,6 +202,12 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <dependency>
+                <groupId>org.apache.spark</groupId>
+                <artifactId>spark-catalyst_${scala.compat.version}</artifactId>
+                <version>${spark.version}</version>
+                <scope>compile</scope>
+            </dependency>
             <!--for CRS transformation-->
             <dependency>
                 <groupId>org.geotools</groupId>

--- a/spark/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
+++ b/spark/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
@@ -229,6 +229,7 @@ object Catalog {
     function[RS_Rotation](),
     function[RS_GeoTransform](),
     function[RS_PixelAsPoint](),
+    function[RS_PixelAsPoints](),
     function[RS_PixelAsPolygon](),
     function[RS_PixelAsCentroid](),
     function[RS_Count](),

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/PixelFunctions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/PixelFunctions.scala
@@ -19,9 +19,22 @@
 package org.apache.spark.sql.sedona_sql.expressions.raster
 
 import org.apache.sedona.common.raster.PixelFunctions
-import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.sedona.sql.utils.GeometrySerializer
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression, GenericRowWithSchema}
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.catalyst.util.GenericArrayData
+import org.apache.spark.sql.sedona_sql.UDT.{GeometryUDT, RasterUDT}
 import org.apache.spark.sql.sedona_sql.expressions.InferrableFunctionConverter._
 import org.apache.spark.sql.sedona_sql.expressions.InferredExpression
+import org.apache.spark.sql.sedona_sql.expressions.raster.implicits.RasterInputExpressionEnhancer
+import org.apache.spark.sql.types.{AbstractDataType, ArrayType, BooleanType, DataType, DoubleType, IntegerType, StructField, StructType}
+import org.geotools.coverage.grid.GridCoverage2D
+import org.locationtech.jts.geom.Geometry
+
+import scala.collection.JavaConverters._
+import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
 
 case class RS_Value(inputExpressions: Seq[Expression]) extends InferredExpression(
   inferrableFunction2(PixelFunctions.value), inferrableFunction3(PixelFunctions.value), inferrableFunction4(PixelFunctions.value)
@@ -36,6 +49,45 @@ case class RS_PixelAsPoint(inputExpressions: Seq[Expression]) extends InferredEx
     copy(inputExpressions = newChildren)
   }
 }
+
+case class RS_PixelAsPoints(inputExpressions: Seq[Expression])
+  extends Expression with CodegenFallback with ExpectsInputTypes {
+
+  override def nullable: Boolean = true
+
+  override def dataType: DataType = ArrayType(new StructType()
+    .add("geom", GeometryUDT)
+    .add("value", DoubleType)
+    .add("x", IntegerType)
+    .add("y", IntegerType))
+
+  override def eval(input: InternalRow): Any = {
+    val rasterGeom = inputExpressions(0).toRaster(input)
+    val band = inputExpressions(1).eval(input).asInstanceOf[Int]
+
+    if (rasterGeom == null) {
+      null
+    } else {
+      val pixelPoints = PixelFunctions.getPixelAsPoints(rasterGeom, band)
+      val rows = pixelPoints.map { case Row(geom, value, x, y) =>
+        val serializedGeom = GeometrySerializer.serialize(geom.asInstanceOf[Geometry])
+        val rowArray = Array[Any](serializedGeom, value, x, y)
+        InternalRow.fromSeq(rowArray)
+      }
+      new GenericArrayData(rows)
+    }
+  }
+
+  override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): RS_PixelAsPoints = {
+    copy(inputExpressions = newChildren)
+  }
+
+  override def inputTypes: Seq[AbstractDataType] = Seq(RasterUDT, IntegerType)
+}
+
+
 
 case class RS_PixelAsPolygon(inputExpressions: Seq[Expression]) extends InferredExpression(PixelFunctions.getPixelAsPolygon _) {
   protected def withNewChildrenInternal(newChilren: IndexedSeq[Expression]) = {

--- a/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
@@ -20,11 +20,11 @@ package org.apache.sedona.sql
 
 import org.apache.sedona.common.raster.MapAlgebra
 import org.apache.sedona.common.utils.RasterUtils
-import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.{Row, SaveMode}
 import org.apache.spark.sql.functions.{collect_list, expr}
 import org.geotools.coverage.grid.GridCoverage2D
 import org.junit.Assert.{assertEquals, assertNull, assertTrue}
-import org.locationtech.jts.geom.{Coordinate, Geometry}
+import org.locationtech.jts.geom.{Coordinate, Geometry, Point}
 import org.scalatest.{BeforeAndAfter, GivenWhenThen}
 
 import java.awt.image.DataBuffer
@@ -929,6 +929,25 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
       val actualCoordinates = result.getCoordinate;
       assertEquals(expectedX, actualCoordinates.x, 1e-5)
       assertEquals(expectedY, actualCoordinates.y, 1e-5)
+    }
+
+    it("Passed RS_PixelAsPoints with empty raster") {
+      val widthInPixel = 5
+      val heightInPixel = 10
+      val upperLeftX = 123.19
+      val upperLeftY = -12
+      val cellSize = 4
+      val numBands = 2
+      val result = sparkSession.sql(s"SELECT RS_PixelAsPoints(RS_MakeEmptyRaster($numBands, $widthInPixel, $heightInPixel, $upperLeftX, $upperLeftY, $cellSize), 1)").first().getList(0);
+      val expected = "[POINT (127.19000244140625 -12),0.0,2,1]"
+      assertEquals(expected, result.get(1).toString)
+    }
+
+    it("Passed RS_PixelAsPoints with raster") {
+      var df = sparkSession.read.format("binaryFile").load(resourceFolder + "raster/test1.tiff")
+      df = df.selectExpr("RS_FromGeoTiff(content) as raster")
+      val result = df.selectExpr("RS_PixelAsPoints(raster, 1)").first().getList(0);
+      assert(result.size() == 264704)
     }
 
     it("Passed RS_PixelAsPolygon with raster") {


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-431. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

- Implements Raster operator RS_PixelAsPoints

## How was this patch tested?

- Passes new and existing tests

## Did this PR include necessary documentation updates?

- Yes, I am adding a new API. I am using the [current SNAPSHOT version number](https://github.com/apache/sedona/blob/a64972027aa4c0fea354898da67a2dd4e6cde46b/pom.xml#L29) in since `vX.Y.Z` format.
