### PR TITLE
[SEDONA-477] Shift the origin of clip results to zero

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/raster/RasterBandEditors.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterBandEditors.java
@@ -32,6 +32,7 @@ import org.opengis.referencing.operation.TransformException;
 import javax.media.jai.RasterFactory;
 import java.awt.geom.Point2D;
 import java.awt.image.Raster;
+import java.awt.image.RenderedImage;
 import java.awt.image.WritableRaster;
 import java.util.Arrays;
 import java.util.Collections;
@@ -259,7 +260,14 @@ public class RasterBandEditors {
             }
             newRaster = RasterUtils.clone(resultRaster, raster.getGridGeometry(), newRaster.getSampleDimensions(), newRaster, noDataValue, true);
         } else {
-            newRaster = RasterUtils.clone(newRaster.getRenderedImage(), newRaster.getGridGeometry(), newRaster.getSampleDimensions(), newRaster, noDataValue, true);
+            RenderedImage image = newRaster.getRenderedImage();
+            int minX = image.getMinX();
+            int minY = image.getMinY();
+            if (minX != 0 || minY != 0) {
+                newRaster = RasterUtils.shiftRasterToZeroOrigin(newRaster, noDataValue);
+            } else {
+                newRaster = RasterUtils.clone(newRaster.getRenderedImage(), newRaster.getGridGeometry(), newRaster.getSampleDimensions(), newRaster, noDataValue, true);
+            }
         }
 
         return newRaster;
@@ -295,24 +303,4 @@ public class RasterBandEditors {
             return clip(raster, band, geometry, noDataValue, true);
         }
     }
-
-//    /**
-//     * Return a clipped raster with the specified ROI by the geometry.
-//     * @param raster Raster to clip
-//     * @param band Band number to perform clipping
-//     * @param geometry Specify ROI
-//     * @param crop Specifies to keep the original extent or not
-//     * @return A clip Raster with defined ROI by the geometry
-//     */
-//    public static GridCoverage2D clip(GridCoverage2D raster, int band, Geometry geometry, boolean crop) {
-//        boolean isDataTypeIntegral = RasterUtils.isDataTypeIntegral(RasterUtils.getDataTypeCode(RasterBandAccessors.getBandType(raster, band)));
-//
-//        if (isDataTypeIntegral) {
-//            double noDataValue = Integer.MIN_VALUE;
-//            return clip(raster, band, geometry, noDataValue, crop);
-//        } else {
-//            double noDataValue = Double.MIN_VALUE;
-//            return clip(raster, band, geometry, noDataValue, crop);
-//        }
-//    }
 }

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterBandEditorsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterBandEditorsTest.java
@@ -189,6 +189,8 @@ public class RasterBandEditorsTest extends RasterTestBase{
         assertTrue(Arrays.equals(expectedValues, actualValues));
 
         GridCoverage2D croppedRaster = RasterBandEditors.clip(raster, 1, geom, 200, true);
+        assertEquals(0, croppedRaster.getRenderedImage().getMinX());
+        assertEquals(0, croppedRaster.getRenderedImage().getMinY());
         points = new ArrayList<>();
         points.add(Constructors.geomFromWKT("POINT(236842 4.20465e+06)", 26918));
         points.add(Constructors.geomFromWKT("POINT(236961 4.20453e+06)", 26918));


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-477. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

The result of RS_Clip returns GridCoverage2D objects containing JAI images with non-zero origin when `crop = true`. This will bring a full range of problems when handling such GridCoverage2D objects, because lots of band operation code assumes that the JAI images have zero origin, and the `BufferedImage` of AWT also does not allow images with non-zero origin, which make it difficult to construct image objects from in-memory buffer.

We decide to make all GridCoverage2D objects having zero origin, rather than fixing all band operation routines to make them handle non-zero origins correctly, since this is very difficult. We defined a helper function `RasterUtils.shiftRasterToZeroOrigin` to shift raster with non-zero origin to have zero origin, and shift the affine transformation to cancel with the origin shift, thus to keep the actual grid coverage unchanged.

![Untitled Diagram drawio (1)](https://github.com/wherobots/wherobots-compute/assets/5501374/94056e8e-cf6a-4dca-a027-fd4bc998ee4d)

## How was this patch tested?

Add test to validate that the result of RS_Clip has zero origin.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
