### PR TITLE
[SEDONA-454] Change the default value of sedona.global.indextype from quadtree to rtree

### DIFF
--- a/docs/api/sql/Parameter.md
+++ b/docs/api/sql/Parameter.md
@@ -26,7 +26,7 @@ sparkSession.conf.set("sedona.global.index","false")
 	* Possible values: true, false
 * sedona.global.indextype
 	* Spatial index type, only valid when "sedona.global.index" is true
-	* Default: quadtree
+	* Default: rtree
 	* Possible values: rtree, quadtree
 * sedona.join.autoBroadcastJoinThreshold
 	* Configures the maximum size in bytes for a table that will be broadcast to all worker nodes when performing a join.

--- a/spark/common/src/main/java/org/apache/sedona/core/utils/SedonaConf.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/utils/SedonaConf.java
@@ -67,7 +67,7 @@ public class SedonaConf
     public SedonaConf(RuntimeConfig runtimeConfig)
     {
         this.useIndex = Boolean.parseBoolean(runtimeConfig.get("sedona.global.index", "true"));
-        this.indexType = IndexType.getIndexType(runtimeConfig.get("sedona.global.indextype", "quadtree"));
+        this.indexType = IndexType.getIndexType(runtimeConfig.get("sedona.global.indextype", "rtree"));
         this.joinApproximateTotalCount = Long.parseLong(runtimeConfig.get("sedona.join.approxcount", "-1"));
         String[] boundaryString = runtimeConfig.get("sedona.join.boundary", "0,0,0,0").split(",");
         this.datasetBoundary = new Envelope(Double.parseDouble(boundaryString[0]), Double.parseDouble(boundaryString[1]),


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-454. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Experiments showed that STRtree has better performance in most of cases, and does not have index efficiency problems when indexing points (see [SEDONA-453](https://issues.apache.org/jira/browse/SEDONA-453)). We consider changing the default value of `sedona.global.indextype` from `quadtree` to `rtree` to achieve better out-of-box performance when running spatial joins using SQL queries.

## How was this patch tested?

Passing existing tests.

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation update.

