### PR TITLE
[DOCS] Bump cibuildwheel version to 2.16.5

### DIFF
--- a/.github/workflows/python-wheel.yml
+++ b/.github/workflows/python-wheel.yml
@@ -39,7 +39,7 @@ jobs:
       with:
         platforms: all
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.16.2
+      uses: pypa/cibuildwheel@v2.16.5
       env:
         CIBW_SKIP: 'pp* *musl*'
         CIBW_ARCHS_LINUX: 'x86_64 aarch64'


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- No, this is a documentation update. The PR name follows the format `[DOCS] my subject`.


## What changes were proposed in this PR?

Bump cibuildwheel to 2.16.5 to fix the incompatibility issue caused by new GitHub Windows image: https://github.com/pypa/cibuildwheel/issues/1748

## How was this patch tested?

Pass the GitHub CI

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
