### PR TITLE
[SEDONA-459] Open-source Sedona Snowflake (SedonaSnow): Add new ST functions added in 1.5.0 and 1.5.1. PR 3/4

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/Functions.java
+++ b/common/src/main/java/org/apache/sedona/common/Functions.java
@@ -463,7 +463,20 @@ public class Functions {
     }
 
     public static boolean isValid(Geometry geometry) {
-        return new IsValidOp(geometry).isValid();
+        return isValid(geometry, OGC_SFS_VALIDITY);
+    }
+
+    public static boolean isValid(Geometry geom, int flags) {
+        IsValidOp isValidOp = new IsValidOp(geom);
+
+        // Set the validity model based on flags
+        if (flags == ESRI_VALIDITY) {
+            isValidOp.setSelfTouchingRingFormingHoleValid(true);
+        } else {
+            isValidOp.setSelfTouchingRingFormingHoleValid(false);
+        }
+
+        return isValidOp.isValid();
     }
 
     public static Geometry addPoint(Geometry linestring, Geometry point) {
@@ -1268,11 +1281,11 @@ public class Functions {
         return GeomUtils.toDegrees(angleInRadian);
     }
 
-    public static Double hausdorffDistance(Geometry g1, Geometry g2, double densityFrac) throws Exception {
+    public static Double hausdorffDistance(Geometry g1, Geometry g2, double densityFrac) {
         return GeomUtils.getHausdorffDistance(g1, g2, densityFrac);
     }
 
-    public static Double hausdorffDistance(Geometry g1, Geometry g2) throws Exception{
+    public static Double hausdorffDistance(Geometry g1, Geometry g2) {
         return GeomUtils.getHausdorffDistance(g1, g2, -1);
     }
 

--- a/common/src/main/java/org/apache/sedona/common/utils/GeomUtils.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/GeomUtils.java
@@ -516,7 +516,7 @@ public class GeomUtils {
         return DiscreteFrechetDistance.distance(g1, g2);
     }
 
-    public static Double getHausdorffDistance(Geometry g1, Geometry g2, double densityFrac) throws Exception {
+    public static Double getHausdorffDistance(Geometry g1, Geometry g2, double densityFrac) {
         if (g1.isEmpty() || g2.isEmpty()) return 0.0;
         DiscreteHausdorffDistance hausdorffDistanceObj = new DiscreteHausdorffDistance(g1, g2);
         if (densityFrac != -1) {

--- a/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctions.java
+++ b/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctions.java
@@ -28,6 +28,14 @@ import java.util.regex.Pattern;
 @RunWith(SnowTestRunner.class)
 public class TestFunctions extends TestBase {
     @Test
+    public void test_GeometryType() {
+        registerUDF("GeometryType", byte[].class);
+        verifySqlSingleRes(
+                "select sedona.GeometryType(sedona.ST_GeomFromText('POINT(1 2)'))",
+                "POINT"
+        );
+    }
+    @Test
     public void test_ST_3DDistance() {
         registerUDF("ST_3DDistance", byte[].class, byte[].class);
         verifySqlSingleRes(
@@ -41,6 +49,40 @@ public class TestFunctions extends TestBase {
         verifySqlSingleRes(
                 "select sedona.ST_AsText(sedona.ST_AddPoint(sedona.ST_GeomFromText('LINESTRING (0 0, 1 1)'), sedona.ST_GeomFromText('POINT (0 1)'), 1))",
                 "LINESTRING (0 0, 0 1, 1 1)"
+        );
+    }
+
+    @Test
+    public void test_ST_Affine() {
+        registerUDF("ST_Affine", byte[].class, double.class, double.class, double.class, double.class, double.class, double.class);
+        verifySqlSingleRes(
+                "select sedona.ST_AsText(sedona.ST_Affine(sedona.ST_GeomFromText('POINT (1 1)'), 2, 0, 0, 0, 2, 0))",
+                "POINT (4 0)"
+        );
+        registerUDF("ST_Affine", byte[].class, double.class, double.class, double.class, double.class, double.class, double.class,
+                double.class, double.class, double.class, double.class, double.class, double.class);
+        verifySqlSingleRes(
+                "select sedona.ST_AsText(sedona.ST_Affine(sedona.ST_GeomFromText('POINT (1 1)'), 2, 0, 0, 0, 2, 0, 0, 0, 1, 0, 0, 0))",
+                "POINT (2 2)"
+        );
+    }
+
+    @Test
+    public void test_ST_Angle() {
+        registerUDF("ST_Angle", byte[].class, byte[].class);
+        verifySqlSingleRes(
+                "select sedona.ST_Angle(sedona.ST_GeomFromText('LINESTRING (0 0, 1 1)'), sedona.ST_GeomFromText('LINESTRING (0 0, 1 0)'))",
+                0.7853981633974483
+        );
+        registerUDF("ST_Angle", byte[].class, byte[].class, byte[].class);
+        verifySqlSingleRes(
+                "select sedona.ST_Angle(sedona.ST_GeomFromText('POINT (1 1)'), sedona.ST_GeomFromText('POINT (2 2)'), sedona.ST_GeomFromText('POINT (3 3)'))",
+                3.141592653589793
+        );
+        registerUDF("ST_Angle", byte[].class, byte[].class, byte[].class, byte[].class);
+        verifySqlSingleRes(
+                "select sedona.ST_Angle(sedona.ST_GeomFromText('POINT (1 1)'), sedona.ST_GeomFromText('POINT (2 2)'), sedona.ST_GeomFromText('POINT (3 3)'), sedona.ST_GeomFromText('POINT (4 4)'))",
+                0.0
         );
     }
 
@@ -132,6 +174,15 @@ public class TestFunctions extends TestBase {
                 "MULTILINESTRING ((10 130, 50 190, 110 190, 140 150, 150 80, 100 10, 20 40, 10 130), (70 40, 100 50, 120 80, 80 110, 50 90, 70 40))"
         );
     }
+
+    @Test
+    public void test_ST_BoundingDiagonal() {
+        registerUDF("ST_BoundingDiagonal", byte[].class);
+        verifySqlSingleRes(
+                "select sedona.ST_AsText(sedona.ST_BoundingDiagonal(sedona.ST_GeomFromText('POLYGON (( 10 130, 50 190, 110 190, 140 150, 150 80, 100 10, 20 40, 10 130 ),( 70 40, 100 50, 120 80, 80 110, 50 90, 70 40 ))')))",
+                "LINESTRING (10 10, 150 190)"
+        );
+    }
     @Test
     public void test_ST_Buffer() {
         registerUDF("ST_Buffer", byte[].class, double.class);
@@ -157,6 +208,14 @@ public class TestFunctions extends TestBase {
         );
     }
     @Test
+    public void test_ST_ClosestPoint() {
+        registerUDF("ST_ClosestPoint", byte[].class, byte[].class);
+        verifySqlSingleRes(
+                "select sedona.ST_AsText(sedona.ST_ClosestPoint(sedona.ST_GeomFromText('POINT (1 1)'), sedona.ST_GeomFromText('LINESTRING (1 1, 2 2, 3 3)')))",
+                "POINT (1 1)"
+        );
+    }
+    @Test
     public void test_ST_CollectionExtract() {
         registerUDF("ST_CollectionExtract", byte[].class);
         verifySqlSingleRes(
@@ -178,6 +237,14 @@ public class TestFunctions extends TestBase {
         );
     }
     @Test
+    public void test_ST_CoordDim() {
+        registerUDF("ST_CoordDim", byte[].class);
+        verifySqlSingleRes(
+                "select sedona.ST_CoordDim(sedona.ST_GeomFromText('POLYGON((0 0, 0 10, 10 10, 10 0, 0 0))'))",
+                2
+        );
+    }
+    @Test
     public void test_ST_ConvexHull() {
         registerUDF("ST_ConvexHull", byte[].class);
         verifySqlSingleRes(
@@ -193,6 +260,25 @@ public class TestFunctions extends TestBase {
                 "POLYGON ((0 -3, -3 -3, -3 3, 0 3, 0 -3))"
         );
     }
+
+    @Test
+    public void test_ST_Degrees() {
+        registerUDF("ST_Degrees", double.class);
+        verifySqlSingleRes(
+                "select sedona.ST_Degrees(1)",
+                57.29577951308232
+        );
+    }
+
+    @Test
+    public void test_ST_Dimension() {
+        registerUDF("ST_Dimension", byte[].class);
+        verifySqlSingleRes(
+                "select sedona.ST_Dimension(sedona.ST_Point(1, 2))",
+                0
+        );
+    }
+
     @Test
     public void test_ST_Distance() {
         registerUDF("ST_Distance", byte[].class, byte[].class);
@@ -283,6 +369,16 @@ public class TestFunctions extends TestBase {
                 "ST_Point"
         );
     }
+
+    @Test
+    public void test_ST_HausdorffDistance() {
+        registerUDF("ST_HausdorffDistance", byte[].class, byte[].class);
+        verifySqlSingleRes(
+                "select sedona.ST_HausdorffDistance(sedona.ST_GeomFromText('LINESTRING(0 0, 1 1, 2 2)'), sedona.ST_GeomFromText('LINESTRING(0 0, 1 1, 3 3)'))",
+                1.4142135623730951
+        );
+    }
+
     @Test
     public void test_ST_InteriorRingN() {
         registerUDF("ST_InteriorRingN", byte[].class, int.class);
@@ -305,6 +401,18 @@ public class TestFunctions extends TestBase {
         verifySqlSingleRes(
                 "select sedona.ST_IsClosed(sedona.ST_GeomFromText('LINESTRING(0 0, 2 2)'))",
                 false
+        );
+    }
+    @Test
+    public void test_ST_IsCollection() {
+        registerUDF("ST_IsCollection", byte[].class);
+        verifySqlSingleRes(
+                "select sedona.ST_IsCollection(sedona.ST_GeomFromText('LINESTRING(0 0, 2 2)'))",
+                false
+        );
+        verifySqlSingleRes(
+                "select sedona.ST_IsCollection(sedona.ST_GeomFromText('GEOMETRYCOLLECTION(POINT(1 2), LINESTRING(1 2, 3 4))'))",
+                true
         );
     }
     @Test
@@ -346,7 +454,27 @@ public class TestFunctions extends TestBase {
                 "select sedona.ST_IsValid(sedona.ST_GeomFromText('POLYGON((0 0, 10 0, 10 10, 0 10, 0 0), (15 15, 15 20, 20 20, 20 15, 15 15))'))",
                 false
         );
+        registerUDF("ST_IsValid", byte[].class, int.class);
+        verifySqlSingleRes(
+                "select sedona.ST_IsValid(sedona.ST_GeomFromText('POLYGON((0 0, 10 0, 10 10, 0 10, 0 0), (15 15, 15 20, 20 20, 20 15, 15 15))'), 1)",
+                false
+        );
     }
+
+    @Test
+    public void test_ST_IsValidReason() {
+        registerUDF("ST_IsValidReason", byte[].class);
+        verifySqlSingleRes(
+                "select sedona.ST_IsValidReason(sedona.ST_GeomFromText('POLYGON((0 0, 10 0, 10 10, 0 10, 0 0), (15 15, 15 20, 20 20, 20 15, 15 15))'))",
+                "Hole lies outside shell at or near point (15.0, 15.0)"
+        );
+        registerUDF("ST_IsValidReason", byte[].class, int.class);
+        verifySqlSingleRes(
+                "select sedona.ST_IsValidReason(sedona.ST_GeomFromText('POLYGON((0 0, 10 0, 10 10, 0 10, 0 0), (15 15, 15 20, 20 20, 20 15, 15 15))'), 1)",
+                "Hole lies outside shell at or near point (15.0, 15.0)"
+        );
+    }
+
     @Test
     public void test_ST_Length() {
         registerUDF("ST_Length", byte[].class);
@@ -371,6 +499,16 @@ public class TestFunctions extends TestBase {
                 "POINT (51.5974135047432 76.5974135047432)"
         );
     }
+
+    @Test
+    public void test_ST_LineLocatePoint() {
+        registerUDF("ST_LineLocatePoint", byte[].class, byte[].class);
+        verifySqlSingleRes(
+                "select sedona.ST_LineLocatePoint(sedona.ST_GeomFromText('LINESTRING(0 0, 10 10)'), sedona.ST_GeomFromText('POINT(2 2)'))",
+                0.2
+        );
+    }
+
     @Test
     public void test_ST_LineMerge() {
         registerUDF("ST_LineMerge", byte[].class);
@@ -379,6 +517,21 @@ public class TestFunctions extends TestBase {
                 "LINESTRING (0 0, 1 1, 2 2)"
         );
     }
+
+    @Test
+    public void test_ST_MakeLine() {
+        registerUDF("ST_MakeLine", byte[].class, byte[].class);
+        verifySqlSingleRes(
+                "select sedona.ST_AsText(sedona.ST_MakeLine(sedona.ST_Point(1, 2), sedona.ST_Point(3, 4)))",
+                "LINESTRING (1 2, 3 4)"
+        );
+        registerUDF("ST_MakeLine", byte[].class);
+        verifySqlSingleRes(
+                "select sedona.ST_AsText(sedona.ST_MakeLine(sedona.ST_GeomFromText('GeometryCollection (POINT (1 2), POINT (3 4))')))",
+                "LINESTRING (1 2, 3 4)"
+        );
+    }
+
     @Test
     public void test_ST_LineSubstring() {
         registerUDF("ST_LineSubstring", byte[].class, double.class, double.class);
@@ -387,6 +540,27 @@ public class TestFunctions extends TestBase {
                 "LINESTRING (45.17311810399485 45.74337011202746, 50 20, 90 80, 112.97593050157862 49.36542599789519)"
         );
     }
+    @Test
+    public void test_ST_MakePoint() {
+        registerUDF("ST_MakePoint", double.class, double.class);
+        verifySqlSingleRes(
+                "select sedona.ST_AsText(sedona.ST_MakePoint(1, 2))",
+                "POINT (1 2)"
+        );
+        registerUDF("ST_MakePoint", double.class, double.class, double.class);
+        verifySqlSingleRes(
+                "select sedona.ST_AsText(sedona.ST_MakePoint(1, 2, 3))",
+                "POINT Z(1 2 3)"
+        );
+        // TODO: fix this when https://github.com/locationtech/jts/pull/734 gets merged.
+        // Sedona Snowflake uses WKB to serialize geometries, and JTS's WKBReader and Writer ignores M values.
+        registerUDF("ST_MakePoint", double.class, double.class, double.class, double.class);
+        verifySqlSingleRes(
+                "select sedona.ST_AsText(sedona.ST_MakePoint(1, 2, 3, 4))",
+                "POINT Z(1 2 3)"
+        );
+    }
+
     @Test
     public void test_ST_MakePolygon() {
         registerUDF("ST_MakePolygon", byte[].class);
@@ -494,6 +668,16 @@ public class TestFunctions extends TestBase {
                 "POINT (2.5 2.5)"
         );
     }
+    @Test
+    public void test_ST_Polygon() {
+        registerUDF("ST_Polygon", byte[].class, int.class);
+        registerUDF("ST_AsEWKT", byte[].class);
+        verifySqlSingleRes(
+                "select sedona.ST_AsEWKT(sedona.ST_Polygon(sedona.ST_GeomFromText('LINESTRING(0 0, 0 1, 1 1, 1 0, 0 0)'), 4326))",
+                "SRID=4326;POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))"
+        );
+    }
+
     @Test
     public void test_ST_PrecisionReduce() {
         registerUDF("ST_PrecisionReduce", byte[].class, int.class);
@@ -612,6 +796,26 @@ public class TestFunctions extends TestBase {
                 "POLYGON ((2 3, 3 3, 3 -3, -3 -3, -3 3, -2 3, -2 4, 2 4, 2 3))"
         );
     }
+
+    @Test
+    public void test_ST_VoronoiPolygons() {
+        registerUDF("ST_VoronoiPolygons", byte[].class);
+        registerUDF("ST_VoronoiPolygons", byte[].class, double.class);
+        registerUDF("ST_VoronoiPolygons", byte[].class, double.class, byte[].class);
+        verifySqlSingleRes(
+                "select sedona.ST_AsText(sedona.ST_VoronoiPolygons(sedona.ST_GeomFromText('MULTIPOINT ((0 0), (1 1))')))",
+                "GEOMETRYCOLLECTION (POLYGON ((-1 -1, -1 2, 2 -1, -1 -1)), POLYGON ((-1 2, 2 2, 2 -1, -1 2)))"
+        );
+        verifySqlSingleRes(
+                "select sedona.ST_AsText(sedona.ST_VoronoiPolygons(sedona.ST_GeomFromText('MULTIPOINT ((0 0), (1 1))'), 1))",
+                "GEOMETRYCOLLECTION (POLYGON ((-1 -1, -1 2, 2 -1, -1 -1)), POLYGON ((-1 2, 2 2, 2 -1, -1 2)))"
+        );
+        verifySqlSingleRes(
+                "select sedona.ST_AsText(sedona.ST_VoronoiPolygons(sedona.ST_GeomFromText('MULTIPOINT ((0 0), (1 1))'), 1, sedona.ST_GeomFromText('POLYGON ((-1 -1, -1 2, 2 -1, -1 -1))')))",
+                "GEOMETRYCOLLECTION (POLYGON ((-1 -1, -1 2, 2 -1, -1 -1)), POLYGON ((-1 2, 2 2, 2 -1, -1 2)))"
+        );
+    }
+
     @Test
     public void test_ST_X() {
         registerUDF("ST_X", byte[].class);
@@ -726,6 +930,15 @@ public class TestFunctions extends TestBase {
         verifySqlSingleRes(
                 "SELECT sedona.ST_DistanceSpheroid(sedona.ST_GeomFromWKT('POINT (-0.56 51.3168)'), sedona.ST_GeomFromWKT('POINT (-3.1883 55.9533)'))",
                 544430.9411996207
+        );
+    }
+
+    @Test
+    public void test_ST_FrechetDistance() {
+        registerUDF("ST_FrechetDistance", byte[].class, byte[].class);
+        verifySqlSingleRes(
+                "SELECT sedona.ST_FrechetDistance(sedona.ST_GeomFromWKT('LINESTRING (0 0, 1 1, 2 2)'), sedona.ST_GeomFromWKT('LINESTRING (0 0, 1 1, 3 3)'))",
+                1.4142135623730951
         );
     }
 

--- a/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctions.java
+++ b/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctions.java
@@ -251,6 +251,15 @@ public class TestFunctions extends TestBase {
         );
     }
     @Test
+    public void test_ST_Force2D() {
+        registerUDF("ST_PointZ", double.class, double.class, double.class);
+        registerUDF("ST_Force2D", byte[].class);
+        verifySqlSingleRes(
+                "select sedona.ST_AsText(sedona.ST_Force2D(sedona.ST_POINTZ(1, 2, 3)))",
+                "POINT (1 2)"
+        );
+    }
+    @Test
     public void test_ST_GeoHash() {
         registerUDF("ST_GeoHash", byte[].class, int.class);
         verifySqlSingleRes(

--- a/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctionsV2.java
+++ b/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctionsV2.java
@@ -28,7 +28,14 @@ import java.util.regex.Pattern;
 @RunWith(SnowTestRunner.class)
 public class TestFunctionsV2
         extends TestBase {
-
+    @Test
+    public void test_GeometryType() {
+        registerUDFV2("GeometryType", String.class);
+        verifySqlSingleRes(
+                "select sedona.GeometryType(ST_GeometryFromWKT('POINT(1 2)'))",
+                "POINT"
+        );
+    }
     @Test
     public void test_ST_3DDistance() {
         registerUDFV2("ST_3DDistance", String.class, String.class);
@@ -44,6 +51,40 @@ public class TestFunctionsV2
         verifySqlSingleRes(
                 "select ST_AsText(sedona.ST_AddPoint(ST_GeometryFromWKT('LINESTRING (0 0, 1 1)'), ST_GeometryFromWKT('POINT (0 1)'), 1))",
                 "LINESTRING(0 0,0 1,1 1)"
+        );
+    }
+
+    @Test
+    public void test_ST_Affine() {
+        registerUDFV2("ST_Affine", String.class, double.class, double.class, double.class, double.class, double.class, double.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_Affine(ST_GeometryFromWKT('POINT (1 1)'), 2, 0, 0, 0, 2, 0))",
+                "POINT(4 0)"
+        );
+        registerUDFV2("ST_Affine", String.class, double.class, double.class, double.class, double.class, double.class, double.class,
+                double.class, double.class, double.class, double.class, double.class, double.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_Affine(ST_GeometryFromWKT('POINT (1 1)'), 2, 0, 0, 0, 2, 0, 0, 0, 1, 0, 0, 0))",
+                "POINT(2 2)"
+        );
+    }
+
+    @Test
+    public void test_ST_Angle() {
+        registerUDFV2("ST_Angle", String.class, String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_Angle(ST_GeometryFromWKT('LINESTRING (0 0, 1 1)'), ST_GeometryFromWKT('LINESTRING (0 0, 1 0)'))",
+                0.7853981633974483
+        );
+        registerUDFV2("ST_Angle", String.class, String.class, String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_Angle(ST_GeometryFromWKT('POINT (1 1)'), ST_GeometryFromWKT('POINT (2 2)'),ST_GeometryFromWKT('POINT (3 3)'))",
+                3.141592653589793
+        );
+        registerUDFV2("ST_Angle", String.class, String.class, String.class, String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_Angle(ST_GeometryFromWKT('POINT (1 1)'), ST_GeometryFromWKT('POINT (2 2)'), ST_GeometryFromWKT('POINT (3 3)'), ST_GeometryFromWKT('POINT (4 4)'))",
+                0.0
         );
     }
 
@@ -136,6 +177,16 @@ public class TestFunctionsV2
                 "MULTILINESTRING((10 130,50 190,110 190,140 150,150 80,100 10,20 40,10 130),(70 40,100 50,120 80,80 110,50 90,70 40))"
         );
     }
+
+    @Test
+    public void test_ST_BoundingDiagonal() {
+        registerUDFV2("ST_BoundingDiagonal", String.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_BoundingDiagonal(ST_GeometryFromWKT('POLYGON (( 10 130, 50 190, 110 190, 140 150, 150 80, 100 10, 20 40, 10 130 ),( 70 40, 100 50, 120 80, 80 110, 50 90, 70 40 ))')))",
+                "LINESTRING(10 10,150 190)"
+        );
+    }
+
     @Test
     public void test_ST_Buffer() {
         registerUDFV2("ST_Buffer", String.class, double.class);
@@ -161,6 +212,14 @@ public class TestFunctionsV2
         );
     }
     @Test
+    public void test_ST_ClosestPoint() {
+        registerUDFV2("ST_ClosestPoint", String.class, String.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_ClosestPoint(ST_GeometryFromWKT('POINT (1 1)'), ST_GeometryFromWKT('LINESTRING (1 1, 2 2, 3 3)')))",
+                "POINT(1 1)"
+        );
+    }
+    @Test
     public void test_ST_CollectionExtract() {
         registerUDFV2("ST_CollectionExtract", String.class);
         verifySqlSingleRes(
@@ -181,6 +240,16 @@ public class TestFunctionsV2
                 "POLYGON((43 69,50 84,57 100,63 118,68 133,74 149,81 164,88 180,101 180,112 180,119 164,126 149,132 131,139 113,143 100,150 84,157 69,163 51,168 36,174 20,163 20,150 20,143 36,139 49,132 64,114 64,99 64,81 64,63 64,57 49,52 36,46 20,37 20,26 20,32 36,35 45,39 55,43 69),(88 124,81 109,74 93,83 82,99 82,112 82,121 96,114 109,110 122,103 138,92 138,88 124))"
         );
     }
+
+    @Test
+    public void test_ST_CoordDim() {
+        registerUDFV2("ST_CoordDim", String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_CoordDim(ST_GeometryFromWKT('POLYGON((0 0, 0 10, 10 10, 10 0, 0 0))'))",
+                2
+        );
+    }
+
     @Test
     public void test_ST_ConvexHull() {
         registerUDFV2("ST_ConvexHull", String.class);
@@ -195,6 +264,14 @@ public class TestFunctionsV2
         verifySqlSingleRes(
                 "select ST_AsText(sedona.ST_Difference(ST_GeometryFromWKT('POLYGON ((-3 -3, 3 -3, 3 3, -3 3, -3 -3))'), ST_GeometryFromWKT('POLYGON ((0 -4, 4 -4, 4 4, 0 4, 0 -4))')))",
                 "POLYGON((0 -3,-3 -3,-3 3,0 3,0 -3))"
+        );
+    }
+    @Test
+    public void test_ST_Dimension() {
+        registerUDFV2("ST_Dimension", String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_Dimension(ST_GeometryFromWKT('POINT(1 2)'))",
+                0
         );
     }
     @Test
@@ -285,6 +362,16 @@ public class TestFunctionsV2
                 "ST_Point"
         );
     }
+
+    @Test
+    public void test_ST_HausdorffDistance() {
+        registerUDFV2("ST_HausdorffDistance", String.class, String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_HausdorffDistance(ST_GeometryFromWKT('LINESTRING(0 0, 1 1, 2 2)'), ST_GeometryFromWKT('LINESTRING(0 0, 1 1, 3 3)'))",
+                1.4142135623730951
+        );
+    }
+
     @Test
     public void test_ST_InteriorRingN() {
         registerUDFV2("ST_InteriorRingN", String.class, int.class);
@@ -307,6 +394,18 @@ public class TestFunctionsV2
         verifySqlSingleRes(
                 "select sedona.ST_IsClosed(ST_GeometryFromWKT('LINESTRING(0 0, 2 2)'))",
                 false
+        );
+    }
+    @Test
+    public void test_ST_IsCollection() {
+        registerUDFV2("ST_IsCollection", String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_IsCollection(ST_GeometryFromWKT('LINESTRING(0 0, 2 2)'))",
+                false
+        );
+        verifySqlSingleRes(
+                "select sedona.ST_IsCollection(ST_GeometryFromWKT('GEOMETRYCOLLECTION(POINT(1 2), LINESTRING(1 2, 3 4))'))",
+                true
         );
     }
     @Test
@@ -348,7 +447,27 @@ public class TestFunctionsV2
                 "select sedona.ST_IsValid(ST_GeometryFromWKT('POLYGON((0 0, 10 0, 10 10, 0 10, 0 0), (15 15, 15 20, 20 20, 20 15, 15 15))', 4326, TRUE))",
                 false
         );
+        registerUDFV2("ST_IsValid", String.class, int.class);
+        verifySqlSingleRes(
+                "select sedona.ST_IsValid(ST_GeometryFromWKT('POLYGON((0 0, 10 0, 10 10, 0 10, 0 0), (15 15, 15 20, 20 20, 20 15, 15 15))', 4326, TRUE), 1)",
+                false
+        );
     }
+
+    @Test
+    public void test_ST_IsValidReason() {
+        registerUDFV2("ST_IsValidReason", String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_IsValidReason(ST_GeometryFromWKT('POLYGON((0 0, 10 0, 10 10, 0 10, 0 0), (15 15, 15 20, 20 20, 20 15, 15 15))', 4326, TRUE))",
+                "Hole lies outside shell at or near point (15.0, 15.0, NaN)"
+        );
+        registerUDFV2("ST_IsValidReason", String.class, int.class);
+        verifySqlSingleRes(
+                "select sedona.ST_IsValidReason(ST_GeometryFromWKT('POLYGON((0 0, 10 0, 10 10, 0 10, 0 0), (15 15, 15 20, 20 20, 20 15, 15 15))', 4326, TRUE), 1)",
+                "Hole lies outside shell at or near point (15.0, 15.0, NaN)"
+        );
+    }
+
     @Test
     public void test_ST_Length() {
         registerUDFV2("ST_Length", String.class);
@@ -373,6 +492,16 @@ public class TestFunctionsV2
                 "POINT(51.597413505 76.597413505)"
         );
     }
+
+    @Test
+    public void test_ST_LineLocatePoint() {
+        registerUDFV2("ST_LineLocatePoint", String.class, String.class);
+        verifySqlSingleRes(
+                "select sedona.ST_LineLocatePoint(ST_GeometryFromWKT('LINESTRING(0 0, 10 10)'), ST_GeometryFromWKT('POINT(2 2)'))",
+                0.2
+        );
+    }
+
     @Test
     public void test_ST_LineMerge() {
         registerUDFV2("ST_LineMerge", String.class);
@@ -488,6 +617,17 @@ public class TestFunctionsV2
                 "POINT(2.5 2.5)"
         );
     }
+
+    @Test
+    public void test_ST_Polygon() {
+        registerUDFV2("ST_Polygon", String.class, int.class);
+        // GeoJSON spec does not contain SRID so the serialization process will lose SRID info
+        verifySqlSingleRes(
+                "select ST_AsEWKT(sedona.ST_Polygon(ST_GeometryFromWKT('LINESTRING(0 0, 0 1, 1 1, 1 0, 0 0)'), 4326))",
+                "SRID=0;POLYGON((0 0,0 1,1 1,1 0,0 0))"
+        );
+    }
+
     @Test
     public void test_ST_PrecisionReduce() {
         registerUDFV2("ST_PrecisionReduce", String.class, int.class);
@@ -619,6 +759,26 @@ public class TestFunctionsV2
                 "POLYGON((2 3,3 3,3 -3,-3 -3,-3 3,-2 3,-2 4,2 4,2 3))"
         );
     }
+
+    @Test
+    public void test_ST_VoronoiPolygons() {
+        registerUDFV2("ST_VoronoiPolygons", String.class);
+        registerUDFV2("ST_VoronoiPolygons", String.class, double.class);
+        registerUDFV2("ST_VoronoiPolygons", String.class, double.class, String.class);
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_VoronoiPolygons(ST_GeometryFromWKT('MULTIPOINT ((0 0), (1 1))')))",
+                "GEOMETRYCOLLECTION(POLYGON((-1 -1,-1 2,2 -1,-1 -1)),POLYGON((-1 2,2 2,2 -1,-1 2)))"
+        );
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_VoronoiPolygons(ST_GeometryFromWKT('MULTIPOINT ((0 0), (1 1))'), 1))",
+                "GEOMETRYCOLLECTION(POLYGON((-1 -1,-1 2,2 -1,-1 -1)),POLYGON((-1 2,2 2,2 -1,-1 2)))"
+        );
+        verifySqlSingleRes(
+                "select ST_AsText(sedona.ST_VoronoiPolygons(ST_GeometryFromWKT('MULTIPOINT ((0 0), (1 1))'), 1, ST_GeometryFromWKT('POLYGON ((-1 -1, -1 2, 2 -1, -1 -1))')))",
+                "GEOMETRYCOLLECTION(POLYGON((-1 -1,-1 2,2 -1,-1 -1)),POLYGON((-1 2,2 2,2 -1,-1 2)))"
+        );
+    }
+
     @Test
     public void test_ST_X() {
         registerUDFV2("ST_X", String.class);
@@ -733,6 +893,15 @@ public class TestFunctionsV2
         verifySqlSingleRes(
                 "SELECT sedona.ST_DistanceSpheroid(ST_GeomFromWKT('POINT (-0.56 51.3168)'), ST_GeomFromWKT('POINT (-3.1883 55.9533)'))",
                 544430.9411996207
+        );
+    }
+
+    @Test
+    public void test_ST_FrechetDistance() {
+        registerUDFV2("ST_FrechetDistance", String.class, String.class);
+        verifySqlSingleRes(
+                "SELECT sedona.ST_FrechetDistance(ST_GeomFromWKT('LINESTRING (0 0, 1 1, 2 2)'), ST_GeomFromWKT('LINESTRING (0 0, 1 1, 3 3)'))",
+                1.4142135623730951
         );
     }
 

--- a/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestPredicates.java
+++ b/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestPredicates.java
@@ -148,4 +148,16 @@ public class TestPredicates extends TestBase{
                 false
         );
     }
+    @Test
+    public void test_ST_DWithin() {
+        registerUDF("ST_DWithin", byte[].class, byte[].class, double.class);
+        verifySqlSingleRes(
+                "SELECT SEDONA.ST_DWithin(SEDONA.ST_GeomFromWKT('POINT (1.5 0.0)'), SEDONA.ST_GeomFromWKT('POLYGON ((0 0, 1 0, 1 1, 0 0))'), 0.5)",
+                true
+        );
+        verifySqlSingleRes(
+                "SELECT SEDONA.ST_DWithin(SEDONA.ST_GeomFromWKT('POINT (0.0 1.0)'), SEDONA.ST_GeomFromWKT('POLYGON ((0 0, 1 0, 1 1, 0 0))'), 0.0)",
+                false
+        );
+    }
 }

--- a/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestPredicatesV2.java
+++ b/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestPredicatesV2.java
@@ -149,4 +149,16 @@ public class TestPredicatesV2
                 false
         );
     }
+    @Test
+    public void test_ST_DWithin() {
+        registerUDFV2("ST_DWithin", String.class,  String.class, double.class);
+        verifySqlSingleRes(
+                "SELECT SEDONA.ST_DWithin(ST_GeometryFromWKT('POINT (1.5 0.0)'), ST_GeometryFromWKT('POLYGON ((0 0, 1 0, 1 1, 0 0))'), 0.5)",
+                true
+        );
+        verifySqlSingleRes(
+                "SELECT SEDONA.ST_DWithin(ST_GeometryFromWKT('POINT (0.0 1.0)'), ST_GeometryFromWKT('POLYGON ((0 0, 1 0, 1 1, 0 0))'), 0.0)",
+                false
+        );
+    }
 }

--- a/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/UDFs.java
+++ b/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/UDFs.java
@@ -1098,13 +1098,6 @@ public class UDFs {
         );
     }
 
-    @UDFAnnotations.ParamMeta(argNames = {"geometry", "extent"})
-    public static byte[] ST_VoronoiPolygons(byte[] geometry, byte[] extent) {
-        return GeometrySerde.serialize(
-                FunctionsGeoTools.voronoiPolygons(GeometrySerde.deserialize(geometry), 0.0, GeometrySerde.deserialize(extent))
-        );
-    }
-
     @UDFAnnotations.ParamMeta(argNames = {"geometry", "tolerance", "extent"})
     public static byte[] ST_VoronoiPolygons(byte[] geometry, double tolerance, byte[] extent) {
         return GeometrySerde.serialize(

--- a/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/UDFs.java
+++ b/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/UDFs.java
@@ -15,6 +15,7 @@ package org.apache.sedona.snowflake.snowsql;
 
 import org.apache.sedona.common.Constructors;
 import org.apache.sedona.common.Functions;
+import org.apache.sedona.common.FunctionsGeoTools;
 import org.apache.sedona.common.Predicates;
 import org.apache.sedona.common.enums.FileDataSplitter;
 import org.apache.sedona.common.sphere.Haversine;
@@ -37,6 +38,10 @@ import java.io.IOException;
  */
 public class UDFs {
 
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"})
+    public static String GeometryType(byte[] geometry) {
+        return Functions.geometryTypeWithMeasured(GeometrySerde.deserialize(geometry));
+    }
     @UDFAnnotations.ParamMeta(argNames = {"linestring", "point", "position"})
     public static byte[] ST_AddPoint(byte[] linestring, byte[] point, int position) {
         return GeometrySerde.serialize(
@@ -46,6 +51,36 @@ public class UDFs {
                         position
                 )
         );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry", "a", "b", "c", "d", "e", "f", "g", "h", "i", "xOff", "yOff", "zOff"})
+    public static byte[] ST_Affine(byte[] geometry, double a, double b, double c, double d, double e, double f, double g, double h, double i, double xOff, double yOff,
+            double zOff) {
+        return GeometrySerde.serialize(
+                Functions.affine(GeometrySerde.deserialize(geometry), a, b, c, d, e, f, g, h, i, xOff, yOff, zOff)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry", "a", "b", "c", "d", "e", "f", "xOff", "yOff"})
+    public static byte[] ST_Affine(byte[] geometry, double a, double b, double d, double e, double xOff, double yOff) {
+        return GeometrySerde.serialize(
+                Functions.affine(GeometrySerde.deserialize(geometry), a, b, d, e, xOff, yOff)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geom1", "geom2"})
+    public static double ST_Angle(byte[] geom1, byte[] geom2) {
+        return Functions.angle(GeometrySerde.deserialize(geom1), GeometrySerde.deserialize(geom2));
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geom1", "geom2", "geom3"})
+    public static double ST_Angle(byte[] geom1, byte[] geom2, byte[] geom3) {
+        return Functions.angle(GeometrySerde.deserialize(geom1), GeometrySerde.deserialize(geom2), GeometrySerde.deserialize(geom3));
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geom1", "geom2", "geom3", "geom4"})
+    public static double ST_Angle(byte[] geom1, byte[] geom2, byte[] geom3, byte[] geom4) {
+        return Functions.angle(GeometrySerde.deserialize(geom1), GeometrySerde.deserialize(geom2), GeometrySerde.deserialize(geom3), GeometrySerde.deserialize(geom4));
     }
 
     @UDFAnnotations.ParamMeta(argNames = {"geometry"})
@@ -114,6 +149,15 @@ public class UDFs {
         );
     }
 
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"})
+    public static byte[] ST_BoundingDiagonal(byte[] geometry) {
+        return GeometrySerde.serialize(
+                Functions.boundingDiagonal(
+                        GeometrySerde.deserialize(geometry)
+                )
+        );
+    }
+
     @UDFAnnotations.ParamMeta(argNames = {"geometry", "radius"})
     public static byte[] ST_Buffer(byte[] geometry, double radius) {
         return GeometrySerde.serialize(
@@ -138,6 +182,16 @@ public class UDFs {
         return GeometrySerde.serialize(
                 Functions.getCentroid(
                         GeometrySerde.deserialize(geometry)
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry1", "geometry2"})
+    public static byte[] ST_ClosestPoint(byte[] geom1, byte[] geom2) {
+        return GeometrySerde.serialize(
+                Functions.closestPoint(
+                        GeometrySerde.deserialize(geom1),
+                        GeometrySerde.deserialize(geom2)
                 )
         );
     }
@@ -190,7 +244,10 @@ public class UDFs {
                 GeometrySerde.deserialize(rightGeometry)
         );
     }
-
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"})
+    public static int ST_CoordDim(byte[] geometry) {
+        return Functions.nDims(GeometrySerde.deserialize(geometry));
+    }
     @UDFAnnotations.ParamMeta(argNames = {"geometry"})
     public static byte[] ST_ConvexHull(byte[] geometry) {
         return GeometrySerde.serialize(
@@ -199,7 +256,6 @@ public class UDFs {
                 )
         );
     }
-
     @UDFAnnotations.ParamMeta(argNames = {"leftGeometry", "rightGeometry"})
     public static boolean ST_CoveredBy(byte[] leftGeometry, byte[] rightGeometry) {
         return Predicates.coveredBy(
@@ -224,6 +280,11 @@ public class UDFs {
         );
     }
 
+    @UDFAnnotations.ParamMeta(argNames = {"angleInRadian"})
+    public static double ST_Degrees(double angleInRadian) {
+        return Functions.degrees(angleInRadian);
+    }
+
     @UDFAnnotations.ParamMeta(argNames = {"leftGeometry", "rightGeometry"})
     public static byte[] ST_Difference(byte[] leftGeometry, byte[] rightGeometry) {
         return GeometrySerde.serialize(
@@ -231,6 +292,13 @@ public class UDFs {
                         GeometrySerde.deserialize(leftGeometry),
                         GeometrySerde.deserialize(rightGeometry)
                 )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"})
+    public static Integer ST_Dimension(byte[] geometry) {
+        return Functions.dimension(
+                GeometrySerde.deserialize(geometry)
         );
     }
 
@@ -314,6 +382,15 @@ public class UDFs {
 
     @UDFAnnotations.ParamMeta(argNames = {"geometry"})
     public static byte[] ST_Force_2D(byte[] geometry) {
+        return GeometrySerde.serialize(
+                Functions.force2D(
+                        GeometrySerde.deserialize(geometry)
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"})
+    public static byte[] ST_Force2D(byte[] geometry) {
         return GeometrySerde.serialize(
                 Functions.force2D(
                         GeometrySerde.deserialize(geometry)
@@ -405,6 +482,25 @@ public class UDFs {
         );
     }
 
+    @UDFAnnotations.ParamMeta(argNames = {"geom1", "geom2"})
+    public static double ST_HausdorffDistance(byte[] geom1, byte[] geom2)
+    {
+        return Functions.hausdorffDistance(
+                GeometrySerde.deserialize(geom1),
+                GeometrySerde.deserialize(geom2)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geom1", "geom2", "densifyFrac"})
+    public static double ST_HausdorffDistance(byte[] geom1, byte[] geom2, double densifyFrac)
+    {
+        return Functions.hausdorffDistance(
+                GeometrySerde.deserialize(geom1),
+                GeometrySerde.deserialize(geom2),
+                densifyFrac
+        );
+    }
+
     @UDFAnnotations.ParamMeta(argNames = {"geometry", "n"})
     public static byte[] ST_InteriorRingN(byte[] geometry, int n) {
         return GeometrySerde.serialize(
@@ -441,6 +537,13 @@ public class UDFs {
     }
 
     @UDFAnnotations.ParamMeta(argNames = {"geometry"})
+    public static boolean ST_IsCollection(byte[] geometry) {
+        return Functions.isCollection(
+                GeometrySerde.deserialize(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"})
     public static boolean ST_IsEmpty(byte[] geometry) {
         return Functions.isEmpty(
                 GeometrySerde.deserialize(geometry)
@@ -465,6 +568,27 @@ public class UDFs {
     public static boolean ST_IsValid(byte[] geometry) {
         return Functions.isValid(
                 GeometrySerde.deserialize(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry", "flags"})
+    public static boolean ST_IsValid(byte[] geometry, int flags) {
+        return Functions.isValid(
+                GeometrySerde.deserialize(geometry), flags
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"})
+    public static String ST_IsValidReason(byte[] geometry) {
+        return Functions.isValidReason(
+                GeometrySerde.deserialize(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry", "flags"})
+    public static String ST_IsValidReason(byte[] geometry, int flags) {
+        return Functions.isValidReason(
+                GeometrySerde.deserialize(geometry), flags
         );
     }
 
@@ -501,6 +625,14 @@ public class UDFs {
         );
     }
 
+    @UDFAnnotations.ParamMeta(argNames = {"geom", "point"})
+    public static double ST_LineLocatePoint(byte[] geom, byte[] point) {
+        return Functions.lineLocatePoint(
+                GeometrySerde.deserialize(geom),
+                GeometrySerde.deserialize(point)
+        );
+    }
+
     @UDFAnnotations.ParamMeta(argNames = {"geometry"})
     public static byte[] ST_LineMerge(byte[] geometry) {
         return GeometrySerde.serialize(
@@ -527,7 +659,38 @@ public class UDFs {
                 )
         );
     }
+    @UDFAnnotations.ParamMeta(argNames = {"point1", "point2"})
+    public static byte[] ST_MakeLine(byte[] geom1, byte[] geom2) {
+        return GeometrySerde.serialize(
+                Functions.makeLine(GeometrySerde.deserialize(geom1), GeometrySerde.deserialize(geom2))
+        );
+    }
 
+    @UDFAnnotations.ParamMeta(argNames = {"geometryCollection"})
+    public static byte[] ST_MakeLine(byte[] geometry) {
+        return GeometrySerde.serialize(
+                Functions.makeLine(GeometrySerde.deserialize2List(geometry))
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"x", "y"})
+    public static byte[] ST_MakePoint(double x, double y) {
+        return GeometrySerde.serialize(
+                Constructors.makePoint(x, y, null, null)
+        );
+    }
+    @UDFAnnotations.ParamMeta(argNames = {"x", "y", "z"})
+    public static byte[] ST_MakePoint(double x, double y, double z) {
+        return GeometrySerde.serialize(
+                Constructors.makePoint(x, y, z, null)
+        );
+    }
+    @UDFAnnotations.ParamMeta(argNames = {"x", "y", "z", "m"})
+    public static byte[] ST_MakePoint(double x, double y, double z, double m) {
+        return GeometrySerde.serialize(
+                Constructors.makePoint(x, y, z, m)
+        );
+    }
     @UDFAnnotations.ParamMeta(argNames = {"wkt", "srid"})
     public static byte[] ST_MLineFromText(String wkt, int srid) throws ParseException {
         return GeometrySerde.serialize(
@@ -712,6 +875,15 @@ public class UDFs {
     public static byte[] ST_PointZ(double x, double y, double z, int srid) {
         return GeometrySerde.serialize(
                 Constructors.pointZ(x, y, z, srid)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry", "srid"})
+    public static byte[] ST_Polygon(byte[] geometry, int srid) {
+        return GeometrySerde.serialize(
+                Functions.makepolygonWithSRID(
+                        GeometrySerde.deserialize(geometry), srid
+                )
         );
     }
 
@@ -912,6 +1084,34 @@ public class UDFs {
         );
     }
 
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"})
+    public static byte[] ST_VoronoiPolygons(byte[] geometry) {
+        return GeometrySerde.serialize(
+                FunctionsGeoTools.voronoiPolygons(GeometrySerde.deserialize(geometry), 0.0, null)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry", "tolerance"})
+    public static byte[] ST_VoronoiPolygons(byte[] geometry, double tolerance) {
+        return GeometrySerde.serialize(
+                FunctionsGeoTools.voronoiPolygons(GeometrySerde.deserialize(geometry), tolerance, null)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry", "extent"})
+    public static byte[] ST_VoronoiPolygons(byte[] geometry, byte[] extent) {
+        return GeometrySerde.serialize(
+                FunctionsGeoTools.voronoiPolygons(GeometrySerde.deserialize(geometry), 0.0, GeometrySerde.deserialize(extent))
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry", "tolerance", "extent"})
+    public static byte[] ST_VoronoiPolygons(byte[] geometry, double tolerance, byte[] extent) {
+        return GeometrySerde.serialize(
+                FunctionsGeoTools.voronoiPolygons(GeometrySerde.deserialize(geometry), tolerance, GeometrySerde.deserialize(extent))
+        );
+    }
+
     @UDFAnnotations.ParamMeta(argNames = {"leftGeometry", "rightGeometry"})
     public static boolean ST_Within(byte[] leftGeometry, byte[] rightGeometry) {
         return Predicates.within(
@@ -1010,6 +1210,23 @@ public class UDFs {
     @UDFAnnotations.ParamMeta(argNames = {"geomA", "geomB"})
     public static Double ST_DistanceSpheroid(byte[] geomA, byte[] geomB) {
         return Spheroid.distance(
+                GeometrySerde.deserialize(geomA),
+                GeometrySerde.deserialize(geomB)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geomA", "geomB", "distance"})
+    public static boolean ST_DWithin(byte[] geomA, byte[] geomB, double distance) {
+        return Predicates.dWithin(
+                GeometrySerde.deserialize(geomA),
+                GeometrySerde.deserialize(geomB),
+                distance
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geomA", "geomB"})
+    public static double ST_FrechetDistance(byte[] geomA, byte[] geomB) {
+        return Functions.frechetDistance(
                 GeometrySerde.deserialize(geomA),
                 GeometrySerde.deserialize(geomB)
         );

--- a/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/UDFsV2.java
+++ b/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/UDFsV2.java
@@ -14,6 +14,7 @@
 package org.apache.sedona.snowflake.snowsql;
 
 import org.apache.sedona.common.Functions;
+import org.apache.sedona.common.FunctionsGeoTools;
 import org.apache.sedona.common.Predicates;
 import org.apache.sedona.common.sphere.Haversine;
 import org.apache.sedona.common.sphere.Spheroid;
@@ -33,6 +34,11 @@ import java.io.IOException;
  */
 public class UDFsV2
 {
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"},
+            argTypes = {"Geometry"})
+    public static String GeometryType(String geometry) {
+        return Functions.geometryTypeWithMeasured(GeometrySerde.deserGeoJson(geometry));
+    }
     @UDFAnnotations.ParamMeta(argNames = {"linestring", "point", "position"},
             argTypes = {"Geometry", "Geometry", "int"},
             returnTypes = "Geometry")
@@ -44,6 +50,40 @@ public class UDFsV2
                         position
                 )
         );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry", "a", "b", "c", "d", "e", "f", "g", "h", "i", "xOff", "yOff", "zOff"},
+            argTypes = {"Geometry", "double", "double", "double", "double", "double", "double", "double", "double", "double", "double", "double", "double"},
+            returnTypes = "Geometry")
+    public static String ST_Affine(String geometry, double a, double b, double c, double d, double e, double f, double g, double h, double i, double xOff, double yOff,
+            double zOff) {
+        return GeometrySerde.serGeoJson(
+                Functions.affine(GeometrySerde.deserGeoJson(geometry), a, b, c, d, e, f, g, h, i, xOff, yOff, zOff)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry", "a", "b", "c", "d", "e", "f", "xOff", "yOff"},
+            argTypes = {"Geometry", "double", "double", "double", "double", "double", "double"},
+            returnTypes = "Geometry")
+    public static String ST_Affine(String geometry, double a, double b, double d, double e, double xOff, double yOff) {
+        return GeometrySerde.serGeoJson(
+                Functions.affine(GeometrySerde.deserGeoJson(geometry), a, b, d, e, xOff, yOff)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geom1", "geom2"}, argTypes = {"Geometry", "Geometry"})
+    public static double ST_Angle(String geom1, String geom2) {
+        return Functions.angle(GeometrySerde.deserGeoJson(geom1), GeometrySerde.deserGeoJson(geom2));
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geom1", "geom2", "geom3"}, argTypes = {"Geometry", "Geometry", "Geometry"})
+    public static double ST_Angle(String geom1, String geom2, String geom3) {
+        return Functions.angle(GeometrySerde.deserGeoJson(geom1), GeometrySerde.deserGeoJson(geom2), GeometrySerde.deserGeoJson(geom3));
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geom1", "geom2", "geom3", "geom4"}, argTypes = {"Geometry", "Geometry", "Geometry", "Geometry"})
+    public static double ST_Angle(String geom1, String geom2, String geom3, String geom4) {
+        return Functions.angle(GeometrySerde.deserGeoJson(geom1), GeometrySerde.deserGeoJson(geom2), GeometrySerde.deserGeoJson(geom3), GeometrySerde.deserGeoJson(geom4));
     }
 
     @UDFAnnotations.ParamMeta(argNames = {"geometry"},
@@ -122,6 +162,15 @@ public class UDFsV2
         );
     }
 
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"}, returnTypes = "Geometry")
+    public static String ST_BoundingDiagonal(String geometry) {
+        return GeometrySerde.serGeoJson(
+                Functions.boundingDiagonal(
+                        GeometrySerde.deserGeoJson(geometry)
+                )
+        );
+    }
+
     @UDFAnnotations.ParamMeta(argNames = {"geometry", "radius"}, argTypes = {"Geometry", "double"}, returnTypes = "Geometry")
     public static String ST_Buffer(String geometry, double radius) {
         return GeometrySerde.serGeoJson(
@@ -146,6 +195,16 @@ public class UDFsV2
         return GeometrySerde.serGeoJson(
                 Functions.getCentroid(
                         GeometrySerde.deserGeoJson(geometry)
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry1", "geometry2"}, argTypes = {"Geometry", "Geometry"}, returnTypes = "Geometry")
+    public static String ST_ClosestPoint(String geom1, String geom2) {
+        return GeometrySerde.serGeoJson(
+                Functions.closestPoint(
+                        GeometrySerde.deserGeoJson(geom1),
+                        GeometrySerde.deserGeoJson(geom2)
                 )
         );
     }
@@ -198,7 +257,10 @@ public class UDFsV2
                 GeometrySerde.deserGeoJson(rightGeometry)
         );
     }
-
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"})
+    public static int ST_CoordDim(String geometry) {
+        return Functions.nDims(GeometrySerde.deserGeoJson(geometry));
+    }
     @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"}, returnTypes = "Geometry")
     public static String ST_ConvexHull(String geometry) {
         return GeometrySerde.serGeoJson(
@@ -239,6 +301,13 @@ public class UDFsV2
                         GeometrySerde.deserGeoJson(leftGeometry),
                         GeometrySerde.deserGeoJson(rightGeometry)
                 )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"})
+    public static Integer ST_Dimension(String geometry) {
+        return Functions.dimension(
+                GeometrySerde.deserGeoJson(geometry)
         );
     }
 
@@ -363,6 +432,25 @@ public class UDFsV2
         );
     }
 
+    @UDFAnnotations.ParamMeta(argNames = {"geom1", "geom2"}, argTypes = {"Geometry", "Geometry"})
+    public static double ST_HausdorffDistance(String geom1, String geom2)
+    {
+        return Functions.hausdorffDistance(
+                GeometrySerde.deserGeoJson(geom1),
+                GeometrySerde.deserGeoJson(geom2)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geom1", "geom2", "densifyFrac"}, argTypes = {"Geometry", "Geometry", "double"})
+    public static double ST_HausdorffDistance(String geom1, String geom2, double densifyFrac)
+    {
+        return Functions.hausdorffDistance(
+                GeometrySerde.deserGeoJson(geom1),
+                GeometrySerde.deserGeoJson(geom2),
+                densifyFrac
+        );
+    }
+
     @UDFAnnotations.ParamMeta(argNames = {"geometry", "n"}, argTypes = {"Geometry", "int"}, returnTypes = "Geometry")
     public static String ST_InteriorRingN(String geometry, int n) {
         return GeometrySerde.serGeoJson(
@@ -399,6 +487,13 @@ public class UDFsV2
     }
 
     @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"})
+    public static boolean ST_IsCollection(String geometry) {
+        return Functions.isCollection(
+                GeometrySerde.deserGeoJson(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"})
     public static boolean ST_IsEmpty(String geometry) {
         return Functions.isEmpty(
                 GeometrySerde.deserGeoJson(geometry)
@@ -423,6 +518,27 @@ public class UDFsV2
     public static boolean ST_IsValid(String geometry) {
         return Functions.isValid(
                 GeometrySerde.deserGeoJson(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry", "flags"}, argTypes = {"Geometry", "int"})
+    public static boolean ST_IsValid(String geometry, int flags) {
+        return Functions.isValid(
+                GeometrySerde.deserGeoJson(geometry), flags
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"})
+    public static String ST_IsValidReason(String geometry) {
+        return Functions.isValidReason(
+                GeometrySerde.deserGeoJson(geometry)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry", "flags"}, argTypes = {"Geometry", "int"})
+    public static String ST_IsValidReason(String geometry, int flags) {
+        return Functions.isValidReason(
+                GeometrySerde.deserGeoJson(geometry), flags
         );
     }
 
@@ -452,6 +568,14 @@ public class UDFsV2
         );
     }
 
+    @UDFAnnotations.ParamMeta(argNames = {"geom", "point"}, argTypes = {"Geometry", "Geometry"})
+    public static double ST_LineLocatePoint(String geom, String point) {
+        return Functions.lineLocatePoint(
+                GeometrySerde.deserGeoJson(geom),
+                GeometrySerde.deserGeoJson(point)
+        );
+    }
+
     @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"}, returnTypes = "Geometry")
     public static String ST_LineMerge(String geometry) {
         return GeometrySerde.serGeoJson(
@@ -469,6 +593,20 @@ public class UDFsV2
                         fromFraction,
                         toFraction
                 )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"point1", "point2"}, argTypes = {"Geometry", "Geometry"}, returnTypes = "Geometry")
+    public static String ST_MakeLine(String geom1, String geom2) {
+        return GeometrySerde.serGeoJson(
+                Functions.makeLine(GeometrySerde.deserGeoJson(geom1), GeometrySerde.deserGeoJson(geom2))
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometryCollection"}, argTypes = {"Geometry"}, returnTypes = "Geometry")
+    public static String ST_MakeLine(String geometry) {
+        return GeometrySerde.serGeoJson(
+                Functions.makeLine(GeometrySerde.deserGeoJson2List(geometry))
         );
     }
 
@@ -599,6 +737,15 @@ public class UDFsV2
         return GeometrySerde.serGeoJson(
                 Functions.pointOnSurface(
                         GeometrySerde.deserGeoJson(geometry)
+                )
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry", "srid"}, argTypes = {"Geometry", "int"}, returnTypes = "Geometry")
+    public static String ST_Polygon(String geometry, int srid) {
+        return GeometrySerde.serGeoJson(
+                Functions.makepolygonWithSRID(
+                        GeometrySerde.deserGeoJson(geometry), srid
                 )
         );
     }
@@ -786,6 +933,34 @@ public class UDFsV2
         );
     }
 
+    @UDFAnnotations.ParamMeta(argNames = {"geometry"}, argTypes = {"Geometry"}, returnTypes = "Geometry")
+    public static String ST_VoronoiPolygons(String geometry) {
+        return GeometrySerde.serGeoJson(
+                FunctionsGeoTools.voronoiPolygons(GeometrySerde.deserGeoJson(geometry), 0.0, null)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry", "tolerance"}, argTypes = {"Geometry", "double"}, returnTypes = "Geometry")
+    public static String ST_VoronoiPolygons(String geometry, double tolerance) {
+        return GeometrySerde.serGeoJson(
+                FunctionsGeoTools.voronoiPolygons(GeometrySerde.deserGeoJson(geometry), tolerance, null)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry", "extent"}, argTypes = {"Geometry", "Geometry"}, returnTypes = "Geometry")
+    public static String ST_VoronoiPolygons(String geometry, String extent) {
+        return GeometrySerde.serGeoJson(
+                FunctionsGeoTools.voronoiPolygons(GeometrySerde.deserGeoJson(geometry), 0.0, GeometrySerde.deserGeoJson(extent))
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geometry", "tolerance", "extent"}, argTypes = {"Geometry", "double", "Geometry"}, returnTypes = "Geometry")
+    public static String ST_VoronoiPolygons(String geometry, double tolerance, String extent) {
+        return GeometrySerde.serGeoJson(
+                FunctionsGeoTools.voronoiPolygons(GeometrySerde.deserGeoJson(geometry), tolerance, GeometrySerde.deserGeoJson(extent))
+        );
+    }
+
     @UDFAnnotations.ParamMeta(argNames = {"leftGeometry", "rightGeometry"}, argTypes = {"Geometry", "Geometry"})
     public static boolean ST_Within(String leftGeometry, String rightGeometry) {
         return Predicates.within(
@@ -884,6 +1059,23 @@ public class UDFsV2
     @UDFAnnotations.ParamMeta(argNames = {"geomA", "geomB"}, argTypes = {"Geometry", "Geometry"})
     public static Double ST_DistanceSpheroid(String geomA, String geomB) {
         return Spheroid.distance(
+                GeometrySerde.deserGeoJson(geomA),
+                GeometrySerde.deserGeoJson(geomB)
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geomA", "geomB", "distance"}, argTypes = {"Geometry", "Geometry", "double"})
+    public static boolean ST_DWithin(String geomA, String geomB, double distance) {
+        return Predicates.dWithin(
+                GeometrySerde.deserGeoJson(geomA),
+                GeometrySerde.deserGeoJson(geomB),
+                distance
+        );
+    }
+
+    @UDFAnnotations.ParamMeta(argNames = {"geomA", "geomB"}, argTypes = {"Geometry", "Geometry"})
+    public static double ST_FrechetDistance(String geomA, String geomB) {
+        return Functions.frechetDistance(
                 GeometrySerde.deserGeoJson(geomA),
                 GeometrySerde.deserGeoJson(geomB)
         );

--- a/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/UDFsV2.java
+++ b/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/UDFsV2.java
@@ -947,13 +947,6 @@ public class UDFsV2
         );
     }
 
-    @UDFAnnotations.ParamMeta(argNames = {"geometry", "extent"}, argTypes = {"Geometry", "Geometry"}, returnTypes = "Geometry")
-    public static String ST_VoronoiPolygons(String geometry, String extent) {
-        return GeometrySerde.serGeoJson(
-                FunctionsGeoTools.voronoiPolygons(GeometrySerde.deserGeoJson(geometry), 0.0, GeometrySerde.deserGeoJson(extent))
-        );
-    }
-
     @UDFAnnotations.ParamMeta(argNames = {"geometry", "tolerance", "extent"}, argTypes = {"Geometry", "double", "Geometry"}, returnTypes = "Geometry")
     public static String ST_VoronoiPolygons(String geometry, double tolerance, String extent) {
         return GeometrySerde.serGeoJson(

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
@@ -260,7 +260,7 @@ case class ST_MakeValid(inputExpressions: Seq[Expression])
   * @param inputExpressions
   */
 case class ST_IsValid(inputExpressions: Seq[Expression])
-  extends InferredExpression(Functions.isValid _) {
+  extends InferredExpression(inferrableFunction2(Functions.isValid), inferrableFunction1(Functions.isValid)) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-459. The PR name follows the format `[SEDONA-XXX] my subject`.


## What changes were proposed in this PR?

The following functions have been added to Sedona Snowflake

1. GeometryType
2. ST_CoordDim
3. ST_MakePoint
4. ST_Dimension
5. ST_ClosestPoint
6. ST_IsCollection
7. ST_MakeLine
8. ST_Polygon
9. ST_LineLocatePoint
10. ST_VoronoiPolygons
11. ST_FrechetDistance
12. ST_Affine
13. ST_BoundingDiagonal
14. ST_Angle
15. ST_Degrees
16. ST_HausdorffDistance
17. ST_DWithin
18. ST_IsValidReason

Among them, the following functions have been overloaded with GeoJSON serializer so they can interact with Snowflake native functions without using `ST_AsWKB` and `to_geometry()`

1. GeometryType
2. ST_CoordDim
4. ST_Dimension
5. ST_ClosestPoint
6. ST_IsCollection
8. ST_Polygon
9. ST_LineLocatePoint
10. ST_VoronoiPolygons
11. ST_FrechetDistance
12. ST_Affine
13. ST_BoundingDiagonal
14. ST_Angle
16. ST_HausdorffDistance
17. ST_DWithin
18. ST_IsValidReason

This PR also has a new variant of ST_IsValid: `ST_IsValid(Geometry geom, int flags)`

## How was this patch tested?

Tested by https://github.com/wherobots/sedona-snowflake-tester/pull/10

## Did this PR include necessary documentation updates?

Docs will be added in PR 4/4
