### PR TITLE
[SEDONA476] Expose kepler & pydeck as extras

### DIFF
--- a/docs/tutorial/sql.md
+++ b/docs/tutorial/sql.md
@@ -580,11 +580,9 @@ Spatial query results can be visualized in a Jupyter lab/notebook environment us
 SedonaPyDeck exposes APIs to create interactive map visualizations using [pydeck](https://pydeck.gl/index.html#) based on [deck.gl](https://deck.gl/)
 
 !!!Note
-	To use SedonaPyDeck, GeoPandas and PyDeck must be installed. We recommend the following installation commands:
+	To use SedonaPyDeck, install sedona with the `pydeck-map` extra:
 	```
-	pip install 'pandas<=1.3.5'
-	pip install 'geopandas<=0.10.2'
-	pip install pydeck==0.8.0
+	pip install sedona[pydeck-map]
 	```
 
 The following tutorial showcases the various maps that can be created using SedonaPyDeck, the datasets used to create these maps are publicly available.
@@ -658,11 +656,9 @@ Spatial query results can be visualized in a Jupyter lab/notebook environment us
 SedonaKepler exposes APIs to create interactive and customizable map visualizations using [KeplerGl](https://kepler.gl/).
 
 !!!Note
-	To use SedonaKepler, GeoPandas and KeplerGL must be installed. We recommend the following installation commands:
+	To use SedonaKepler, install sedona with the `kepler-map` extra:
 	```
-	pip install 'pandas<=1.3.5'
-	pip install 'geopandas<=0.10.2'
-	pip install keplergl==0.3.2
+	pip install sedona[kepler-map]
 	```
 
 This tutorial showcases how simple it is to instantly visualize geospatial data using SedonaKepler.

--- a/python/sedona/maps/SedonaKepler.py
+++ b/python/sedona/maps/SedonaKepler.py
@@ -15,7 +15,6 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-from keplergl import KeplerGl
 from sedona.maps.SedonaMapUtils import SedonaMapUtils
 
 
@@ -30,6 +29,13 @@ class SedonaKepler:
         dataframe, if a df is passed with no name, a default name of 'unnamed' is set for it.
         param config: [Optional] A map config to be applied to the rendered map :return: A map object
         """
+
+        try:
+            from keplergl import KeplerGl
+        except ImportError:
+            msg = "Install sedona[kepler-map] to convert sedona dataframes to kepler maps."
+            raise ImportError(msg) from None
+
         kepler_map = KeplerGl()
         if df is not None:
             SedonaKepler.add_df(kepler_map, df, name)

--- a/python/sedona/maps/SedonaPyDeck.py
+++ b/python/sedona/maps/SedonaPyDeck.py
@@ -15,7 +15,7 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-import pydeck as pdk
+from types import ModuleType
 from sedona.maps.SedonaMapUtils import SedonaMapUtils
 
 
@@ -37,6 +37,7 @@ class SedonaPyDeck:
         :param map_provider:
         :return: A pydeck Map object with choropleth layer added:
         """
+        pdk = _try_import_pydeck()
 
         if initial_view_state is None:
             gdf = SedonaPyDeck._prepare_df_(df, add_coords=True)
@@ -79,6 +80,8 @@ class SedonaPyDeck:
         :param map_provider: optional map_provider of the pydeck map
         :return: A pydeck map with a GeoJsonLayer map added
         """
+        pdk = _try_import_pydeck()
+
         geometry_col = SedonaMapUtils.__get_geometry_col__(df)
         gdf = SedonaPyDeck._prepare_df_(df, geometry_col=geometry_col)
         geom_type = gdf[geometry_col][0].geom_type
@@ -116,6 +119,8 @@ class SedonaPyDeck:
         :param map_provider: optional map_provider to be added to the pydeck map
         :return: A pydeck map object with a scatterplot layer added
         """
+        pdk = _try_import_pydeck()
+
         gdf = SedonaPyDeck._prepare_df_(df, add_coords=True)
         layer = pdk.Layer(
             "ScatterplotLayer",
@@ -152,6 +157,7 @@ class SedonaPyDeck:
         :param map_provider: Optional map_provider for the pydeck map
         :return: A pydeck map with a heatmap layer added
         """
+        pdk = _try_import_pydeck()
 
         gdf = SedonaPyDeck._prepare_df_(df, add_coords=True)
 
@@ -239,6 +245,7 @@ class SedonaPyDeck:
 
     @classmethod
     def _create_fat_layer_(cls, gdf, fill_color, line_color, elevation_col):
+        pdk = _try_import_pydeck()
         layer = pdk.Layer(
             'GeoJsonLayer',  # `type` positional argument is here
             data=gdf,
@@ -254,3 +261,14 @@ class SedonaPyDeck:
         )
 
         return layer
+
+
+def _try_import_pydeck() -> ModuleType:
+    try:
+        import pydeck as pdk
+
+    except ImportError:
+        msg = "Install sedona[pydeck-map] to convert sedona dataframes to pydeck maps."
+        raise ImportError(msg) from None
+
+    return pdk

--- a/python/sedona/spark/__init__.py
+++ b/python/sedona/spark/__init__.py
@@ -41,11 +41,4 @@ from sedona.utils import SedonaKryoRegistrator
 from sedona.register import SedonaRegistrator
 from sedona.spark.SedonaContext import SedonaContext
 from sedona.raster_utils.SedonaUtils import SedonaUtils
-try:
-    from sedona.maps.SedonaKepler import SedonaKepler
-except:
-    print('Skipping SedonaKepler import, verify if keplergl is installed')
-try:
-    from sedona.maps.SedonaPyDeck import SedonaPyDeck
-except:
-    print('Skipping SedonaPyDeck import, verify if pydeck is installed')
+from sedona.maps import SedonaKepler, SedonaPyDeck

--- a/python/setup.py
+++ b/python/setup.py
@@ -57,6 +57,7 @@ setup(
         "spark": ["pyspark>=2.3.0"],
         "pydeck-map": ["pandas<=1.3.5", "geopandas<=0.10.2", "pydeck==0.8.0"],
         "kepler-map": ["pandas<=1.3.5", "geopandas<=0.10.2", "keplergl==0.3.2"],
+        "all": ["pyspark>=2.3.0", "pandas<=1.3.5", "geopandas<=0.10.2","pydeck==0.8.0", "keplergl==0.3.2"],
     },
     project_urls={
         'Documentation': 'https://sedona.apache.org',

--- a/python/setup.py
+++ b/python/setup.py
@@ -53,7 +53,11 @@ setup(
     long_description_content_type="text/markdown",
     python_requires='>=3.6',
     install_requires=['attrs', "shapely>=1.7.0"],
-    extras_require={"spark": ['pyspark>=2.3.0']},
+    extras_require={
+        "spark": ["pyspark>=2.3.0"],
+        "pydeck-map": ["pandas<=1.3.5", "geopandas<=0.10.2", "pydeck==0.8.0"],
+        "kepler-map": ["pandas<=1.3.5", "geopandas<=0.10.2", "keplergl==0.3.2"],
+    },
     project_urls={
         'Documentation': 'https://sedona.apache.org',
         'Source code': 'https://github.com/apache/sedona',


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- No, this is a documentation update. The PR name follows the format `[DOCS] my subject`.

## What changes were proposed in this PR?

This updates the Sedona python package with three new extras: `kepler-map`, `pydeck-map`, and an `all` extras. 

It also moves the import of the optional dependencies `kepler` and `pydeck` inside the functions where they are used. This avoids logging unnecessary warnings like those described in #1222.

## How was this patch tested?

I tested the addition of the extras by doing local installs of the module in a virtual environment. The changes to `SedonaKepler` and `SedonaPyDeck` have been tested in the CI.

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.
