### PR TITLE
[DOCS] Enable markdownlint rule MD030

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -27,9 +27,6 @@ MD026: false
 # ol-prefix - Ordered list item prefix
 MD029: false
 
-# list-marker-space - Spaces after list markers
-MD030: false
-
 # blanks-around-fences - Fenced code blocks should be surrounded by blank lines
 MD031: false
 

--- a/docs/api/flink/Function.md
+++ b/docs/api/flink/Function.md
@@ -2177,21 +2177,21 @@ SELECT ST_PointOnSurface(df.geometry)
 FROM df
 ```
 
-1.  Input: `POINT (0 5)`
+1. Input: `POINT (0 5)`
 
-    Output: `POINT (0 5)`
+   Output: `POINT (0 5)`
 
-2.  Input: `LINESTRING(0 5, 0 10)`
+2. Input: `LINESTRING(0 5, 0 10)`
 
-    Output: `POINT (0 5)`
+   Output: `POINT (0 5)`
 
-3.  Input: `POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))`
+3. Input: `POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))`
 
-    Output: `POINT (2.5 2.5)`
+   Output: `POINT (2.5 2.5)`
 
-4.  Input: `LINESTRING(0 5 1, 0 0 1, 0 10 2)`
+4. Input: `LINESTRING(0 5 1, 0 0 1, 0 10 2)`
 
-    Output: `POINT Z(0 0 1)`
+   Output: `POINT Z(0 0 1)`
 
 ## ST_Polygon
 


### PR DESCRIPTION
https://github.com/DavidAnson/markdownlint/blob/main/doc/md030.md



## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- No, this is a documentation update. The PR name follows the format `[DOCS] my subject`.

## What changes were proposed in this PR?

Standardized the Markdown and enabled rule MD030

## How was this patch tested?

`pre-commit run --all-files`

or

`pre-commit run markdownlint --all-files`

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
