### PR TITLE
[DOCS] Enable markdownlint rule MD037

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -17,7 +17,6 @@ MD032: false
 MD033: false
 MD034: false
 MD036: false
-MD037: false
 MD038: false
 MD040: false
 MD041: false

--- a/docs/community/release-manager.md
+++ b/docs/community/release-manager.md
@@ -56,8 +56,8 @@ JAVA_HOME="${JAVA_HOME:-$(/usr/libexec/java_home -v 1.8)}" exec "/usr/local/Cell
 ### 3. Use SVN to update KEYS
 
 Use SVN to append your armored PGP public key to the `KEYS` files
-     * https://dist.apache.org/repos/dist/dev/sedona/KEYS
-     * https://dist.apache.org/repos/dist/release/sedona/KEYS
+   * https://dist.apache.org/repos/dist/dev/sedona/KEYS
+   * https://dist.apache.org/repos/dist/release/sedona/KEYS
 
 1. Check out both KEYS files
 ```bash


### PR DESCRIPTION
https://github.com/DavidAnson/markdownlint/blob/main/doc/md037.md

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- No, this is a documentation update. The PR name follows the format `[DOCS] my subject`.

## What changes were proposed in this PR?

Standardized and formatted the Markdown correctly.

## How was this patch tested?

Tested by visual inspection.

Before:

![Screenshot from 2024-01-01 00-15-42](https://github.com/apache/sedona/assets/418747/d933a27f-460b-4cd0-be6c-1b5379d751dd)

After:

![Screenshot from 2024-01-01 00-21-47](https://github.com/apache/sedona/assets/418747/12dfd367-c320-4f55-99ae-114a9b6d6107)

as seen here:

https://github.com/jbampton/sedona/blob/enable-markdownlint-rule-md037/docs/community/release-manager.md#3-use-svn-to-update-keys

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
