### PR TITLE
[SEDONA-505] Fix handling of geometries with SRID=0 in some raster functions

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/utils/RasterUtils.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/RasterUtils.java
@@ -456,10 +456,13 @@ public class RasterUtils {
         // to the raster CRS.
         // Note that:
         // In Sedona vector, we do not perform implicit CRS transform. Everything must be done explicitly via ST_Transform
-        // In Sedona raster, we do implicit CRS transform if the geometry has a SRID and the raster has a CRS
-        if (targetCRS != null && !(targetCRS instanceof DefaultEngineeringCRS) && geomSRID > 0) {
+        // In Sedona raster, we do implicit CRS transform if the raster has a CRS. If the the SRID of the geometry is 0, we assume it is 4326.
+        if (geomSRID == 0) {
+            geomSRID = 4326;
+        }
+        if (targetCRS != null && !(targetCRS instanceof DefaultEngineeringCRS)) {
             try {
-                geometry = FunctionsGeoTools.transformToGivenTarget(geometry, null, targetCRS, true);
+                geometry = FunctionsGeoTools.transformToGivenTarget(geometry, "epsg:" + geomSRID, targetCRS, true);
             } catch (FactoryException | TransformException e) {
                 throw new RuntimeException("Cannot transform CRS of query window", e);
             }

--- a/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.{Row, SaveMode}
 import org.apache.spark.sql.functions.{col, collect_list, expr, row_number}
 import org.geotools.coverage.grid.GridCoverage2D
-import org.junit.Assert.{assertEquals, assertNull, assertTrue}
+import org.junit.Assert.{assertEquals, assertNotNull, assertNull, assertTrue}
 import org.locationtech.jts.geom.{Coordinate, Geometry}
 import org.scalatest.{BeforeAndAfter, GivenWhenThen}
 
@@ -988,6 +988,10 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
 
       actual = df.selectExpr("RS_ZonalStats(raster, geom, 'sd')").first().get(0)
       assertEquals(92.13277429243035, actual)
+
+      // Test with a polygon in EPSG:4326
+      actual = df.selectExpr("RS_ZonalStats(raster, ST_GeomFromWKT('POLYGON ((-77.96672569800863073 37.91971182746296876, -77.9688630154902711 37.89620133516485367, -77.93936803424354309 37.90517806858776595, -77.96672569800863073 37.91971182746296876))'), 1, 'mean', false)").first().get(0)
+      assertNotNull(actual)
     }
 
     it("Passed RS_ZonalStats - Raster with no data") {
@@ -1235,25 +1239,37 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
     it("Passed RS_WorldToRasterCoord with raster - geom parameter") {
       var df = sparkSession.read.format("binaryFile").load(resourceFolder + "raster/test1.tiff")
       df = df.selectExpr("RS_FromGeoTiff(content) as raster")
-      val result = df.selectExpr("ST_AsText(RS_WorldToRasterCoord(raster, ST_GeomFromText('POINT (-13095817.809482181 4021262.7487925636)')))").first().getString(0);
+      val results = df.selectExpr(
+        "ST_AsText(RS_WorldToRasterCoord(raster, ST_GeomFromText('POINT (-13095817.809482181 4021262.7487925636)', 3857)))",
+        "ST_AsText(RS_WorldToRasterCoord(raster, ST_GeomFromText('POINT (-117.64173 33.943833)')))"
+      ).first()
       val expected = "POINT (1 1)"
-      assertEquals(expected, result)
+      assertEquals(expected, results.getString(0))
+      assertEquals(expected, results.getString(1))
     }
 
     it("Passed RS_WorldToRasterCoordX with raster - geom parameter") {
       var df = sparkSession.read.format("binaryFile").load(resourceFolder + "raster/test1.tiff")
       df = df.selectExpr("RS_FromGeoTiff(content) as raster")
-      val result = df.selectExpr("RS_WorldToRasterCoordX(raster, ST_GeomFromText('POINT (-13095817.809482181 4021262.7487925636)'))").first().getInt(0);
+      val results = df.selectExpr(
+        "RS_WorldToRasterCoordX(raster, ST_GeomFromText('POINT (-13095817.809482181 4021262.7487925636)', 3857))",
+        "RS_WorldToRasterCoordX(raster, ST_GeomFromText('POINT (-117.64173 33.943833)'))"
+      ).first()
       val expected = 1
-      assertEquals(expected, result)
+      assertEquals(expected, results.getInt(0))
+      assertEquals(expected, results.getInt(1))
     }
 
     it("Passed RS_WorldToRasterCoordY with raster - geom parameter") {
       var df = sparkSession.read.format("binaryFile").load(resourceFolder + "raster/test1.tiff")
       df = df.selectExpr("RS_FromGeoTiff(content) as raster")
-      val result = df.selectExpr("RS_WorldToRasterCoordY(raster, ST_GeomFromText('POINT (-13095817.809482181 4021262.7487925636)'))").first().getInt(0);
+      val results = df.selectExpr(
+        "RS_WorldToRasterCoordY(raster, ST_GeomFromText('POINT (-13095817.809482181 4021262.7487925636)', 3857))",
+        "RS_WorldToRasterCoordY(raster, ST_GeomFromText('POINT (-117.64173 33.943833)'))"
+      ).first()
       val expected = 1
-      assertEquals(expected, result)
+      assertEquals(expected, results.getInt(0))
+      assertEquals(expected, results.getInt(1))
     }
 
     it("Passed RS_Contains") {


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-505. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

The following RS functions do not perform implicit CRS transformation when the geometry has SRID=0:

* RS_ZonalStats
* RS_ZonalStatsAll
* RS_WorldToRasterCoord
* RS_WorldToRasterCoordX
* RS_WorldToRasterCoordY

This behavior is inconsistent with other raster functions such as RS_Value, RS_Intersects, and RS_Clip. We'll change the behavior of listed functions to treat geometries with SRID=0 as if they were in EPSG:4326 and perform implicit CRS transformation if needed.

## How was this patch tested?

Updated existing tests and added additional tests

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
