### PR TITLE
[SEDONA-453] Fix Quadtree index efficiency degrade when indexing points

### DIFF
--- a/spark/common/src/main/java/org/apache/sedona/core/joinJudgement/DynamicIndexLookupJudgement.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/joinJudgement/DynamicIndexLookupJudgement.java
@@ -123,7 +123,7 @@ public class DynamicIndexLookupJudgement<T extends Geometry, U extends Geometry>
             if (index instanceof Quadtree && (envelope.getWidth() == 0 || envelope.getHeight() == 0)) {
                 // Quadtree works poorly with envelopes with 0 extent. Such envelopes are usually obtained from
                 // points. We expand the envelope by a small amount to avoid this problem.
-                envelope.expandBy(1e-6);
+                envelope.expandBy(1e-3);
             }
             index.insert(envelope, geometry);
             count++;

--- a/spark/common/src/main/java/org/apache/sedona/core/joinJudgement/DynamicIndexLookupJudgement.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/joinJudgement/DynamicIndexLookupJudgement.java
@@ -119,7 +119,13 @@ public class DynamicIndexLookupJudgement<T extends Geometry, U extends Geometry>
         final SpatialIndex index = newIndex();
         while (geometries.hasNext()) {
             Geometry geometry = geometries.next();
-            index.insert(geometry.getEnvelopeInternal(), geometry);
+            Envelope envelope = geometry.getEnvelopeInternal();
+            if (index instanceof Quadtree && (envelope.getWidth() == 0 || envelope.getHeight() == 0)) {
+                // Quadtree works poorly with envelopes with 0 extent. Such envelopes are usually obtained from
+                // points. We expand the envelope by a small amount to avoid this problem.
+                envelope.expandBy(1e-6);
+            }
+            index.insert(envelope, geometry);
             count++;
         }
         index.query(new Envelope(0.0, 0.0, 0.0, 0.0));

--- a/spark/common/src/main/java/org/apache/sedona/core/spatialRddTool/IndexBuilder.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/spatialRddTool/IndexBuilder.java
@@ -54,7 +54,13 @@ public final class IndexBuilder<T extends Geometry>
         }
         while (objectIterator.hasNext()) {
             T spatialObject = objectIterator.next();
-            spatialIndex.insert(spatialObject.getEnvelopeInternal(), spatialObject);
+            Envelope envelope = spatialObject.getEnvelopeInternal();
+            if (spatialIndex instanceof Quadtree && (envelope.getWidth() == 0 || envelope.getHeight() == 0)) {
+                // Quadtree works poorly with envelopes with 0 extent. Such envelopes are usually obtained from
+                // points. We expand the envelope by a small amount to avoid this problem.
+                envelope.expandBy(1e-6);
+            }
+            spatialIndex.insert(envelope, spatialObject);
         }
         Set<SpatialIndex> result = new HashSet();
         spatialIndex.query(new Envelope(0.0, 0.0, 0.0, 0.0));

--- a/spark/common/src/main/java/org/apache/sedona/core/spatialRddTool/IndexBuilder.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/spatialRddTool/IndexBuilder.java
@@ -58,7 +58,7 @@ public final class IndexBuilder<T extends Geometry>
             if (spatialIndex instanceof Quadtree && (envelope.getWidth() == 0 || envelope.getHeight() == 0)) {
                 // Quadtree works poorly with envelopes with 0 extent. Such envelopes are usually obtained from
                 // points. We expand the envelope by a small amount to avoid this problem.
-                envelope.expandBy(1e-6);
+                envelope.expandBy(1e-3);
             }
             spatialIndex.insert(envelope, spatialObject);
         }

--- a/spark/common/src/test/java/org/apache/sedona/core/spatialRDD/PointRDDTest.java
+++ b/spark/common/src/test/java/org/apache/sedona/core/spatialRDD/PointRDDTest.java
@@ -20,9 +20,12 @@ package org.apache.sedona.core.spatialRDD;
 
 import org.apache.sedona.core.enums.IndexType;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.index.SpatialIndex;
 import org.locationtech.jts.index.strtree.STRtree;
 
 import java.util.List;
@@ -139,5 +142,18 @@ public class PointRDDTest
         else {
             List<Point> result = spatialRDD.indexedRDD.take(1).get(0).query(spatialRDD.boundaryEnvelope);
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testQuadtreeIndexEfficiency() throws Exception
+    {
+        PointRDD spatialRDD = new PointRDD(sc, InputLocation, offset, splitter, true, 1);
+        spatialRDD.buildIndex(IndexType.QUADTREE, false);
+        List<SpatialIndex> indexes = spatialRDD.indexedRawRDD.collect();
+        Assert.assertEquals(1, indexes.size());
+        SpatialIndex index = indexes.get(0);
+        List<Point> results = index.query(new Envelope(-85.868310, -85.868300, 34.280345, 34.280349));
+        Assert.assertTrue(results.size() > 0 && results.size() < 100);
     }
 }


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-453. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

We found that the index efficiency of Quadtree drastically degrades when indexing datasets made up of points. The index returns way more candidates than expected when querying the Quadtree using envelopes. The reason is that JTS Quadtree automatically expands indexed envelopes by 0.5 if the envelope has zero width and height (see [Quadtree.java#L61-L96](https://github.com/locationtech/jts/blob/1.19.0/modules/core/src/main/java/org/locationtech/jts/index/quadtree/Quadtree.java#L61-L96)), this makes the indexed envelopes of points are way larger than necessary, especially when indexed points are WGS84 coordinates.

Suppose that we are indexing the following dataset using Quadtree:

<img width="611" alt="Screenshot 2023-12-21 at 9 10 58 PM" src="https://github.com/apache/sedona/assets/5501374/c92e22b4-ad9b-457b-bc97-9e2586ecdd5d">

The envelopes indexed by Quadtree happens to be something like this:

<img width="611" alt="Screenshot 2023-12-21 at 9 12 16 PM" src="https://github.com/apache/sedona/assets/5501374/32cc440e-9905-4a5f-96e2-9ec503352465">

This PR workarounds this problem by manually extendinging envelopes with 0 width or height by 1e-3. This will prevent JTS Quadtree from extending the envelopes by 0.5, and 1e-3 is small enough to cope with the most common use cases. However, this will significantly increase the size of Quadtree since the tree will be deeper.

## How was this patch tested?

Add test to verify Quad tree index efficiency for PointRDD.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
