### PR TITLE
[SEDONA-475] Add RS_NormalizeAll

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
@@ -438,6 +438,45 @@ public class MapAlgebra
     }
 
     /**
+     *
+     * @param rasterGeom Raster to be normalized
+     * @return a raster with all values in all bands normalized between [0 - 255]
+     */
+    public static GridCoverage2D normalizeAll(GridCoverage2D rasterGeom) {
+        return normalizeAll(rasterGeom, 0d, 255d);
+    }
+
+    /**
+     *
+     * @param rasterGeom Raster to be normalized
+     * @param minLim Lower limit of normalization range
+     * @param maxLim Upper limit of normalization range
+     * @return a raster with all values in all bands normalized between minLim and maxLim
+     */
+    public static GridCoverage2D normalizeAll(GridCoverage2D rasterGeom, double minLim, double maxLim) {
+        int numBands = rasterGeom.getNumSampleDimensions();
+
+        for (int bandIndex = 1; bandIndex <= numBands; bandIndex++) {
+            // Get the band values as an array
+            double[] bandValues = bandAsArray(rasterGeom, bandIndex);
+
+            // Find min and max values in the band
+            double minValue = Arrays.stream(bandValues).min().orElse(Double.NaN);
+            double maxValue = Arrays.stream(bandValues).max().orElse(Double.NaN);
+
+            // Normalize the band values
+            for (int i = 0; i < bandValues.length; i++) {
+                bandValues[i] = minLim + ((bandValues[i] - minValue) * (maxLim - minLim)) / (maxValue - minValue);
+            }
+
+            // Update the raster with the normalized band
+            rasterGeom = addBandFromArray(rasterGeom, bandValues, bandIndex);
+        }
+
+        return rasterGeom;
+    }
+
+    /**
      * @param band1 band values
      * @param band2 band values
      * @return an array with the normalized difference of the provided bands

--- a/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
@@ -454,6 +454,10 @@ public class MapAlgebra
      * @return a raster with all values in all bands normalized between minLim and maxLim
      */
     public static GridCoverage2D normalizeAll(GridCoverage2D rasterGeom, double minLim, double maxLim) {
+        if (minLim > maxLim) {
+            throw new IllegalArgumentException("minLim cannot be greater than maxLim");
+        }
+
         int numBands = rasterGeom.getNumSampleDimensions();
 
         for (int bandIndex = 1; bandIndex <= numBands; bandIndex++) {

--- a/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
@@ -467,10 +467,18 @@ public class MapAlgebra
             // Find min and max values in the band
             double minValue = Arrays.stream(bandValues).min().orElse(Double.NaN);
             double maxValue = Arrays.stream(bandValues).max().orElse(Double.NaN);
+            System.out.println("minValue: "+minValue);
+            System.out.println("maxValue: "+maxValue);
 
-            // Normalize the band values
-            for (int i = 0; i < bandValues.length; i++) {
-                bandValues[i] = minLim + ((bandValues[i] - minValue) * (maxLim - minLim)) / (maxValue - minValue);
+            if (minValue == maxValue) {
+                // If all values in the band are same - set middle value of range as default value.
+                double defaultValue = (minLim + maxLim) / 2.0;
+                Arrays.fill(bandValues, defaultValue);
+            } else {
+                // Normalize the band values
+                for (int i = 0; i < bandValues.length; i++) {
+                    bandValues[i] = minLim + ((bandValues[i] - minValue) * (maxLim - minLim)) / (maxValue - minValue);
+                }
             }
 
             // Update the raster with the normalized band

--- a/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
@@ -329,54 +329,69 @@ public class MapAlgebraTest extends RasterTestBase
         GridCoverage2D raster2 = RasterConstructors.makeEmptyRaster(2, 4, 4, 0, 0, 1);
         GridCoverage2D raster3 = RasterConstructors.makeEmptyRaster(2, "I", 4, 4, 0, 0, 1);
         GridCoverage2D raster4 = RasterConstructors.makeEmptyRaster(2, 4, 4, 0, 0, 1);
+        GridCoverage2D raster5 = RasterConstructors.makeEmptyRaster(2, 4, 4, 0, 0, 1);
 
         for (int band = 1; band <= 2; band++) {
             double[] bandValues1 = new double[4 * 4];
             double[] bandValues2 = new double[4 * 4];
-            double[] bandValues3 = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,-9999};
+            double[] bandValues3 = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16};
             double[] bandValues4 = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,0};
+            double[] bandValues5 = new double[4 * 4];
             for (int i = 0; i < bandValues1.length; i++) {
                 bandValues1[i] = (i) * band;
                 bandValues2[i] = (1) * (band-1);
+                bandValues5[i] = i + ((band-1)*15);
             }
             raster1 = MapAlgebra.addBandFromArray(raster1, bandValues1, band);
             raster2 = MapAlgebra.addBandFromArray(raster2, bandValues2, band);
             raster3 = MapAlgebra.addBandFromArray(raster3, bandValues3, band);
             raster4 = MapAlgebra.addBandFromArray(raster4, bandValues4, band);
+            raster4 = RasterBandEditors.setBandNoDataValue(raster4, band, 0.0);
+            raster5 = MapAlgebra.addBandFromArray(raster5, bandValues5, band);
         }
+        raster3 = RasterBandEditors.setBandNoDataValue(raster3, 1, 16.0);
+        raster3 = RasterBandEditors.setBandNoDataValue(raster3, 2, 1.0);
 
-        GridCoverage2D normalizedRaster1 = MapAlgebra.normalizeAll(raster1);
-        GridCoverage2D normalizedRaster2 = MapAlgebra.normalizeAll(raster1, 256d, 511d);
+        GridCoverage2D normalizedRaster1 = MapAlgebra.normalizeAll(raster1, 0, 255, -9999.0, false);
+        GridCoverage2D normalizedRaster2 = MapAlgebra.normalizeAll(raster1, 256d, 511d, -9999.0, false);
         GridCoverage2D normalizedRaster3 = MapAlgebra.normalizeAll(raster2);
-        GridCoverage2D normalizedRaster4 = MapAlgebra.normalizeAll(raster3, 0, 255);
-        GridCoverage2D normalizedRaster5 = MapAlgebra.normalizeAll(raster4, 0, 255, 0, 1, 15);
+        GridCoverage2D normalizedRaster4 = MapAlgebra.normalizeAll(raster3, 0, 255, 95.0);
+        GridCoverage2D normalizedRaster5 = MapAlgebra.normalizeAll(raster4, 0, 255);
+        GridCoverage2D normalizedRaster6 = MapAlgebra.normalizeAll(raster5, 0.0, 255.0, -9999.0, 0.0, 30.0);
+        GridCoverage2D normalizedRaster7 = MapAlgebra.normalizeAll(raster5, 0, 255, -9999.0, false);
 
+        double[] expected1 = {0.0, 17.0, 34.0, 51.0, 68.0, 85.0, 102.0, 119.0, 136.0, 153.0, 170.0, 187.0, 204.0, 221.0, 238.0, 255.0};
+        double[] expected2 = {256.0, 273.0, 290.0, 307.0, 324.0, 341.0, 358.0, 375.0, 392.0, 409.0, 426.0, 443.0, 460.0, 477.0, 494.0, 511.0};
+        double[] expected3 = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+        double[] expected4 = {0.0, 17.0, 34.0, 51.0, 68.0, 85.0, 102.0, 119.0, 136.0, 153.0, 170.0, 187.0, 204.0, 221.0, 238.0, 95.0};
+        double[] expected5 = {95.0, 17.0, 34.0, 51.0, 68.0, 85.0, 102.0, 119.0, 136.0, 153.0, 170.0, 187.0, 204.0, 221.0, 238.0, 255.0};
+        double[] expected6 = {0.0, 18.214285714285715, 36.42857142857143, 54.642857142857146, 72.85714285714286, 91.07142857142857, 109.28571428571429, 127.5, 145.71428571428572, 163.92857142857142, 182.14285714285714, 200.35714285714286, 218.57142857142858, 236.78571428571428, 255.0, 255.0};
+
+        // Step 3: Validate the results for each band
         for (int band = 1; band <= 2; band++) {
             double[] normalizedBand1 = MapAlgebra.bandAsArray(normalizedRaster1, band);
             double[] normalizedBand2 = MapAlgebra.bandAsArray(normalizedRaster2, band);
-            double[] normalizedBand3 = MapAlgebra.bandAsArray(normalizedRaster3, band);
-            double[] normalizedBand4 = MapAlgebra.bandAsArray(normalizedRaster4, band);
             double[] normalizedBand5 = MapAlgebra.bandAsArray(normalizedRaster5, band);
-            double normalizedMin1 = Arrays.stream(normalizedBand1).min().getAsDouble();
-            double normalizedMax1 = Arrays.stream(normalizedBand1).max().getAsDouble();
-            double normalizedMin2 = Arrays.stream(normalizedBand2).min().getAsDouble();
-            double normalizedMax2 = Arrays.stream(normalizedBand2).max().getAsDouble();
-            double[] expected1 = {0.0, 17.0, 34.0, 51.0, 68.0, 85.0, 102.0, 119.0, 136.0, 153.0, 170.0, 187.0, 204.0, 221.0, 238.0, 255.0};
-            double[] expected2 = {256.0, 273.0, 290.0, 307.0, 324.0, 341.0, 358.0, 375.0, 392.0, 409.0, 426.0, 443.0, 460.0, 477.0, 494.0, 511.0};
-            double[] expected3 = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
-            double[] expected4 = {0.0, 18.0, 36.0, 54.0, 72.0, 91.0, 109.0, 127.0, 145.0, 163.0, 182.0, 200.0, 218.0, 236.0, 255.0, 255.0};
-            double[] expected5 = {0.0, 18.214285714285715, 36.42857142857143, 54.642857142857146, 72.85714285714286, 91.07142857142857, 109.28571428571429, 127.5, 145.71428571428572, 163.92857142857142, 182.14285714285714, 200.35714285714286, 218.57142857142858, 236.78571428571428, 255.0, 255.0};
+            double[] normalizedBand6 = MapAlgebra.bandAsArray(normalizedRaster6, band);
+            double[] normalizedBand7 = MapAlgebra.bandAsArray(normalizedRaster7, band);
+            double normalizedMin6 = Arrays.stream(normalizedBand6).min().getAsDouble();
+            double normalizedMax6 = Arrays.stream(normalizedBand6).max().getAsDouble();
 
-            assertEquals(0d, normalizedMin1, 0.01d);
-            assertEquals(255d, normalizedMax1, 0.01d);
-            assertEquals(256d, normalizedMin2, 0.01d);
-            assertEquals(511d, normalizedMax2, 0.01d);
             assertEquals(Arrays.toString(expected1), Arrays.toString(normalizedBand1));
             assertEquals(Arrays.toString(expected2), Arrays.toString(normalizedBand2));
-            assertEquals(Arrays.toString(expected3), Arrays.toString(normalizedBand3));
-            assertEquals(Arrays.toString(expected4), Arrays.toString(normalizedBand4));
-            assertEquals(Arrays.toString(expected5), Arrays.toString(normalizedBand5));
+            assertEquals(Arrays.toString(expected6), Arrays.toString(normalizedBand5));
+            assertEquals(Arrays.toString(expected1), Arrays.toString(normalizedBand7));
+
+            assertEquals(0+((band-1)*127.5), normalizedMin6, 0.01d);
+            assertEquals(127.5+((band-1)*127.5), normalizedMax6, 0.01d);
         }
+
+        assertEquals(95.0, RasterUtils.getNoDataValue(normalizedRaster4.getSampleDimension(0)), 0.01d);
+        assertEquals(95.0, RasterUtils.getNoDataValue(normalizedRaster4.getSampleDimension(1)), 0.01d);
+
+        assertEquals(Arrays.toString(expected3), Arrays.toString(MapAlgebra.bandAsArray(normalizedRaster3, 1)));
+        assertEquals(Arrays.toString(expected4), Arrays.toString(MapAlgebra.bandAsArray(normalizedRaster4, 1)));
+        assertEquals(Arrays.toString(expected5), Arrays.toString(MapAlgebra.bandAsArray(normalizedRaster4, 2)));
     }
 
     @Test

--- a/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
@@ -25,6 +25,8 @@ import org.junit.Test;
 import org.opengis.referencing.FactoryException;
 
 import java.awt.image.DataBuffer;
+import java.lang.reflect.Array;
+import java.util.Arrays;
 import java.util.Random;
 
 import static org.junit.Assert.*;
@@ -319,6 +321,40 @@ public class MapAlgebraTest extends RasterTestBase
         double[] actual = MapAlgebra.normalize(band);
         double[] expected = new double[] {226.0, 255.0, 0.0, 72.0};
         assertArrayEquals(expected, actual, 0.1d);
+    }
+
+    @Test
+    public void testNormalizeAll() throws FactoryException {
+        GridCoverage2D raster = RasterConstructors.makeEmptyRaster(3, 4, 4, 0, 0, 1);
+
+        for (int band = 1; band <= 3; band++) {
+            double[] bandValues = new double[4 * 4];
+            for (int i = 0; i < bandValues.length; i++) {
+                bandValues[i] = (i) * band;
+            }
+            raster = MapAlgebra.addBandFromArray(raster, bandValues, band);
+        }
+
+        GridCoverage2D normalizedRaster1 = MapAlgebra.normalizeAll(raster);
+        GridCoverage2D normalizedRaster2 = MapAlgebra.normalizeAll(raster, 256d, 511d);
+
+        for (int band = 1; band <= 3; band++) {
+            double[] normalizedBand1 = MapAlgebra.bandAsArray(normalizedRaster1, band);
+            double[] normalizedBand2 = MapAlgebra.bandAsArray(normalizedRaster2, band);
+            double normalizedMin1 = Arrays.stream(normalizedBand1).min().getAsDouble();
+            double normalizedMax1 = Arrays.stream(normalizedBand1).max().getAsDouble();
+            double normalizedMin2 = Arrays.stream(normalizedBand2).min().getAsDouble();
+            double normalizedMax2 = Arrays.stream(normalizedBand2).max().getAsDouble();
+            double[] expected1 = {0.0, 17.0, 34.0, 51.0, 68.0, 85.0, 102.0, 119.0, 136.0, 153.0, 170.0, 187.0, 204.0, 221.0, 238.0, 255.0};
+            double[] expected2 = {256.0, 273.0, 290.0, 307.0, 324.0, 341.0, 358.0, 375.0, 392.0, 409.0, 426.0, 443.0, 460.0, 477.0, 494.0, 511.0};
+
+            assertEquals(0d, normalizedMin1, 0.01d);
+            assertEquals(255d, normalizedMax1, 0.01d);
+            assertEquals(256d, normalizedMin2, 0.01d);
+            assertEquals(511d, normalizedMax2, 0.01d);
+            assertEquals(Arrays.toString(expected1), Arrays.toString(normalizedBand1));
+            assertEquals(Arrays.toString(expected2), Arrays.toString(normalizedBand2));
+        }
     }
 
     @Test

--- a/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
@@ -325,28 +325,35 @@ public class MapAlgebraTest extends RasterTestBase
 
     @Test
     public void testNormalizeAll() throws FactoryException {
-        GridCoverage2D raster = RasterConstructors.makeEmptyRaster(3, 4, 4, 0, 0, 1);
+        GridCoverage2D raster1 = RasterConstructors.makeEmptyRaster(3, 4, 4, 0, 0, 1);
+        GridCoverage2D raster2 = RasterConstructors.makeEmptyRaster(3, 4, 4, 0, 0, 1);
 
         for (int band = 1; band <= 3; band++) {
-            double[] bandValues = new double[4 * 4];
-            for (int i = 0; i < bandValues.length; i++) {
-                bandValues[i] = (i) * band;
+            double[] bandValues1 = new double[4 * 4];
+            double[] bandValues2 = new double[4 * 4];
+            for (int i = 0; i < bandValues1.length; i++) {
+                bandValues1[i] = (i) * band;
+                bandValues2[i] = (1) * (band-1);
             }
-            raster = MapAlgebra.addBandFromArray(raster, bandValues, band);
+            raster1 = MapAlgebra.addBandFromArray(raster1, bandValues1, band);
+            raster2 = MapAlgebra.addBandFromArray(raster2, bandValues2, band);
         }
 
-        GridCoverage2D normalizedRaster1 = MapAlgebra.normalizeAll(raster);
-        GridCoverage2D normalizedRaster2 = MapAlgebra.normalizeAll(raster, 256d, 511d);
+        GridCoverage2D normalizedRaster1 = MapAlgebra.normalizeAll(raster1);
+        GridCoverage2D normalizedRaster2 = MapAlgebra.normalizeAll(raster1, 256d, 511d);
+        GridCoverage2D normalizedRaster3 = MapAlgebra.normalizeAll(raster2);
 
         for (int band = 1; band <= 3; band++) {
             double[] normalizedBand1 = MapAlgebra.bandAsArray(normalizedRaster1, band);
             double[] normalizedBand2 = MapAlgebra.bandAsArray(normalizedRaster2, band);
+            double[] normalizedBand3 = MapAlgebra.bandAsArray(normalizedRaster3, band);
             double normalizedMin1 = Arrays.stream(normalizedBand1).min().getAsDouble();
             double normalizedMax1 = Arrays.stream(normalizedBand1).max().getAsDouble();
             double normalizedMin2 = Arrays.stream(normalizedBand2).min().getAsDouble();
             double normalizedMax2 = Arrays.stream(normalizedBand2).max().getAsDouble();
             double[] expected1 = {0.0, 17.0, 34.0, 51.0, 68.0, 85.0, 102.0, 119.0, 136.0, 153.0, 170.0, 187.0, 204.0, 221.0, 238.0, 255.0};
             double[] expected2 = {256.0, 273.0, 290.0, 307.0, 324.0, 341.0, 358.0, 375.0, 392.0, 409.0, 426.0, 443.0, 460.0, 477.0, 494.0, 511.0};
+            double[] expected3 = {127.5, 127.5, 127.5, 127.5, 127.5, 127.5, 127.5, 127.5, 127.5, 127.5, 127.5, 127.5, 127.5, 127.5, 127.5, 127.5};
 
             assertEquals(0d, normalizedMin1, 0.01d);
             assertEquals(255d, normalizedMax1, 0.01d);
@@ -354,6 +361,7 @@ public class MapAlgebraTest extends RasterTestBase
             assertEquals(511d, normalizedMax2, 0.01d);
             assertEquals(Arrays.toString(expected1), Arrays.toString(normalizedBand1));
             assertEquals(Arrays.toString(expected2), Arrays.toString(normalizedBand2));
+            assertEquals(Arrays.toString(expected3), Arrays.toString(normalizedBand3));
         }
     }
 

--- a/docs/api/sql/Raster-operators.md
+++ b/docs/api/sql/Raster-operators.md
@@ -2482,13 +2482,29 @@ SELECT RS_Normalize(band)
 
 ### RS_NormalizeAll
 
-Introduction: Normalizes values in all bands of a raster between a given normalization range. By default, the values are normalized to range [0, 255].
+Introduction: Normalizes values in all bands of a raster between a given normalization range. By default, the values are normalized to range [0, 255]. RS_NormalizeAll can take upto 6 of the following arguments.
 
-Format:
+- `raster`: The raster to be normalized.
+- `minLim` and `maxLim` (Optional): The lower and upper limits of the normalization range. By default, normalization range is set to [0, 255].
+- `noDataValue` (Optional): NoDataValues in rasters represent missing or invalid data. By default, -9999 is taken as NoDataValue.
+- `minValue` and `maxValue` (Optional): Optionally, specific minimum and maximum values of the input raster can be provided. If not provided, these values are computed from the raster data.
 
-`RS_NormalizeAll (raster: Raster)`
+!!!Note
+    The function maintains the data type of the raster values. It ensures that the normalized values are cast back to the original data type of each band in the raster.
 
-`RS_NormalizeAll (raster: Raster, minLim: Double, maxLim: Double)`
+Formats:
+```
+RS_NormalizeAll (raster: Raster)`
+```
+```
+RS_NormalizeAll (raster: Raster, minLim: Double, maxLim: Double)
+```
+```
+RS_NormalizeAll (raster: Raster, minLim: Double, maxLim: Double, noDataValue: Double)
+```
+```
+RS_NormalizeAll (raster: Raster, minLim: Double, maxLim: Double, noDataValue: Double, minValue: Double, maxValue: Double)
+```
 
 Since: `v1.6.0`
 

--- a/docs/api/sql/Raster-operators.md
+++ b/docs/api/sql/Raster-operators.md
@@ -2482,8 +2482,7 @@ SELECT RS_Normalize(band)
 
 ### RS_NormalizeAll
 
-Introduction: Normalizes values in all bands of a raster between a given normalization range. The function maintains the data type of the raster values by ensuring that the normalized values are cast back to the original data type of each band in the raster. 
-By default, the values are normalized to range [0, 255]. RS_NormalizeAll can take upto 6 of the following arguments.
+Introduction: Normalizes values in all bands of a raster between a given normalization range. The function maintains the data type of the raster values by ensuring that the normalized values are cast back to the original data type of each band in the raster. By default, the values are normalized to range [0, 255]. RS_NormalizeAll can take upto 6 of the following arguments.
 
 - `raster`: The raster to be normalized.
 - `minLim` and `maxLim` (Optional): The lower and upper limits of the normalization range. By default, normalization range is set to [0, 255].

--- a/docs/api/sql/Raster-operators.md
+++ b/docs/api/sql/Raster-operators.md
@@ -2480,6 +2480,24 @@ Spark SQL Example:
 SELECT RS_Normalize(band)
 ```
 
+### RS_NormalizeAll
+
+Introduction: Normalizes values in all bands of a raster between a given normalization range. By default, the values are normalized to range [0, 255].
+
+Format:
+
+`RS_NormalizeAll (raster: Raster)`
+
+`RS_NormalizeAll (raster: Raster, minLim: Double, maxLim: Double)`
+
+Since: `v1.6.0`
+
+Spark SQL Example:
+
+```sql
+SELECT RS_NormalizeAll(raster, 0, 1)
+```
+
 ### RS_NormalizedDifference
 
 Introduction: Returns Normalized Difference between two bands(band2 and band1) in a Geotiff image(example: NDVI, NDBI)

--- a/docs/api/sql/Raster-operators.md
+++ b/docs/api/sql/Raster-operators.md
@@ -2482,15 +2482,17 @@ SELECT RS_Normalize(band)
 
 ### RS_NormalizeAll
 
-Introduction: Normalizes values in all bands of a raster between a given normalization range. By default, the values are normalized to range [0, 255]. RS_NormalizeAll can take upto 6 of the following arguments.
+Introduction: Normalizes values in all bands of a raster between a given normalization range. The function maintains the data type of the raster values by ensuring that the normalized values are cast back to the original data type of each band in the raster. 
+By default, the values are normalized to range [0, 255]. RS_NormalizeAll can take upto 6 of the following arguments.
 
 - `raster`: The raster to be normalized.
 - `minLim` and `maxLim` (Optional): The lower and upper limits of the normalization range. By default, normalization range is set to [0, 255].
-- `noDataValue` (Optional): NoDataValues in rasters represent missing or invalid data. By default, -9999 is taken as NoDataValue.
+- `noDataValue` (Optional): Defines the value to be used for missing or invalid data in raster bands. By default, noDataValue is set to `maxLim`.
 - `minValue` and `maxValue` (Optional): Optionally, specific minimum and maximum values of the input raster can be provided. If not provided, these values are computed from the raster data.
+- `normalizeAcrossBands` (Optional): A boolean flag to determine the normalization method. If set to true (default), normalization is performed across all bands based on global min and max values. If false, each band is normalized individually based on its own min and max values.
 
-!!!Note
-    The function maintains the data type of the raster values. It ensures that the normalized values are cast back to the original data type of each band in the raster.
+!!! Warning
+    Using a noDataValue that falls within the normalization range can lead to loss of valid data. If any data value within a raster band matches the specified noDataValue, it will be replaced and cannot be distinguished or recovered later. Exercise caution in selecting a noDataValue to avoid unintentional data alteration.
 
 Formats:
 ```
@@ -2503,7 +2505,13 @@ RS_NormalizeAll (raster: Raster, minLim: Double, maxLim: Double)
 RS_NormalizeAll (raster: Raster, minLim: Double, maxLim: Double, noDataValue: Double)
 ```
 ```
+RS_NormalizeAll (raster: Raster, minLim: Double, maxLim: Double, noDataValue: Double, normalizeAcrossBands: Boolean)
+```
+```
 RS_NormalizeAll (raster: Raster, minLim: Double, maxLim: Double, noDataValue: Double, minValue: Double, maxValue: Double)
+```
+```
+RS_NormalizeAll (raster: Raster, minLim: Double, maxLim: Double, noDataValue: Double, minValue: Double, maxValue: Double, normalizeAcrossBands: Boolean)
 ```
 
 Since: `v1.6.0`

--- a/spark/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
+++ b/spark/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
@@ -199,6 +199,7 @@ object Catalog {
     function[RS_LogicalOver](),
     function[RS_Array](),
     function[RS_Normalize](),
+    function[RS_NormalizeAll](),
     function[RS_AddBandFromArray](),
     function[RS_BandAsArray](),
     function[RS_MapAlgebra](null),

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
@@ -180,7 +180,7 @@ case class RS_Normalize(inputExpressions: Seq[Expression]) extends InferredExpre
 }
 
 case class RS_NormalizeAll(inputExpressions: Seq[Expression]) extends InferredExpression(
-  inferrableFunction1(MapAlgebra.normalizeAll), inferrableFunction3(MapAlgebra.normalizeAll), inferrableFunction4(MapAlgebra.normalizeAll), inferrableFunction6(MapAlgebra.normalizeAll)
+  inferrableFunction1(MapAlgebra.normalizeAll), inferrableFunction3(MapAlgebra.normalizeAll), inferrableFunction4(MapAlgebra.normalizeAll), inferrableFunction5(MapAlgebra.normalizeAll), inferrableFunction6(MapAlgebra.normalizeAll), inferrableFunction7(MapAlgebra.normalizeAll)
 ) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
@@ -180,7 +180,7 @@ case class RS_Normalize(inputExpressions: Seq[Expression]) extends InferredExpre
 }
 
 case class RS_NormalizeAll(inputExpressions: Seq[Expression]) extends InferredExpression(
-  inferrableFunction1(MapAlgebra.normalizeAll), inferrableFunction3(MapAlgebra.normalizeAll)
+  inferrableFunction1(MapAlgebra.normalizeAll), inferrableFunction3(MapAlgebra.normalizeAll), inferrableFunction4(MapAlgebra.normalizeAll), inferrableFunction6(MapAlgebra.normalizeAll)
 ) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
@@ -179,6 +179,14 @@ case class RS_Normalize(inputExpressions: Seq[Expression]) extends InferredExpre
   }
 }
 
+case class RS_NormalizeAll(inputExpressions: Seq[Expression]) extends InferredExpression(
+  inferrableFunction1(MapAlgebra.normalizeAll), inferrableFunction3(MapAlgebra.normalizeAll)
+) {
+  override protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
+}
+
 case class RS_AddBandFromArray(inputExpressions: Seq[Expression])
   extends InferredExpression(nullTolerantInferrableFunction3(MapAlgebra.addBandFromArray), nullTolerantInferrableFunction4(MapAlgebra.addBandFromArray), inferrableFunction2(MapAlgebra.addBandFromArray)) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/MapAlgebra.scala
@@ -182,7 +182,7 @@ case class RS_Normalize(inputExpressions: Seq[Expression]) extends InferredExpre
 case class RS_NormalizeAll(inputExpressions: Seq[Expression]) extends InferredExpression(
   inferrableFunction1(MapAlgebra.normalizeAll), inferrableFunction3(MapAlgebra.normalizeAll)
 ) {
-  override protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }

--- a/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
@@ -216,6 +216,13 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
       assert(df.first().getAs[mutable.WrappedArray[Double]](0)(1) == 255)
     }
 
+    it("should pass RS_NormalizeAll") {
+      var df = sparkSession.read.format("binaryFile").load(resourceFolder + "raster/test1.tiff")
+      df = df.selectExpr("RS_FromGeoTiff(content) as raster")
+      val result = df.selectExpr("RS_NormalizeAll(raster) as normalized").first().get(0)
+      assert(result.isInstanceOf[GridCoverage2D])
+    }
+
     it("should pass RS_Array") {
       val df = sparkSession.sql("SELECT RS_Array(6, 1e-6) as band")
       val result = df.first().getAs[mutable.WrappedArray[Double]](0)

--- a/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
@@ -219,8 +219,10 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
     it("should pass RS_NormalizeAll") {
       var df = sparkSession.read.format("binaryFile").load(resourceFolder + "raster/test1.tiff")
       df = df.selectExpr("RS_FromGeoTiff(content) as raster")
-      val result = df.selectExpr("RS_NormalizeAll(raster) as normalized").first().get(0)
-      assert(result.isInstanceOf[GridCoverage2D])
+      val result1 = df.selectExpr("RS_NormalizeAll(raster, 0, 255) as normalized").first().get(0)
+      val result2 = df.selectExpr("RS_NormalizeAll(raster, 0, 255, 0) as normalized").first().get(0)
+      assert(result1.isInstanceOf[GridCoverage2D])
+      assert(result2.isInstanceOf[GridCoverage2D])
     }
 
     it("should pass RS_Array") {


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)


## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-475. The PR name follows the format `[SEDONA-XXX] my subject`.


## What changes were proposed in this PR?

Adds RS_NormalizeAll, to normalize values in all bands of a raster between a given normalization range. 
Key features - 
- **Flexible Normalization Range**: Optionally specify normalization range through `minLim` and `maxLim`. By default, the values are normalized to range [0, 255].
- **Handling Uniform Bands**: For bands where all pixel values are identical, normalized values are set to lower limit of normalization range.
- **Handling NoDataValues**: Allows defining `noDataValue` to be used for missing or invalid data in raster bands. By default, noDataValue is set to maxLim.
- **Optional Min/Max range of raster**: Min and Max range of the input raster's pixel values can be specified via `minValue` and `maxValue` to skip computation of them during runtime.
- **Data Type Integrity**: The function maintains the data type of raster values ensuring normalized values are cast back to the original raster's data type.
- **Normalization across bands**: `normalizeAcrossBands` flag, when set, normalization is performed across all bands based on global min and max values. If false, each band is normalized individually based on its own min and max values.


## How was this patch tested?

Passes new and existing tests


## Did this PR include necessary documentation updates?

- Yes, I am adding a new API. I am using the [current SNAPSHOT version number](https://github.com/apache/sedona/blob/99239524f17389fc4ae9548ea88756f8ea538bb9/pom.xml#L29) in since `vX.Y.Z` format.
