### PR TITLE
[SEDONA-466] Add new parameter `useGeometryExtent` to RS_AsRaster

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/raster/RasterConstructors.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterConstructors.java
@@ -89,7 +89,7 @@ public class RasterConstructors
      * @param value The value of the pixel of the resultant raster
      * @param noDataValue The noDataValue of the resultant raster
      * @param useGeometryExtent  The way to generate extent of the resultant raster.
-     *        Use the extent of the geometry to covert if true, else use the extent of the reference raster
+     *        Use the extent of the geometry to convert if true, else use the extent of the reference raster
      *
      * @return Rasterized Geometry
      * @throws FactoryException

--- a/common/src/main/java/org/apache/sedona/common/raster/RasterConstructors.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterConstructors.java
@@ -82,7 +82,28 @@ public class RasterConstructors
     }
 
     /**
-    * Returns a raster that is converted from the geometry provided.
+     * Returns a raster that is converted from the geometry provided.
+     * @param geom The geometry to convert
+     * @param raster The reference raster
+     * @param pixelType The data type of pixel/cell of resultant raster
+     * @param value The value of the pixel of the resultant raster
+     * @param noDataValue The noDataValue of the resultant raster
+     * @param useGeometryExtent  The way to generate extent of the resultant raster.
+     *        Use the extent of the geometry to covert if true, else use the extent of the reference raster
+     *
+     * @return Rasterized Geometry
+     * @throws FactoryException
+     */
+    public static GridCoverage2D asRaster(Geometry geom, GridCoverage2D raster, String pixelType, double value, Double noDataValue, boolean useGeometryExtent) throws FactoryException {
+        List<Object> objects = rasterization(geom, raster, pixelType, value, noDataValue, useGeometryExtent);
+        WritableRaster writableRaster = (WritableRaster) objects.get(0);
+        GridCoverage2D rasterized = (GridCoverage2D) objects.get(1);
+
+        return RasterUtils.clone(writableRaster, rasterized.getSampleDimensions(), rasterized, noDataValue, false); //no need to original raster metadata since this is a new raster.
+    }
+
+    /**
+    * Returns a raster that is converted from the geometry provided. A convenience function for asRaster.
      * @param geom The geometry to convert
      * @param raster The reference raster
      * @param pixelType The data type of pixel/cell of resultant raster
@@ -93,12 +114,7 @@ public class RasterConstructors
      * @throws FactoryException
     */
     public static GridCoverage2D asRaster(Geometry geom, GridCoverage2D raster, String pixelType, double value, Double noDataValue) throws FactoryException {
-
-        List<Object> objects = rasterization(geom, raster, pixelType, value, noDataValue, true);
-        WritableRaster writableRaster = (WritableRaster) objects.get(0);
-        GridCoverage2D rasterized = (GridCoverage2D) objects.get(1);
-
-        return RasterUtils.clone(writableRaster, rasterized.getSampleDimensions(), rasterized, noDataValue, false); //no need to original raster metadata since this is a new raster.
+        return asRaster(geom, raster, pixelType, value, noDataValue, true);
     }
 
     /**
@@ -209,11 +225,7 @@ public class RasterConstructors
      * @throws FactoryException
      */
     public static GridCoverage2D asRasterWithRasterExtent(Geometry geom, GridCoverage2D raster, String pixelType, double value, Double noDataValue) throws FactoryException {
-        List<Object> objects = rasterization(geom, raster, pixelType, value, noDataValue, false);
-        WritableRaster writableRaster = (WritableRaster) objects.get(0);
-        GridCoverage2D rasterized = (GridCoverage2D) objects.get(1);
-
-        return RasterUtils.clone(writableRaster, rasterized.getSampleDimensions(), rasterized, noDataValue, false); //no need to original raster metadata since this is a new raster.
+        return asRaster(geom, raster, pixelType, value, noDataValue, false);
     }
 
     public static DefaultFeatureCollection getFeatureCollection(Geometry geom, CoordinateReferenceSystem crs) {

--- a/docs/api/sql/Raster-writer.md
+++ b/docs/api/sql/Raster-writer.md
@@ -212,8 +212,12 @@ The newly created DataFrame can be written to disk again but must be under a dif
 
 Introduction: Converts a Geometry to a Raster dataset. Defaults to using `1.0` for cell `value` and `null` for `noDataValue` if not provided. Supports all geometry types. 
 The `pixelType` argument defines data type of the output raster. This can be one of the following, D (double), F (float), I (integer), S (short), US (unsigned short) or B (byte).
-
+The `useGeomeryExtent` argument defines the extent of the resultant raster. When set to true, it corresponds to the extent of geom, and when set to false, it corresponds to the extent of raster.
 Format:
+
+```
+RS_AsRaster(geom: Geometry, raster: Raster, pixelType: String, value: Double, noDataValue: Double, useGeometryExtent: Boolean)
+```
 
 ```
 RS_AsRaster(geom: Geometry, raster: Raster, pixelType: String, value: Double, noDataValue: Double)
@@ -263,6 +267,20 @@ SELECT RS_AsRaster(
     	RS_MakeEmptyRaster(2, 255, 255, 3, -215, 2, -2, 0, 0, 4326),
     	'D'
 	)
+```
+
+Output:
+
+```
+GridCoverage2D["g...
+```
+
+```sql
+SELECT RS_AsRaster(
+		ST_GeomFromWKT('POLYGON((15 15, 18 20, 15 24, 24 25, 15 15))'),
+		RS_MakeEmptyRaster(2, 255, 255, 3, 215, 2, -2, 0, 0, 0),
+       'D',255, 0d, false
+)
 ```
 
 Output:

--- a/docs/api/sql/Raster-writer.md
+++ b/docs/api/sql/Raster-writer.md
@@ -212,7 +212,7 @@ The newly created DataFrame can be written to disk again but must be under a dif
 
 Introduction: Converts a Geometry to a Raster dataset. Defaults to using `1.0` for cell `value` and `null` for `noDataValue` if not provided. Supports all geometry types. 
 The `pixelType` argument defines data type of the output raster. This can be one of the following, D (double), F (float), I (integer), S (short), US (unsigned short) or B (byte).
-The `useGeomeryExtent` argument defines the extent of the resultant raster. When set to true, it corresponds to the extent of geom, and when set to false, it corresponds to the extent of raster.
+The `useGeomeryExtent` argument defines the extent of the resultant raster. When set to `true`, it corresponds to the extent of `geom`, and when set to false, it corresponds to the extent of `raster`. Default value is `true` if not set.
 Format:
 
 ```

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterConstructors.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterConstructors.scala
@@ -34,7 +34,7 @@ case class RS_FromArcInfoAsciiGrid(inputExpressions: Seq[Expression])
 
 case class RS_AsRaster(inputExpressions: Seq[Expression]) extends InferredExpression(
   inferrableFunction5(RasterConstructors.asRaster), inferrableFunction3(RasterConstructors.asRaster),
-  inferrableFunction4(RasterConstructors.asRaster)
+  inferrableFunction4(RasterConstructors.asRaster), inferrableFunction6(RasterConstructors.asRaster)
 ) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-466. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

- Expose the `useGeometryExtent` parameter to user and RS_AsRaster support 6 parameters now.
- A new `asRaster` function with 6 parameters.  Old `asRaster` and `asRasterwithRasterExtent` functions are revised accordingly.
- Add new tests to test the new parameter.
- Add relative docs and example aboput the new parameter.

## How was this patch tested?

- Passed added tests and old relevant tests

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation update.

