### PR TITLE
[SEDONA-500] Fix failures and data consistency problems when reading multiple shapefiles in one directory

### DIFF
--- a/spark/common/src/main/java/org/apache/sedona/core/formatMapper/shapefileParser/shapes/ShapeInputFormat.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/formatMapper/shapefileParser/shapes/ShapeInputFormat.java
@@ -101,16 +101,20 @@ public class ShapeInputFormat
                 String filename = FilenameUtils.removeExtension(filePath.getName()).toLowerCase();
                 String suffix = FilenameUtils.getExtension(filePath.getName()).toLowerCase();
 
-                fileSplitPathParts.add(filePath);
-                fileSplitSizeParts.add(filePathSizePair.get(filePath));
+                if (!(suffix.equals(SHX_SUFFIX) || suffix.equals(DBF_SUFFIX) || suffix.equals(SHP_SUFFIX))) {
+                    // Currently we only support .shp, .shx, and .dbf files
+                    continue;
+                }
 
-                if (prevfilename != "" && !prevfilename.equals(filename)
-                        && (suffix.equals(SHX_SUFFIX) || suffix.equals(DBF_SUFFIX) || suffix.equals(SHP_SUFFIX))) {
-                    // compare file name and if it is different then all same filename is into CombileFileSplit
+                if (!prevfilename.isEmpty() && !prevfilename.equals(filename)) {
+                    // compare file name and if it is different then all same filename is into CombineFileSplit
                     splits.add(new CombineFileSplit(fileSplitPathParts.toArray(new Path[0]), Longs.toArray(fileSplitSizeParts)));
                     fileSplitPathParts.clear();
                     fileSplitSizeParts.clear();
                 }
+
+                fileSplitPathParts.add(filePath);
+                fileSplitSizeParts.add(filePathSizePair.get(filePath));
                 prevfilename = filename;
             }
 

--- a/spark/common/src/test/java/org/apache/sedona/core/formatMapper/shapefileParser/shapes/ShapefileReaderTest.java
+++ b/spark/common/src/test/java/org/apache/sedona/core/formatMapper/shapefileParser/shapes/ShapefileReaderTest.java
@@ -392,11 +392,12 @@ public class ShapefileReaderTest
     {
         // load shape with geotool.shapefile
         String inputLocation = getShapeFilePath("multipleshapefiles");
-        FeatureCollection<SimpleFeatureType, SimpleFeature> collection = loadFeatures(inputLocation);
         // load shapes with our tool
         SpatialRDD shapeRDD = ShapefileReader.readToGeometryRDD(sc, inputLocation);
         assert (shapeRDD.rawSpatialRDD.getNumPartitions() == 2);
         assertEquals("[STATEFP, COUNTYFP, COUNTYNS, AFFGEOID, GEOID, NAME, LSAD, ALAND, AWATER]", shapeRDD.fieldNames.toString());
+        long count = shapeRDD.rawSpatialRDD.count();
+        assertEquals(3220, count);
     }
 
     /**


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-500. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Fix problems when generating splits for directories containing multiple shapefiles. This fixes the following issues:

1. Reading fails with errors such as "shape record loses attributes in .dbf file at ID=2387"
2. Geometry values and other fields do not match.
3. Not all records were read into SpatialRDD

## How was this patch tested?

Add additional assertion to the `testReadMultipleShapeFilesByMultiPartitions` test case.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
