### PR TITLE
[SEDONA-444] pre-commit: add hook to trim trailing whitespace

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -13,7 +13,7 @@ on:
       - 'docker/**'
 env:
   MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=60
-      
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Cache SBT
       uses: actions/cache@v3
       with:
-        path: | 
+        path: |
           ~/.ivy2/cache
           ~/.sbt
         key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -26,7 +26,7 @@ on:
 
 env:
   MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=60
-      
+
 jobs:
   build:
 
@@ -50,15 +50,15 @@ jobs:
           - spark: 3.3.0
             scala: 2.12.15
             jdk: '8'
-            skipTests: ''            
+            skipTests: ''
           - spark: 3.2.3
             scala: 2.12.15
             jdk: '8'
-            skipTests: ''            
+            skipTests: ''
           - spark: 3.1.2
             scala: 2.12.15
             jdk: '8'
-            skipTests: ''            
+            skipTests: ''
           - spark: 3.0.3
             scala: 2.12.15
             jdk: '8'

--- a/.github/workflows/python-extension.yml
+++ b/.github/workflows/python-extension.yml
@@ -19,7 +19,7 @@ on:
       - 'spark-shaded/**'
       - 'pom.xml'
       - 'python/**'
-      
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/python-wheel.yml
+++ b/.github/workflows/python-wheel.yml
@@ -19,7 +19,7 @@ on:
       - 'spark-shaded/**'
       - 'pom.xml'
       - 'python/**'
-      
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -22,7 +22,7 @@ on:
 
 env:
   MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=60
-      
+
 jobs:
   build:
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,8 @@ repos:
       - id: end-of-file-fixer
         files: \.(java|md|py|scala)$
         exclude: ^docs/image|^spark/common/src/test/resources
+      - id: trailing-whitespace
+        files: \.(ipynb|java|py|R|scala|sh|xml|yaml|yml)$
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.38.0
     hooks:

--- a/R/R/data_interface.R
+++ b/R/R/data_interface.R
@@ -19,7 +19,7 @@
 # ------- Read RDD ------------
 
 #' Create a SpatialRDD from an external data source.
-#' 
+#'
 #' Import spatial object from an external data source into a Sedona SpatialRDD.
 #'
 #' @param sc A `spark_connection`.
@@ -155,14 +155,14 @@ sedona_read_dsv_to_typed_rdd <- function(sc,
 #'
 #' @description
 #' `r lifecycle::badge("deprecated")`
-#' 
+#'
 #' Constructors of typed RDD (PointRDD, PolygonRDD, LineStringRDD) are soft deprecated, use non-types versions
-#' 
+#'
 #' Create a typed SpatialRDD (namely, a PointRDD, a PolygonRDD, or a
 #' LineStringRDD)
 #' * `sedona_read_shapefile_to_typed_rdd`: from a shapefile data source
 #' * `sedona_read_geojson_to_typed_rdd`: from a GeoJSON data source
-#' 
+#'
 #'
 #' @param sc A `spark_connection`.
 #' @param location Location of the data source.
@@ -197,13 +197,13 @@ sedona_read_shapefile_to_typed_rdd <- function(sc,
                                                location,
                                                type = c("point", "polygon", "linestring"),
                                                storage_level = "MEMORY_ONLY") {
-  
+
   lifecycle::deprecate_soft(
     "1.4.0",
     "sedona_read_shapefile_to_typed_rdd()",
     with = "sedona_read_shapefile()"
   )
-  
+
   invoke_static(
     sc,
     "org.apache.sedona.core.formatMapper.shapefileParser.ShapefileReader",
@@ -224,13 +224,13 @@ sedona_read_geojson_to_typed_rdd <- function(sc,
                                              has_non_spatial_attrs = TRUE,
                                              storage_level = "MEMORY_ONLY",
                                              repartition = 1L) {
-  
+
   lifecycle::deprecate_soft(
     "1.4.0",
     "sedona_read_geojson_to_typed_rdd()",
     with = "sedona_read_geojson()"
   )
-  
+
   invoke_new(
     sc,
     rdd_cls_from_type(type),
@@ -249,10 +249,10 @@ sedona_read_geojson_to_typed_rdd <- function(sc,
 #' Read geospatial data into a Spatial RDD
 #'
 #' @description Import spatial object from an external data source into a Sedona SpatialRDD.
-#' * `sedona_read_shapefile`: from a shapefile 
-#' * `sedona_read_geojson`: from a geojson file 
-#' * `sedona_read_wkt`: from a geojson file 
-#' * `sedona_read_wkb`: from a geojson file 
+#' * `sedona_read_shapefile`: from a shapefile
+#' * `sedona_read_geojson`: from a geojson file
+#' * `sedona_read_wkt`: from a geojson file
+#' * `sedona_read_wkb`: from a geojson file
 #'
 #' @param sc A `spark_connection`.
 #' @param location Location of the data source.
@@ -388,12 +388,12 @@ sedona_read_shapefile <- function(sc,
 
 # ------- Read SDF ------------
 #' Read geospatial data into a Spark DataFrame.
-#' 
+#'
 #' @description Functions to read geospatial data from a variety of formats into Spark DataFrames.
-#' 
-#' * `spark_read_shapefile`: from a shapefile 
-#' * `spark_read_geojson`: from a geojson file 
-#' * `spark_read_geoparquet`: from a geoparquet file 
+#'
+#' * `spark_read_shapefile`: from a shapefile
+#' * `spark_read_geojson`: from a geojson file
+#' * `spark_read_geoparquet`: from a geoparquet file
 #'
 #' @inheritParams sparklyr::spark_read_source
 #'
@@ -419,19 +419,19 @@ spark_read_shapefile <- function(sc,
                                  path = name,
                                  options = list(),
                                  ...) {
-  
+
   lapply(names(options), function(name) {
     if (!name %in% c("")) {
       warning(paste0("Ignoring unknown option '", name,"'"))
     }
   })
-  
+
   rdd <- sedona_read_shapefile(sc,
                                location = path,
                                storage_level = "MEMORY_ONLY")
-  
-  
-  
+
+
+
   rdd %>% sdf_register(name = name)
 }
 
@@ -445,7 +445,7 @@ spark_read_geojson <- function(sc,
                                repartition = 0,
                                memory = TRUE,
                                overwrite = TRUE) {
-  
+
   # check options
   if ("allow_invalid_geometries" %in% names(options)) final_allow_invalid <- options[["allow_invalid_geometries"]] else final_allow_invalid <- TRUE
   if ("skip_syntactically_invalid_geometries" %in% names(options)) final_skip <- options[["skip_syntactically_invalid_geometries"]] else final_skip <- TRUE
@@ -454,18 +454,18 @@ spark_read_geojson <- function(sc,
       warning(paste0("Ignoring unknown option '", name,"'"))
     }
   })
-  
+
   final_repartition <- max(as.integer(repartition), 1L)
-  
+
   rdd <- sedona_read_geojson(sc,
                              location = path,
                              allow_invalid_geometries = final_allow_invalid,
                              skip_syntactically_invalid_geometries = final_skip,
                              storage_level = "MEMORY_ONLY",
                              repartition = final_repartition)
-  
-  
-  
+
+
+
   rdd %>% sdf_register(name = name)
 }
 
@@ -479,8 +479,8 @@ spark_read_geoparquet <- function(sc,
                                   repartition = 0,
                                   memory = TRUE,
                                   overwrite = TRUE) {
-  
-  spark_read_source(sc, 
+
+  spark_read_source(sc,
                     name = name,
                     path = path,
                     source = "geoparquet",
@@ -603,7 +603,7 @@ sedona_save_spatial_rdd <- function(x,
 #' Write geospatial data from a Spark DataFrame.
 #'
 #' @description Functions to write geospatial data into a variety of formats from Spark DataFrames.
-#' 
+#'
 #' * `spark_write_geojson`: to GeoJSON
 #' * `spark_write_geoparquet`: to GeoParquet
 #' * `spark_write_raster`: to raster tiles after using RS output functions (`RS_AsXXX`)
@@ -643,12 +643,12 @@ spark_write_geojson <- function(x,
                                 options = list(),
                                 partition_by = NULL,
                                 ...) {
-  
+
   ## find geometry column if not specified
   if (!"spatial_col" %in% names(options)) {
     schema <- x %>% sdf_schema()
     potential_cols <- which(sapply(schema, function(x) x$type == "GeometryUDT"))
-    
+
     if (length(potential_cols) == 0) {
       cli::cli_abort("No geometry column found")
     } else if (length(potential_cols) > 1) {
@@ -657,15 +657,15 @@ spark_write_geojson <- function(x,
     } else {
       spatial_col = names(potential_cols)
     }
-    
+
   } else {
     spatial_col = options[["spatial_col"]]
   }
-  
+
   rdd <- x %>% to_spatial_rdd(spatial_col = spatial_col)
-  
+
   sedona_write_geojson(x = rdd, output_location = path)
-  
+
 }
 
 
@@ -678,7 +678,7 @@ spark_write_geoparquet <- function(x,
                                    options = list(),
                                    partition_by = NULL,
                                    ...) {
-  
+
   spark_write_source(
     x = x,
     source = "geoparquet",
@@ -688,7 +688,7 @@ spark_write_geoparquet <- function(x,
     save_args = list(path),
     ...
   )
-  
+
 }
 
 
@@ -701,7 +701,7 @@ spark_write_raster <- function(x,
                                    options = list(),
                                    partition_by = NULL,
                                    ...) {
-  
+
   spark_write_source(
     x = x,
     source = "raster",
@@ -711,7 +711,7 @@ spark_write_raster <- function(x,
     save_args = list(path),
     ...
   )
-  
+
 }
 
 

--- a/R/R/sdf_interface.R
+++ b/R/R/sdf_interface.R
@@ -17,7 +17,7 @@
 
 
 #' Import data from a spatial RDD into a Spark Dataframe.
-#' 
+#'
 #' @description Import data from a spatial RDD (possibly with non-spatial attributes) into a
 #' Spark Dataframe.
 #' * `sdf_register`: method for sparklyr's sdf_register to handle Spatial RDD
@@ -48,7 +48,7 @@
 #'     type = "polygon"
 #'   )
 #'   sdf <- sdf_register(rdd)
-#'   
+#'
 #'   input_location <- "/dev/null" # replace it with the path to your input file
 #'   rdd <- sedona_read_dsv_to_typed_rdd(
 #'     sc,
@@ -71,7 +71,7 @@ sdf_register.spatial_rdd <- function(x, name = NULL) {
 #' @rdname sdf_register.spatial_rdd
 as.spark.dataframe <- function(x, non_spatial_cols = NULL, name = NULL) {
   sc <- spark_connection(x$.jobj)
-  
+
   # Default keep all columns
   if (is.null(non_spatial_cols)) {
     if (!is.null(invoke(x$.jobj, "%>%", list("fieldNames")))) { ## Only if dataset has field names
@@ -82,7 +82,7 @@ as.spark.dataframe <- function(x, non_spatial_cols = NULL, name = NULL) {
   } else {
     stopifnot("non_spatial_cols needs to be a character vector (or NULL, default)" = is.character(non_spatial_cols))
   }
-  
+
   sdf <- invoke_static(
     sc,
     "org.apache.sedona.sql.utils.Adapter",

--- a/R/_pkgdown.yml
+++ b/R/_pkgdown.yml
@@ -23,7 +23,7 @@ home:
         title: Sedona Project
         text: >
           [Homepage](https://sedona.apache.org/)
- 
+
 reference:
 - title: "Reading and Writing Spatial DataFrames"
   desc: "Functions for reading and writing Spark DataFrames."

--- a/R/tests/testthat/helper-initialize.R
+++ b/R/tests/testthat/helper-initialize.R
@@ -29,10 +29,10 @@ testthat_spark_connection <- function(conn_retry_interval_s = 2) {
     for (attempt in seq(conn_attempts)) {
       success <- tryCatch(
         {
-          
+
           config <- spark_config()
           config[["sparklyr.connect.timeout"]] <- 300
-          
+
           sc <- spark_connect(
             master = "local",
             method = "shell",

--- a/R/tests/testthat/test-crs-transform.R
+++ b/R/tests/testthat/test-crs-transform.R
@@ -24,7 +24,7 @@ test_that("crs_transform() works as expected", {
     type = "point"
   ) %>%
     crs_transform("epsg:4326", "epsg:3857")
-  
+
 #  expect_equivalent(
 #    pt_rdd %>%
 #      sdf_register() %>%

--- a/R/tests/testthat/test-data-interface-raster.R
+++ b/R/tests/testthat/test-data-interface-raster.R
@@ -27,11 +27,11 @@ test_that("Passed RS_FromGeoTiff from binary", {
   ## Load
   sdf_name <- random_string("spatial_sdf")
   binary_sdf <- spark_read_binary(sc, dir = test_data("raster/test1.tiff"), name = sdf_name)
-  
-  raster_sdf <- 
-    binary_sdf %>% 
+
+  raster_sdf <-
+    binary_sdf %>%
     mutate(raster = RS_FromGeoTiff(content))
-  
+
   expect_equal(
     raster_sdf %>% sdf_schema() ,
     list(
@@ -41,29 +41,29 @@ test_that("Passed RS_FromGeoTiff from binary", {
       content          = list(name = "content", type = "BinaryType"),
       raster           = list(name = "raster", type = "RasterUDT"))
   )
-  
+
   a <- raster_sdf %>% head(1) %>%  collect()
   expect_equal(
     a$raster[[1]] %>% sparklyr::invoke("getClass") %>% sparklyr::invoke("getSimpleName"),
     "GridCoverage2D"
   )
-  
+
   ## Cleanup
   sc %>% DBI::dbExecute(paste0("DROP TABLE ", sdf_name))
   # sc %>% DBI::dbExecute(paste0("DROP TABLE ", dbplyr::remote_name(raster_sdf)))
   rm(a)
-  
+
 })
 
 test_that("Passed RS_FromArcInfoAsciiGrid from binary", {
   ## Load
   sdf_name <- random_string("spatial_sdf")
   binary_sdf <- spark_read_binary(sc, dir = test_data("raster_asc/test1.asc"), name = sdf_name)
-  
-  raster_sdf <- 
-    binary_sdf %>% 
+
+  raster_sdf <-
+    binary_sdf %>%
     mutate(raster = RS_FromArcInfoAsciiGrid(content))
-  
+
   expect_equal(
     raster_sdf %>% sdf_schema() ,
     list(
@@ -73,18 +73,18 @@ test_that("Passed RS_FromArcInfoAsciiGrid from binary", {
       content          = list(name = "content", type = "BinaryType"),
       raster           = list(name = "raster", type = "RasterUDT"))
   )
-  
+
   a <- raster_sdf %>% head(1) %>%  collect()
   expect_equal(
     a$raster[[1]] %>% sparklyr::invoke("getClass") %>% sparklyr::invoke("getSimpleName"),
     "GridCoverage2D"
   )
-  
+
   ## Cleanup
   sc %>% DBI::dbExecute(paste0("DROP TABLE ", sdf_name))
   # sc %>% DBI::dbExecute(paste0("DROP TABLE ", dbplyr::remote_name(raster_sdf)))
   rm(a)
-  
+
 })
 
 
@@ -92,14 +92,14 @@ test_that("Passed RS_Envelope with raster", {
   ## Load
   sdf_name <- random_string("spatial_sdf")
   binary_sdf <- spark_read_binary(sc, dir = test_data("raster/test1.tiff"), name = sdf_name)
-  
-  raster_sdf <- 
-    binary_sdf %>% 
+
+  raster_sdf <-
+    binary_sdf %>%
     mutate(
       raster = RS_FromGeoTiff(content),
       env = RS_Envelope(raster)
     )
-  
+
   expect_equal(
     raster_sdf %>% sdf_schema() ,
     list(
@@ -111,17 +111,17 @@ test_that("Passed RS_Envelope with raster", {
       env              = list(name = "env", type = "GeometryUDT")
     )
   )
-  
-  a <- 
-    raster_sdf %>% 
-    mutate(env = env %>% st_astext()) %>% 
-    select(env) %>% 
+
+  a <-
+    raster_sdf %>%
+    mutate(env = env %>% st_astext()) %>%
+    select(env) %>%
     head(1) %>%  collect()
   expect_equal(
     a$env[1] %>% substr(1, 129),
     "POLYGON ((-13095817.809482181 3983868.8560156375, -13095817.809482181 4021262.7487925636, -13058785.559768861 4021262.7487925636,"
   )
-  
+
   ## Cleanup
   sc %>% DBI::dbExecute(paste0("DROP TABLE ", sdf_name))
   # sc %>% DBI::dbExecute(paste0("DROP TABLE ", dbplyr::remote_name(raster_sdf)))
@@ -133,23 +133,23 @@ test_that("Passed RS_NumBands with raster", {
   ## Load
   sdf_name <- random_string("spatial_sdf")
   binary_sdf <- spark_read_binary(sc, dir = test_data("raster"), name = sdf_name)
-  
+
   a <-
-    binary_sdf %>% 
+    binary_sdf %>%
     mutate(
       raster = RS_FromGeoTiff(content),
       nbands = RS_NumBands(raster)
-    ) %>% 
-    select(nbands) %>% 
+    ) %>%
+    select(nbands) %>%
     collect()
-  
+
   expect_equal(
     a %>% as.list(),
     list(nbands = c(1, 1, 4))
-    
+
   )
-  
-  
+
+
   ## Cleanup
   sc %>% DBI::dbExecute(paste0("DROP TABLE ", sdf_name))
   rm(a)
@@ -160,23 +160,23 @@ test_that("Passed RS_Value with raster", {
   ## Load
   sdf_name <- random_string("spatial_sdf")
   binary_sdf <- spark_read_binary(sc, dir = test_data("raster/test1.tiff"), name = sdf_name)
-  
+
   a <-
-    binary_sdf %>% 
+    binary_sdf %>%
     mutate(
       raster = RS_FromGeoTiff(content),
       val = RS_Value(raster, ST_SetSRID(ST_Point(-13077301.685, 4002565.802), RS_SRID(raster)))
-    ) %>% 
-    select(val) %>% 
+    ) %>%
+    select(val) %>%
     collect()
-  
+
   expect_equal(
     a %>% as.list(),
     list(val = c(255))
-    
+
   )
-  
-  
+
+
   ## Cleanup
   sc %>% DBI::dbExecute(paste0("DROP TABLE ", sdf_name))
   rm(a)
@@ -186,22 +186,22 @@ test_that("Passed RS_Values with raster", {
   ## Load
   sdf_name <- random_string("spatial_sdf")
   binary_sdf <- spark_read_binary(sc, dir = test_data("raster"), name = sdf_name)
-  
+
   a <-
-    binary_sdf %>% 
+    binary_sdf %>%
     mutate(
       raster = RS_FromGeoTiff(content),
       val = RS_Values(raster, array(ST_SetSRID(ST_Point(-13077301.685, 4002565.802), RS_SRID(raster)), NULL))
-    ) %>% 
+    ) %>%
     select(val) %>%
     collect()
-  
+
   expect_equal(
     a %>% as.list(),
     list(val = list(c(255, NA_real_), c(255, NA_real_), c(NA_real_, NA_real_)))
-    
+
   )
-  
+
   ## Cleanup
   sc %>% DBI::dbExecute(paste0("DROP TABLE ", sdf_name))
   rm(a)
@@ -210,169 +210,169 @@ test_that("Passed RS_Values with raster", {
 
 # Write Binary and RS_functions  -----------------
 test_that("Should read geotiff using binary source and write geotiff back to disk using raster source", {
-  
+
   ## Load
   sdf_name <- random_string("spatial_sdf")
   binary_sdf <- spark_read_binary(sc, dir = test_data("raster"), name = sdf_name)
-  
+
   tmp_dest <- tempfile()
-  
-  binary_sdf %>% 
+
+  binary_sdf %>%
     spark_write_raster(path = tmp_dest)
-  
+
   sdf_name_2 <- random_string("spatial_sdf_2")
   binary_2_sdf <- spark_read_binary(sc, dir = tmp_dest, name = sdf_name_2, recursive_file_lookup = TRUE)
-  
+
   expect_equal(
     sc %>% DBI::dbGetQuery("SELECT count(*) as n FROM ? LIMIT 1", DBI::dbQuoteIdentifier(sc, sdf_name)),
     sc %>% DBI::dbGetQuery("SELECT count(*) as n FROM (SELECT RS_FromGeoTiff(content) as raster FROM ?) LIMIT 1", DBI::dbQuoteIdentifier(sc, sdf_name_2))
   )
-  
+
   ## Cleanup
   sc %>% DBI::dbExecute(paste0("DROP TABLE ", sdf_name))
   sc %>% DBI::dbExecute(paste0("DROP TABLE ", sdf_name_2))
   rm(binary_sdf, binary_2_sdf, tmp_dest)
-  
-  
+
+
 
 })
 
 test_that("Should read and write geotiff using given options", {
-  
+
   ## Load
   sdf_name <- random_string("spatial_sdf")
   binary_sdf <- spark_read_binary(sc, dir = test_data("raster"), name = sdf_name)
-  
+
   tmp_dest <- tempfile()
-  
-  binary_sdf %>% 
-    spark_write_raster(path = tmp_dest, 
-                       options = list("rasterField" = "content", 
+
+  binary_sdf %>%
+    spark_write_raster(path = tmp_dest,
+                       options = list("rasterField" = "content",
                                       "fileExtension" = ".tiff",
                                       "pathField" = "path"
                                       ))
-  
+
   sdf_name_2 <- random_string("spatial_sdf_2")
   binary_2_sdf <- spark_read_binary(sc, dir = tmp_dest, name = sdf_name_2, recursive_file_lookup = TRUE)
-  
-  
+
+
   expect_equal(
     sc %>% DBI::dbGetQuery("SELECT count(*) as n FROM ? LIMIT 1", DBI::dbQuoteIdentifier(sc, sdf_name)),
     sc %>% DBI::dbGetQuery("SELECT count(*) as n FROM (SELECT RS_FromGeoTiff(content) as raster FROM ?) LIMIT 1", DBI::dbQuoteIdentifier(sc, sdf_name_2))
   )
-  
+
   ## Cleanup
   sc %>% DBI::dbExecute(paste0("DROP TABLE ", sdf_name))
   sc %>% DBI::dbExecute(paste0("DROP TABLE ", sdf_name_2))
   rm(binary_sdf, binary_2_sdf, tmp_dest)
-  
+
 })
 
 test_that("Should read and write via RS_FromGeoTiff and RS_AsGeoTiff", {
-  
-  
+
+
   ## Load
   sdf_name <- random_string("spatial_sdf")
   binary_sdf <- spark_read_binary(sc, dir = test_data("raster"), name = sdf_name)
-  
-  raster_sdf <- 
-    binary_sdf %>% 
-    mutate(raster = RS_FromGeoTiff(content)) %>% 
+
+  raster_sdf <-
+    binary_sdf %>%
+    mutate(raster = RS_FromGeoTiff(content)) %>%
     mutate(content = RS_AsGeoTiff(raster))
-  
-  
+
+
   tmp_dest <- tempfile()
-  
-  raster_sdf %>% 
-    spark_write_raster(path = tmp_dest, 
-                       options = list("rasterField" = "content", 
+
+  raster_sdf %>%
+    spark_write_raster(path = tmp_dest,
+                       options = list("rasterField" = "content",
                                       "fileExtension" = ".tiff",
                                       "pathField" = "path"
                        ))
-  
+
   sdf_name_2 <- random_string("spatial_sdf_2")
   binary_2_sdf <- spark_read_binary(sc, dir = tmp_dest, name = sdf_name_2, recursive_file_lookup = TRUE)
-  
-  
+
+
   expect_equal(
     sc %>% DBI::dbGetQuery("SELECT count(*) as n FROM ? LIMIT 1", DBI::dbQuoteIdentifier(sc, sdf_name)),
     sc %>% DBI::dbGetQuery("SELECT count(*) as n FROM (SELECT RS_FromGeoTiff(content) as raster FROM ?) LIMIT 1", DBI::dbQuoteIdentifier(sc, sdf_name))
   )
-  
+
   ## Cleanup
   sc %>% DBI::dbExecute(paste0("DROP TABLE ", sdf_name))
   sc %>% DBI::dbExecute(paste0("DROP TABLE ", sdf_name_2))
   rm(raster_sdf, binary_sdf, binary_2_sdf, tmp_dest)
-  
+
 })
 
 test_that("Should handle null", {
-  
+
   ## Load
   sdf_name <- random_string("spatial_sdf")
   binary_sdf <- spark_read_binary(sc, dir = test_data("raster"), name = sdf_name)
-  
-  raster_sdf <- 
-    binary_sdf %>% 
-    mutate(raster = RS_FromGeoTiff(NULL)) %>% 
+
+  raster_sdf <-
+    binary_sdf %>%
+    mutate(raster = RS_FromGeoTiff(NULL)) %>%
     mutate(content = RS_AsGeoTiff(raster))
-  
+
   tmp_dest <- tempfile()
-  
-  raster_sdf %>% 
+
+  raster_sdf %>%
     spark_write_raster(path = tmp_dest)
-  
+
   sdf_name_2 <- random_string("spatial_sdf_2")
   binary_2_sdf <- spark_read_binary(sc, dir = tmp_dest, name = sdf_name_2, recursive_file_lookup = TRUE)
-  
+
   out <- sc %>% DBI::dbGetQuery("SELECT count(*) as n FROM (SELECT RS_FromGeoTiff(content) as raster FROM ?) LIMIT 1", DBI::dbQuoteIdentifier(sc, sdf_name_2))
-  
+
   expect_equal(
     out$n,
     0
   )
-  
+
   ## Cleanup
   sc %>% DBI::dbExecute(paste0("DROP TABLE ", sdf_name))
   sc %>% DBI::dbExecute(paste0("DROP TABLE ", sdf_name_2))
   rm(raster_sdf, binary_sdf, binary_2_sdf, tmp_dest)
-  
+
 })
 
 test_that("Should read RS_FromGeoTiff and write RS_AsArcGrid", {
-  
+
   ## Load
   sdf_name <- random_string("spatial_sdf")
   binary_sdf <- spark_read_binary(sc, dir = test_data("raster"), name = sdf_name)
-  
-  raster_sdf <- 
-    binary_sdf %>% 
-    mutate(raster = RS_FromGeoTiff(content)) %>% 
-    mutate(content = RS_AsArcGrid(raster)) %>% 
+
+  raster_sdf <-
+    binary_sdf %>%
+    mutate(raster = RS_FromGeoTiff(content)) %>%
+    mutate(content = RS_AsArcGrid(raster)) %>%
     sdf_register()
-  
+
   tmp_dest <- tempfile()
-  
-  raster_sdf %>% 
-    spark_write_raster(path = tmp_dest, 
-                       options = list("rasterField" = "content", 
+
+  raster_sdf %>%
+    spark_write_raster(path = tmp_dest,
+                       options = list("rasterField" = "content",
                                       "fileExtension" = ".asc",
                                       "pathField" = "path"
                        ))
-  
+
   sdf_name_2 <- random_string("spatial_sdf_2")
   binary_2_sdf <- spark_read_binary(sc, dir = tmp_dest, name = sdf_name_2, recursive_file_lookup = TRUE)
-  
-  
-  
+
+
+
   expect_equal(
     sc %>% DBI::dbGetQuery("SELECT count(*) as n FROM ? LIMIT 1", DBI::dbQuoteIdentifier(sc, dbplyr::remote_name(raster_sdf))),
     sc %>% DBI::dbGetQuery("SELECT count(*) as n FROM (SELECT RS_FromGeoTiff(content) as raster FROM ?) LIMIT 1", DBI::dbQuoteIdentifier(sc, sdf_name_2))
   )
-  
+
   ## Cleanup
   sc %>% DBI::dbExecute(paste0("DROP TABLE ", sdf_name))
   sc %>% DBI::dbExecute(paste0("DROP TABLE ", sdf_name_2))
   rm(raster_sdf, binary_sdf, binary_2_sdf, tmp_dest)
-  
+
 })

--- a/R/tests/testthat/test-data-interface.R
+++ b/R/tests/testthat/test-data-interface.R
@@ -78,7 +78,7 @@ test_that("sedona_read_dsv_to_typed_rdd() creates PointRDD correctly", {
     first_spatial_col_index = 1,
     has_non_spatial_attrs = TRUE
   )
-  
+
   expect_equal(class(pt_rdd), c("point_rdd", "spatial_rdd"))
   expect_equal(pt_rdd$.jobj %>% invoke("approximateTotalCount"), 3000)
   expect_boundary_envelope(pt_rdd, c(-173.120769, -84.965961, 30.244859, 71.355134))
@@ -106,7 +106,7 @@ test_that("sedona_read_dsv_to_typed_rdd() creates PolygonRDD correctly", {
     first_spatial_col_index = 0,
     has_non_spatial_attrs = FALSE
   )
-  
+
   expect_equal(class(polygon_rdd), c("polygon_rdd", "spatial_rdd"))
   expect_equal(polygon_rdd$.jobj %>% invoke("approximateTotalCount"), 3000)
   expect_boundary_envelope(polygon_rdd, c(-158.104182, -66.03575, 17.986328, 48.645133))
@@ -121,7 +121,7 @@ test_that("sedona_read_dsv_to_typed_rdd() creates LineStringRDD correctly", {
     first_spatial_col_index = 0,
     has_non_spatial_attrs = FALSE
   )
-  
+
   expect_equal(class(linestring_rdd), c("linestring_rdd", "spatial_rdd"))
   expect_equal(linestring_rdd$.jobj %>% invoke("approximateTotalCount"), 3000)
   expect_boundary_envelope(linestring_rdd, c(-123.393766, -65.648659, 17.982169, 49.002374))
@@ -135,7 +135,7 @@ test_that("sedona_read_geojson_to_typed_rdd() creates PointRDD correctly", {
       type = "point"
     )
   })
-  
+
   expect_equal(class(pt_rdd), c("point_rdd", "spatial_rdd"))
   expect_equal(pt_rdd$.jobj %>% invoke("approximateTotalCount"), 7)
   expect_boundary_envelope(pt_rdd, c(-88.1234, -85.3333, 31.3699, 34.9876))
@@ -163,7 +163,7 @@ test_that("sedona_read_geojson_to_typed_rdd() creates PolygonRDD correctly", {
       has_non_spatial_attrs = TRUE
     )
   })
-  
+
   expect_equal(class(polygon_rdd), c("polygon_rdd", "spatial_rdd"))
   expect_equal(polygon_rdd$.jobj %>% invoke("approximateTotalCount"), 1001)
   expect_false(is.null(polygon_rdd$.jobj %>% invoke("boundaryEnvelope")))
@@ -189,7 +189,7 @@ test_that("sedona_read_geojson_to_typed_rdd() creates PolygonRDD correctly", {
 
 test_that("sedona_read_geojson() works as expected on geojson input with 'type' and 'geometry' properties", {
   geojson_rdd <- sedona_read_geojson(sc, test_data("testPolygon.json"))
-  
+
   expect_equal(
     geojson_rdd$.jobj %>% invoke("%>%", list("rawSpatialRDD"), list("count")), 1001
   )
@@ -197,7 +197,7 @@ test_that("sedona_read_geojson() works as expected on geojson input with 'type' 
 
 test_that("sedona_read_geojson() works as expected on geojson input without 'type' or 'geometry' properties", {
   geojson_rdd <- sedona_read_geojson(sc, test_data("testpolygon-no-property.json"))
-  
+
   expect_equal(
     geojson_rdd$.jobj %>% invoke("%>%", list("rawSpatialRDD"), list("count")), 10
   )
@@ -205,7 +205,7 @@ test_that("sedona_read_geojson() works as expected on geojson input without 'typ
 
 test_that("sedona_read_geojson() works as expected on geojson input with null property value", {
   geojson_rdd <- sedona_read_geojson(sc, test_data("testpolygon-with-null-property-value.json"))
-  
+
   expect_equal(
     geojson_rdd$.jobj %>% invoke("%>%", list("rawSpatialRDD"), list("count")), 3
   )
@@ -218,18 +218,18 @@ test_that("sedona_read_geojson() can skip invalid geometries correctly", {
     allow_invalid_geometries = TRUE,
     skip_syntactically_invalid_geometries = FALSE
   )
-  
+
   expect_equal(
     geojson_rdd$.jobj %>% invoke("%>%", list("rawSpatialRDD"), list("count")), 3
   )
-  
+
   geojson_rdd <- sedona_read_geojson(
     sc,
     test_data("testInvalidPolygon.json"),
     allow_invalid_geometries = FALSE,
     skip_syntactically_invalid_geometries = FALSE
   )
-  
+
   expect_equal(
     geojson_rdd$.jobj %>% invoke("%>%", list("rawSpatialRDD"), list("count")), 2
   )
@@ -237,7 +237,7 @@ test_that("sedona_read_geojson() can skip invalid geometries correctly", {
 
 test_that("sedona_read_wkb() works as expected", {
   wkb_rdd <- sedona_read_wkb(sc, test_data("county_small_wkb.tsv"))
-  
+
   expect_equal(
     wkb_rdd$.jobj %>% invoke("%>%", list("rawSpatialRDD"), list("count")), 103
   )
@@ -250,7 +250,7 @@ test_that("sedona_read_shapefile_to_typed_rdd() creates PointRDD correctly", {
       location = shapefile("point"), type = "point"
     )
   })
-  
+
   expect_equal(class(pt_rdd), c("point_rdd", "spatial_rdd"))
   expect_equal(
     pt_rdd$.jobj %>% invoke("%>%", list("rawSpatialRDD"), list("count")),
@@ -263,7 +263,7 @@ test_that("sedona_read_shapefile_to_typed_rdd() creates PolygonRDD correctly", {
     sc,
     location = shapefile("polygon"), type = "polygon"
   )
-  
+
   expect_equal(class(polygon_rdd), c("polygon_rdd", "spatial_rdd"))
   expect_equal(
     polygon_rdd$.jobj %>% invoke("%>%", list("rawSpatialRDD"), list("count")),
@@ -276,7 +276,7 @@ test_that("sedona_read_shapefile_to_typed_rdd() creates LineStringRDD correctly"
     sc,
     location = shapefile("polyline"), type = "linestring"
   )
-  
+
   expect_equal(class(linestring_rdd), c("linestring_rdd", "spatial_rdd"))
   expect_equal(
     linestring_rdd$.jobj %>% invoke("%>%", list("rawSpatialRDD"), list("count")),
@@ -286,7 +286,7 @@ test_that("sedona_read_shapefile_to_typed_rdd() creates LineStringRDD correctly"
 
 test_that("sedona_read_shapefile() works as expected", {
   wkb_rdd <- sedona_read_shapefile(sc, shapefile("polygon"))
-  
+
   expect_equal(
     wkb_rdd$.jobj %>% invoke("%>%", list("rawSpatialRDD"), list("count")), 10000
   )
@@ -298,32 +298,32 @@ test_that("sedona_read_shapefile() works as expected", {
 test_that("spark_read_geoparquet() works as expected", {
   sdf_name <- random_string("spatial_sdf")
   geoparquet_sdf <- spark_read_geoparquet(sc, geoparquet("example1.parquet"), name = sdf_name)
-  
+
   ## Right number of rows
   geoparquet_df <-
-    geoparquet_sdf %>% 
+    geoparquet_sdf %>%
     spark_dataframe()
-  
+
   expect_equal(
     invoke(geoparquet_df, 'count'), 5
   )
-  
+
   ## Right registered name
   expect_equal(geoparquet_sdf %>% dbplyr::remote_name(), sdf_name)
-  
+
   ## Right schema
   expect_equivalent(
     geoparquet_sdf %>% sdf_schema(),
     list(
-      pop_est    = list(name = "pop_est", type = "LongType"), 
-      continent  = list(name = "continent", type = "StringType"), 
-      name       = list(name = "name", type = "StringType"), 
-      iso_a3     = list(name = "iso_a3", type = "StringType"), 
-      gdp_md_est = list(name = "gdp_md_est", type = "DoubleType"), 
+      pop_est    = list(name = "pop_est", type = "LongType"),
+      continent  = list(name = "continent", type = "StringType"),
+      name       = list(name = "name", type = "StringType"),
+      iso_a3     = list(name = "iso_a3", type = "StringType"),
+      gdp_md_est = list(name = "gdp_md_est", type = "DoubleType"),
       geometry   = list(name = "geometry", type = "GeometryUDT")
     )
   )
-  
+
   ## Right data (first row)
   expect_equivalent(
     geoparquet_sdf %>% head(1) %>% mutate(geometry = geometry %>% st_astext()) %>% collect() %>% as.list(),
@@ -336,22 +336,22 @@ test_that("spark_read_geoparquet() works as expected", {
       geometry = "MULTIPOLYGON (((180 -16.067132663642447, 180 -16.555216566639196, 179.36414266196414 -16.801354076946883, 178.72505936299711 -17.01204167436804, 178.59683859511713 -16.639150000000004, 179.0966093629971 -16.433984277547403, 179.4135093629971 -16.379054277547404, 180 -16.067132663642447)), ((178.12557 -17.50481, 178.3736 -17.33992, 178.71806 -17.62846, 178.55271 -18.15059, 177.93266000000003 -18.28799, 177.38146 -18.16432, 177.28504 -17.72465, 177.67087 -17.381140000000002, 178.12557 -17.50481)), ((-179.79332010904864 -16.020882256741224, -179.9173693847653 -16.501783135649397, -180 -16.555216566639196, -180 -16.067132663642447, -179.79332010904864 -16.020882256741224)))"
     )
   )
-  
+
   ## Spatial predicate
-  filtered <- 
-    geoparquet_sdf %>% 
-    filter(ST_Intersects(ST_Point(35.174722, -6.552465), geometry)) %>% 
+  filtered <-
+    geoparquet_sdf %>%
+    filter(ST_Intersects(ST_Point(35.174722, -6.552465), geometry)) %>%
     collect()
   expect_equal(filtered %>% nrow(), 1)
   expect_equal(filtered$name, "Tanzania")
-  
+
 })
 
 
 test_that("spark_read_geoparquet() works as expected, ex 2", {
   sdf_name <- random_string("spatial_sdf")
   geoparquet_sdf <- spark_read_geoparquet(sc, geoparquet("example2.parquet"), name = sdf_name)
-  
+
   ## Right data (first row)
   expect_equivalent(
     geoparquet_sdf %>% head(1) %>% select(name, geometry) %>%  mutate(geometry = geometry %>% st_astext()) %>% collect() %>% as.list(),
@@ -360,14 +360,14 @@ test_that("spark_read_geoparquet() works as expected, ex 2", {
       geometry = "POINT (12.453386544971766 41.903282179960115)"
     )
   )
-  
+
 })
 
 
 test_that("spark_read_geoparquet() works as expected, ex 3", {
   sdf_name <- random_string("spatial_sdf")
   geoparquet_sdf <- spark_read_geoparquet(sc, geoparquet("example3.parquet"), name = sdf_name)
-  
+
   ## Right data (first row)
   expect_equivalent(
     geoparquet_sdf %>% head(1) %>% mutate(geometry = geometry %>% st_astext() %>% substring(1, 26)) %>% collect() %>% as.list(),
@@ -379,72 +379,72 @@ test_that("spark_read_geoparquet() works as expected, ex 3", {
       geometry = "MULTIPOLYGON (((970217.022"
     )
   )
-  
+
 })
 
 
 test_that("spark_read_geoparquet() works as expected, ex 1.0.0-beta.1", {
   sdf_name <- random_string("spatial_sdf")
   geoparquet_sdf <- spark_read_geoparquet(sc, geoparquet("example-1.0.0-beta.1.parquet"), name = sdf_name)
-  
+
   ## Right number of rows
   geoparquet_df <-
-    geoparquet_sdf %>% 
+    geoparquet_sdf %>%
     spark_dataframe()
-  
+
   expect_equal(
     invoke(geoparquet_df, 'count'), 5
   )
-  
+
 })
 
 
 
 test_that("spark_read_geoparquet() works as expected, multiple geom", {
-  
+
   ## Load
   sdf_name <- random_string("spatial_sdf")
-  
-  test_data <- 
+
+  test_data <-
     data.frame(
       id = 1:3,
       g0 = c("POINT (1 2)", "POINT Z(1 2 3)", "MULTIPOINT (0 0, 1 1, 2 2)"),
       g1 = c("POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))", "POLYGON Z((0 0 2, 1 0 2, 1 1 2, 0 1 2, 0 0 2))", "MULTILINESTRING ((0 0, 1 1), (2 2, 3 3))")
     )
-  
+
   geoparquet_sdf <- copy_to(sc, test_data, sdf_name)
   geoparquet_sdf <- geoparquet_sdf %>% mutate(g0 = st_geomfromtext(g0), g1 = st_geomfromtext(g1))
-  
+
   ## Write
   tmp_dest <- tempfile()
   spark_write_geoparquet(geoparquet_sdf, path = tmp_dest, mode = "overwrite")
-  
+
   ## Check
   ### Can't check on geoparquet metadata with available packages
-  
+
   file <- dir(tmp_dest, full.names = TRUE, pattern = "parquet$")
-  
+
   geoparquet_2_sdf <- spark_read_geoparquet(sc, path = file)
   out <- geoparquet_2_sdf %>% sdf_schema()
-  
+
   expect_match(out$g0$type, "GeometryUDT")
   expect_match(out$g1$type, "GeometryUDT")
-  
+
   ## Cleanup
   unlink(tmp_dest, recursive = TRUE)
   sc %>% DBI::dbExecute(paste0("DROP TABLE ", sdf_name))
   sc %>% DBI::dbExecute(paste0("DROP TABLE ", dbplyr::remote_name(geoparquet_2_sdf)))
-  
+
 })
 
 
 test_that("spark_read_geoparquet() throws an error with plain parquet files", {
-  
+
   expect_error(
     spark_read_geoparquet(sc, geoparquet("plain.parquet")),
     regexp = "not contain valid geo"
   )
-  
+
 })
 
 
@@ -452,111 +452,111 @@ test_that("spark_read_geojson() works as expected", {
   sdf_name <- random_string("spatial_sdf")
   geojson_sdf <- spark_read_geojson(sc, path = test_data("testPolygon.json"), name = sdf_name)
   tmp_dest <- tempfile(fileext = ".json")
-  
+
   ## Right number of rows
   geojson_df <-
-    geojson_sdf %>% 
+    geojson_sdf %>%
     spark_dataframe()
-  
+
   expect_equal(
     invoke(geojson_df, 'count'), 1001
   )
-  
+
   ## Right registered name
   expect_equal(geojson_sdf %>% dbplyr::remote_name(), sdf_name)
-  
+
 })
 
 
 test_that("spark_read_geojson() works as expected, no feat", {
   sdf_name <- random_string("spatial_sdf")
   geojson_sdf <- spark_read_geojson(sc, path = test_data("testpolygon-no-property.json"), name = sdf_name)
-  
+
   ## Right number of rows
   expect_equal(
     invoke(geojson_sdf %>% spark_dataframe(), 'count'), 10
   )
-  
+
   ## Right registered name
   expect_equal(geojson_sdf %>% dbplyr::remote_name(), sdf_name)
-  
+
   sc %>% DBI::dbExecute(paste0("DROP TABLE ", sdf_name))
-  
+
 })
 
 test_that("spark_read_geojson() works as expected, null values", {
   sdf_name <- random_string("spatial_sdf")
   geojson_sdf <- spark_read_geojson(sc, path = test_data("testpolygon-with-null-property-value.json"), name = sdf_name)
-  
+
   ## Right number of rows
   expect_equal(
     invoke(geojson_sdf %>% spark_dataframe(), 'count'), 3
   )
-  
+
   ## Right registered name
   expect_equal(geojson_sdf %>% dbplyr::remote_name(), sdf_name)
-  
+
   sc %>% DBI::dbExecute(paste0("DROP TABLE ", sdf_name))
-  
+
 })
 
 
 test_that("spark_read_geojson() works as expected, with id", {
   sdf_name <- random_string("spatial_sdf")
   geojson_sdf <- spark_read_geojson(sc, path = test_data("testContainsId.json"), name = sdf_name)
-  
+
   ## Right number of rows
   expect_equal(
     invoke(geojson_sdf %>% spark_dataframe(), 'count'), 1
   )
-  
+
   ## Right cols
   expect_equal(
     geojson_sdf %>% sdf_schema(),
     list(
       geometry = list(name = "geometry", type = "GeometryUDT"),
-      id       = list(name = "id", type = "StringType"), 
-      zipcode  = list(name = "zipcode", type = "StringType"), 
+      id       = list(name = "id", type = "StringType"),
+      zipcode  = list(name = "zipcode", type = "StringType"),
       name     = list(name = "name", type = "StringType")
     )
   )
-  
+
   ## Right registered name
   expect_equal(geojson_sdf %>% dbplyr::remote_name(), sdf_name)
-  
+
   sc %>% DBI::dbExecute(paste0("DROP TABLE ", sdf_name))
-  
+
 })
 
 
 test_that("spark_read_geojson() works as expected, invalid geom", {
   sdf_name <- random_string("spatial_sdf")
-  
+
   # Keep invalid
   geojson_sdf <- spark_read_geojson(sc, path = test_data("testInvalidPolygon.json"), name = sdf_name)
-  
+
   ## Right number of rows
   expect_equal(
     invoke(geojson_sdf %>% spark_dataframe(), 'count'), 3
   )
-  
+
   ## Right registered name
   expect_equal(geojson_sdf %>% dbplyr::remote_name(), sdf_name)
-  
-  
+
+
   # Remove invalid
   geojson_sdf <- spark_read_geojson(sc, path = test_data("testInvalidPolygon.json"), name = sdf_name, options = list(allow_invalid_geometries = FALSE))
-  
+
   ## Right number of rows
   expect_equal(
     invoke(geojson_sdf %>% spark_dataframe(), 'count'), 2
   )
-  
+
   ## Right registered name
   expect_equal(geojson_sdf %>% dbplyr::remote_name(), sdf_name)
-  
+
   sc %>% DBI::dbExecute(paste0("DROP TABLE ", sdf_name))
-  
+
 })
 
 
@@ -576,7 +576,7 @@ test_that("sedona_write_wkb() works as expected", {
     TRUE,
     1L # numPartitions
   )
-  
+
   expect_result_matches_original(pt_rdd)
 })
 
@@ -593,7 +593,7 @@ test_that("sedona_write_wkt() works as expected", {
     TRUE,
     1L # numPartitions
   )
-  
+
   expect_result_matches_original(pt_rdd)
 })
 
@@ -610,7 +610,7 @@ test_that("sedona_write_geojson() works as expected", {
     TRUE,
     1L # numPartitions
   )
-  
+
   expect_result_matches_original_geojson(pt_rdd)
 })
 
@@ -629,7 +629,7 @@ test_that("sedona_save_spatial_rdd() works as expected", {
         spatial_col = "pt", output_location = location, output_format = fmt
       )
     sdf <- do.call(paste0("sedona_read_", fmt), list(sc, location))
-    
+
     expect_equal(
       sdf$.jobj %>% invoke("%>%", list("rawSpatialRDD"), list("count")), 1
     )
@@ -647,45 +647,45 @@ test_that("sedona_save_spatial_rdd() works as expected", {
 test_that("spark_write_geoparquet() works as expected", {
   geoparquet_sdf <- spark_read_geoparquet(sc, geoparquet("example2.parquet"))
   tmp_dest <- tempfile(fileext = ".parquet")
-  
+
   ## Save
   geoparquet_sdf %>% spark_write_geoparquet(tmp_dest)
-  
+
   ### Reload
   geoparquet_2_sdf <- spark_read_geoparquet(sc, tmp_dest)
-  
+
   expect_equivalent(
     geoparquet_sdf %>% mutate(geometry = geometry %>% st_astext()) %>% collect(),
     geoparquet_2_sdf %>% mutate(geometry = geometry %>% st_astext()) %>% collect()
   )
-  
+
   unlink(tmp_dest, recursive = TRUE)
-  
+
 })
 
 test_that("spark_write_geojson() works as expected", {
   sdf_name <- random_string("spatial_sdf")
   geojson_sdf <- spark_read_geojson(sc, path = test_data("testPolygon.json"), name = sdf_name)
   tmp_dest <- tempfile(fileext = ".json")
-  
+
   ## Save
   geojson_sdf %>% spark_write_geojson(tmp_dest)
-  
+
   ### Reload
   geojson_2_sdf <- spark_read_geojson(sc, path = tmp_dest)
-  
+
   ## order of columns changes !
   expect_equal(
-    colnames(geojson_sdf) %>% sort(), 
+    colnames(geojson_sdf) %>% sort(),
     colnames(geojson_2_sdf) %>% sort()
   )
   expect_equal(
     geojson_sdf %>% mutate(geometry = geometry %>% st_astext()) %>% collect(),
-    geojson_2_sdf %>% mutate(geometry = geometry %>% st_astext()) %>% collect() %>% 
+    geojson_2_sdf %>% mutate(geometry = geometry %>% st_astext()) %>% collect() %>%
       select(colnames(geojson_sdf))
   )
-  
-  
+
+
   unlink(tmp_dest, recursive = TRUE)
-  
+
 })

--- a/R/tests/testthat/test-dbplyr-integration.R
+++ b/R/tests/testthat/test-dbplyr-integration.R
@@ -21,9 +21,9 @@ sc <- testthat_spark_connection()
 
 test_that("ST_Point() works as expected", {
   sdf <- sdf_len(sc, 1) %>%
-    dplyr::mutate(pt = ST_Point(-40, 40)) 
+    dplyr::mutate(pt = ST_Point(-40, 40))
   df <- sdf %>% collect()
-  
+
   expect_equal(nrow(df), 1)
   expect_equal(colnames(df), c("id", "pt"))
   expect_equal(
@@ -39,7 +39,7 @@ test_that("ST_PolygonFromEnvelope() works as expected", {
   sdf <- sdf_len(sc, 1) %>%
     dplyr::mutate(rectangle = ST_PolygonFromEnvelope(-40, -30, 40, 30))
   df <- sdf %>% collect()
-  
+
   expect_equal(nrow(df), 1)
   expect_equal(colnames(df), c("id", "rectangle"))
   expect_equal(
@@ -59,7 +59,7 @@ test_that("ST_Buffer() works as expected", {
     dplyr::mutate(pt = ST_Point(-40, 40)) %>%
     # dplyr::compute() ## fixed in dev version of sparklyr (compute caches, sdf_register does not)
     sdf_register()
-  
+
   expect_equal(
     sdf %>%
       dplyr::mutate(pt = ST_Buffer(pt, 3L)) %>%
@@ -76,9 +76,9 @@ test_that("ST_ReducePrecision() works as expected", {
   sdf <- sdf_len(sc, 1) %>%
     dplyr::mutate(rectangle = ST_PolygonFromEnvelope(-40.12345678, -30.12345678, 40.11111111, 30.11111111)) %>%
     dplyr::mutate(rectangle = ST_ReducePrecision(rectangle, 2))
-  
+
   df <- sdf %>% collect()
-  
+
   expect_equal(nrow(df), 1)
   expect_equal(colnames(df), c("id", "rectangle"))
   expect_equal(
@@ -98,7 +98,7 @@ test_that("ST_SimplifyPreserveTopology() works as expected", {
     dplyr::mutate(pt = ST_Point(-40, 40)) %>%
     # dplyr::compute() ## fixed in dev version of sparklyr (compute caches, sdf_register does not)
     sdf_register()
-  
+
   expect_equal(
     sdf %>%
       dplyr::mutate(pt = ST_SimplifyPreserveTopology(pt, 1L)) %>%
@@ -116,7 +116,7 @@ test_that("ST_GeometryN() works as expected", {
     dplyr::mutate(pts = ST_GeomFromText("MULTIPOINT((1 2), (3 4), (5 6), (8 9))")) %>%
     dplyr::transmute(pt = ST_GeometryN(pts, 2))
   df <- sdf %>% collect()
-  
+
   expect_equal(nrow(df), 1)
   expect_equal(colnames(df), c("pt"))
   expect_equal(
@@ -133,7 +133,7 @@ test_that("ST_InteriorRingN() works as expected", {
     dplyr::mutate(polygon = ST_GeomFromText("POLYGON((0 0, 0 5, 5 5, 5 0, 0 0), (1 1, 2 1, 2 2, 1 2, 1 1), (1 3, 2 3, 2 4, 1 4, 1 3), (3 3, 4 3, 4 4, 3 4, 3 3))")) %>%
     dplyr::transmute(interior_ring = ST_InteriorRingN(polygon, 0))
   df <- sdf %>% collect()
-  
+
   expect_equal(nrow(df), 1)
   expect_equal(colnames(df), c("interior_ring"))
   expect_equal(
@@ -150,9 +150,9 @@ test_that("ST_InteriorRingN() works as expected", {
 test_that("ST_AddPoint() works as expected", {
   sdf <- sdf_len(sc, 1) %>%
     dplyr::mutate(linestring = ST_GeomFromText("LINESTRING(0 0, 1 1, 1 0)")) %>%
-    dplyr::transmute(linestring = ST_AddPoint(linestring, ST_GeomFromText("Point(21 52)"), 1)) 
+    dplyr::transmute(linestring = ST_AddPoint(linestring, ST_GeomFromText("Point(21 52)"), 1))
   df <- sdf %>% collect()
-  
+
   expect_equal(nrow(df), 1)
   expect_equal(colnames(df), c("linestring"))
   expect_equal(
@@ -164,12 +164,12 @@ test_that("ST_AddPoint() works as expected", {
     df$linestring[[1]],
     list(c(0, 0), c(21, 52), c(1, 1), c(1, 0))
   )
-  
+
   sdf <- sdf_len(sc, 1) %>%
     dplyr::mutate(linestring = ST_GeomFromText("LINESTRING(0 0, 1 1, 1 0)")) %>%
     dplyr::transmute(linestring = ST_AddPoint(linestring, ST_GeomFromText("Point(21 52)")))
   df <- sdf %>% collect()
-  
+
   expect_equal(nrow(df), 1)
   expect_equal(colnames(df), c("linestring"))
   expect_equal(
@@ -186,9 +186,9 @@ test_that("ST_AddPoint() works as expected", {
 test_that("ST_RemovePoint() works as expected", {
   sdf <- sdf_len(sc, 1) %>%
     dplyr::mutate(linestring = ST_GeomFromText("LINESTRING(0 0, 21 52, 1 1, 1 0)")) %>%
-    dplyr::transmute(linestring = ST_RemovePoint(linestring, 1)) 
+    dplyr::transmute(linestring = ST_RemovePoint(linestring, 1))
   df <- sdf %>% collect()
-  
+
   expect_equal(nrow(df), 1)
   expect_equal(colnames(df), c("linestring"))
   expect_equal(

--- a/R/tests/testthat/test-sdf-interface.R
+++ b/R/tests/testthat/test-sdf-interface.R
@@ -28,16 +28,16 @@ shapefile <- function(filename) {
 test_that("sdf_register() works as expected for Spatial RDDs", {
   sdf_name <- random_string("spatial_sdf")
   pt_sdf <- sdf_register(pt_rdd, name = sdf_name)
-  
+
   expect_equivalent(
     pt_sdf %>% sdf_schema(),
     list(
       geometry = list(name = "geometry", type = "GeometryUDT")
-      
+
     )
   )
   expect_equal(pt_sdf %>% dbplyr::remote_name(), sdf_name)
-  
+
   pt_sdf %>% collect()
   succeed()
 })
@@ -50,7 +50,7 @@ test_that("sdf_register() works as expected for Spatial RDDs with fieldNames", {
     location = shapefile("dbf"), type = "polygon"
   )
   polygon_sdf <- sdf_register(polygon_rdd, name = sdf_name)
-  
+
   expect_equivalent(
     polygon_sdf %>% sdf_schema(),
     list(
@@ -64,12 +64,12 @@ test_that("sdf_register() works as expected for Spatial RDDs with fieldNames", {
       geometry = list(name = "LSAD", type = "StringType"),
       geometry = list(name = "ALAND", type = "StringType"),
       geometry = list(name = "AWATER", type = "StringType")
-      
+
     )
   )
-  
+
   expect_equal(polygon_sdf %>% dbplyr::remote_name(), sdf_name)
-  
+
   polygon_sdf %>% collect()
   succeed()
 })

--- a/common/src/main/java/org/apache/sedona/common/Constructors.java
+++ b/common/src/main/java/org/apache/sedona/common/Constructors.java
@@ -50,7 +50,7 @@ public class Constructors {
         }
         int SRID = 0;
         String wkt = ewkt;
-        
+
         int index = ewkt.indexOf("SRID=");
         if (index != -1) {
             int semicolonIndex = ewkt.indexOf(';', index);

--- a/common/src/main/java/org/apache/sedona/common/raster/PixelFunctionEditors.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/PixelFunctionEditors.java
@@ -63,7 +63,7 @@ public class PixelFunctionEditors {
 
         // making them 0-indexed
         colX--; rowY--;
-      
+
         int iterator = 0;
         for (int j = rowY; j < rowY + height; j++) {
             for (int i = colX; i < colX + width; i++) {

--- a/common/src/main/java/org/apache/sedona/common/raster/PixelFunctions.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/PixelFunctions.java
@@ -266,7 +266,7 @@ public class PixelFunctions
                 rasterGeom = pair.getLeft();
             }
         }
-        
+
         int numBands = rasterGeom.getNumSampleDimensions();
         double noDataValue = RasterUtils.getNoDataValue(rasterGeom.getSampleDimension(band - 1));
         double[] pixelBuffer = new double[numBands];

--- a/common/src/main/java/org/apache/sedona/common/raster/RasterConstructors.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterConstructors.java
@@ -154,7 +154,7 @@ public class RasterConstructors
         }
 
         Envelope2D bound = null;
-        
+
         if (useGeometryExtent) {
             bound = JTS.getEnvelope2D(geom.getEnvelopeInternal(), raster.getCoordinateReferenceSystem2D());
         } else {
@@ -188,7 +188,7 @@ public class RasterConstructors
         WritableRaster writableRaster = RasterFactory.createBandedRaster(RasterUtils.getDataTypeCode(pixelType), width, height, 1, null);
         double [] samples = RasterUtils.getRaster(rasterized.getRenderedImage()).getSamples(0, 0, width, height, 0, (double[]) null);
         writableRaster.setSamples(0, 0, width, height, 0, samples);
-        
+
         List<Object> objects = new ArrayList<>();
         objects.add(writableRaster);
         objects.add(rasterized);

--- a/common/src/main/java/org/apache/sedona/common/utils/PointGeoHashEncoder.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/PointGeoHashEncoder.java
@@ -40,7 +40,7 @@ public class PointGeoHashEncoder {
         if (currentPrecision >= precision) {
             return geoHash;
         }
-        
+
         BBox updatedBbox = null;
         int updatedCh = -1;
         if (isEven) {

--- a/common/src/main/java/org/apache/sedona/common/utils/RasterUtils.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/RasterUtils.java
@@ -444,7 +444,7 @@ public class RasterUtils {
     }
 
     /**
-     * If the raster has a CRS, then it transforms the geom to the raster's CRS. 
+     * If the raster has a CRS, then it transforms the geom to the raster's CRS.
      * If any of the inputs, raster or geom doesn't have a CRS, it defaults to 4326.
      * @param raster
      * @param geom

--- a/examples/flink-sql/pom.xml
+++ b/examples/flink-sql/pom.xml
@@ -230,4 +230,4 @@
         </resources>
     </build>
 </project>
-  
+

--- a/flink/pom.xml
+++ b/flink/pom.xml
@@ -140,4 +140,4 @@
         </dependency>
     </dependencies>
 </project>
-  
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ nav:
     - Home: index.md
     - Setup:
       - Overview: setup/overview.md
-      - Supported platforms: 
+      - Supported platforms:
         - Sedona with Apache Spark:
           - Modules: setup/modules.md
           - Language wrappers: setup/platform.md
@@ -24,7 +24,7 @@ nav:
         - Set up Spark cluster: setup/cluster.md
       - Install with Apache Flink:
         - Install Sedona Scala/Java: setup/flink/install-scala.md
-      - Release notes: setup/release-notes.md      
+      - Release notes: setup/release-notes.md
       - Compile the code: setup/compile.md
     - Download: download.md
     - Programming Guides:
@@ -84,7 +84,7 @@ nav:
           - Aggregator: api/flink/Aggregator.md
           - Predicate: api/flink/Predicate.md
     - Community:
-      - Community: community/contact.md 
+      - Community: community/contact.md
       - Contributor Guide:
         - Rules: community/rule.md
         - Develop: community/develop.md
@@ -170,7 +170,7 @@ markdown_extensions:
   - pymdownx.smartsymbols
   - pymdownx.superfences
   - pymdownx.tabbed:
-      alternate_style: true 
+      alternate_style: true
   - pymdownx.tasklist:
       custom_checkbox: true
   - pymdownx.tilde

--- a/python/sedona/sql/dataframe_api.py
+++ b/python/sedona/sql/dataframe_api.py
@@ -52,7 +52,7 @@ def call_sedona_function(object_name: str, function_name: str, args: Union[Any, 
     spark = SparkSession.getActiveSession()
     if spark is None:
         raise ValueError("No active spark session was detected. Unable to call sedona function.")
-    
+
     # apparently a Column is an Iterable so we need to check for it explicitly
     if (not isinstance(args, Iterable)) or isinstance(args, str) or isinstance(args, Column):
         args = [args]
@@ -61,7 +61,7 @@ def call_sedona_function(object_name: str, function_name: str, args: Union[Any, 
 
     jobject = getattr(spark._jvm, object_name)
     jfunc = getattr(jobject, function_name)
-    
+
     jc = jfunc(*args)
     return Column(jc)
 
@@ -79,11 +79,11 @@ def _get_type_list(annotated_type: Type) -> Tuple[Type, ...]:
     # in 3.8 there is a much nicer way to do this with typing.get_origin
     # we have to be a bit messy until we drop support for 3.7
     if isinstance(annotated_type, typing._GenericAlias) and annotated_type.__origin__._name == "Union":
-        # again, there is a really nice method for this in 3.8: typing.get_args 
+        # again, there is a really nice method for this in 3.8: typing.get_args
         valid_types = annotated_type.__args__
     else:
         valid_types = (annotated_type,)
-    
+
     return valid_types
 
 

--- a/python/sedona/sql/st_constructors.py
+++ b/python/sedona/sql/st_constructors.py
@@ -51,7 +51,7 @@ _call_constructor_function = partial(call_sedona_function, "st_constructors")
 def ST_GeomFromGeoHash(geohash: ColumnOrName, precision: Union[ColumnOrName, int]) -> Column:
     """Generate a geometry column from a geohash column at a specified precision.
 
-    :param geohash: Geohash string column to generate from. 
+    :param geohash: Geohash string column to generate from.
     :type geohash: ColumnOrName
     :param precision: Geohash precision to use, either an integer or an integer column.
     :type precision: Union[ColumnOrName, int]
@@ -261,13 +261,13 @@ def ST_PolygonFromEnvelope(min_x: ColumnOrNameOrNumber, min_y: ColumnOrNameOrNum
 
 
 @validate_argument_types
-def ST_PolygonFromText(coords: ColumnOrName, delimiter: ColumnOrName) -> Column: 
+def ST_PolygonFromText(coords: ColumnOrName, delimiter: ColumnOrName) -> Column:
     """Generate a polygon from a list of coordinates separated by a delimiter stored
     in a string column.
 
     :param coords: String column containing the coordinates.
     :type coords: ColumnOrName
-    :param delimiter: Delimiter separating the coordinates, a string constant must be wrapped as a string literal (using pyspark.sql.functions.lit). 
+    :param delimiter: Delimiter separating the coordinates, a string constant must be wrapped as a string literal (using pyspark.sql.functions.lit).
     :type delimiter: ColumnOrName
     :return: Polygon geometry column generated from the list of coordinates.
     :rtype: Column

--- a/python/sedona/sql/st_functions.py
+++ b/python/sedona/sql/st_functions.py
@@ -1433,13 +1433,13 @@ def ST_Translate(geometry: ColumnOrName, deltaX: Union[ColumnOrName, float], del
 @validate_argument_types
 def ST_VoronoiPolygons(geometry: ColumnOrName, tolerance: Optional[Union[ColumnOrName, float]] = 0.0, extendTo: Optional[ColumnOrName] = None) -> Column:
     """
-    ST_VoronoiPolygons computes a two-dimensional Voronoi diagram from the vertices of the supplied geometry. 
-    The result is a GeometryCollection of Polygons that covers an envelope larger than the extent of the input vertices. 
+    ST_VoronoiPolygons computes a two-dimensional Voronoi diagram from the vertices of the supplied geometry.
+    The result is a GeometryCollection of Polygons that covers an envelope larger than the extent of the input vertices.
     Returns null if input geometry is null. Returns an empty geometry collection if the input geometry contains only one vertex. Returns an empty geometry collection if the extend_to envelope has zero area.
     :param geometry: Geometry column whose coordinates are to be built from.
-    :param tolerance: The distance within which vertices will be considered equivalent. 
+    :param tolerance: The distance within which vertices will be considered equivalent.
     Robustness of the algorithm can be improved by supplying a nonzero tolerance distance. (default = 0.0)
-    :param extendTo: If a geometry is supplied as the "extend_to" parameter, the diagram will be extended to cover the envelope of the "extend_to" geometry, unless that envelope is smaller than the default envelope 
+    :param extendTo: If a geometry is supplied as the "extend_to" parameter, the diagram will be extended to cover the envelope of the "extend_to" geometry, unless that envelope is smaller than the default envelope
     (default = NULL, default envelope is boundingbox of input geometry extended by about 50% in each direction).
     :return: The two-dimensional Voronoi diagram geometry.
     """

--- a/python/tests/sql/test_function.py
+++ b/python/tests/sql/test_function.py
@@ -1188,7 +1188,7 @@ class TestPredicateJoin(TestBase):
 
     def test_st_h3_kring(self):
         df = self.spark.sql("""
-        SELECT 
+        SELECT
             ST_H3KRing(ST_H3CellIDs(ST_GeomFromWKT('POINT(1 2)'), 8, true)[0], 1, true) exactRings,
             ST_H3KRing(ST_H3CellIDs(ST_GeomFromWKT('POINT(1 2)'), 8, true)[0], 1, false) allRings,
             ST_H3CellIDs(ST_GeomFromWKT('POINT(1 2)'), 8, true) original_cells

--- a/python/tests/sql/test_predicate_join.py
+++ b/python/tests/sql/test_predicate_join.py
@@ -494,5 +494,3 @@ class TestPredicateJoin(TestBase):
         range_join_df.show(3)
         assert range_join_df.rdd.getNumPartitions() == 9
         assert range_join_df.count() == 1000
-
-        

--- a/spark/common/src/main/java/org/apache/sedona/viz/extension/visualizationEffect/ChoroplethMap.java
+++ b/spark/common/src/main/java/org/apache/sedona/viz/extension/visualizationEffect/ChoroplethMap.java
@@ -107,12 +107,12 @@ public class ChoroplethMap
         super(resolutionX, resolutionY, datasetBoundary, ColorizeOption.NORMAL, reverseSpatialCoordinate,
                 partitionX, partitionY, false, parallelRenderImage, generateVectorImage);
     }
-	
+
 	/*
 	@Override
 	protected JavaPairRDD<Integer, Color> GenerateColorMatrix()
 	{
-		//This Color Matrix version controls some too high pixel weights by dividing the max weight to 1/4. 
+		//This Color Matrix version controls some too high pixel weights by dividing the max weight to 1/4.
 		logger.debug("[VisualizationOperator][GenerateColorMatrix][Start]");
 		final long maxWeight = this.distributedCountMatrix.max(new PixelCountComparator())._2;
 		final long minWeight = 0;

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/st_functions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/st_functions.scala
@@ -429,4 +429,3 @@ object st_functions extends DataFrameAPI {
   def ST_IsCollection(geometry: String): Column = wrapExpression[ST_IsCollection](geometry)
 
 }
- 

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/SpatialIndexExec.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/SpatialIndexExec.scala
@@ -41,7 +41,7 @@ case class SpatialIndexExec(child: SparkPlan,
     with Logging {
 
   override def output: Seq[Attribute] = child.output
-  
+
   override protected def doExecute(): RDD[InternalRow] = {
     throw new UnsupportedOperationException(
       "SpatialIndex does not support the execute() code path.")

--- a/spark/common/src/test/java/org/apache/sedona/core/formatMapper/testSerNetCDF.java
+++ b/spark/common/src/test/java/org/apache/sedona/core/formatMapper/testSerNetCDF.java
@@ -46,23 +46,23 @@ public class testSerNetCDF {
 
 	@Ignore
 	public void test() {
-		NetcdfDataset ncfile = null;		
+		NetcdfDataset ncfile = null;
 		int offset = 2;
 		int increment = 5;
 		double scaleFactor = 0.02;
-		
+
 		String swathName = "MOD_Swath_LST";
 		String geolocationFieldName = "Geolocation_Fields";
 		String dataFieldName = "Data_Fields";
 		String dataVariableName = "LST";
 		ncfile =  SerNetCDFUtils.loadNetCDFDataSet(filename);
-		
+
 		List<Variable> variables = ncfile.getVariables();
 		Array longitude = SerNetCDFUtils.getNetCDF2DArray(ncfile, swathName+"/"+geolocationFieldName+"/Longitude");
 		Array latitude = SerNetCDFUtils.getNetCDF2DArray(ncfile, swathName+"/"+geolocationFieldName+"/Latitude");
 		Array dataVariable = SerNetCDFUtils.getNetCDF2DArray(ncfile, swathName+"/"+dataFieldName+"/"+dataVariableName);
 		int[] geolocationShape = longitude.getShape();
-		
+
 		for (int j = 0; j < geolocationShape[0]; j++) {
 			for (int i = 0; i < geolocationShape[1]; i++) {
 				// We probably need to switch longitude and latitude if needed.
@@ -71,7 +71,7 @@ public class testSerNetCDF {
 				String userData = String.valueOf(SerNetCDFUtils.getDataAsym(dataVariable, j, i, offset, increment));
 			}
 		}
-		    
+
 	}
 
 }

--- a/spark/common/src/test/java/org/apache/sedona/core/spatialRDD/LineStringRDDTest.java
+++ b/spark/common/src/test/java/org/apache/sedona/core/spatialRDD/LineStringRDDTest.java
@@ -140,7 +140,7 @@ public class LineStringRDDTest
             List<Polygon> result = spatialRDD.indexedRDD.take(1).get(0).query(spatialRDD.boundaryEnvelope);
         }
     }
-    
+
     /*
     @Test
     public void testPolygonUnion()

--- a/spark/common/src/test/java/org/apache/sedona/core/utils/SedonaConfTest.java
+++ b/spark/common/src/test/java/org/apache/sedona/core/utils/SedonaConfTest.java
@@ -45,7 +45,7 @@ public class SedonaConfTest {
         SparkSession.active().conf().set("sedona.join.numpartition", "3");
         assertEquals(3, SedonaConf.fromActiveSession().getFallbackPartitionNum());
     }
-    
+
     @Test
     public void testDatasetBoundary() {
         SparkSession.active().conf().set("sedona.join.boundary", "1,2,3,4");

--- a/spark/common/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
@@ -2250,5 +2250,5 @@ class functionTestScala extends TestBaseScala with Matchers with GeometrySample 
     }
 
   }
-  
+
 }


### PR DESCRIPTION
https://github.com/pre-commit/pre-commit-hooks#trailing-whitespace



## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-444. The PR name follows the format `[SEDONA-XXX] my subject`.


## What changes were proposed in this PR?

Adds another hook to our pre-commit framework that will trim trailing whitespace from files when run locally.

Just pass or fail when run with GitHub actions.

We don't need all this extra whitespace at the end of lines.  


## How was this patch tested?

`pre-commit run trailing-whitespace --all-files`


## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
