### PR TITLE
[DOCS] Enable markdownlint rule MD005

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -1,7 +1,6 @@
 # https://github.com/DavidAnson/markdownlint#rules--aliases
 MD001: false
 MD004: false
-MD005: false
 MD007: false
 MD009: false
 MD010: false

--- a/docs/community/release-manager.md
+++ b/docs/community/release-manager.md
@@ -39,18 +39,18 @@ JAVA_HOME="${JAVA_HOME:-$(/usr/libexec/java_home -v 1.8)}" exec "/usr/local/Cell
 
 1. Install GNUGPG if it was not installed before. On Mac: `brew install gnupg gnupg2`
 2. Generate a secret key. It must be RSA4096 (4096 bits long). 
-	* Run `gpg --full-generate-key`. If not work, run `gpg --default-new-key-algo rsa4096 --gen-key`
-	* At the prompt, specify the kind of key you want: Select `RSA`, then press `enter`
-    * At the prompt, specify the key size you want: Enter `4096`
-    * At the prompt, enter the length of time the key should be valid: Press `enter` to make the key never expire.
-    * Verify that your selections are correct.
-    * Enter your user ID information: use your real name and Apache email address.
-    * Type a secure passphrase. Make sure you remember this because we will use it later.
-    * Use the `gpg --list-secret-keys --keyid-format=long` command to list the long form of the GPG keys.
-    * From the list of GPG keys, copy the long form of the GPG key ID you'd like to use (e.g., `3AA5C34371567BD2`)
-    * Run `gpg --export --armor 3AA5C34371567BD2`, substituting in the GPG key ID you'd like to use.
-    * Copy your GPG key, beginning with `-----BEGIN PGP PUBLIC KEY BLOCK-----` and ending with `-----END PGP PUBLIC KEY BLOCK-----`.
-    * There must be an empty line between `-----BEGIN PGP PUBLIC KEY BLOCK-----` and the actual key.
+   * Run `gpg --full-generate-key`. If not work, run `gpg --default-new-key-algo rsa4096 --gen-key`
+   * At the prompt, specify the kind of key you want: Select `RSA`, then press `enter`
+   * At the prompt, specify the key size you want: Enter `4096`
+   * At the prompt, enter the length of time the key should be valid: Press `enter` to make the key never expire.
+   * Verify that your selections are correct.
+   * Enter your user ID information: use your real name and Apache email address.
+   * Type a secure passphrase. Make sure you remember this because we will use it later.
+   * Use the `gpg --list-secret-keys --keyid-format=long` command to list the long form of the GPG keys.
+   * From the list of GPG keys, copy the long form of the GPG key ID you'd like to use (e.g., `3AA5C34371567BD2`)
+   * Run `gpg --export --armor 3AA5C34371567BD2`, substituting in the GPG key ID you'd like to use.
+   * Copy your GPG key, beginning with `-----BEGIN PGP PUBLIC KEY BLOCK-----` and ending with `-----END PGP PUBLIC KEY BLOCK-----`.
+   * There must be an empty line between `-----BEGIN PGP PUBLIC KEY BLOCK-----` and the actual key.
 3. Publish your armored key in major key servers: https://keyserver.pgp.com/
 
 ### 3. Use SVN to update KEYS


### PR DESCRIPTION
https://github.com/DavidAnson/markdownlint/blob/main/doc/md005.md


## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)


## Is this PR related to a JIRA ticket?


- No, this is a documentation update. The PR name follows the format `[DOCS] my subject`.


## What changes were proposed in this PR?

Standardized the markdown by enabling rule MD005.



## How was this patch tested?

`pre-commit run --all-files`


## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
