### PR TITLE
[DOCS] Enable markdownlint rule MD009

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -2,7 +2,6 @@
 MD001: false
 MD004: false
 MD007: false
-MD009: false
 MD010: false
 MD012: false
 MD013: false


### PR DESCRIPTION
https://github.com/DavidAnson/markdownlint/blob/main/doc/md009.md

Previous commits have already removed the trailing whitespace



## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)


## Is this PR related to a JIRA ticket?


- No, this is a documentation update. The PR name follows the format `[DOCS] my subject`.


## What changes were proposed in this PR?

Enabled a markdownlint rule to check for trailing whitespace

## How was this patch tested?

`pre-commit run --all-files`

or

`pre-commit run markdownlint --all-files`


## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
