### PR TITLE
[SEDONA-456] Fix kepler.gl integration for geopandas >= 0.13

### DIFF
--- a/python/sedona/maps/SedonaMapUtils.py
+++ b/python/sedona/maps/SedonaMapUtils.py
@@ -34,7 +34,7 @@ class SedonaMapUtils:
         pandas_df = df.toPandas()
         geo_df = gpd.GeoDataFrame(pandas_df, geometry=geometry_col)
         if geometry_col != "geometry" and rename is True:
-            geo_df = geo_df.rename(columns={geometry_col: "geometry"})
+            geo_df.rename_geometry("geometry", inplace=True)
         return geo_df
 
     @classmethod

--- a/python/tests/maps/test_sedonakepler_visualization.py
+++ b/python/tests/maps/test_sedonakepler_visualization.py
@@ -40,7 +40,7 @@ class TestVisualization(TestBase):
         polygon_wkt_df.createOrReplaceTempView("polygontable")
         polygon_df = self.spark.sql("select ST_GeomFromWKT(polygontable._c0) as countyshape from polygontable")
         polygon_gdf = gpd.GeoDataFrame(data=polygon_df.toPandas(), geometry="countyshape")
-        polygon_gdf_renamed = polygon_gdf.rename(columns={"countyshape": "geometry"})
+        polygon_gdf_renamed = polygon_gdf.rename_geometry("geometry")
 
         sedona_kepler_map = SedonaKepler.create_map(df=polygon_df, name="data_1")
         kepler_map = KeplerGl()
@@ -59,7 +59,7 @@ class TestVisualization(TestBase):
 
         polygon_df = self.spark.sql("select ST_GeomFromWKT(polygontable._c0) as countyshape from polygontable")
         polygon_gdf = gpd.GeoDataFrame(data=polygon_df.toPandas(), geometry="countyshape")
-        polygon_gdf_renamed = polygon_gdf.rename(columns={"countyshape": "geometry"})
+        polygon_gdf_renamed = polygon_gdf.rename_geometry("geometry")
 
         sedona_kepler_empty_map = SedonaKepler.create_map()
         SedonaKepler.add_df(sedona_kepler_empty_map, polygon_df, name="data_1")
@@ -188,9 +188,9 @@ class TestVisualization(TestBase):
         SedonaKepler.add_df(sedona_kepler_map, point_df, name="data_2")
 
         polygon_gdf = gpd.GeoDataFrame(data=polygon_df.toPandas(), geometry="countyshape")
-        polygon_gdf_renamed = polygon_gdf.rename(columns={"countyshape": "geometry"})
+        polygon_gdf_renamed = polygon_gdf.rename_geometry("geometry")
         point_gdf = gpd.GeoDataFrame(data=point_df.toPandas(), geometry="arealandmark")
-        point_gdf_renamed = point_gdf.rename(columns={"arealandmark": "geometry"})
+        point_gdf_renamed = point_gdf.rename_geometry("geometry")
 
         kepler_map = KeplerGl(config=config)
         kepler_map.add_data(polygon_gdf_renamed, "data_1")


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-456. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

This PR makes dataframes with geometry columns not named "geometry" being visualized correctly when using geopandas >= 0.13.0. Please refer to the [JIRA ticket](https://issues.apache.org/jira/browse/SEDONA-456) for details.

## How was this patch tested?

Upgrading the geopandas version to 0.13.2 (manually) and passing existing tests.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
