### PR TITLE
[SEDONA-461] Add ST_IsValidReason

### DIFF
--- a/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
@@ -1884,4 +1884,32 @@ public class FunctionsTest extends TestBase {
         assertEquals(expectedResult2, actual2, FP_TOLERANCE);
         assertEquals(expectedResult3, actual3, FP_TOLERANCE);
     }
+
+    @Test
+    public void isValidReason() {
+        // Valid geometry
+        Geometry validGeom = GEOMETRY_FACTORY.createPolygon(coordArray(30, 10, 40, 40, 20, 40, 10, 20, 30, 10));
+        String validReasonDefault = Functions.isValidReason(validGeom);
+        assertEquals("Valid Geometry", validReasonDefault);
+
+        Integer OGC_SFS_VALIDITY = 0;
+        Integer ESRI_VALIDITY = 1;
+
+        String validReasonOGC = Functions.isValidReason(validGeom, OGC_SFS_VALIDITY);
+        assertEquals("Valid Geometry", validReasonOGC);
+
+        String validReasonESRI = Functions.isValidReason(validGeom, ESRI_VALIDITY);
+        assertEquals("Valid Geometry", validReasonESRI);
+
+        // Invalid geometry (self-intersection)
+        Geometry invalidGeom = GEOMETRY_FACTORY.createPolygon(coordArray(30, 10, 40, 40, 20, 40, 30, 10, 10, 20, 30, 10));
+        String invalidReasonDefault = Functions.isValidReason(invalidGeom);
+        assertEquals("Ring Self-intersection at or near point (30.0, 10.0, NaN)", invalidReasonDefault);
+
+        String invalidReasonOGC = Functions.isValidReason(invalidGeom, OGC_SFS_VALIDITY);
+        assertEquals("Ring Self-intersection at or near point (30.0, 10.0, NaN)", invalidReasonOGC);
+
+        String invalidReasonESRI = Functions.isValidReason(invalidGeom, ESRI_VALIDITY);
+        assertEquals("Self-intersection at or near point (10.0, 20.0, NaN)", invalidReasonESRI);
+    }
 }

--- a/docs/api/flink/Function.md
+++ b/docs/api/flink/Function.md
@@ -1610,6 +1610,56 @@ Output:
 false
 ```
 
+## ST_IsValidReason
+
+Introduction: Returns text stating if the geometry is valid. If not, it provides a reason why it is invalid. The function can be invoked with just the geometry or with an additional flag. The flag alters the validity checking behavior. The flags parameter is a bitfield with the following options:
+
+- 0 (default): Use usual OGC SFS (Simple Features Specification) validity semantics.
+- 1: "ESRI flag", Accepts certain self-touching rings as valid, which are considered invalid under OGC standards.
+
+Formats:
+```
+ST_IsValidReason (A: Geometry)
+```
+```
+ST_IsValidReason (A: Geometry, flag: Integer)
+```
+
+Since: `v1.5.1`
+
+SQL Example for valid geometry:
+
+```sql
+SELECT ST_IsValidReason(ST_GeomFromWKT('POLYGON ((100 100, 100 300, 300 300, 300 100, 100 100))')) as validity_info
+```
+
+Output:
+
+```
+Valid Geometry
+```
+
+SQL Example for invalid geometries:
+
+```sql
+SELECT gid, ST_IsValidReason(geom) as validity_info
+FROM Geometry_table
+WHERE ST_IsValid(geom) = false
+ORDER BY gid
+```
+
+Output:
+
+```
+gid  |                  validity_info
+-----+----------------------------------------------------
+5330 | Self-intersection at or near point (32.0, 5.0, NaN)
+5340 | Self-intersection at or near point (42.0, 5.0, NaN)
+5350 | Self-intersection at or near point (52.0, 5.0, NaN)
+
+```
+
+
 ## ST_Length
 
 Introduction: Return the perimeter of A

--- a/docs/api/sql/Function.md
+++ b/docs/api/sql/Function.md
@@ -1620,6 +1620,55 @@ Output:
 false
 ```
 
+## ST_IsValidReason
+
+Introduction: Returns text stating if the geometry is valid. If not, it provides a reason why it is invalid. The function can be invoked with just the geometry or with an additional flag. The flag alters the validity checking behavior. The flags parameter is a bitfield with the following options:
+
+- 0 (default): Use usual OGC SFS (Simple Features Specification) validity semantics.
+- 1: "ESRI flag", Accepts certain self-touching rings as valid, which are considered invalid under OGC standards.
+
+Formats:
+```
+ST_IsValidReason (A: Geometry)
+```
+```
+ST_IsValidReason (A: Geometry, flag: Integer)
+```
+
+Since: `v1.5.1`
+
+SQL Example for valid geometry:
+
+```sql
+SELECT ST_IsValidReason(ST_GeomFromWKT('POLYGON ((100 100, 100 300, 300 300, 300 100, 100 100))')) as validity_info
+```
+
+Output:
+
+```
+Valid Geometry
+```
+
+SQL Example for invalid geometries:
+
+```sql
+SELECT gid, ST_IsValidReason(geom) as validity_info
+FROM Geometry_table
+WHERE ST_IsValid(geom) = false
+ORDER BY gid
+```
+
+Output:
+
+```
+gid  |                  validity_info
+-----+----------------------------------------------------
+5330 | Self-intersection at or near point (32.0, 5.0, NaN)
+5340 | Self-intersection at or near point (42.0, 5.0, NaN)
+5350 | Self-intersection at or near point (52.0, 5.0, NaN)
+
+```
+
 ## ST_Length
 
 Introduction: Return the perimeter of A

--- a/flink/src/main/java/org/apache/sedona/flink/Catalog.java
+++ b/flink/src/main/java/org/apache/sedona/flink/Catalog.java
@@ -145,6 +145,7 @@ public class Catalog {
                 new Functions.ST_HausdorffDistance(),
                 new Functions.ST_IsCollection(),
                 new Functions.ST_CoordDim(),
+                new Functions.ST_IsValidReason()
         };
     }
 

--- a/flink/src/main/java/org/apache/sedona/flink/expressions/Functions.java
+++ b/flink/src/main/java/org/apache/sedona/flink/expressions/Functions.java
@@ -1086,4 +1086,17 @@ public class Functions {
 
         }
     }
+
+    public static class ST_IsValidReason extends ScalarFunction {
+        @DataTypeHint("String")
+        public String eval(@DataTypeHint(value = "RAW", bridgedTo = Geometry.class) Object geomObject) {
+            Geometry geom = (Geometry) geomObject;
+            return org.apache.sedona.common.Functions.isValidReason(geom);
+        }
+        @DataTypeHint("String")
+        public String eval(@DataTypeHint(value = "RAW", bridgedTo = Geometry.class) Object geomObject, @DataTypeHint("Integer") Integer flags) {
+            Geometry geom = (Geometry) geomObject;
+            return org.apache.sedona.common.Functions.isValidReason(geom, flags);
+        }
+    }
 }

--- a/python/sedona/sql/st_functions.py
+++ b/python/sedona/sql/st_functions.py
@@ -129,7 +129,8 @@ __all__ = [
     "ST_CoordDim",
     "ST_IsCollection",
     "ST_Affine",
-    "ST_BoundingDiagonal"
+    "ST_BoundingDiagonal",
+    "ST_IsValidReason"
 ]
 
 
@@ -1582,3 +1583,19 @@ def ST_IsCollection(geometry: ColumnOrName) -> Column:
     :rtype: Column
     """
     return _call_st_function("ST_IsCollection", geometry)
+
+@validate_argument_types
+def ST_IsValidReason(geometry: ColumnOrName, flag: Optional[Union[ColumnOrName, int]] = None) -> Column:
+    """
+    Provides a text description of why a geometry is not valid or states that it is valid.
+    An optional flag parameter can be provided for additional options.
+
+    :param geometry: Geometry column to validate.
+    :type geometry: ColumnOrName
+    :param flag: Optional flag to modify behavior of the validity check.
+    :type flag: Optional[Union[ColumnOrName, int]]
+    :return: Description of validity as a string column.
+    :rtype: Column
+    """
+    args = (geometry,) if flag is None else (geometry, flag)
+    return _call_st_function("ST_IsValidReason", args)

--- a/python/tests/sql/test_dataframe_api.py
+++ b/python/tests/sql/test_dataframe_api.py
@@ -159,6 +159,8 @@ test_configurations = [
     (stf.ST_YMax, ("geom",), "triangle_geom", "", 1.0),
     (stf.ST_YMin, ("geom",), "triangle_geom", "", 0.0),
     (stf.ST_Z, ("b",), "two_points", "", 4.0),
+    (stf.ST_IsValidReason, ("geom",), "triangle_geom", "", "Valid Geometry"),
+    (stf.ST_IsValidReason, ("geom", 1), "triangle_geom", "", "Valid Geometry"),
 
     # predicates
     (stp.ST_Contains, ("geom", lambda: f.expr("ST_Point(0.5, 0.25)")), "triangle_geom", "", True),

--- a/spark/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
+++ b/spark/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
@@ -175,6 +175,7 @@ object Catalog {
     function[ST_Degrees](),
     function[ST_HausdorffDistance](-1),
     function[ST_DWithin](),
+    function[ST_IsValidReason](),
     // Expression for rasters
     function[RS_NormalizedDifference](),
     function[RS_Mean](),

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
@@ -1163,3 +1163,17 @@ case class ST_IsCollection(inputExpressions: Seq[Expression])
     copy(inputExpressions = newChildren)
   }
 }
+
+/**
+ * Returns a text description of the validity of the geometry considering the specified flags.
+ * If flag not specified, it defaults to OGC SFS validity semantics.
+ *
+ * @param geom  The geometry to validate.
+ * @param flag The validation flags.
+ * @return A string describing the validity of the geometry.
+ */
+case class ST_IsValidReason(inputExpressions: Seq[Expression])
+  extends InferredExpression(inferrableFunction2(Functions.isValidReason), inferrableFunction1(Functions.isValidReason)) {
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = copy(inputExpressions = newChildren)
+}

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/st_functions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/st_functions.scala
@@ -431,4 +431,12 @@ object st_functions extends DataFrameAPI {
 
   def ST_IsCollection(geometry: String): Column = wrapExpression[ST_IsCollection](geometry)
 
+  def ST_IsValidReason(geometry: Column): Column = wrapExpression[ST_IsValidReason](geometry)
+
+  def ST_IsValidReason(geometry: Column, flag: Column): Column = wrapExpression[ST_IsValidReason](geometry, flag)
+
+  def ST_IsValidReason(geometry: String): Column = wrapExpression[ST_IsValidReason](geometry)
+
+  def ST_IsValidReason(geometry: String, flag: Integer): Column = wrapExpression[ST_IsValidReason](geometry, flag)
+
 }


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)


## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-461. The PR name follows the format `[SEDONA-XXX] my subject`.


## What changes were proposed in this PR?

Adds vector function ST_IsValidReason
- Returns text stating if the geometry is valid. If not, it provides a reason why it is invalid.


## How was this patch tested?

- Passed new and existing tests


## Did this PR include necessary documentation updates?

- Yes, I am adding a new API. I am using the [current SNAPSHOT version number](https://github.com/prantogg/sedona/blob/f37bb46e101fac2aa1c62ace2f56818c51c17a03/pom.xml#L29) in since `vX.Y.Z` format.