### PR TITLE
[SEDONA-497] Fix incorrect fieldNames property of SpatialRDD read from a directory containing multiple shapefiles

### DIFF
--- a/spark/common/src/main/java/org/apache/sedona/core/formatMapper/shapefileParser/ShapefileReader.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/formatMapper/shapefileParser/ShapefileReader.java
@@ -178,10 +178,16 @@ public class ShapefileReader
         fieldDescriptors = fieldDescriptors.reduceByKey(new Function2<String, String, String>()
         {
             @Override
-            public String call(String descripter1, String descripter2)
+            public String call(String descriptor1, String descriptor2)
                     throws Exception
             {
-                return descripter1 + " " + descripter2;
+                if (!descriptor1.equals(descriptor2)) {
+                    String message = String.format("Detected different schema in the input shapefiles:\n  %s\n  %s\n" +
+                            "Please make sure all shapefiles have the same schema.",
+                            descriptor1, descriptor2);
+                    throw new IOException(message);
+                }
+                return descriptor1;
             }
         });
         // if there is a result assign it to variable : fieldNames


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-497]. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

We won't concatenate the schema of all shapefiles when inferring the `fieldNames` property of the resulting SpatialRDD. This behavior is strange so I changed it to check if all the shapefiles have consistent schema. If there's any concern regarding this change please let me know.

## How was this patch tested?

Add new tests for reading multiple shapefiles.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
