### PR TITLE
[SEDONA-474] python: remove manipulation of warnings config

### DIFF
--- a/python/sedona/core/jvm/config.py
+++ b/python/sedona/core/jvm/config.py
@@ -18,7 +18,7 @@
 import logging
 import os
 from re import findall
-from typing import Any, Optional, Tuple
+from typing import Optional, Tuple
 
 from py4j.protocol import Py4JJavaError
 from pyspark.sql import SparkSession
@@ -89,13 +89,11 @@ def deprecated(reason):
 
             @functools.wraps(func1)
             def new_func1(*args, **kwargs):
-                warnings.simplefilter('always', DeprecationWarning)
                 warnings.warn(
                     fmt1.format(name=func1.__name__, reason=reason),
                     category=DeprecationWarning,
                     stacklevel=2
                 )
-                warnings.simplefilter('default', DeprecationWarning)
                 return func1(*args, **kwargs)
 
             return new_func1
@@ -121,13 +119,11 @@ def deprecated(reason):
 
         @functools.wraps(func2)
         def new_func2(*args, **kwargs):
-            warnings.simplefilter('always', DeprecationWarning)
             warnings.warn(
                 fmt2.format(name=func2.__name__),
                 category=DeprecationWarning,
                 stacklevel=2
             )
-            warnings.simplefilter('default', DeprecationWarning)
             return func2(*args, **kwargs)
 
         return new_func2


### PR DESCRIPTION
The removed lines prevent the application developer using this library to ignore these warnings with e.g. `pytest -W
ignore::DeprecationWarning`

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)


## Is this PR related to a JIRA ticket?

- No


## What changes were proposed in this PR?

Removing some code that changes the application filters configuration

## How was this patch tested?


## Did this PR include necessary documentation updates?


- No, this PR does not affect any public API so no need to change the docs.
