### PR TITLE
[SEDONA-435] Add RS_PixelAsPolygons

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/raster/PixelFunctions.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/PixelFunctions.java
@@ -105,12 +105,15 @@ public class PixelFunctions
                 // Calculate the world coordinates of the pixel's four corners
                 double worldX1 = upperLeft.getX() + (x - 1) * cellSizeX + (y - 1) * shearX;
                 double worldY1 = upperLeft.getY() + (y - 1) * cellSizeY + (x - 1) * shearY;
+
                 double worldX2 = worldX1 + cellSizeX;
-                double worldY2 = worldY1;
-                double worldX3 = worldX2;
-                double worldY3 = worldY1 + cellSizeY;
-                double worldX4 = worldX1;
-                double worldY4 = worldY3;
+                double worldY2 = worldY1 + shearY;
+
+                double worldX3 = worldX2 + shearX;
+                double worldY3 = worldY2 + cellSizeY;
+
+                double worldX4 = worldX1 + shearX;
+                double worldY4 = worldY1 + cellSizeY;
 
                 Coordinate[] coordinates = new Coordinate[] {
                         new Coordinate(worldX1, worldY1),

--- a/common/src/main/java/org/apache/sedona/common/raster/PixelFunctions.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/PixelFunctions.java
@@ -96,22 +96,18 @@ public class PixelFunctions
         GeometryFactory geometryFactory = srid != 0 ? new GeometryFactory(new PrecisionModel(), srid) : GEOMETRY_FACTORY;
 
         Point2D upperLeft = RasterUtils.getWorldCornerCoordinates(rasterGeom, 1, 1);
-        List<PixelRecord> polygonRecords = new ArrayList<>();
+        List<PixelRecord> pixelRecords = new ArrayList<>();
 
         for (int y = 1; y <= height; y++) {
             for (int x = 1; x <= width; x++) {
                 double pixelValue = pixels[(y - 1) * width + (x - 1)];
 
-                // Calculate the world coordinates of the pixel's four corners
                 double worldX1 = upperLeft.getX() + (x - 1) * cellSizeX + (y - 1) * shearX;
                 double worldY1 = upperLeft.getY() + (y - 1) * cellSizeY + (x - 1) * shearY;
-
                 double worldX2 = worldX1 + cellSizeX;
                 double worldY2 = worldY1 + shearY;
-
                 double worldX3 = worldX2 + shearX;
                 double worldY3 = worldY2 + cellSizeY;
-
                 double worldX4 = worldX1 + shearX;
                 double worldY4 = worldY1 + cellSizeY;
 
@@ -120,17 +116,16 @@ public class PixelFunctions
                         new Coordinate(worldX2, worldY2),
                         new Coordinate(worldX3, worldY3),
                         new Coordinate(worldX4, worldY4),
-                        new Coordinate(worldX1, worldY1) // Close the polygon
+                        new Coordinate(worldX1, worldY1)
                 };
 
                 Geometry polygon = geometryFactory.createPolygon(coordinates);
-                polygonRecords.add(new PixelRecord(polygon, pixelValue, x, y));
+                pixelRecords.add(new PixelRecord(polygon, pixelValue, x, y));
             }
         }
 
-        return polygonRecords;
+        return pixelRecords;
     }
-
 
     public static Geometry getPixelAsCentroid(GridCoverage2D raster, int colX, int rowY) throws FactoryException, TransformException {
         Geometry polygon = PixelFunctions.getPixelAsPolygon(raster, colX, rowY);

--- a/common/src/main/java/org/apache/sedona/common/raster/PixelRecord.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/PixelRecord.java
@@ -1,0 +1,16 @@
+package org.apache.sedona.common.raster;
+
+import org.locationtech.jts.geom.Geometry;
+
+public class PixelRecord {
+    public final Geometry geom;
+    public final double value;
+    public final int colX, rowY;
+
+    public PixelRecord(Geometry geom, double value, int colX, int rowY) {
+        this.geom = geom;
+        this.value = value;
+        this.colX = colX;
+        this.rowY = rowY;
+    }
+}

--- a/common/src/test/java/org/apache/sedona/common/raster/FunctionsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/FunctionsTest.java
@@ -109,6 +109,28 @@ public class FunctionsTest extends RasterTestBase {
     }
 
     @Test
+    public void testPixelAsPointsPolygons() throws FactoryException, TransformException {
+        GridCoverage2D emptyRaster = RasterConstructors.makeEmptyRaster(1, 5, 10, 123, -230, 8);
+        List<PixelRecord> points = PixelFunctions.getPixelAsPolygons(emptyRaster, 1);
+
+//        for (PixelRecord record : points){
+//            System.out.println(record.geom+"   "+record.value+"   "+record.colX+"   "+record.rowY);
+//        }
+
+//        PixelRecord point1 = points.get(0);
+//        Geometry geom1 = (Geometry) point1.geom;
+//        assertEquals(0, geom1.getCoordinate().x, 1e-9);
+//        assertEquals(0, geom1.getCoordinate().y, 1e-9);
+//        assertEquals(0.0, point1.value, 1e-9);
+//
+//        PixelRecord point2 = points.get(1);
+//        Geometry geom2 = (Geometry) point2.geom;
+//        assertEquals(1, geom2.getCoordinate().x, 1e-9);
+//        assertEquals(0, geom2.getCoordinate().y, 1e-9);
+//        assertEquals(0.0, point2.value, 1e-9);
+    }
+
+    @Test
     public void testPixelAsCentroid() throws FactoryException, TransformException {
         GridCoverage2D emptyRaster = RasterConstructors.makeEmptyRaster(1, 12, 13, 134, -53, 9);
         String actual = Functions.asWKT(PixelFunctions.getPixelAsCentroid(emptyRaster, 3, 3));

--- a/common/src/test/java/org/apache/sedona/common/raster/FunctionsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/FunctionsTest.java
@@ -113,21 +113,18 @@ public class FunctionsTest extends RasterTestBase {
         GridCoverage2D emptyRaster = RasterConstructors.makeEmptyRaster(1, 5, 10, 123, -230, 8);
         List<PixelRecord> points = PixelFunctions.getPixelAsPolygons(emptyRaster, 1);
 
-//        for (PixelRecord record : points){
-//            System.out.println(record.geom+"   "+record.value+"   "+record.colX+"   "+record.rowY);
-//        }
+        PixelRecord point = points.get(11);
+        Geometry geom = (Geometry) point.geom;
+        String expected = "POLYGON ((131 -246, 139 -246, 139 -254, 131 -254, 131 -246))";
+        assertEquals(expected,geom.toString());
 
-//        PixelRecord point1 = points.get(0);
-//        Geometry geom1 = (Geometry) point1.geom;
-//        assertEquals(0, geom1.getCoordinate().x, 1e-9);
-//        assertEquals(0, geom1.getCoordinate().y, 1e-9);
-//        assertEquals(0.0, point1.value, 1e-9);
-//
-//        PixelRecord point2 = points.get(1);
-//        Geometry geom2 = (Geometry) point2.geom;
-//        assertEquals(1, geom2.getCoordinate().x, 1e-9);
-//        assertEquals(0, geom2.getCoordinate().y, 1e-9);
-//        assertEquals(0.0, point2.value, 1e-9);
+        // Testing with skewed raster
+        emptyRaster = RasterConstructors.makeEmptyRaster(1, 5, 10, 234, -43, 3, 4, 2,3,0);
+        points = PixelFunctions.getPixelAsPolygons(emptyRaster, 1);
+        point = points.get(11);
+        geom = (Geometry) point.geom;
+        expected = "POLYGON ((241 -32, 244 -29, 246 -25, 243 -28, 241 -32))";
+        assertEquals(expected,geom.toString());
     }
 
     @Test

--- a/docs/api/sql/Raster-operators.md
+++ b/docs/api/sql/Raster-operators.md
@@ -78,6 +78,55 @@ Output:
 POLYGON ((131 -246, 139 -246, 139 -254, 131 -254, 131 -246))
 ```
 
+### RS_PixelAsPolygons
+Introduction: Returns a list of the polygon geometry, the pixel value and its raster X and Y coordinates for each pixel in the raster at the specified band.
+
+Format: `RS_PixelAsPolygons(raster: Raster, band: Integer)`
+
+Since: `v1.5.1`
+
+Spark SQL Example:
+```sql
+SELECT ST_AsText(RS_PixelAsPolygons(raster, 1)) from rasters
+```
+
+Output:
+```
+[[POLYGON ((123.19000244140625 -12, 127.19000244140625 -12, 127.19000244140625 -16, 123.19000244140625 -16, 123.19000244140625 -12)),0.0,1,1], 
+[POLYGON ((127.19000244140625 -12, 131.19000244140625 -12, 131.19000244140625 -16, 127.19000244140625 -16, 127.19000244140625 -12)),0.0,2,1], 
+[POLYGON ((131.19000244140625 -12, 135.19000244140625 -12, 135.19000244140625 -16, 131.19000244140625 -16, 131.19000244140625 -12)),0.0,3,1]]
+```
+
+Spark SQL example for extracting Point, value, raster x and y coordinates:
+
+```scala
+val pointDf = sedona.read...
+val rasterDf = sedona.read.format("binaryFile").load("/some/path/*.tiff")
+var df = sedona.read.format("binaryFile").load("/some/path/*.tiff")
+df = df.selectExpr("RS_FromGeoTiff(content) as raster")
+
+df.selectExpr(
+  "explode(RS_PixelAsPolygons(raster, 1)) as exploded"
+).selectExpr(
+  "exploded.geom as geom",
+  "exploded.value as value",
+  "exploded.x as x",
+  "exploded.y as y"
+).show(3)
+```
+
+Output:
+
+```
++--------------------+-----+---+---+
+|                geom|value|  x|  y|
++--------------------+-----+---+---+
+|POLYGON ((-130958...|  0.0|  1|  1|
+|POLYGON ((-130957...|  0.0|  2|  1|
+|POLYGON ((-130956...|  0.0|  3|  1|
++--------------------+-----+---+---+
+```
+
 ## Geometry Functions
 
 ### RS_Envelope

--- a/docs/api/sql/Raster-operators.md
+++ b/docs/api/sql/Raster-operators.md
@@ -13,7 +13,7 @@ Since: `v1.5.0`
 Spark SQL Example:
 
 ```sql
-SELECT ST_AsText(RS_PixelAsPolygon(RS_MakeEmptyRaster(1, 12, 13, 134, -53, 9), 3, 3))
+SELECT ST_AsText(RS_PixelAsCentroid(RS_MakeEmptyRaster(1, 12, 13, 134, -53, 9), 3, 3))
 ```
 
 Output:

--- a/spark/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
+++ b/spark/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
@@ -230,6 +230,7 @@ object Catalog {
     function[RS_GeoTransform](),
     function[RS_PixelAsPoint](),
     function[RS_PixelAsPolygon](),
+    function[RS_PixelAsPolygons](),
     function[RS_PixelAsCentroid](),
     function[RS_Count](),
     function[RS_Clip](),

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/PixelFunctions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/PixelFunctions.scala
@@ -18,7 +18,7 @@
  */
 package org.apache.spark.sql.sedona_sql.expressions.raster
 
-import org.apache.sedona.common.raster.PixelFunctions
+import org.apache.sedona.common.raster.{PixelFunctions}
 import org.apache.sedona.sql.utils.GeometrySerializer
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression}

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/PixelFunctions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/PixelFunctions.scala
@@ -19,9 +19,18 @@
 package org.apache.spark.sql.sedona_sql.expressions.raster
 
 import org.apache.sedona.common.raster.PixelFunctions
-import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.sedona.sql.utils.GeometrySerializer
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression}
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.catalyst.util.GenericArrayData
+import org.apache.spark.sql.sedona_sql.UDT.{GeometryUDT, RasterUDT}
 import org.apache.spark.sql.sedona_sql.expressions.InferrableFunctionConverter._
 import org.apache.spark.sql.sedona_sql.expressions.InferredExpression
+import org.apache.spark.sql.sedona_sql.expressions.raster.implicits.RasterInputExpressionEnhancer
+import org.apache.spark.sql.types.{AbstractDataType, ArrayType, DataType, DoubleType, IntegerType, StructType}
+
+import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
 
 case class RS_Value(inputExpressions: Seq[Expression]) extends InferredExpression(
   inferrableFunction2(PixelFunctions.value), inferrableFunction3(PixelFunctions.value), inferrableFunction4(PixelFunctions.value)
@@ -41,6 +50,43 @@ case class RS_PixelAsPolygon(inputExpressions: Seq[Expression]) extends Inferred
   protected def withNewChildrenInternal(newChilren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChilren)
   }
+}
+
+case class RS_PixelAsPolygons(inputExpressions: Seq[Expression])
+  extends Expression with CodegenFallback with ExpectsInputTypes {
+
+  override def nullable: Boolean = true
+
+  override def dataType: DataType = ArrayType(new StructType()
+    .add("geom", GeometryUDT)
+    .add("value", DoubleType)
+    .add("x", IntegerType)
+    .add("y", IntegerType))
+
+  override def eval(input: InternalRow): Any = {
+    val rasterGeom = inputExpressions(0).toRaster(input)
+    val band = inputExpressions(1).eval(input).asInstanceOf[Int]
+
+    if (rasterGeom == null) {
+      null
+    } else {
+      val pixelRecords = PixelFunctions.getPixelAsPolygons(rasterGeom, band)
+      val rows = pixelRecords.map { pixelRecord =>
+        val serializedGeom = GeometrySerializer.serialize(pixelRecord.geom)
+        val rowArray = Array[Any](serializedGeom, pixelRecord.value, pixelRecord.colX, pixelRecord.rowY)
+        InternalRow.fromSeq(rowArray)
+      }
+      new GenericArrayData(rows.toArray)
+    }
+  }
+
+  override def children: Seq[Expression] = inputExpressions
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): RS_PixelAsPolygons = {
+    copy(inputExpressions = newChildren)
+  }
+
+  override def inputTypes: Seq[AbstractDataType] = Seq(RasterUDT, IntegerType)
 }
 
 case class RS_PixelAsCentroid(inputExpressions: Seq[Expression]) extends InferredExpression(PixelFunctions.getPixelAsCentroid _) {

--- a/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
@@ -943,6 +943,35 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
       assertEquals(expected, result)
     }
 
+    it("Passed RS_PixelAsPolygons with empty raster") {
+      val widthInPixel = 5
+      val heightInPixel = 10
+      val upperLeftX = 123.19
+      val upperLeftY = -12
+      val cellSize = 4
+      val numBands = 2
+      val result = sparkSession.sql(s"SELECT RS_PixelAsPolygons(RS_MakeEmptyRaster($numBands, $widthInPixel, $heightInPixel, $upperLeftX, $upperLeftY, $cellSize), 1)").first().getList(0);
+      val expected = "[POLYGON ((127.19000244140625 -20, 131.19000244140625 -20, 131.19000244140625 -24, 127.19000244140625 -24, 127.19000244140625 -20)),0.0,2,3]"
+      assertEquals(expected, result.get(11).toString)
+    }
+
+
+    it("Passed RS_PixelAsPolygons with raster") {
+      var df = sparkSession.read.format("binaryFile").load(resourceFolder + "raster/test1.tiff")
+      df = df.selectExpr("RS_FromGeoTiff(content) as raster")
+
+      var result = df.selectExpr(
+        "explode(RS_PixelAsPolygons(raster, 1)) as exploded"
+      ).selectExpr(
+        "exploded.geom as geom",
+        "exploded.value as value",
+        "exploded.x as x",
+        "exploded.y as y"
+      )
+
+      assert(result.count() == 264704)
+    }
+
     it("Passed RS_PixelAsCentroid with raster") {
       val widthInPixel = 12
       val heightInPixel = 13


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-435. The PR name follows the format `[SEDONA-XXX] my subject`.


## What changes were proposed in this PR?

- Implements Raster operator RS_PixelAsPolygons


## How was this patch tested?

- Passes new and existing tests


## Did this PR include necessary documentation updates?

- Yes, I am adding a new API. I am using the [current SNAPSHOT version number](https://github.com/apache/sedona/blob/a64972027aa4c0fea354898da67a2dd4e6cde46b/pom.xml#L29) in since `vX.Y.Z` format.
