### PR TITLE
[SEDONA-470] Distinguish between missing or null crs from the result of geoparquet.metadata

### DIFF
--- a/spark/spark-3.0/src/main/scala/org/apache/spark/sql/execution/datasources/v2/geoparquet/metadata/GeoParquetMetadataPartitionReaderFactory.scala
+++ b/spark/spark-3.0/src/main/scala/org/apache/spark/sql/execution/datasources/v2/geoparquet/metadata/GeoParquetMetadataPartitionReaderFactory.scala
@@ -66,7 +66,8 @@ object GeoParquetMetadataPartitionReaderFactory {
             UTF8String.fromString(columnMetadata.encoding),
             new GenericArrayData(columnMetadata.geometryTypes.map(UTF8String.fromString).toArray),
             new GenericArrayData(columnMetadata.bbox.toArray),
-            columnMetadata.crs.map(projjson => UTF8String.fromString(compact(render(projjson)))).orNull)
+            columnMetadata.crs.map(projjson => UTF8String.fromString(compact(render(projjson))))
+              .getOrElse(UTF8String.fromString("")))
           val columnMetadataStruct = new GenericInternalRow(columnMetadataFields)
           UTF8String.fromString(columnName) -> columnMetadataStruct
         }

--- a/spark/spark-3.4/src/main/scala/org/apache/spark/sql/execution/datasources/v2/geoparquet/metadata/GeoParquetMetadataPartitionReaderFactory.scala
+++ b/spark/spark-3.4/src/main/scala/org/apache/spark/sql/execution/datasources/v2/geoparquet/metadata/GeoParquetMetadataPartitionReaderFactory.scala
@@ -66,7 +66,8 @@ object GeoParquetMetadataPartitionReaderFactory {
             UTF8String.fromString(columnMetadata.encoding),
             new GenericArrayData(columnMetadata.geometryTypes.map(UTF8String.fromString).toArray),
             new GenericArrayData(columnMetadata.bbox.toArray),
-            columnMetadata.crs.map(projjson => UTF8String.fromString(compact(render(projjson)))).orNull)
+            columnMetadata.crs.map(projjson => UTF8String.fromString(compact(render(projjson))))
+              .getOrElse(UTF8String.fromString("")))
           val columnMetadataStruct = new GenericInternalRow(columnMetadataFields)
           UTF8String.fromString(columnName) -> columnMetadataStruct
         }

--- a/spark/spark-3.5/src/main/scala/org/apache/spark/sql/execution/datasources/v2/geoparquet/metadata/GeoParquetMetadataPartitionReaderFactory.scala
+++ b/spark/spark-3.5/src/main/scala/org/apache/spark/sql/execution/datasources/v2/geoparquet/metadata/GeoParquetMetadataPartitionReaderFactory.scala
@@ -66,7 +66,8 @@ object GeoParquetMetadataPartitionReaderFactory {
             UTF8String.fromString(columnMetadata.encoding),
             new GenericArrayData(columnMetadata.geometryTypes.map(UTF8String.fromString).toArray),
             new GenericArrayData(columnMetadata.bbox.toArray),
-            columnMetadata.crs.map(projjson => UTF8String.fromString(compact(render(projjson)))).orNull)
+            columnMetadata.crs.map(projjson => UTF8String.fromString(compact(render(projjson))))
+              .getOrElse(UTF8String.fromString("")))
           val columnMetadataStruct = new GenericInternalRow(columnMetadataFields)
           UTF8String.fromString(columnName) -> columnMetadataStruct
         }


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-470. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

This PR makes geoparquet files with null or missing crs fields show different results when inspecting using geoparquet.metadata file format. Please refer to the JIRA ticket for details.

This is done by adding a postprocessing after parsing the geo metadata using json4s. I've not found any other way yet so I decided to keep it that way.

## How was this patch tested?

Add new tests and also tested manually using Apache Spark 3.5.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
