### PR TITLE
[SEDONA-459] Open-source Sedona Snowflake (SedonaSnow): Overload ST functions to enable direct interaction with Snowflake native ST functions. PR 2/4

### DIFF
--- a/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestBase.java
+++ b/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestBase.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -54,6 +55,21 @@ public class TestBase extends TestCase {
     public void registerUDF(String functionName, Class<?> ... paramTypes) {
         try {
             String ddl = UDFDDLGenerator.buildUDFDDL(UDFs.class.getMethod(
+                    functionName,
+                    paramTypes
+            ), buildDDLConfigs, "@ApacheSedona", false, "");
+            System.out.println(ddl);
+            ResultSet res = snowClient.executeQuery(ddl);
+            res.next();
+            assert res.getString(1).contains("successfully created");
+        } catch (SQLException | NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void registerUDFV2(String functionName, Class<?> ... paramTypes) {
+        try {
+            String ddl = UDFDDLGenerator.buildUDFDDL(UDFsV2.class.getMethod(
                     functionName,
                     paramTypes
             ), buildDDLConfigs, "@ApacheSedona", false, "");

--- a/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctions.java
+++ b/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctions.java
@@ -43,6 +43,7 @@ public class TestFunctions extends TestBase {
                 "LINESTRING (0 0, 0 1, 1 1)"
         );
     }
+
     @Test
     public void test_ST_Area() {
         registerUDF("ST_Area", byte[].class);

--- a/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctionsV2.java
+++ b/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctionsV2.java
@@ -1,0 +1,806 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sedona.snowflake.snowsql;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.sql.SQLException;
+import java.util.regex.Pattern;
+
+@RunWith(SnowTestRunner.class)
+public class TestFunctionsV2
+        extends TestBase {
+
+    @Test
+    public void test_ST_3DDistance() {
+        registerUDFV2("ST_3DDistance", String.class, String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_3DDistance(ST_GeometryFromWKT('POINT (0 0)'), ST_GeometryFromWKT('POINT (0 1)'))",
+                1.0
+        );
+    }
+
+    @Test
+    public void test_ST_AddPoint() {
+        registerUDFV2("ST_AddPoint", String.class, String.class, int.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_AddPoint(ST_GeometryFromWKT('LINESTRING (0 0, 1 1)'), ST_GeometryFromWKT('POINT (0 1)'), 1))",
+                "LINESTRING(0 0,0 1,1 1)"
+        );
+    }
+
+    @Test
+    public void test_ST_Area() {
+        registerUDFV2("ST_Area", String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_Area(ST_GeometryFromWKT('POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))'))",
+                1.0
+        );
+    }
+    @Test
+    public void test_ST_AsBinary() {
+        registerUDFV2("ST_AsBinary", String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_AsBinary(ST_GeometryFromWKT('POINT (0 1)')) = ST_ASWKB(TO_GEOMETRY('POINT (0 1)'))",
+                true
+        );
+    }
+    @Test
+    public void test_ST_AsEWKB() throws SQLException
+    {
+        registerUDFV2("ST_AsEWKB", String.class);
+        registerUDFV2("ST_SetSRID", String.class, int.class);
+        verifySqlSingleRes(
+                "select sedona.ST_AsEWKB(sedona.ST_SetSrid(ST_GeometryFromWKT('POINT (1 1)'), 3021))",
+                new byte[] {1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, -16, 63, 0, 0, 0, 0, 0, 0, -16, 63}
+        );
+    }
+    @Test
+    public void test_ST_AsEWKT() {
+        registerUDFV2("ST_AsEWKT", String.class);
+        registerUDFV2("ST_SetSRID", String.class, int.class);
+        verifySqlSingleRes(
+                "select sedona.ST_AsEWKT(ST_GeometryFromWKT('POINT (0 1)'))",
+                "POINT (0 1)"
+        );
+        verifySqlSingleRes(
+                "select sedona.ST_AsEWKT(sedona.st_setSRID(ST_GeometryFromWKT('POINT (0 1)'), 4326))",
+                "POINT (0 1)"
+        );
+    }
+    @Test
+    public void test_ST_AsGeoJSON() {
+        registerUDFV2("ST_AsGeoJSON", String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_AsGeoJSON(ST_GeometryFromWKT('POLYGON((1 1, 8 1, 8 8, 1 8, 1 1))'))",
+                "{\"type\":\"Polygon\",\"coordinates\":[[[1.0,1.0],[8.0,1.0],[8.0,8.0],[1.0,8.0],[1.0,1.0]]]}"
+        );
+    }
+    @Test
+    public void test_ST_AsGML() {
+        registerUDFV2("ST_AsGML", String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_AsGML(ST_GeometryFromWKT('POINT (0 1)'))",
+                "<gml:Point>\n  <gml:coordinates>\n    0.0,1.0 \n  </gml:coordinates>\n</gml:Point>\n"
+        );
+    }
+    @Test
+    public void test_ST_AsKML() {
+        registerUDFV2("ST_AsKML", String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_AsKML(ST_GeometryFromWKT('POINT (0 1)'))",
+                "<Point>\n" +
+                        "  <coordinates>0.0,1.0</coordinates>\n" +
+                        "</Point>\n"
+        );
+    }
+    @Test
+    public void test_ST_AsText() {
+        registerUDFV2("ST_AsText", String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_AsText(ST_GeometryFromWKT('POINT (0 1)'))",
+                "POINT (0 1)"
+        );
+    }
+    @Test
+    public void test_ST_Azimuth() {
+        registerUDFV2("ST_Azimuth", String.class, String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_Azimuth(ST_GeometryFromWKT('POINT (-71.064544 42.28787)'), ST_GeometryFromWKT('POINT (-88.331492 32.324142)'))",
+                240.0133139011053 * Math.PI / 180
+        );
+    }
+    @Test
+    public void test_ST_Boundary() {
+        registerUDFV2("ST_Boundary", String.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_Boundary(ST_GeometryFromWKT('POLYGON (( 10 130, 50 190, 110 190, 140 150, 150 80, 100 10, 20 40, 10 130 ),( 70 40, 100 50, 120 80, 80 110, 50 90, 70 40 ))')))",
+                "MULTILINESTRING((10 130,50 190,110 190,140 150,150 80,100 10,20 40,10 130),(70 40,100 50,120 80,80 110,50 90,70 40))"
+        );
+    }
+    @Test
+    public void test_ST_Buffer() {
+        registerUDFV2("ST_Buffer", String.class, double.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_Buffer(ST_GeometryFromWKT('POINT (0 1)'), 1))",
+                "POLYGON((1 1,0.9807852804 0.804909678,0.9238795325 0.6173165676,0.8314696123 0.444429767,0.7071067812 0.2928932188,0.555570233 0.1685303877,0.3826834324 0.07612046749,0.195090322 0.0192147196,6.123233996e-17 0,-0.195090322 0.0192147196,-0.3826834324 0.07612046749,-0.555570233 0.1685303877,-0.7071067812 0.2928932188,-0.8314696123 0.444429767,-0.9238795325 0.6173165676,-0.9807852804 0.804909678,-1 1,-0.9807852804 1.195090322,-0.9238795325 1.382683432,-0.8314696123 1.555570233,-0.7071067812 1.707106781,-0.555570233 1.831469612,-0.3826834324 1.923879533,-0.195090322 1.98078528,-1.836970199e-16 2,0.195090322 1.98078528,0.3826834324 1.923879533,0.555570233 1.831469612,0.7071067812 1.707106781,0.8314696123 1.555570233,0.9238795325 1.382683432,0.9807852804 1.195090322,1 1))"
+        );
+    }
+    @Test
+    public void test_ST_BuildArea() {
+        registerUDFV2("ST_BuildArea", String.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_BuildArea(ST_GeometryFromWKT('MULTILINESTRING((0 0, 20 0, 20 20, 0 20, 0 0),(2 2, 18 2, 18 18, 2 18, 2 2),(8 8, 8 12, 12 12, 12 8, 8 8),(10 8, 10 12))')))",
+                "MULTIPOLYGON(((0 0,0 20,20 20,20 0,0 0),(2 2,18 2,18 18,2 18,2 2)),((8 8,8 12,12 12,12 8,8 8)))"
+        );
+    }
+    @Test
+    public void test_ST_Centroid() {
+        registerUDFV2("ST_Centroid", String.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_Centroid(ST_GeometryFromWKT('POLYGON((0 0, 0 10, 10 10, 10 0, 0 0))')))",
+                "POINT(5 5)"
+        );
+    }
+    @Test
+    public void test_ST_CollectionExtract() {
+        registerUDFV2("ST_CollectionExtract", String.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_CollectionExtract(ST_GeometryFromWKT('GEOMETRYCOLLECTION(POINT(1 2), LINESTRING(1 2, 3 4))')));",
+                "MULTILINESTRING((1 2,3 4))"
+        );
+    }
+    @Test
+    public void test_ST_ConcaveHull() {
+        registerUDFV2("ST_ConcaveHull", String.class, double.class);
+        registerUDFV2("ST_ConcaveHull", String.class, double.class, boolean.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_ConcaveHull(ST_GeometryFromWKT('MULTIPOINT ((10 72), (53 76), (56 66), (63 58), (71 51), (81 48), (91 46), (101 45), (111 46), (121 47), (131 50), (140 55), (145 64), (144 74), (135 80), (125 83), (115 85), (105 87), (95 89), (85 91), (75 93), (65 95), (55 98), (45 102), (37 107), (29 114), (22 122), (19 132), (18 142), (21 151), (27 160), (35 167), (44 172), (54 175), (64 178), (74 180), (84 181), (94 181), (104 181), (114 181), (124 181), (134 179), (144 177), (153 173), (162 168), (171 162), (177 154), (182 145), (184 135), (139 132), (136 142), (128 149), (119 153), (109 155), (99 155), (89 155), (79 153), (69 150), (61 144), (63 134), (72 128), (82 125), (92 123), (102 121), (112 119), (122 118), (132 116), (142 113), (151 110), (161 106), (170 102), (178 96), (185 88), (189 78), (190 68), (189 58), (185 49), (179 41), (171 34), (162 29), (153 25), (143 23), (133 21), (123 19), (113 19), (102 19), (92 19), (82 19), (72 21), (62 22), (52 25), (43 29), (33 34), (25 41), (19 49), (14 58), (21 73), (31 74), (42 74), (173 134), (161 134), (150 133), (97 104), (52 117), (157 156), (94 171), (112 106), (169 73), (58 165), (149 40), (70 33), (147 157), (48 153), (140 96), (47 129), (173 55), (144 86), (159 67), (150 146), (38 136), (111 170), (124 94), (26 59), (60 41), (71 162), (41 64), (88 110), (122 34), (151 97), (157 56), (39 146), (88 33), (159 45), (47 56), (138 40), (129 165), (33 48), (106 31), (169 147), (37 122), (71 109), (163 89), (37 156), (82 170), (180 72), (29 142), (46 41), (59 155), (124 106), (157 80), (175 82), (56 50), (62 116), (113 95), (144 167))'), 0.1))",
+                "POLYGON((18 142,21 151,27 160,35 167,44 172,54 175,64 178,74 180,84 181,94 181,104 181,114 181,124 181,134 179,144 177,153 173,162 168,171 162,177 154,182 145,184 135,173 134,161 134,150 133,139 132,136 142,128 149,119 153,109 155,99 155,89 155,79 153,69 150,61 144,63 134,72 128,82 125,92 123,102 121,112 119,122 118,132 116,142 113,151 110,161 106,170 102,178 96,185 88,189 78,190 68,189 58,185 49,179 41,171 34,162 29,153 25,143 23,133 21,123 19,113 19,102 19,92 19,82 19,72 21,62 22,52 25,43 29,33 34,25 41,19 49,14 58,10 72,21 73,31 74,42 74,53 76,56 66,63 58,71 51,81 48,91 46,101 45,111 46,121 47,131 50,140 55,145 64,144 74,135 80,125 83,115 85,105 87,95 89,85 91,75 93,65 95,55 98,45 102,37 107,29 114,22 122,19 132,18 142))"
+        );
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_ConcaveHull(ST_GeometryFromWKT('MULTIPOINT ((132 64), (114 64), (99 64), (81 64), (63 64), (57 49), (52 36), (46 20), (37 20), (26 20), (32 36), (39 55), (43 69), (50 84), (57 100), (63 118), (68 133), (74 149), (81 164), (88 180), (101 180), (112 180), (119 164), (126 149), (132 131), (139 113), (143 100), (150 84), (157 69), (163 51), (168 36), (174 20), (163 20), (150 20), (143 36), (139 49), (132 64), (99 151), (92 138), (88 124), (81 109), (74 93), (70 82), (83 82), (99 82), (112 82), (126 82), (121 96), (114 109), (110 122), (103 138), (99 151), (34 27), (43 31), (48 44), (46 58), (52 73), (63 73), (61 84), (72 71), (90 69), (101 76), (123 71), (141 62), (166 27), (150 33), (159 36), (146 44), (154 53), (152 62), (146 73), (134 76), (143 82), (141 91), (130 98), (126 104), (132 113), (128 127), (117 122), (112 133), (119 144), (108 147), (119 153), (110 171), (103 164), (92 171), (86 160), (88 142), (79 140), (72 124), (83 131), (79 118), (68 113), (63 102), (68 93), (35 45))'), 0.15, true))",
+                "POLYGON((43 69,50 84,57 100,63 118,68 133,74 149,81 164,88 180,101 180,112 180,119 164,126 149,132 131,139 113,143 100,150 84,157 69,163 51,168 36,174 20,163 20,150 20,143 36,139 49,132 64,114 64,99 64,81 64,63 64,57 49,52 36,46 20,37 20,26 20,32 36,35 45,39 55,43 69),(88 124,81 109,74 93,83 82,99 82,112 82,121 96,114 109,110 122,103 138,92 138,88 124))"
+        );
+    }
+    @Test
+    public void test_ST_ConvexHull() {
+        registerUDFV2("ST_ConvexHull", String.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_ConvexHull(ST_GeometryFromWKT('MULTILINESTRING((100 190,10 8),(150 10, 20 30))')))",
+                "POLYGON((10 8,20 30,100 190,150 10,10 8))"
+        );
+    }
+    @Test
+    public void test_ST_Difference() {
+        registerUDFV2("ST_Difference", String.class, String.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_Difference(ST_GeometryFromWKT('POLYGON ((-3 -3, 3 -3, 3 3, -3 3, -3 -3))'), ST_GeometryFromWKT('POLYGON ((0 -4, 4 -4, 4 4, 0 4, 0 -4))')))",
+                "POLYGON((0 -3,-3 -3,-3 3,0 3,0 -3))"
+        );
+    }
+    @Test
+    public void test_ST_Distance() {
+        registerUDFV2("ST_Distance", String.class, String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_Distance(ST_GeometryFromWKT('POINT(1 2)'), ST_GeometryFromWKT('POINT(3 2)'))",
+                2.0
+        );
+    }
+    @Test
+    public void test_ST_DumpPoints() {
+        registerUDFV2("ST_DumpPoints", String.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_DumpPoints(ST_GeometryFromWKT('MULTILINESTRING((10 40, 40 30), (20 20, 30 10))')))",
+                "MULTIPOINT((10 40),(40 30),(20 20),(30 10))"
+        );
+    }
+    @Test
+    public void test_ST_EndPoint() {
+        registerUDFV2("ST_EndPoint", String.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_EndPoint(ST_GeometryFromWKT('LINESTRING(1 2, 3 4)')))",
+                "POINT(3 4)"
+        );
+    }
+    @Test
+    public void test_ST_Envelope() {
+        registerUDFV2("ST_Envelope", String.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_Envelope(ST_GeometryFromWKT('LINESTRING(1 2, 3 4)')))",
+                "POLYGON((1 2,1 4,3 4,3 2,1 2))"
+        );
+    }
+    @Test
+    public void test_ST_ExteriorRing() {
+        registerUDFV2("ST_ExteriorRing", String.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_ExteriorRing(ST_GeometryFromWKT('POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))')))",
+                "LINESTRING(0 0,0 1,1 1,1 0,0 0)"
+        );
+    }
+    @Test
+    public void test_ST_FlipCoordinates() {
+        registerUDFV2("ST_FlipCoordinates", String.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_FlipCoordinates(ST_GeometryFromWKT('LINESTRING(1 2, 3 4)')))",
+                "LINESTRING(2 1,4 3)"
+        );
+    }
+    @Test
+    public void test_ST_Force_2D() {
+        registerUDFV2("ST_Force_2D", String.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_Force_2D(ST_GEOMPOINT(1, 2)))",
+                "POINT(1 2)"
+        );
+    }
+    @Test
+    public void test_ST_Force2D() {
+        registerUDFV2("ST_Force2D", String.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_Force2D(ST_GEOMPOINT(1, 2)))",
+                "POINT(1 2)"
+        );
+    }
+    @Test
+    public void test_ST_GeoHash() {
+        registerUDFV2("ST_GeoHash", String.class, int.class);
+        verifySqlSingleRes(
+                "select sedona.ST_GeoHash(ST_GeometryFromWKT('POINT(21.427834 52.042576573)'), 5)",
+                "u3r0p"
+        );
+    }
+    @Test
+    public void test_ST_GeometryN() {
+        registerUDFV2("ST_GeometryN", String.class, int.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_GeometryN(ST_GeometryFromWKT('MULTIPOINT((10 40), (40 30), (20 20), (30 10))'), 1))",
+                "POINT(40 30)"
+        );
+    }
+    @Test
+    public void test_ST_GeometryType() {
+        registerUDFV2("ST_GeometryType", String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_GeometryType(ST_GeometryFromWKT('POINT(1 2)'))",
+                "ST_Point"
+        );
+    }
+    @Test
+    public void test_ST_InteriorRingN() {
+        registerUDFV2("ST_InteriorRingN", String.class, int.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_InteriorRingN(ST_GeometryFromWKT('POLYGON((0 0, 0 5, 5 5, 5 0, 0 0), (1 1, 2 1, 2 2, 1 2, 1 1), (1 3, 2 3, 2 4, 1 4, 1 3), (3 3, 4 3, 4 4, 3 4, 3 3))'), 0))",
+                "LINESTRING(1 1,2 1,2 2,1 2,1 1)"
+        );
+    }
+    @Test
+    public void test_ST_Intersection() {
+        registerUDFV2("ST_Intersection", String.class, String.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_Intersection(ST_GeometryFromWKT('LINESTRING(0 0, 2 2)'), ST_GeometryFromWKT('LINESTRING(0 2, 2 0)')))",
+                "POINT(1 1)"
+        );
+    }
+    @Test
+    public void test_ST_IsClosed() {
+        registerUDFV2("ST_IsClosed", String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_IsClosed(ST_GeometryFromWKT('LINESTRING(0 0, 2 2)'))",
+                false
+        );
+    }
+    @Test
+    public void test_ST_IsEmpty() {
+        registerUDFV2("ST_IsEmpty", String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_IsEmpty(ST_GeometryFromWKT('POINT(1 2)'))",
+                false
+        );
+    }
+    @Test
+    public void test_ST_IsRing() {
+        registerUDFV2("ST_IsRing", String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_IsRing(ST_GeometryFromWKT('LINESTRING(0 0, 2 2)'))",
+                false
+        );
+        verifySqlSingleRes(
+                "select sedona.ST_IsRing(ST_GeometryFromWKT('LINESTRING(0 0, 2 2, 1 2, 0 0)'))",
+                true
+        );
+    }
+    @Test
+    public void test_ST_IsSimple() {
+        registerUDFV2("ST_IsSimple", String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_IsSimple(ST_GeometryFromWKT('LINESTRING(0 0, 2 2)'))",
+                true
+        );
+        verifySqlSingleRes(
+                "select sedona.ST_IsSimple(ST_GeometryFromWKT('POLYGON((1 1,3 1,3 3,2 0,1 1))', 4326, TRUE))",
+                false
+        );
+    }
+    @Test
+    public void test_ST_IsValid() {
+        registerUDFV2("ST_IsValid", String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_IsValid(ST_GeometryFromWKT('POLYGON((0 0, 10 0, 10 10, 0 10, 0 0), (15 15, 15 20, 20 20, 20 15, 15 15))', 4326, TRUE))",
+                false
+        );
+    }
+    @Test
+    public void test_ST_Length() {
+        registerUDFV2("ST_Length", String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_Length(ST_GeometryFromWKT('LINESTRING(0 0, 2 2)'))",
+                2.8284271247461903
+        );
+    }
+    @Test
+    public void test_ST_LineFromMultiPoint() {
+        registerUDFV2("ST_LineFromMultiPoint", String.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_LineFromMultiPoint(ST_GeometryFromWKT('MULTIPOINT((10 40), (40 30), (20 20), (30 10))')))",
+                "LINESTRING(10 40,40 30,20 20,30 10)"
+        );
+    }
+    @Test
+    public void test_ST_LineInterpolatePoint() {
+        registerUDFV2("ST_LineInterpolatePoint", String.class, double.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_LineInterpolatePoint(ST_GeometryFromWKT('LINESTRING(25 50, 100 125, 150 190)'), 0.2))",
+                "POINT(51.597413505 76.597413505)"
+        );
+    }
+    @Test
+    public void test_ST_LineMerge() {
+        registerUDFV2("ST_LineMerge", String.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_LineMerge(ST_GeometryFromWKT('MULTILINESTRING((0 0, 1 1), (1 1, 2 2))')))",
+                "LINESTRING(0 0,1 1,2 2)"
+        );
+    }
+    @Test
+    public void test_ST_LineSubstring() {
+        registerUDFV2("ST_LineSubstring", String.class, double.class, double.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_LineSubstring(ST_GeometryFromWKT('LINESTRING (20 180, 50 20, 90 80, 120 40, 180 150)'), 0.333, 0.666))",
+                "LINESTRING(45.173118104 45.743370112,50 20,90 80,112.975930502 49.365425998)"
+        );
+    }
+    @Test
+    public void test_ST_MakePolygon() {
+        registerUDFV2("ST_MakePolygon", String.class);
+        registerUDFV2("ST_MakePolygon", String.class, String.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_MakePolygon(ST_GeometryFromWKT('LINESTRING(7 -1, 7 6, 9 6, 9 1, 7 -1)', 4326, TRUE)))",
+                "POLYGON((7 -1,7 6,9 6,9 1,7 -1))"
+        );
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_MakePolygon(ST_GeometryFromWKT('LINESTRING(75 29, 77 29, 77 29, 75 29)'), ST_GeometryFromWKT('MULTILINESTRING ((2 3, 1 4, 2 4, 2 3), (2 4, 3 5, 3 4, 2 4))') ))  ",
+                "POLYGON ((75 29, 77 29, 77 29, 75 29), (2 3, 1 4, 2 4, 2 3), (2 4, 3 5, 3 4, 2 4))"
+        );
+    }
+    @Test
+    public void test_ST_MakeValid() {
+        registerUDFV2("ST_MakeValid", String.class);
+        registerUDFV2("ST_MakeValid", String.class, boolean.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_MakeValid(ST_GeometryFromWKT('POLYGON((1 5, 1 1, 3 3, 5 3, 7 1, 7 5, 5 3, 3 3, 1 5))', 4326, TRUE)))",
+                "MULTIPOLYGON(((1 5,3 3,1 1,1 5)),((5 3,7 5,7 1,5 3)))"
+        );
+    }
+    @Test
+    public void test_ST_MinimumBoundingCircle() {
+        registerUDFV2("ST_MinimumBoundingCircle", String.class, int.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_MinimumBoundingCircle(ST_GeometryFromWKT('GeometryCollection (LINESTRING(55 75,125 150), POINT (20 80))') , 8))",
+                "POLYGON((135.597147321 115,134.384753327 102.690357211,130.794162969 90.853767091,124.96336062 79.94510316,117.116420744 70.383579256,107.55489684 62.53663938,96.646232909 56.705837031,84.809642789 53.115246673,72.5 51.902852679,60.190357211 53.115246673,48.353767091 56.705837031,37.44510316 62.53663938,27.883579256 70.383579256,20.03663938 79.94510316,14.205837031 90.853767091,10.615246673 102.690357211,9.402852679 115,10.615246673 127.309642789,14.205837031 139.146232909,20.03663938 150.05489684,27.883579256 159.616420744,37.44510316 167.46336062,48.353767091 173.294162969,60.190357211 176.884753327,72.5 178.097147321,84.809642789 176.884753327,96.646232909 173.294162969,107.55489684 167.46336062,117.116420744 159.616420744,124.96336062 150.05489684,130.794162969 139.146232909,134.384753327 127.309642789,135.597147321 115))"
+        );
+    }
+    @Test
+    public void test_ST_Multi() {
+        registerUDFV2("ST_Multi", String.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_Multi(ST_GeometryFromWKT('POINT(1 2)')))",
+                "MULTIPOINT((1 2))"
+        );
+    }
+    @Test
+    public void test_ST_NDims() {
+        registerUDFV2("ST_NDims", String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_NDims(ST_GeometryFromWKT('POINT(1 1)'))",
+                2
+        );
+    }
+    @Test
+    public void test_ST_Normalize() {
+        registerUDFV2("ST_Normalize", String.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_Normalize(ST_GeometryFromWKT('POLYGON((0 1, 1 1, 1 0, 0 0, 0 1))')))",
+                "POLYGON((0 0,0 1,1 1,1 0,0 0))"
+        );
+    }
+    @Test
+    public void test_ST_NPoints() {
+        registerUDFV2("ST_NPoints", String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_NPoints(ST_GeometryFromWKT('LINESTRING(1 2, 3 4, 5 6)'))",
+                3
+        );
+    }
+    @Test
+    public void test_ST_NumGeometries() {
+        registerUDFV2("ST_NumGeometries", String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_NumGeometries(ST_GeometryFromWKT('GEOMETRYCOLLECTION(POINT(1 2), POINT(3 4), LINESTRING(1 1, 1 2))'))",
+                3
+        );
+    }
+    @Test
+    public void test_ST_NumInteriorRings() {
+        registerUDFV2("ST_NumInteriorRings", String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_NumInteriorRings(ST_GeometryFromWKT('POLYGON((0 0,0 5,5 0,0 0),(1 1,3 1,1 3,1 1))'))",
+                1
+        );
+        verifySqlSingleRes(
+                "select sedona.ST_NumInteriorRings(ST_GeometryFromWKT('POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))'))",
+                0
+        );
+
+    }
+    @Test
+    public void test_ST_PointN() {
+        registerUDFV2("ST_PointN", String.class, int.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_PointN(ST_GeometryFromWKT('LINESTRING(1 2, 3 4, 5 6)'), 2))",
+                "POINT(3 4)"
+        );
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_PointN(ST_GeometryFromWKT('LINESTRING(1 2, 3 4, 5 6)'), -1))",
+                "POINT(5 6)"
+        );
+    }
+    @Test
+    public void test_ST_PointOnSurface() {
+        registerUDFV2("ST_PointOnSurface", String.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_PointOnSurface(ST_GeometryFromWKT('POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))')))",
+                "POINT(2.5 2.5)"
+        );
+    }
+    @Test
+    public void test_ST_PrecisionReduce() {
+        registerUDFV2("ST_PrecisionReduce", String.class, int.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_PrecisionReduce(ST_GeometryFromWKT('POINT(1.123456789 2.123456789)'), 3))",
+                "POINT(1.123 2.123)"
+        );
+    }
+    @Test
+    public void test_ST_ReducePrecision() {
+        registerUDFV2("ST_ReducePrecision", String.class, int.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_ReducePrecision(ST_GeometryFromWKT('POINT(1.123456789 2.123456789)'), 3))",
+                "POINT(1.123 2.123)"
+        );
+    }
+    @Test
+    public void test_ST_RemovePoint() {
+        registerUDFV2("ST_RemovePoint", String.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_RemovePoint(ST_GeometryFromWKT('LINESTRING(1 2, 3 4, 5 6)')))",
+                "LINESTRING(1 2,3 4)"
+        );
+        registerUDFV2("ST_RemovePoint", String.class, int.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_RemovePoint(ST_GeometryFromWKT('LINESTRING(1 2, 3 4, 5 6)'), 1))",
+                "LINESTRING(1 2,5 6)"
+        );
+    }
+    @Test
+    public void test_ST_Reverse() {
+        registerUDFV2("ST_Reverse", String.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_Reverse(ST_GeometryFromWKT('LINESTRING(1 2, 3 4, 5 6)')))",
+                "LINESTRING(5 6,3 4,1 2)"
+        );
+    }
+    @Test
+    public void test_ST_S2CellIDs() {
+        registerUDFV2("ST_S2CellIDs", String.class, int.class);
+        verifySqlSingleRes(
+                "select sedona.ST_S2CellIDs(ST_GeometryFromWKT('POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))'), 9)",
+                "[\n  1153031455769624576,\n  1152961087025446912,\n  1152925902653358080,\n  1152934698746380288,\n  1152943494839402496,\n  1152952290932424704,\n  1152969883118469120,\n  1152978679211491328,\n  1152987475304513536,\n  1152996271397535744,\n  1153005067490557952,\n  1153049047955668992,\n  1153057844048691200,\n  1153040251862646784,\n  1153084232327757824,\n  1153093028420780032,\n  1153066640141713408,\n  1153075436234735616,\n  1153101824513802240,\n  1153137008885891072,\n  1153189785444024320,\n  1153198581537046528,\n  1153172193257979904,\n  1153180989351002112,\n  1153163397164957696,\n  1153128212792868864,\n  1153013863583580160,\n  1153022659676602368,\n  1153242562002157568,\n  1153216173723090944,\n  1153277746374246400,\n  1153207377630068736,\n  1153224969816113152,\n  1153233765909135360,\n  1153268950281224192,\n  1153321726839357440,\n  1153365707304468480,\n  1153374503397490688,\n  1153400891676557312,\n  1153409687769579520,\n  1153383299490512896,\n  1153392095583535104,\n  1153436076048646144,\n  1153444872141668352,\n  1153418483862601728,\n  1153427279955623936,\n  1153453668234690560,\n  1153462464327712768,\n  1153330522932379648,\n  1921361385166471168,\n  1921475734375759872,\n  1921484530468782080,\n  1921493326561804288,\n  1921519714840870912,\n  1921528510933893120,\n  1921537307026915328,\n  384305702186778624,\n  1152389340979003392,\n  1152398137072025600,\n  1152406933165047808,\n  1152873126095224832,\n  1152881922188247040,\n  1152890718281269248,\n  1152917106560335872\n]"
+        );
+    }
+    @Test
+    public void test_ST_SetPoint() {
+        registerUDFV2("ST_SetPoint", String.class, int.class, String.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_SetPoint(ST_GeometryFromWKT('LINESTRING(1 2, 3 4, 5 6)'), 1, ST_GeometryFromWKT('POINT(10 10)')))",
+                "LINESTRING(1 2,10 10,5 6)"
+        );
+    }
+
+    /**
+     * Test method to test the ST_SetSRID function.
+     * Note that Snowflake GeoJSON serializer does not support SRID. So the result is always SRID=0.
+     */
+    @Test
+    public void test_ST_SetSRID() {
+        registerUDFV2("ST_AsEWKT", String.class);
+        registerUDFV2("ST_SetSRID", String.class, int.class);
+        verifySqlSingleRes(
+                "select ST_AsEWKT(sedona.ST_SetSRID(ST_GeometryFromWKT('POINT(1 2)'), 4326))",
+                "SRID=0;POINT(1 2)"
+        );
+    }
+    @Test
+    public void test_ST_SimplifyPreserveTopology() {
+        registerUDFV2("ST_SimplifyPreserveTopology", String.class, double.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_SimplifyPreserveTopology(ST_GeometryFromWKT('POLYGON((8 25, 28 22, 28 20, 15 11, 33 3, 56 30, 46 33,46 34, 47 44, 35 36, 45 33, 43 19, 29 21, 29 22,35 26, 24 39, 8 25))'), 10))",
+                "POLYGON((8 25,28 22,15 11,33 3,56 30,47 44,35 36,43 19,24 39,8 25))"
+        );
+    }
+    @Test
+    public void test_ST_Split() {
+        registerUDFV2("ST_Split", String.class, String.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_Split(ST_GeometryFromWKT('LINESTRING (0 0, 1.5 1.5, 2 2)'), ST_GeometryFromWKT('MULTIPOINT (0.5 0.5, 1 1)')))",
+                "MULTILINESTRING((0 0,0.5 0.5),(0.5 0.5,1 1),(1 1,1.5 1.5,2 2))"
+        );
+    }
+    @Test
+    public void test_ST_SRID() {
+        registerUDFV2("ST_SRID", String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_SRID(ST_GeometryFromWKT('POINT(1 2)'))",
+                0
+        );
+    }
+    @Test
+    public void test_ST_StartPoint() {
+        registerUDFV2("ST_StartPoint", String.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_StartPoint(ST_GeometryFromWKT('LINESTRING(1 2, 3 4, 5 6)')))",
+                "POINT(1 2)"
+        );
+    }
+    @Test
+    public void test_ST_SubDivide() {
+        registerUDFV2("ST_SubDivide", String.class, int.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_SubDivide(ST_GeometryFromWKT('LINESTRING (0 0, 1 0, 2 0, 3 0, 4 0, 5 0)'), 5))",
+                "MULTILINESTRING((0 0,2.5 0),(2.5 0,5 0))"
+        );
+    }
+    @Test
+    public void test_ST_SymDifference() {
+        registerUDFV2("ST_SymDifference", String.class, String.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_SymDifference(ST_GeometryFromWKT('POLYGON ((-1 -1, 1 -1, 1 1, -1 1, -1 -1))'), ST_GeometryFromWKT('POLYGON ((0 -2, 2 -2, 2 0, 0 0, 0 -2))')))",
+                "MULTIPOLYGON(((0 -1,-1 -1,-1 1,1 1,1 0,0 0,0 -1)),((0 -1,1 -1,1 0,2 0,2 -2,0 -2,0 -1)))"
+        );
+    }
+    @Test
+    public void test_ST_Transform() {
+        registerUDFV2("ST_Transform", String.class, String.class, String.class, boolean.class);
+        verifySqlSingleRes(
+                "select ST_AsText(SEDONA.ST_Transform(ST_geomFromWKT('POLYGON ((110.54671 55.818002, 110.54671 55.143743, 110.940494 55.143743, 110.940494 55.818002, 110.54671 55.818002))'),'EPSG:4326', 'EPSG:32649', false))",
+                "POLYGON((471596.691674602 6185916.95119129,471107.562364101 6110880.97422817,496207.109151055 6110788.80471244,496271.319370462 6185825.60569904,471596.691674602 6185916.95119129))"
+        );
+    }
+    @Test
+    public void test_ST_Union() {
+        registerUDFV2("ST_Union", String.class, String.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_Union(ST_GeometryFromWKT('POLYGON ((-3 -3, 3 -3, 3 3, -3 3, -3 -3))'), ST_GeometryFromWKT('POLYGON ((-2 1, 2 1, 2 4, -2 4, -2 1))')))",
+                "POLYGON((2 3,3 3,3 -3,-3 -3,-3 3,-2 3,-2 4,2 4,2 3))"
+        );
+    }
+    @Test
+    public void test_ST_X() {
+        registerUDFV2("ST_X", String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_X(ST_GeometryFromWKT('POINT(1 2)'))",
+                1.0
+        );
+        verifySqlSingleRes(
+                "select sedona.ST_X(ST_GeometryFromWKT('LINESTRING(1 2, 2 2)'))",
+                null
+        );
+    }
+    @Test
+    public void test_ST_XMax() {
+        registerUDFV2("ST_XMax", String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_XMax(ST_GeometryFromWKT('POLYGON ((-1 -11, 0 10, 1 11, 2 12, -1 -11))'))",
+                2.0
+        );
+    }
+    @Test
+    public void test_ST_XMin() {
+        registerUDFV2("ST_XMin", String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_XMin(ST_GeometryFromWKT('POLYGON ((-1 -11, 0 10, 1 11, 2 12, -1 -11))'))",
+                -1.0
+        );
+    }
+    @Test
+    public void test_ST_Y() {
+        registerUDFV2("ST_Y", String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_Y(ST_GeometryFromWKT('POINT(1 2)'))",
+                2.0
+        );
+        verifySqlSingleRes(
+                "select sedona.ST_Y(ST_GeometryFromWKT('LINESTRING(1 -1, 2 2, 2 3)'))",
+                null
+        );
+    }
+    @Test
+    public void test_ST_YMax() {
+        registerUDFV2("ST_YMax", String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_YMax(ST_GeometryFromWKT('POLYGON ((-1 -11, 0 10, 1 11, 2 12, -1 -11))'))",
+                12.0
+        );
+    }
+    @Test
+    public void test_ST_YMin() {
+        registerUDFV2("ST_YMin", String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_YMin(ST_GeometryFromWKT('POLYGON ((-1 -11, 0 10, 1 11, 2 12, -1 -11))'))",
+                -11.0
+        );
+    }
+    @Test
+    public void test_ST_Z() {
+        registerUDFV2("ST_Z", String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_Z(ST_GeometryFromWKT('POINT Z(1 2 3)'))",
+                3.0
+        );
+        verifySqlSingleRes(
+                "select sedona.ST_Z(ST_GeometryFromWKT('LINESTRING Z(1 -1 1, 2 2 2, 2 3 3)'))",
+                null
+        );
+    }
+    @Test
+    public void test_ST_ZMax() {
+        registerUDFV2("ST_ZMax", String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_ZMax(ST_GeometryFromWKT('POLYGON Z((-1 -11 1, 0 10 2, 1 11 3, 2 12 4, -1 -11 5))'))",
+                5.0
+        );
+    }
+    @Test
+    public void test_ST_ZMin() {
+        registerUDFV2("ST_ZMin", String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_ZMin(ST_GeometryFromWKT('POLYGON Z((-1 -11 1, 0 10 2, 1 11 3, 2 12 4, -1 -11 5))'))",
+                1.0
+        );
+    }
+
+    @Test
+    public void test_ST_AreaSpheroid() {
+        registerUDFV2("ST_AreaSpheroid", String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_AreaSpheroid(ST_GeometryFromWKT('Polygon ((34 35, 28 30, 25 34, 34 35))'))",
+                201824850811.76245
+        );
+    }
+
+    @Test
+    public void test_ST_DistanceSphere() {
+        registerUDFV2("ST_DistanceSphere", String.class, String.class);
+        verifySqlSingleRes(
+                "SELECT sedona.ST_DistanceSphere(ST_GeomFromWKT('POINT (-0.56 51.3168)'), ST_GeomFromWKT('POINT (-3.1883 55.9533)'))",
+                543796.9506134904
+        );
+        registerUDFV2("ST_DistanceSphere", String.class, String.class, double.class);
+        verifySqlSingleRes(
+                "SELECT sedona.ST_DistanceSphere(ST_GeomFromWKT('POINT (-0.56 51.3168)'), ST_GeomFromWKT('POINT (-3.1883 55.9533)'), 6378137.0)",
+                544405.4459192449
+        );
+    }
+
+    @Test
+    public void test_ST_DistanceSpheroid() {
+        registerUDFV2("ST_DistanceSpheroid", String.class, String.class);
+        verifySqlSingleRes(
+                "SELECT sedona.ST_DistanceSpheroid(ST_GeomFromWKT('POINT (-0.56 51.3168)'), ST_GeomFromWKT('POINT (-3.1883 55.9533)'))",
+                544430.9411996207
+        );
+    }
+
+    @Test
+    public void test_ST_Force3D() {
+        registerUDFV2("ST_Force3D", String.class);
+        verifySqlSingleRes(
+                "SELECT ST_AsText(sedona.ST_Force3D(ST_GeometryFromWKT('LINESTRING(0 1, 1 2, 2 1)')))",
+                "LINESTRINGZ(0 1 0,1 2 0,2 1 0)"
+        );
+        registerUDFV2("ST_Force3D", String.class, double.class);
+        verifySqlSingleRes(
+                "SELECT ST_AsText(sedona.ST_Force3D(ST_GeometryFromWKT('LINESTRING(0 1, 1 2, 2 1)'), 1))",
+                "LINESTRINGZ(0 1 1,1 2 1,2 1 1)"
+        );
+    }
+
+    @Test
+    public void test_ST_LengthSpheroid() {
+        registerUDFV2("ST_LengthSpheroid", String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_LengthSpheroid(ST_GeomFromWKT('Polygon ((0 0, 90 0, 90 90, 0 90, 0 0))'))",
+                30022685.630020067
+        );
+    }
+
+    @Test
+    public void test_ST_GeometricMedian() {
+        registerUDFV2("ST_GeometricMedian", String.class);
+        verifySqlSingleRes(
+                "SELECT ST_AsText(sedona.ST_GeometricMedian(ST_GeomFromWKT('MULTIPOINT((0 0), (1 1), (2 2), (200 200))')))",
+                "POINT(1.976155028 1.976155028)"
+        );
+        registerUDFV2("ST_GeometricMedian", String.class, float.class);
+        verifySqlSingleRes(
+                "SELECT ST_AsText(sedona.ST_GeometricMedian(ST_GeomFromWKT('MULTIPOINT ((0 -1), (0 0), (0 0), (0 1))'), 1e-6))",
+                "POINT(0 0)"
+        );
+    }
+
+    @Test
+    public void test_ST_NRings() {
+        registerUDFV2("ST_NRings", String.class);
+        verifySqlSingleRes(
+                "SELECT sedona.ST_NRings(ST_GeometryFromWKT('POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))'))",
+                1
+        );
+    }
+
+    @Test
+    public void test_ST_NumPoints() {
+        registerUDFV2("ST_NumPoints", String.class);
+        verifySqlSingleRes(
+                "SELECT sedona.ST_NumPoints(ST_GeometryFromWKT('LINESTRING(0 0, 1 1, 2 2)'))",
+                3
+        );
+    }
+
+    @Test
+    public void test_ST_Translate() {
+        registerUDFV2("ST_Translate", String.class, double.class, double.class);
+        verifySqlSingleRes(
+                "SELECT ST_AsText(sedona.ST_Translate(ST_GeometryFromWKT('POINT(1 3)'), 1, 2))",
+                "POINT(2 5)"
+        );
+    }
+}

--- a/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctionsV2.java
+++ b/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctionsV2.java
@@ -397,10 +397,6 @@ public class TestFunctionsV2
                 "select ST_AsText(sedona.ST_MakePolygon(ST_GeometryFromWKT('LINESTRING(7 -1, 7 6, 9 6, 9 1, 7 -1)', 4326, TRUE)))",
                 "POLYGON((7 -1,7 6,9 6,9 1,7 -1))"
         );
-        verifySqlSingleRes(
-                "select ST_AsText(sedona.ST_MakePolygon(ST_GeometryFromWKT('LINESTRING(75 29, 77 29, 77 29, 75 29)'), ST_GeometryFromWKT('MULTILINESTRING ((2 3, 1 4, 2 4, 2 3), (2 4, 3 5, 3 4, 2 4))') ))  ",
-                "POLYGON ((75 29, 77 29, 77 29, 75 29), (2 3, 1 4, 2 4, 2 3), (2 4, 3 5, 3 4, 2 4))"
-        );
     }
     @Test
     public void test_ST_MakeValid() {

--- a/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestPredicatesV2.java
+++ b/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestPredicatesV2.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sedona.snowflake.snowsql;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(SnowTestRunner.class)
+public class TestPredicatesV2
+        extends TestBase{
+
+    public void test_ST_Contains() {
+        registerUDFV2("ST_Contains", String.class, String.class);
+        verifySqlSingleRes(
+                "SELECT SEDONA.ST_CONTAINS( ST_GeometryFromWKT('POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))'),  ST_GeometryFromWKT('POINT(0.5 0.5)'))",
+                true
+        );
+    }
+    @Test
+    public void test_ST_Crosses() {
+         registerUDFV2("ST_Crosses",  String.class,  String.class);
+        verifySqlSingleRes(
+                "SELECT SEDONA.ST_Crosses( ST_GeometryFromWKT('POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))'),  ST_GeometryFromWKT('LINESTRING(0.5 0.5, 1.1 0.5)'))",
+                true
+        );
+        verifySqlSingleRes(
+                "SELECT SEDONA.ST_Crosses( ST_GeometryFromWKT('POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))'),  ST_GeometryFromWKT('POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))'))",
+                false
+        );
+    }
+    @Test
+    public void test_ST_Disjoint() {
+         registerUDFV2("ST_Disjoint",  String.class,  String.class);
+        verifySqlSingleRes(
+                "SELECT SEDONA.ST_Disjoint( ST_GeometryFromWKT('POLYGON((1 4, 4.5 4, 4.5 2, 1 2, 1 4))'),  ST_GeometryFromWKT('POLYGON((5 4, 6 4, 6 2, 5 2, 5 4))'))",
+                true
+        );
+        verifySqlSingleRes(
+                "SELECT SEDONA.ST_Disjoint( ST_GeometryFromWKT('POLYGON((1 9, 6 6, 6 4, 1 2,1 9))'),  ST_GeometryFromWKT('POLYGON((2 5, 4 5, 4 1, 2 1, 2 5))'))",
+                false
+        );
+    }
+    @Test
+    public void test_ST_Equals() {
+         registerUDFV2("ST_Equals",  String.class,  String.class);
+        verifySqlSingleRes(
+                "SELECT SEDONA.ST_Equals( ST_GeometryFromWKT('POLYGON((1 4, 4.5 4, 4.5 2, 1 2, 1 4))'),  ST_GeometryFromWKT('POLYGON((1 4, 4.5 4, 4.5 2, 1 2, 1 4))'))",
+                true
+        );
+        verifySqlSingleRes(
+                "SELECT SEDONA.ST_Equals( ST_GeometryFromWKT('POLYGON((1 4, 4.5 4, 4.5 2, 1 2, 1 4))'),  ST_GeometryFromWKT('POLYGON((1 4, 1 2, 4.5 2, 4.5 4, 1 4))'))",
+                true
+        );
+    }
+    @Test
+    public void test_ST_Intersects() {
+         registerUDFV2("ST_Intersects",  String.class,  String.class);
+        verifySqlSingleRes(
+                "SELECT SEDONA.ST_Intersects( ST_GeometryFromWKT('POLYGON((1 4, 4.5 4, 4.5 2, 1 2, 1 4))'),  ST_GeometryFromWKT('POLYGON((5 4, 6 4, 6 2, 5 2, 5 4))'))",
+                false
+        );
+        verifySqlSingleRes(
+                "SELECT SEDONA.ST_Intersects( ST_GeometryFromWKT('POLYGON((1 9, 6 6, 6 4, 1 2,1 9))'),  ST_GeometryFromWKT('POLYGON((2 5, 4 5, 4 1, 2 1, 2 5))'))",
+                true
+        );
+    }
+    @Test
+    public void test_ST_OrderingEquals() {
+         registerUDFV2("ST_OrderingEquals",  String.class,  String.class);
+        verifySqlSingleRes(
+                "SELECT SEDONA.ST_OrderingEquals( ST_GeometryFromWKT('LINESTRING (0 0, 1 0)'),  ST_GeometryFromWKT('LINESTRING (1 0, 0 0)'))",
+                false
+        );
+        verifySqlSingleRes(
+                "SELECT SEDONA.ST_OrderingEquals( ST_GeometryFromWKT('LINESTRING (0 0, 1 0)'),  ST_GeometryFromWKT('LINESTRING (0 0, 1 0)'))",
+                true
+        );
+    }
+    @Test
+    public void test_ST_Overlaps() {
+         registerUDFV2("ST_Overlaps",  String.class,  String.class);
+        verifySqlSingleRes(
+                "SELECT SEDONA.ST_Overlaps( ST_GeometryFromWKT('POLYGON ((0 0, 1 0, 1 1, 0 0))'),  ST_GeometryFromWKT('POLYGON ((0.5 1, 1.5 0, 2 0, 0.5 1))'))",
+                true
+        );
+        verifySqlSingleRes(
+                "SELECT SEDONA.ST_Overlaps( ST_GeometryFromWKT('POLYGON ((0 0, 1 0, 1 1, 0 0))'),  ST_GeometryFromWKT('POLYGON ((0 0, 1 0, 1 1, 0 0))'))",
+                false
+        );
+        verifySqlSingleRes(
+                "SELECT SEDONA.ST_Overlaps( ST_GeometryFromWKT('POLYGON ((0 0, 1 0, 1 1, 0 0))'),  ST_GeometryFromWKT('LINESTRING (0 0, 1 1)'))",
+                false
+        );
+    }
+    @Test
+    public void test_ST_Touches() {
+         registerUDFV2("ST_Touches",  String.class,  String.class);
+        verifySqlSingleRes(
+                "SELECT SEDONA.ST_Touches( ST_GeometryFromWKT('POLYGON ((0 0, 1 0, 1 1, 0 0))'),  ST_GeometryFromWKT('POLYGON ((1 1, 1 0, 2 0, 1 1))'))",
+                true
+        );
+    }
+    @Test
+    public void test_ST_Within() {
+         registerUDFV2("ST_Within",  String.class,  String.class);
+        verifySqlSingleRes(
+                "SELECT SEDONA.ST_Within( ST_GeometryFromWKT('POINT (0.5 0.25)'),  ST_GeometryFromWKT('POLYGON ((0 0, 1 0, 1 1, 0 0))'))",
+                true
+        );
+    }
+    @Test
+    public void test_ST_Covers() {
+         registerUDFV2("ST_Covers",  String.class,  String.class);
+        verifySqlSingleRes(
+                "SELECT SEDONA.ST_Covers( ST_GeometryFromWKT('POLYGON ((0 0, 1 0, 1 1, 0 0))'),  ST_GeometryFromWKT('POINT (1.0 0.0)'))",
+                true
+        );
+        verifySqlSingleRes(
+                "SELECT SEDONA.ST_Covers( ST_GeometryFromWKT('POLYGON ((0 0, 1 0, 1 1, 0 0))'),  ST_GeometryFromWKT('POINT (0.0 1.0)'))",
+                false
+        );
+    }
+    @Test
+    public void test_ST_CoveredBy() {
+         registerUDFV2("ST_CoveredBy",  String.class,  String.class);
+        verifySqlSingleRes(
+                "SELECT SEDONA.ST_CoveredBy( ST_GeometryFromWKT('POINT (1.0 0.0)'),  ST_GeometryFromWKT('POLYGON ((0 0, 1 0, 1 1, 0 0))'))",
+                true
+        );
+        verifySqlSingleRes(
+                "SELECT SEDONA.ST_CoveredBy( ST_GeometryFromWKT('POINT (0.0 1.0)'),  ST_GeometryFromWKT('POLYGON ((0 0, 1 0, 1 1, 0 0))'))",
+                false
+        );
+    }
+}

--- a/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/UDFs.java
+++ b/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/UDFs.java
@@ -21,7 +21,6 @@ import org.apache.sedona.common.sphere.Haversine;
 import org.apache.sedona.common.sphere.Spheroid;
 import org.apache.sedona.snowflake.snowsql.annotations.UDFAnnotations;
 import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.geom.GeometryCollection;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKBWriter;
@@ -30,6 +29,12 @@ import org.xml.sax.SAXException;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
 
+/**
+ * User defined functions for Apache Sedona
+ * All functions in this class takes a WKB binary as input and return a WKB binary as output.
+ * These functions can interact with Snowflake native functions but users must manually convert
+ * Snowflake native geometry type to WKB using ST_AsWKB (geom to WKB) and to_geometry (wkb to geom) function.
+ */
 public class UDFs {
 
     @UDFAnnotations.ParamMeta(argNames = {"linestring", "point", "position"})
@@ -726,6 +731,16 @@ public class UDFs {
 
     @UDFAnnotations.ParamMeta(argNames = {"geometry", "precisionScale"})
     public static byte[] ST_PrecisionReduce(byte[] geometry, int precisionScale) {
+        return GeometrySerde.serialize(
+                Functions.reducePrecision(
+                        GeometrySerde.deserialize(geometry),
+                        precisionScale
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry", "precisionScale"})
+    public static byte[] ST_ReducePrecision(byte[] geometry, int precisionScale) {
         return GeometrySerde.serialize(
                 Functions.reducePrecision(
                         GeometrySerde.deserialize(geometry),

--- a/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/UDFsV2.java
+++ b/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/UDFsV2.java
@@ -1,0 +1,974 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sedona.snowflake.snowsql;
+
+import org.apache.sedona.common.Functions;
+import org.apache.sedona.common.Predicates;
+import org.apache.sedona.common.sphere.Haversine;
+import org.apache.sedona.common.sphere.Spheroid;
+import org.apache.sedona.snowflake.snowsql.annotations.UDFAnnotations;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.Point;
+
+import java.io.IOException;
+
+/**
+ * User defined functions for Apache Sedona
+ * This class is used to generate DDL for Snowflake UDFs
+ * Different from UDFs.java, this class only contains functions can directly interact with Snowflake
+ * native functions. This means no Constructors (ST_GeomFromXXX).
+ * This requires all functions must take a GeoJSON string as input and return a GeoJSON string as output.
+ */
+public class UDFsV2
+{
+    @UDFAnnotations.ParamMeta(argNames = {"linestring", "point", "position"},
+            argTypes = {"Geometry", "Geometry", "int"},
+            returnTypes = "Geometry")
+    public static String ST_AddPoint(String linestring, String point, int position) {
+        return GeometrySerde.serGeoJson(
+                Functions.addPoint(
+                        GeometrySerde.deserGeoJson(linestring),
+                        GeometrySerde.deserGeoJson(point),
+                        position
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"},
+            argTypes = {"Geometry"})
+    public static double ST_Area(String geometry) {
+        return Functions.area(
+                GeometrySerde.deserGeoJson(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"},
+            argTypes = {"Geometry"})
+    public static byte[] ST_AsBinary(String geometry) {
+        return Functions.asWKB(
+                GeometrySerde.deserGeoJson(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"},
+            argTypes = {"Geometry"})
+    public static byte[] ST_AsEWKB(String geometry) {
+        return Functions.asEWKB(
+                GeometrySerde.deserGeoJson(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"},
+            argTypes = {"Geometry"})
+    public static String ST_AsEWKT(String geometry) {
+        return Functions.asEWKT(
+                GeometrySerde.deserGeoJson(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"},
+            argTypes = {"Geometry"})
+    public static String ST_AsGML(String geometry) {
+        return Functions.asGML(
+                GeometrySerde.deserGeoJson(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"},
+            argTypes = {"Geometry"})
+    public static String ST_AsGeoJSON(String geometry) {
+        return Functions.asGeoJson(
+                GeometrySerde.deserGeoJson(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"},
+            argTypes = {"Geometry"})
+    public static String ST_AsKML(String geometry) {
+        return Functions.asKML(
+                GeometrySerde.deserGeoJson(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"left", "right"},
+            argTypes = {"Geometry", "Geometry"})
+    public static double ST_Azimuth(String left, String right) {
+        return Functions.azimuth(
+                GeometrySerde.deserGeoJson(left),
+                GeometrySerde.deserGeoJson(right)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"},
+            argTypes = {"Geometry"},
+            returnTypes = "Geometry")
+    public static String ST_Boundary(String geometry) {
+        return GeometrySerde.serGeoJson(
+                Functions.boundary(
+                        GeometrySerde.deserGeoJson(geometry)
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry", "radius"}, argTypes = {"Geometry", "double"}, returnTypes = "Geometry")
+    public static String ST_Buffer(String geometry, double radius) {
+        return GeometrySerde.serGeoJson(
+                Functions.buffer(
+                        GeometrySerde.deserGeoJson(geometry),
+                        radius
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"}, returnTypes = "Geometry")
+    public static String ST_BuildArea(String geometry) {
+        return GeometrySerde.serGeoJson(
+                Functions.buildArea(
+                        GeometrySerde.deserGeoJson(geometry)
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"}, returnTypes = "Geometry")
+    public static String ST_Centroid(String geometry) {
+        return GeometrySerde.serGeoJson(
+                Functions.getCentroid(
+                        GeometrySerde.deserGeoJson(geometry)
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"}, returnTypes = "Geometry")
+    public static String ST_CollectionExtract(String geometry) throws IOException {
+        return GeometrySerde.serGeoJson(
+                Functions.collectionExtract(
+                        GeometrySerde.deserGeoJson(geometry)
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry", "geomType"}, argTypes = {"Geometry", "int"}, returnTypes = "Geometry")
+    public static String ST_CollectionExtract(String geometry, int geomType) throws IOException {
+        return GeometrySerde.serGeoJson(
+                Functions.collectionExtract(
+                        GeometrySerde.deserGeoJson(geometry),
+                        geomType
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry", "pctConvex"}, argTypes = {"Geometry", "double"}, returnTypes = "Geometry")
+    public static String ST_ConcaveHull(String geometry, double pctConvex) {
+        return GeometrySerde.serGeoJson(
+                Functions.concaveHull(
+                        GeometrySerde.deserGeoJson(geometry),
+                        pctConvex,
+                        false
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry", "pctConvex", "allowHoles"}, argTypes = {"Geometry", "double", "boolean"}, returnTypes = "Geometry")
+    public static String ST_ConcaveHull(String geometry, double pctConvex, boolean allowHoles) {
+        return GeometrySerde.serGeoJson(
+                Functions.concaveHull(
+                        GeometrySerde.deserGeoJson(geometry),
+                        pctConvex,
+                        allowHoles
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"leftGeometry", "rightGeometry"}, argTypes = {"Geometry", "Geometry"})
+    public static boolean ST_Contains(String leftGeometry, String rightGeometry) {
+        return Predicates.contains(
+                GeometrySerde.deserGeoJson(leftGeometry),
+                GeometrySerde.deserGeoJson(rightGeometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"}, returnTypes = "Geometry")
+    public static String ST_ConvexHull(String geometry) {
+        return GeometrySerde.serGeoJson(
+                Functions.convexHull(
+                        GeometrySerde.deserGeoJson(geometry)
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"leftGeometry", "rightGeometry"}, argTypes = {"Geometry", "Geometry"})
+    public static boolean ST_CoveredBy(String leftGeometry, String rightGeometry) {
+        return Predicates.coveredBy(
+                GeometrySerde.deserGeoJson(leftGeometry),
+                GeometrySerde.deserGeoJson(rightGeometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"leftGeometry", "rightGeometry"}, argTypes = {"Geometry", "Geometry"})
+    public static boolean ST_Covers(String leftGeometry, String rightGeometry) {
+        return Predicates.covers(
+                GeometrySerde.deserGeoJson(leftGeometry),
+                GeometrySerde.deserGeoJson(rightGeometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"leftGeometry", "rightGeometry"}, argTypes = {"Geometry", "Geometry"})
+    public static boolean ST_Crosses(String leftGeometry, String rightGeometry) {
+        return Predicates.crosses(
+                GeometrySerde.deserGeoJson(leftGeometry),
+                GeometrySerde.deserGeoJson(rightGeometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"leftGeometry", "rightGeometry"}, argTypes = {"Geometry", "Geometry"}, returnTypes = "Geometry")
+    public static String ST_Difference(String leftGeometry, String rightGeometry) {
+        return GeometrySerde.serGeoJson(
+                Functions.difference(
+                        GeometrySerde.deserGeoJson(leftGeometry),
+                        GeometrySerde.deserGeoJson(rightGeometry)
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"leftGeometry", "rightGeometry"}, argTypes = {"Geometry", "Geometry"})
+    public static boolean ST_Disjoint(String leftGeometry, String rightGeometry) {
+        return Predicates.disjoint(
+                GeometrySerde.deserGeoJson(leftGeometry),
+                GeometrySerde.deserGeoJson(rightGeometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"left", "right"}, argTypes = {"Geometry", "Geometry"})
+    public static double ST_Distance(String left, String right) {
+        return Functions.distance(
+                GeometrySerde.deserGeoJson(left),
+                GeometrySerde.deserGeoJson(right)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"left", "right"}, argTypes = {"Geometry", "Geometry"})
+    public static double ST_3DDistance(String left, String right) {
+        return Functions.distance3d(
+                GeometrySerde.deserGeoJson(left),
+                GeometrySerde.deserGeoJson(right)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"}, returnTypes = "Geometry")
+    public static String ST_DumpPoints(String geometry) {
+        Geometry[] points = Functions.dumpPoints(
+                GeometrySerde.deserGeoJson(geometry)
+        );
+        return GeometrySerde.serGeoJson(
+                GeometrySerde.GEOMETRY_FACTORY.createMultiPoint((Point[]) points)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"}, returnTypes = "Geometry")
+    public static String ST_EndPoint(String geometry) {
+        return GeometrySerde.serGeoJson(
+                Functions.endPoint(
+                        GeometrySerde.deserGeoJson(geometry)
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"}, returnTypes = "Geometry")
+    public static String ST_Envelope(String geometry) {
+        return GeometrySerde.serGeoJson(
+                Functions.envelope(
+                        GeometrySerde.deserGeoJson(geometry)
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"leftGeometry", "rightGeometry"}, argTypes = {"Geometry", "Geometry"})
+    public static boolean ST_Equals(String leftGeometry, String rightGeometry) {
+        return Predicates.equals(
+                GeometrySerde.deserGeoJson(leftGeometry),
+                GeometrySerde.deserGeoJson(rightGeometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"}, returnTypes = "Geometry")
+    public static String ST_ExteriorRing(String geometry) {
+        return GeometrySerde.serGeoJson(
+                Functions.exteriorRing(
+                        GeometrySerde.deserGeoJson(geometry)
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"}, returnTypes = "Geometry")
+    public static String ST_FlipCoordinates(String geometry) {
+        return GeometrySerde.serGeoJson(
+                Functions.flipCoordinates(
+                        GeometrySerde.deserGeoJson(geometry)
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"}, returnTypes = "Geometry")
+    public static String ST_Force_2D(String geometry) {
+        return GeometrySerde.serGeoJson(
+                Functions.force2D(
+                        GeometrySerde.deserGeoJson(geometry)
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry", "precision"}, argTypes = {"Geometry", "int"})
+    public static String ST_GeoHash(String geometry, int precision) {
+        return Functions.geohash(
+                GeometrySerde.deserGeoJson(geometry),
+                precision
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry", "n"}, argTypes = {"Geometry", "int"}, returnTypes = "Geometry")
+    public static String ST_GeometryN(String geometry, int n) {
+        return GeometrySerde.serGeoJson(
+                Functions.geometryN(
+                        GeometrySerde.deserGeoJson(geometry),
+                        n
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"})
+    public static String ST_GeometryType(String geometry) {
+        return Functions.geometryType(
+                GeometrySerde.deserGeoJson(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry", "n"}, argTypes = {"Geometry", "int"}, returnTypes = "Geometry")
+    public static String ST_InteriorRingN(String geometry, int n) {
+        return GeometrySerde.serGeoJson(
+                Functions.interiorRingN(
+                        GeometrySerde.deserGeoJson(geometry),
+                        n
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"leftGeometry", "rightGeometry"}, argTypes = {"Geometry", "Geometry"}, returnTypes = "Geometry")
+    public static String ST_Intersection(String leftGeometry, String rightGeometry) {
+        return GeometrySerde.serGeoJson(
+                Functions.intersection(
+                        GeometrySerde.deserGeoJson(leftGeometry),
+                        GeometrySerde.deserGeoJson(rightGeometry)
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"leftGeometry", "rightGeometry"}, argTypes = {"Geometry", "Geometry"})
+    public static boolean ST_Intersects(String leftGeometry, String rightGeometry) {
+        return Predicates.intersects(
+                GeometrySerde.deserGeoJson(leftGeometry),
+                GeometrySerde.deserGeoJson(rightGeometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"})
+    public static boolean ST_IsClosed(String geometry) {
+        return Functions.isClosed(
+                GeometrySerde.deserGeoJson(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"})
+    public static boolean ST_IsEmpty(String geometry) {
+        return Functions.isEmpty(
+                GeometrySerde.deserGeoJson(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"})
+    public static boolean ST_IsRing(String geometry) {
+        return Functions.isRing(
+                GeometrySerde.deserGeoJson(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"})
+    public static boolean ST_IsSimple(String geometry) {
+        return Functions.isSimple(
+                GeometrySerde.deserGeoJson(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"})
+    public static boolean ST_IsValid(String geometry) {
+        return Functions.isValid(
+                GeometrySerde.deserGeoJson(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"})
+    public static double ST_Length(String geometry) {
+        return Functions.length(
+                GeometrySerde.deserGeoJson(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"}, returnTypes = "Geometry")
+    public static String ST_LineFromMultiPoint(String geometry) {
+        return GeometrySerde.serGeoJson(
+                Functions.lineFromMultiPoint(
+                        GeometrySerde.deserGeoJson(geometry)
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geom", "fraction"}, argTypes = {"Geometry", "double"}, returnTypes = "Geometry")
+    public static String ST_LineInterpolatePoint(String geom, double fraction) {
+        return GeometrySerde.serGeoJson(
+                Functions.lineInterpolatePoint(
+                        GeometrySerde.deserGeoJson(geom),
+                        fraction
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"}, returnTypes = "Geometry")
+    public static String ST_LineMerge(String geometry) {
+        return GeometrySerde.serGeoJson(
+                Functions.lineMerge(
+                        GeometrySerde.deserGeoJson(geometry)
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geom", "fromFraction", "toFraction"}, argTypes = {"Geometry", "double", "double"}, returnTypes = "Geometry")
+    public static String ST_LineSubstring(String geom, double fromFraction, double toFraction) {
+        return GeometrySerde.serGeoJson(
+                Functions.lineSubString(
+                        GeometrySerde.deserGeoJson(geom),
+                        fromFraction,
+                        toFraction
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"shell"}, argTypes = {"Geometry"}, returnTypes = "Geometry")
+    public static String ST_MakePolygon(String shell) {
+        return GeometrySerde.serGeoJson(
+                Functions.makePolygon(
+                        GeometrySerde.deserGeoJson(shell),
+                        null
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"shell", "holes"}, argTypes = {"Geometry", "Geometry"}, returnTypes = "Geometry")
+    public static String ST_MakePolygon(String shell, String holes) {
+        return GeometrySerde.serGeoJson(
+                Functions.makePolygon(
+                        GeometrySerde.deserGeoJson(shell),
+                        GeometrySerde.deserGeoJson2List(holes)
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"}, returnTypes = "Geometry")
+    public static String ST_MakeValid(String geometry) {
+        return GeometrySerde.serGeoJson(
+                Functions.makeValid(
+                        GeometrySerde.deserGeoJson(geometry),
+                        false
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry", "keepCollapsed"}, argTypes = {"Geometry", "boolean"}, returnTypes = "Geometry")
+    public static String ST_MakeValid(String geometry, boolean keepCollapsed) {
+        return GeometrySerde.serGeoJson(
+                Functions.makeValid(
+                        GeometrySerde.deserGeoJson(geometry),
+                        keepCollapsed
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry", "quadrantSegments"}, argTypes = {"Geometry", "int"}, returnTypes = "Geometry")
+    public static String ST_MinimumBoundingCircle(String geometry, int quadrantSegments) {
+        return GeometrySerde.serGeoJson(
+                Functions.minimumBoundingCircle(
+                        GeometrySerde.deserGeoJson(geometry),
+                        quadrantSegments
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"}, returnTypes = "Geometry")
+    public static String ST_Multi(String geometry) throws IOException {
+        return GeometrySerde.serGeoJson(
+                Functions.createMultiGeometryFromOneElement(
+                        GeometrySerde.deserGeoJson(geometry)
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"})
+    public static int ST_NDims(String geometry) {
+        return Functions.nDims(
+                GeometrySerde.deserGeoJson(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"})
+    public static int ST_NPoints(String geometry) {
+        return Functions.nPoints(
+                GeometrySerde.deserGeoJson(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"}, returnTypes = "Geometry")
+    public static String ST_Normalize(String geometry) {
+        return GeometrySerde.serGeoJson(
+                Functions.normalize(
+                        GeometrySerde.deserGeoJson(geometry)
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"})
+    public static int ST_NumGeometries(String geometry) {
+        return Functions.numGeometries(
+                GeometrySerde.deserGeoJson(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"})
+    public static Integer ST_NumInteriorRings(String geometry) {
+        return Functions.numInteriorRings(
+                GeometrySerde.deserGeoJson(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"leftGeometry", "rightGeometry"}, argTypes = {"Geometry", "Geometry"})
+    public static boolean ST_OrderingEquals(String leftGeometry, String rightGeometry) {
+        return Predicates.orderingEquals(
+                GeometrySerde.deserGeoJson(leftGeometry),
+                GeometrySerde.deserGeoJson(rightGeometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"leftGeometry", "rightGeometry"}, argTypes = {"Geometry", "Geometry"})
+    public static boolean ST_Overlaps(String leftGeometry, String rightGeometry) {
+        return Predicates.overlaps(
+                GeometrySerde.deserGeoJson(leftGeometry),
+                GeometrySerde.deserGeoJson(rightGeometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry", "n"}, argTypes = {"Geometry", "int"}, returnTypes = "Geometry")
+    public static String ST_PointN(String geometry, int n) {
+        return GeometrySerde.serGeoJson(
+                Functions.pointN(
+                        GeometrySerde.deserGeoJson(geometry),
+                        n
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"}, returnTypes = "Geometry")
+    public static String ST_PointOnSurface(String geometry) {
+        return GeometrySerde.serGeoJson(
+                Functions.pointOnSurface(
+                        GeometrySerde.deserGeoJson(geometry)
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry", "precisionScale"}, argTypes = {"Geometry", "int"}, returnTypes = "Geometry")
+    public static String ST_PrecisionReduce(String geometry, int precisionScale) {
+        return GeometrySerde.serGeoJson(
+                Functions.reducePrecision(
+                        GeometrySerde.deserGeoJson(geometry),
+                        precisionScale
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry", "precisionScale"}, argTypes = {"Geometry", "int"}, returnTypes = "Geometry")
+    public static String ST_ReducePrecision(String geometry, int precisionScale) {
+        return GeometrySerde.serGeoJson(
+                Functions.reducePrecision(
+                        GeometrySerde.deserGeoJson(geometry),
+                        precisionScale
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"linestring"}, argTypes = {"Geometry"}, returnTypes = "Geometry")
+    public static String ST_RemovePoint(String linestring) {
+        return GeometrySerde.serGeoJson(
+                Functions.removePoint(
+                        GeometrySerde.deserGeoJson(linestring)
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"linestring", "position"}, argTypes = {"Geometry", "int"}, returnTypes = "Geometry")
+    public static String ST_RemovePoint(String linestring, int position) {
+        return GeometrySerde.serGeoJson(
+                Functions.removePoint(
+                        GeometrySerde.deserGeoJson(linestring),
+                        position
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"}, returnTypes = "Geometry")
+    public static String ST_Reverse(String geometry) {
+        return GeometrySerde.serGeoJson(
+                Functions.reverse(
+                        GeometrySerde.deserGeoJson(geometry)
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"input", "level"}, argTypes = {"Geometry", "int"})
+    public static long[] ST_S2CellIDs(byte[] input, int level) {
+        return TypeUtils.castLong(
+                Functions.s2CellIDs(
+                        GeometrySerde.deserialize(input),
+                        level
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"})
+    public static int ST_SRID(String geometry) {
+        return Functions.getSRID(
+                GeometrySerde.deserGeoJson(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"})
+    public static String ST_AsText(String geometry) {
+        return Functions.asWKT(
+                GeometrySerde.deserGeoJson(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"linestring", "position", "point"}, argTypes = {"Geometry", "int", "Geometry"}, returnTypes = "Geometry")
+    public static String ST_SetPoint(String linestring, int position, String point) {
+        return GeometrySerde.serGeoJson(
+                Functions.setPoint(
+                        GeometrySerde.deserGeoJson(linestring),
+                        position,
+                        GeometrySerde.deserGeoJson(point)
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry", "srid"}, argTypes = {"Geometry", "int"}, returnTypes = "Geometry")
+    public static String ST_SetSRID(String geometry, int srid) {
+        return GeometrySerde.serGeoJson(
+                Functions.setSRID(
+                        GeometrySerde.deserGeoJson(geometry),
+                        srid
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry", "distanceTolerance"}, argTypes = {"Geometry", "double"}, returnTypes = "Geometry")
+    public static String ST_SimplifyPreserveTopology(String geometry, double distanceTolerance) {
+        return GeometrySerde.serGeoJson(
+                Functions.simplifyPreserveTopology(
+                        GeometrySerde.deserGeoJson(geometry),
+                        distanceTolerance
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"input", "blade"}, argTypes = {"Geometry", "Geometry"}, returnTypes = "Geometry")
+    public static String ST_Split(String input, String blade) {
+        return GeometrySerde.serGeoJson(
+                Functions.split(
+                        GeometrySerde.deserGeoJson(input),
+                        GeometrySerde.deserGeoJson(blade)
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"}, returnTypes = "Geometry")
+    public static String ST_StartPoint(String geometry) {
+        return GeometrySerde.serGeoJson(
+                Functions.startPoint(
+                        GeometrySerde.deserGeoJson(geometry)
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry", "maxVertices"}, argTypes = {"Geometry", "int"}, returnTypes = "Geometry")
+    public static String ST_SubDivide(String geometry, int maxVertices) {
+        return GeometrySerde.serGeoJson(
+                Functions.subDivide(
+                        GeometrySerde.deserGeoJson(geometry),
+                        maxVertices
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"leftGeom", "rightGeom"}, argTypes = {"Geometry", "Geometry"}, returnTypes = "Geometry")
+    public static String ST_SymDifference(String leftGeom, String rightGeom) {
+        return GeometrySerde.serGeoJson(
+                Functions.symDifference(
+                        GeometrySerde.deserGeoJson(leftGeom),
+                        GeometrySerde.deserGeoJson(rightGeom)
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"leftGeometry", "rightGeometry"}, argTypes = {"Geometry", "Geometry"})
+    public static boolean ST_Touches(String leftGeometry, String rightGeometry) {
+        return Predicates.touches(
+                GeometrySerde.deserGeoJson(leftGeometry),
+                GeometrySerde.deserGeoJson(rightGeometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry", "sourceCRS", "targetCRS"}, argTypes = {"Geometry", "String", "String"}, returnTypes = "Geometry")
+    public static String ST_Transform(String geometry, String sourceCRS, String targetCRS) {
+        return GeometrySerde.serGeoJson(
+                GeoToolsWrapper.transform(
+                        GeometrySerde.deserGeoJson(geometry),
+                        sourceCRS,
+                        targetCRS
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry", "sourceCRS", "targetCRS", "lenient"}, argTypes = {"Geometry", "String", "String", "boolean"}, returnTypes = "Geometry")
+    public static String ST_Transform(String geometry, String sourceCRS, String targetCRS, boolean lenient) {
+        return GeometrySerde.serGeoJson(
+                GeoToolsWrapper.transform(
+                        GeometrySerde.deserGeoJson(geometry),
+                        sourceCRS,
+                        targetCRS,
+                        lenient
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"leftGeom", "rightGeom"}, argTypes = {"Geometry", "Geometry"}, returnTypes = "Geometry")
+    public static String ST_Union(String leftGeom, String rightGeom) {
+        return GeometrySerde.serGeoJson(
+                Functions.union(
+                        GeometrySerde.deserGeoJson(leftGeom),
+                        GeometrySerde.deserGeoJson(rightGeom)
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"leftGeometry", "rightGeometry"}, argTypes = {"Geometry", "Geometry"})
+    public static boolean ST_Within(String leftGeometry, String rightGeometry) {
+        return Predicates.within(
+                GeometrySerde.deserGeoJson(leftGeometry),
+                GeometrySerde.deserGeoJson(rightGeometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"})
+    public static Double ST_X(String geometry) {
+        return Functions.x(
+                GeometrySerde.deserGeoJson(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"})
+    public static double ST_XMax(String geometry) {
+        return Functions.xMax(
+                GeometrySerde.deserGeoJson(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"})
+    public static double ST_XMin(String geometry) {
+        return Functions.xMin(
+                GeometrySerde.deserGeoJson(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"})
+    public static Double ST_Y(String geometry) {
+        return Functions.y(
+                GeometrySerde.deserGeoJson(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"})
+    public static double ST_YMax(String geometry) {
+        return Functions.yMax(
+                GeometrySerde.deserGeoJson(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"})
+    public static double ST_YMin(String geometry) {
+        return Functions.yMin(
+                GeometrySerde.deserGeoJson(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"})
+    public static Double ST_Z(String geometry) {
+        return Functions.z(
+                GeometrySerde.deserGeoJson(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"})
+    public static Double ST_ZMax(String geometry) {
+        return Functions.zMax(
+                GeometrySerde.deserGeoJson(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"})
+    public static Double ST_ZMin(String geometry) {
+        return Functions.zMin(
+                GeometrySerde.deserGeoJson(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"})
+    public static Double ST_AreaSpheroid(String geometry) {
+        return Spheroid.area(
+                GeometrySerde.deserGeoJson(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geomA", "geomB"}, argTypes = {"Geometry", "Geometry"})
+    public static Double ST_DistanceSphere(String geomA, String geomB) {
+        return Haversine.distance(
+                GeometrySerde.deserGeoJson(geomA),
+                GeometrySerde.deserGeoJson(geomB)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geomA", "geomB", "radius"}, argTypes = {"Geometry", "Geometry", "double"})
+    public static Double ST_DistanceSphere(String geomA, String geomB, double radius) {
+        return Haversine.distance(
+                GeometrySerde.deserGeoJson(geomA),
+                GeometrySerde.deserGeoJson(geomB),
+                radius
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geomA", "geomB"}, argTypes = {"Geometry", "Geometry"})
+    public static Double ST_DistanceSpheroid(String geomA, String geomB) {
+        return Spheroid.distance(
+                GeometrySerde.deserGeoJson(geomA),
+                GeometrySerde.deserGeoJson(geomB)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geom", "zValue"}, argTypes = {"Geometry", "double"}, returnTypes = "Geometry")
+    public static String ST_Force3D(String geom, double zValue) {
+        return GeometrySerde.serGeoJson(
+                Functions.force3D(
+                        GeometrySerde.deserGeoJson(geom),
+                        zValue
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geom"}, argTypes = {"Geometry"}, returnTypes = "Geometry")
+    public static String ST_Force3D(String geom) {
+        return GeometrySerde.serGeoJson(
+                Functions.force3D(
+                        GeometrySerde.deserGeoJson(geom)
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geom"}, argTypes = {"Geometry"})
+    public static double ST_LengthSpheroid(String geom) {
+        return Spheroid.length(
+                GeometrySerde.deserGeoJson(geom)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geom"}, argTypes = {"Geometry"}, returnTypes = "Geometry")
+    public static String ST_GeometricMedian(String geom) throws Exception {
+        return GeometrySerde.serGeoJson(
+                Functions.geometricMedian(
+                        GeometrySerde.deserGeoJson(geom)
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geom", "tolerance"}, argTypes = {"Geometry", "float"}, returnTypes = "Geometry")
+    public static String ST_GeometricMedian(String geom, float tolerance) throws Exception {
+        return GeometrySerde.serGeoJson(
+                Functions.geometricMedian(
+                        GeometrySerde.deserGeoJson(geom),
+                        tolerance
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geom", "tolerance", "maxIter"}, argTypes = {"Geometry", "float", "int"}, returnTypes = "Geometry")
+    public static String ST_GeometricMedian(String geom, float tolerance, int maxIter) throws Exception {
+        return GeometrySerde.serGeoJson(
+                Functions.geometricMedian(
+                        GeometrySerde.deserGeoJson(geom),
+                        tolerance,
+                        maxIter
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geom"}, argTypes = {"Geometry"})
+    public static int ST_NRings(String geom) throws Exception {
+        return Functions.nRings(
+                GeometrySerde.deserGeoJson(geom)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geom"}, argTypes = {"Geometry"})
+    public static int ST_NumPoints(String geom) throws Exception {
+        return Functions.numPoints(
+                GeometrySerde.deserGeoJson(geom)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geom", "deltaX", "deltaY"}, argTypes = {"Geometry", "double", "double"}, returnTypes = "Geometry")
+    public static String ST_Translate(String geom, double deltaX, double deltaY) {
+        return GeometrySerde.serGeoJson(
+                Functions.translate(
+                        GeometrySerde.deserGeoJson(geom),
+                        deltaX,
+                        deltaY
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geom", "deltaX", "deltaY", "deltaZ"}, argTypes = {"Geometry", "double", "double", "double"}, returnTypes = "Geometry")
+    public static String ST_Translate(String geom, double deltaX, double deltaY, double deltaZ) {
+        return GeometrySerde.serGeoJson(
+                Functions.translate(
+                        GeometrySerde.deserGeoJson(geom),
+                        deltaX,
+                        deltaY,
+                        deltaZ
+                )
+        );
+    }
+}

--- a/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/UDFsV2.java
+++ b/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/UDFsV2.java
@@ -27,7 +27,8 @@ import java.io.IOException;
  * User defined functions for Apache Sedona
  * This class is used to generate DDL for Snowflake UDFs
  * Different from UDFs.java, this class only contains functions can directly interact with Snowflake
- * native functions. This means no Constructors (ST_GeomFromXXX).
+ * native functions. This means no Constructors (ST_GeomFromXXX). Technically any ST functions that do not take
+ * geometry as input are ignored here. The trick here is to overload the functions in UDFs.java and UDFsV2.java.
  * This requires all functions must take a GeoJSON string as input and return a GeoJSON string as output.
  */
 public class UDFsV2
@@ -321,6 +322,15 @@ public class UDFsV2
 
     @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"}, returnTypes = "Geometry")
     public static String ST_Force_2D(String geometry) {
+        return GeometrySerde.serGeoJson(
+                Functions.force2D(
+                        GeometrySerde.deserGeoJson(geometry)
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"}, returnTypes = "Geometry")
+    public static String ST_Force2D(String geometry) {
         return GeometrySerde.serGeoJson(
                 Functions.force2D(
                         GeometrySerde.deserGeoJson(geometry)
@@ -642,10 +652,10 @@ public class UDFsV2
     }
 
     @UDFAnnotations.ParamMeta(argNames = {"input", "level"}, argTypes = {"Geometry", "int"})
-    public static long[] ST_S2CellIDs(byte[] input, int level) {
+    public static long[] ST_S2CellIDs(String input, int level) {
         return TypeUtils.castLong(
                 Functions.s2CellIDs(
-                        GeometrySerde.deserialize(input),
+                        GeometrySerde.deserGeoJson(input),
                         level
                 )
         );

--- a/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/annotations/UDFAnnotations.java
+++ b/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/annotations/UDFAnnotations.java
@@ -37,8 +37,16 @@ public class UDFAnnotations {
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.METHOD)
     public static @interface ParamMeta {
+        // Arg names are always required
         String[] argNames();
+        // Arg types are optional. If not specified, Reflection is used to get the type name
+        // This is required for Snowflake Geometry type which is serialized as a Java String type when UDF
+        // is called from Snowflake.
+        // If specified, the length of argTypes must match the length of argNames
+        // If specified, the type name must be one of the keys in Constants.snowflakeTypeMap
         String[] argTypes() default {};
+        // Return types are optional. If not specified, Reflection is used to get the type name
+        // This is required for Snowflake Geometry type which is serialized as a Java String type when UDF
         String returnTypes() default "";
     }
 }

--- a/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/annotations/UDFAnnotations.java
+++ b/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/annotations/UDFAnnotations.java
@@ -38,6 +38,7 @@ public class UDFAnnotations {
     @Target(ElementType.METHOD)
     public static @interface ParamMeta {
         String[] argNames();
-
+        String[] argTypes() default {};
+        String returnTypes() default "";
     }
 }

--- a/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/annotations/UDTFAnnotations.java
+++ b/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/annotations/UDTFAnnotations.java
@@ -40,5 +40,14 @@ public class UDTFAnnotations {
         String name();
 
         String[] argNames();
+        // Arg types are optional. If not specified, Reflection is used to get the type name
+        // This is required for Snowflake Geometry type which is serialized as a Java String type when UDF
+        // is called from Snowflake.
+        // If specified, the length of argTypes must match the length of argNames
+        // If specified, the type name must be one of the keys in Constants.snowflakeTypeMap
+        String[] argTypes() default {};
+        // Return types are optional. If not specified, Reflection is used to get the type name
+        // This is required for Snowflake Geometry type which is serialized as a Java String type when UDF
+        String returnTypes() default "";
     }
 }

--- a/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/ddl/ArgSpecBuilder.java
+++ b/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/ddl/ArgSpecBuilder.java
@@ -19,19 +19,20 @@ public class ArgSpecBuilder
 {
     /**
      * Build argument spec for a function. Format: argName1 argType1, argName2 argType2, ...
-     * @param paramTypes
+     * @param argTypesRaw
      * @param argNames
      * @return
      */
-    public static String args(Parameter[] paramTypes, String[] argNames){
+    public static String args(Parameter[] argTypesRaw, String[] argNames, String[] argTypesCustom){
         StringBuilder argTypesBuilder = new StringBuilder();
-        for (int it = 0; it < paramTypes.length; it++) {
+        for (int it = 0; it < argTypesRaw.length; it++) {
             argTypesBuilder.append(String.format(
                     "%s %s",
                     argNames[it],
-                    Constants.snowflakeTypeMap.get(paramTypes[it].getType().getTypeName())
+                    // Use the argTypes array if types are manually specified, otherwise use Reflection to get the type name
+                    Constants.snowflakeTypeMap.get(argTypesCustom.length == 0?argTypesRaw[it].getType().getTypeName():argTypesCustom[it])
             ));
-            if (it + 1 != paramTypes.length) {
+            if (it + 1 != argTypesRaw.length) {
                 argTypesBuilder.append(", ");
             }
         }
@@ -41,17 +42,18 @@ public class ArgSpecBuilder
 
     /**
      * Build argument spec for a function. Format: argType1, argType2, ...
-     * @param paramTypes
+     * @param argTypesRaw
      * @return
      */
-    public static String argTypes(Parameter[] paramTypes){
+    public static String argTypes(Parameter[] argTypesRaw, String[] argTypesCustom){
         StringBuilder argTypesBuilder = new StringBuilder();
-        for (int it = 0; it < paramTypes.length; it++) {
+        for (int it = 0; it < argTypesRaw.length; it++) {
             argTypesBuilder.append(String.format(
                     "%s",
-                    Constants.snowflakeTypeMap.get(paramTypes[it].getType().getTypeName())
+                    // Use the argTypes array if types are manually specified, otherwise use Reflection to get the type name
+                    Constants.snowflakeTypeMap.get(argTypesCustom.length == 0?argTypesRaw[it].getType().getTypeName():argTypesCustom[it])
             ));
-            if (it + 1 != paramTypes.length) {
+            if (it + 1 != argTypesRaw.length) {
                 argTypesBuilder.append(", ");
             }
         }

--- a/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/ddl/Constants.java
+++ b/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/ddl/Constants.java
@@ -21,6 +21,7 @@ public class Constants {
 
     static {
         snowflakeTypeMap.put(String.class.getTypeName(), "VARCHAR");
+        snowflakeTypeMap.put("String", "VARCHAR");
         snowflakeTypeMap.put(byte[].class.getTypeName(), "BINARY");
         snowflakeTypeMap.put(long.class.getTypeName(), "NUMBER");
         snowflakeTypeMap.put(Long.class.getTypeName(), "NUMBER");
@@ -34,6 +35,7 @@ public class Constants {
         snowflakeTypeMap.put(Double.class.getTypeName(), "DOUBLE");
         snowflakeTypeMap.put(float.class.getTypeName(), "FLOAT");
         snowflakeTypeMap.put(Float.class.getTypeName(), "FLOAT");
+        snowflakeTypeMap.put("Geometry", "GEOMETRY");
     }
 
     public static String SEDONA_VERSION = "sedona_version";

--- a/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/ddl/DDLGenerator.java
+++ b/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/ddl/DDLGenerator.java
@@ -40,7 +40,7 @@ public class DDLGenerator {
             }
         }
         // add sedona version to argMap. This fetches value from pom.xml and only works when running from the terminal
-        argMap.put(Constants.SEDONA_VERSION, DDLGenerator.class.getPackage().getImplementationVersion());
+        argMap.put(Constants.SEDONA_VERSION, DDLGenerator.class.getPackage().getImplementationVersion() == null ? "unknown" : DDLGenerator.class.getPackage().getImplementationVersion());
         try {
             assert argMap.containsKey(Constants.GEOTOOLS_VERSION);
         } catch (AssertionError e) {

--- a/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/ddl/UDFDDLGenerator.java
+++ b/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/ddl/UDFDDLGenerator.java
@@ -14,6 +14,7 @@
 package org.apache.sedona.snowflake.snowsql.ddl;
 
 import org.apache.sedona.snowflake.snowsql.UDFs;
+import org.apache.sedona.snowflake.snowsql.UDFsV2;
 import org.apache.sedona.snowflake.snowsql.annotations.UDFAnnotations;
 
 import java.io.BufferedReader;
@@ -33,26 +34,33 @@ public class UDFDDLGenerator {
         return UDFs.class.getDeclaredMethods();
     }
 
+    public static Method[] udfV2Methods() {
+        return UDFsV2.class.getDeclaredMethods();
+    }
+
     public static String buildUDFDDL(Method method, Map<String, String> configs, String stageName, boolean isNativeApp, String appRoleName) {
         if (!method.isAnnotationPresent(UDFAnnotations.ParamMeta.class)) {
             throw new RuntimeException("Missing ParamMeta annotation for method: " + method.getName());
         }
-        String[] args = method.getAnnotation(UDFAnnotations.ParamMeta.class).argNames();
-        Parameter[] argTypes = method.getParameters();
+        String[] argNames = method.getAnnotation(UDFAnnotations.ParamMeta.class).argNames();
+        Parameter[] argTypesRaw = method.getParameters();
+        String argTypesCustom[] = method.getAnnotation(UDFAnnotations.ParamMeta.class).argTypes();
         // generate return type
-        String returnType = Constants.snowflakeTypeMap.get(method.getReturnType().getTypeName());
+        String returnType = Constants.snowflakeTypeMap.get(method.getAnnotation(UDFAnnotations.ParamMeta.class).returnTypes().isEmpty() ? method.getReturnType().getTypeName()
+                : method.getAnnotation(UDFAnnotations.ParamMeta.class).returnTypes());
         if (returnType == null) {
             throw new RuntimeException("Unsupported type: " + method.getReturnType().getTypeName());
         }
-        String handlerName = UDFs.class.getPackage().getName() + "." + UDFs.class.getSimpleName() + "." + method.getName();
+        String handlerName = method.getDeclaringClass().getName() + "." + method.getName();
         // check some function attributes
         String null_input_conf = method.isAnnotationPresent(UDFAnnotations.CallOnNull.class) ? "CALLED ON NULL INPUT" : "RETURNS NULL ON NULL INPUT";
         String immutable_conf = method.isAnnotationPresent(UDFAnnotations.Volatile.class) ? "VOLATILE" : "IMMUTABLE";
         return formatUDFDDL(
                 method.getName(),
                 configs.getOrDefault("schema", "sedona"),
-                argTypes,
-                args,
+                argTypesRaw,
+                argNames,
+                argTypesCustom,
                 returnType,
                 stageName,
                 handlerName,
@@ -72,14 +80,20 @@ public class UDFDDLGenerator {
                 ddlList.add(buildUDFDDL(method, configs, stageName, isNativeApp, appRoleName));
             }
         }
+        for (Method method : udfV2Methods()) {
+            if (method.getModifiers() == (Modifier.PUBLIC | Modifier.STATIC)) {
+                ddlList.add(buildUDFDDL(method, configs, stageName, isNativeApp, appRoleName));
+            }
+        }
         return ddlList;
     }
 
     public static String formatUDFDDL(
             String functionName,
             String schemaName,
-            Parameter[] argTypes,
+            Parameter[] argTypesRaw,
             String[] argNames,
+            String[] argTypesCustom,
             String returnType,
             String stageName,
             String handlerName,
@@ -100,7 +114,7 @@ public class UDFDDLGenerator {
         ).replace(
                 "{KW_SCHEMA_NAME}", schemaName
         ).replace(
-                "{KW_ARG_SPEC}", ArgSpecBuilder.args(argTypes, argNames)
+                "{KW_ARG_SPEC}", ArgSpecBuilder.args(argTypesRaw, argNames, argTypesCustom)
         ).replace(
                 "{KW_RETURN_TYPE}", returnType
         ).replace(
@@ -118,7 +132,7 @@ public class UDFDDLGenerator {
         );
         if (isNativeApp) {
             ddl += "\n";
-            ddl += "GRANT USAGE ON FUNCTION " + schemaName + "." + functionName + "(" + ArgSpecBuilder.argTypes(argTypes) + ") TO APPLICATION ROLE " + appRoleName + ";";
+            ddl += "GRANT USAGE ON FUNCTION " + schemaName + "." + functionName + "(" + ArgSpecBuilder.argTypes(argTypesRaw, argTypesCustom) + ") TO APPLICATION ROLE " + appRoleName + ";";
         }
         return ddl;
     }

--- a/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/ddl/UDTFDDLGenerator.java
+++ b/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/ddl/UDTFDDLGenerator.java
@@ -31,7 +31,11 @@ public class UDTFDDLGenerator {
             ST_Envelope_Aggr.class,
             ST_Union_Aggr.class,
             ST_Collect.class,
-            ST_Dump.class
+            ST_Dump.class,
+            // ST_SubDivideExplodeV2 is not supported in Snowflake.
+            // The error message is "java.lang.RuntimeException: net.snowflake.client.jdbc.SnowflakeSQLException: Data type GEOMETRY is not supported in non-SQL UDTF return type."
+            // Keep this comment here for future reference.
+//            ST_SubDivideExplodeV2.class
     };
 
     public static String formatUDTFDDL(
@@ -39,6 +43,7 @@ public class UDTFDDLGenerator {
             String schemaName,
             Parameter[] argTypesRaw,
             String[] argNames,
+            String[] argTypesCustom,
             String returnType,
             String stageName,
             String handlerName,
@@ -59,7 +64,7 @@ public class UDTFDDLGenerator {
         ).replace(
                 "{KW_SCHEMA_NAME}", schemaName
         ).replace(
-                "{KW_ARG_SPEC}", ArgSpecBuilder.args(argTypesRaw, argNames, new String[]{})
+                "{KW_ARG_SPEC}", ArgSpecBuilder.args(argTypesRaw, argNames, argTypesCustom)
         ).replace(
                 "{KW_RETURN_TYPE}", returnType
         ).replace(
@@ -77,7 +82,7 @@ public class UDTFDDLGenerator {
         );
         if (isNativeApp) {
             ddl += "\n";
-            ddl += "GRANT USAGE ON FUNCTION " + schemaName + "." + functionName + "(" + ArgSpecBuilder.argTypes(argTypesRaw, new String[]{}) + ") TO APPLICATION ROLE " + appRoleName + ";";
+            ddl += "GRANT USAGE ON FUNCTION " + schemaName + "." + functionName + "(" + ArgSpecBuilder.argTypes(argTypesRaw, argTypesCustom) + ") TO APPLICATION ROLE " + appRoleName + ";";
         }
         return ddl;
     }
@@ -88,20 +93,23 @@ public class UDTFDDLGenerator {
         Class outputRowClass = Arrays.stream(c.getDeclaredClasses()).filter(
                 cls -> cls.getName().endsWith("OutputRow")
         ).findFirst().get();
-        String returnTypes = Arrays.stream(outputRowClass.getFields()).map(
-                field -> field.getName() + " " + Constants.snowflakeTypeMap.get(field.getType().getTypeName())
-        ).collect(Collectors.joining(", "));
+
         Method processMethod = Arrays.stream(c.getDeclaredMethods()).filter(m -> m.getName().equals("process")).findFirst().get();
-        Parameter[] paramTypes = processMethod.getParameters();
+        Parameter[] argTypesRaw = processMethod.getParameters();
         String[] argNames = funcProps.argNames();
+        String[] argTypesCustom = funcProps.argTypes();
+        String returnTypes = Arrays.stream(outputRowClass.getFields()).map(
+                field -> field.getName() + " " + Constants.snowflakeTypeMap.get(funcProps.returnTypes().isEmpty()? field.getType().getTypeName() : funcProps.returnTypes())
+        ).collect(Collectors.joining(", "));
         String handlerName = c.getPackage().getName() + "." + c.getSimpleName();
         String null_input_conf = c.isAnnotationPresent(UDTFAnnotations.CallOnNull.class) ? "CALLED ON NULL INPUT" : "RETURNS NULL ON NULL INPUT";
         String immutable_conf = c.isAnnotationPresent(UDTFAnnotations.Volatile.class) ? "VOLATILE" : "IMMUTABLE";
         return formatUDTFDDL(
                 funcProps.name(),
                 configs.getOrDefault("schema", "sedona"),
-                paramTypes,
+                argTypesRaw,
                 argNames,
+                argTypesCustom,
                 returnTypes,
                 stageName,
                 handlerName,

--- a/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/ddl/UDTFDDLGenerator.java
+++ b/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/ddl/UDTFDDLGenerator.java
@@ -37,7 +37,7 @@ public class UDTFDDLGenerator {
     public static String formatUDTFDDL(
             String functionName,
             String schemaName,
-            Parameter[] argTypes,
+            Parameter[] argTypesRaw,
             String[] argNames,
             String returnType,
             String stageName,
@@ -59,7 +59,7 @@ public class UDTFDDLGenerator {
         ).replace(
                 "{KW_SCHEMA_NAME}", schemaName
         ).replace(
-                "{KW_ARG_SPEC}", ArgSpecBuilder.args(argTypes, argNames)
+                "{KW_ARG_SPEC}", ArgSpecBuilder.args(argTypesRaw, argNames, new String[]{})
         ).replace(
                 "{KW_RETURN_TYPE}", returnType
         ).replace(
@@ -77,7 +77,7 @@ public class UDTFDDLGenerator {
         );
         if (isNativeApp) {
             ddl += "\n";
-            ddl += "GRANT USAGE ON FUNCTION " + schemaName + "." + functionName + "(" + ArgSpecBuilder.argTypes(argTypes) + ") TO APPLICATION ROLE " + appRoleName + ";";
+            ddl += "GRANT USAGE ON FUNCTION " + schemaName + "." + functionName + "(" + ArgSpecBuilder.argTypes(argTypesRaw, new String[]{}) + ") TO APPLICATION ROLE " + appRoleName + ";";
         }
         return ddl;
     }

--- a/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/udtfs/ST_SubDivideExplodeV2.java
+++ b/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/udtfs/ST_SubDivideExplodeV2.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sedona.snowflake.snowsql.udtfs;
+
+import org.apache.sedona.common.Functions;
+import org.apache.sedona.snowflake.snowsql.GeometrySerde;
+import org.apache.sedona.snowflake.snowsql.annotations.UDTFAnnotations;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.io.ParseException;
+
+import java.util.stream.Stream;
+
+/**
+ * This class is a copy of ST_SubDivideExplode.java, but with the input and output types changed to Snowflake Geometry
+ * Unfortunately, Data type GEOMETRY is not supported in non-SQL UDTF return type.
+ * Just keep this class here for future reference.
+ * The error message is "java.lang.RuntimeException: net.snowflake.client.jdbc.SnowflakeSQLException: Data type GEOMETRY is not supported in non-SQL UDTF return type."
+ */
+@UDTFAnnotations.TabularFunc(name = "ST_SubDivideExplode", argNames = {"geom", "maxVertices"}, argTypes = {"Geometry", "int"}, returnTypes = "Geometry")
+public class ST_SubDivideExplodeV2
+{
+
+    public static final GeometryFactory geometryFactory = new GeometryFactory();
+
+    public static class OutputRow {
+
+        public String geom;
+
+        public OutputRow(String geom) {
+            this.geom = geom;
+        }
+    }
+
+    public static Class getOutputClass() {
+        return OutputRow.class;
+    }
+
+    public ST_SubDivideExplodeV2() {
+    }
+
+    public Stream<OutputRow> process(String geometry, int maxVertices) throws ParseException {
+        Geometry[] geometries = Functions.subDivide(
+                GeometrySerde.deserGeoJson(geometry),
+                maxVertices
+        );
+        return Stream.of(geometries).map(g -> new OutputRow(GeometrySerde.serGeoJson(g)));
+    }
+}


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-459. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Added UDFsV2 which overload all ST functions with native Snowflake Geometry type. Now SedonaSnow functions can directly interact with Snowflake native ST functions. Users can mix-match Sedona / Snowflake ST functions together in the same SQL query, without additional WKB serialization like Snowflake `ST_AsWKB` and `to_geometry`

Example:

```
SELECT ST_AsText(SEDONA.ST_ReducePrecision(ST_GeometryFromWKT('POINT(1.123456789 2.123456789)'), 3))
```

In this example, `SEDONA.ST_ReducePrecision` is the Sedona UDF, ST_AsText and ST_GeometryFromWKT are Snowflake native functions.

However, due to the limitation imposed by Snowflake, the following functions cannot directly interact with Snowflake native functions because they cannot be overloaded or supported. However, **Users still can use Snowflake `ST_AsWKB` and `to_geometry` to interact with these Sedona functions.**

### Functions that cannot be overloaded by Snowflake

Any ST functions that only use primitive types as input excluding `Geometry` type. All ST constructors cannot be overloaded.

For example, `ST_GeomFromWKT`, `ST_Point`.

### Functions that have incorrect behavior

Snowflake natively serializes Geometry type data to GeoJSON String and sends to UDF as input. GeoJSON spec does not include SRID. So the SRID information will be lost if you mix-match Snowflake functions and Sedona functions directly without using `WKB`.

Example:

```
SELECT ST_AsEWKT(SEDONA.ST_SetSRID(ST_GeometryFromWKT('POINT(1 2)'), 4326))
```

Output:

`SRID=0;POINT(1 2)`

`SRID=4326` is lost.

### Functions that are not supported by Snowflake

All User Defined Table Functions are not supported due to Snowflake current limitation `Data type GEOMETRY is not supported in non-SQL UDTF return type`.

This includes 

* ST_MinimumBoundingRadius
* ST_Intersection_Aggr
* ST_SubDivideExplode
* ST_Envelope_Aggr
* ST_Union_Aggr
* ST_Collect
* ST_Dump

## How was this patch tested?

Tested by sedona-snowflake-tester:https://github.com/wherobots/sedona-snowflake-tester/pull/9

## Did this PR include necessary documentation updates?

Docs will be added in PR 4/4
