### PR TITLE
[SEDONA-496] Dependabot: reduce the open pull requests limit to 2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,10 +2,12 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
+    open-pull-requests-limit: 2
     schedule:
       interval: monthly
 
   - package-ecosystem: pip
     directory: /docker/sedona-spark-jupyterlab
+    open-pull-requests-limit: 2
     schedule:
       interval: monthly


### PR DESCRIPTION
This will reduce the number of open pull requests for version updates at any one time.

Might help to reduce spam like content on the mailing list.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit



## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)


## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-496. The PR name follows the format `[SEDONA-XXX] my subject`.



## What changes were proposed in this PR?

Reduce the open pull requests limit to 2

## How was this patch tested?


## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
