### PR TITLE
[SEDONA-506] Lenient mode for RS_ZonalStats and RS_ZonalStatsAll

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/raster/RasterBandAccessors.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterBandAccessors.java
@@ -131,7 +131,7 @@ public class RasterBandAccessors {
      * @throws FactoryException
      */
     public static double[] getZonalStatsAll(GridCoverage2D raster, Geometry roi, int band, boolean excludeNoData) throws FactoryException {
-        return getZonalStatsAll(raster, roi, band, excludeNoData, false);
+        return getZonalStatsAll(raster, roi, band, excludeNoData, true);
     }
 
     /**
@@ -200,9 +200,8 @@ public class RasterBandAccessors {
         }
     }
 
-    public static double getZonalStats(GridCoverage2D raster, Geometry roi, int band, String statType, boolean excludeNoData) throws FactoryException {
-        Double stat = getZonalStats(raster, roi, band, statType, excludeNoData, false);
-        return Objects.requireNonNull(stat);
+    public static Double getZonalStats(GridCoverage2D raster, Geometry roi, int band, String statType, boolean excludeNoData) throws FactoryException {
+        return getZonalStats(raster, roi, band, statType, excludeNoData, true);
     }
 
     /**
@@ -213,7 +212,7 @@ public class RasterBandAccessors {
      * @return A double precision floating point number representing the requested statistic calculated over the specified region. The excludeNoData is set to true.
      * @throws FactoryException
      */
-    public static double getZonalStats(GridCoverage2D raster, Geometry roi, int band, String statType) throws FactoryException {
+    public static Double getZonalStats(GridCoverage2D raster, Geometry roi, int band, String statType) throws FactoryException {
         return getZonalStats(raster, roi, band, statType, true);
     }
 
@@ -224,7 +223,7 @@ public class RasterBandAccessors {
      * @return A double precision floating point number representing the requested statistic calculated over the specified region. The excludeNoData is set to true and band is set to 1.
      * @throws FactoryException
      */
-    public static double getZonalStats(GridCoverage2D raster, Geometry roi, String statType) throws FactoryException {
+    public static Double getZonalStats(GridCoverage2D raster, Geometry roi, String statType) throws FactoryException {
         return getZonalStats(raster, roi, 1, statType, true);
     }
 

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterBandAccessorsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterBandAccessorsTest.java
@@ -114,6 +114,15 @@ public class RasterBandAccessorsTest extends RasterTestBase {
         actual = RasterBandAccessors.getZonalStats(raster, geom, 1, "sd", false);
         expected = 92.1327;
         assertEquals(expected, actual, FP_TOLERANCE);
+
+        geom = Constructors.geomFromWKT("POLYGON ((-77.96672569800863073 37.91971182746296876, -77.9688630154902711 37.89620133516485367, -77.93936803424354309 37.90517806858776595, -77.96672569800863073 37.91971182746296876))", 0);
+        Double statValue = RasterBandAccessors.getZonalStats(raster, geom, 1, "sum", false, true);
+        assertNotNull(statValue);
+
+        Geometry nonIntersectingGeom = Constructors.geomFromWKT("POLYGON ((-78.22106647832458748 37.76411511479908967, -78.20183062098976734 37.72863564460374874, -78.18088490966962922 37.76753482276972562, -78.22106647832458748 37.76411511479908967))", 0);
+        statValue = RasterBandAccessors.getZonalStats(raster, nonIntersectingGeom, 1, "sum", false, true);
+        assertNull(statValue);
+        assertThrows(IllegalArgumentException.class, () -> RasterBandAccessors.getZonalStats(raster, nonIntersectingGeom, 1, "sum", false, false));
     }
 
     @Test
@@ -161,6 +170,15 @@ public class RasterBandAccessorsTest extends RasterTestBase {
         double[] actual = RasterBandAccessors.getZonalStatsAll(raster, geom, 1, false);
         double[] expected = new double[] {184792.0, 1.0690406E7, 57.8510, 0.0, 0.0, 92.1327, 8488.4480, 0.0, 255.0};
         assertArrayEquals(expected, actual, FP_TOLERANCE);
+
+        geom = Constructors.geomFromWKT("POLYGON ((-77.96672569800863073 37.91971182746296876, -77.9688630154902711 37.89620133516485367, -77.93936803424354309 37.90517806858776595, -77.96672569800863073 37.91971182746296876))", 0);
+        actual = RasterBandAccessors.getZonalStatsAll(raster, geom, 1, false);
+        assertNotNull(actual);
+
+        Geometry nonIntersectingGeom = Constructors.geomFromWKT("POLYGON ((-78.22106647832458748 37.76411511479908967, -78.20183062098976734 37.72863564460374874, -78.18088490966962922 37.76753482276972562, -78.22106647832458748 37.76411511479908967))", 0);
+        actual = RasterBandAccessors.getZonalStatsAll(raster, nonIntersectingGeom, 1, false, true);
+        assertNull(actual);
+        assertThrows(IllegalArgumentException.class, () -> RasterBandAccessors.getZonalStatsAll(raster, nonIntersectingGeom, 1, false, false));
     }
 
     @Test

--- a/docs/api/sql/Raster-operators.md
+++ b/docs/api/sql/Raster-operators.md
@@ -1098,7 +1098,7 @@ Introduction: This returns a statistic value specified by `statType` over the re
     - The provided `raster` and `zone` geometry should intersect when `lenient` parameter is set to `false`.
     - The option provided to `statType` should be valid.
 
-    `lenient` parameter is set to `false` by default. If `lenient` is set to `true`, then the function will return `null` if the `raster` and `zone` geometry do not intersect.
+    `lenient` parameter is set to `true` by default. The function will return `null` if the `raster` and `zone` geometry do not intersect.
 
 Format:
 
@@ -1166,7 +1166,7 @@ Introduction: Returns an array of statistic values, where each statistic is comp
     - The provided `raster` and `zone` geometry should intersect when `lenient` parameter is set to `false`.
     - The option provided to `statType` should be valid.
 
-    `lenient` parameter is set to `false` by default. If `lenient` is set to `true`, then the function will return `null` if the `raster` and `zone` geometry do not intersect.
+    `lenient` parameter is set to `true` by default. The function will return `null` if the `raster` and `zone` geometry do not intersect.
 
 Format:
 

--- a/docs/api/sql/Raster-operators.md
+++ b/docs/api/sql/Raster-operators.md
@@ -1095,10 +1095,16 @@ Introduction: This returns a statistic value specified by `statType` over the re
 
     The following conditions will throw an `IllegalArgumentException` if they are not met:
 
-    - The provided `raster` and `zone` geometry should intersect.
+    - The provided `raster` and `zone` geometry should intersect when `lenient` parameter is set to `false`.
     - The option provided to `statType` should be valid.
 
+    `lenient` parameter is set to `false` by default. If `lenient` is set to `true`, then the function will return `null` if the `raster` and `zone` geometry do not intersect.
+
 Format:
+
+```
+RS_ZonalStats(raster: Raster, zone: Geometry, band: Integer, statType: String, excludeNoData: Boolean, lenient: Boolean)
+```
 
 ```
 RS_ZonalStats(raster: Raster, zone: Geometry, band: Integer, statType: String, excludeNoData: Boolean)
@@ -1157,10 +1163,16 @@ Introduction: Returns an array of statistic values, where each statistic is comp
 
     The following conditions will throw an `IllegalArgumentException` if they are not met:
 
-    - The provided `raster` and `zone` geometry should intersect.
+    - The provided `raster` and `zone` geometry should intersect when `lenient` parameter is set to `false`.
     - The option provided to `statType` should be valid.
 
+    `lenient` parameter is set to `false` by default. If `lenient` is set to `true`, then the function will return `null` if the `raster` and `zone` geometry do not intersect.
+
 Format:
+
+```
+RS_ZonalStatsAll(raster: Raster, zone: Geometry, band: Integer, excludeNodata: Boolean, lenient: Boolean)
+```
 
 ```
 RS_ZonalStatsAll(raster: Raster, zone: Geometry, band: Integer, excludeNodata: Boolean)

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterBandAccessors.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterBandAccessors.scala
@@ -44,7 +44,9 @@ case class RS_Count(inputExpressions: Seq[Expression]) extends InferredExpressio
   }
 
 case class RS_ZonalStats(inputExpressions: Seq[Expression]) extends InferredExpression(
-  inferrableFunction5(RasterBandAccessors.getZonalStats), inferrableFunction4(RasterBandAccessors.getZonalStats),
+  inferrableFunction6(RasterBandAccessors.getZonalStats),
+  inferrableFunction5(RasterBandAccessors.getZonalStats),
+  inferrableFunction4(RasterBandAccessors.getZonalStats),
   inferrableFunction3(RasterBandAccessors.getZonalStats)
 ) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -54,7 +56,7 @@ case class RS_ZonalStats(inputExpressions: Seq[Expression]) extends InferredExpr
 
 case class RS_ZonalStatsAll(inputExpressions: Seq[Expression]) extends InferredExpression(
   inferrableFunction2(RasterBandAccessors.getZonalStatsAll), inferrableFunction4(RasterBandAccessors.getZonalStatsAll),
-  inferrableFunction3(RasterBandAccessors.getZonalStatsAll)
+  inferrableFunction3(RasterBandAccessors.getZonalStatsAll), inferrableFunction5(RasterBandAccessors.getZonalStatsAll)
 ) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)

--- a/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
@@ -992,6 +992,10 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
       // Test with a polygon in EPSG:4326
       actual = df.selectExpr("RS_ZonalStats(raster, ST_GeomFromWKT('POLYGON ((-77.96672569800863073 37.91971182746296876, -77.9688630154902711 37.89620133516485367, -77.93936803424354309 37.90517806858776595, -77.96672569800863073 37.91971182746296876))'), 1, 'mean', false, true)").first().get(0)
       assertNotNull(actual)
+
+      // Test with a polygon that does not intersect the raster in lenient mode
+      actual = df.selectExpr("RS_ZonalStats(raster, ST_GeomFromWKT('POLYGON ((-78.22106647832458748 37.76411511479908967, -78.20183062098976734 37.72863564460374874, -78.18088490966962922 37.76753482276972562, -78.22106647832458748 37.76411511479908967))'), 1, 'mean', false, true)").first().get(0)
+      assertNull(actual)
     }
 
     it("Passed RS_ZonalStats - Raster with no data") {
@@ -1019,6 +1023,10 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
       val actual = df.selectExpr("RS_ZonalStatsAll(raster, geom, 1, true)").first().get(0)
       val expected = Seq(184792.0, 1.0690406E7, 57.851021689230684, 0.0, 0.0, 92.13277429243035, 8488.448098819916, 0.0, 255.0)
       assertTrue(expected.equals(actual))
+
+      // Test with a polygon that does not intersect the raster in lenient mode
+      val actual2 = df.selectExpr("RS_ZonalStatsAll(raster, ST_GeomFromWKT('POLYGON ((-78.22106647832458748 37.76411511479908967, -78.20183062098976734 37.72863564460374874, -78.18088490966962922 37.76753482276972562, -78.22106647832458748 37.76411511479908967))'), 1, false, true)").first().get(0)
+      assertNull(actual2)
     }
 
     it("Passed RS_ZonalStatsAll - Raster with no data") {

--- a/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
@@ -990,11 +990,11 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
       assertEquals(92.13277429243035, actual)
 
       // Test with a polygon in EPSG:4326
-      actual = df.selectExpr("RS_ZonalStats(raster, ST_GeomFromWKT('POLYGON ((-77.96672569800863073 37.91971182746296876, -77.9688630154902711 37.89620133516485367, -77.93936803424354309 37.90517806858776595, -77.96672569800863073 37.91971182746296876))'), 1, 'mean', false, true)").first().get(0)
+      actual = df.selectExpr("RS_ZonalStats(raster, ST_GeomFromWKT('POLYGON ((-77.96672569800863073 37.91971182746296876, -77.9688630154902711 37.89620133516485367, -77.93936803424354309 37.90517806858776595, -77.96672569800863073 37.91971182746296876))'), 1, 'mean', false)").first().get(0)
       assertNotNull(actual)
 
       // Test with a polygon that does not intersect the raster in lenient mode
-      actual = df.selectExpr("RS_ZonalStats(raster, ST_GeomFromWKT('POLYGON ((-78.22106647832458748 37.76411511479908967, -78.20183062098976734 37.72863564460374874, -78.18088490966962922 37.76753482276972562, -78.22106647832458748 37.76411511479908967))'), 1, 'mean', false, true)").first().get(0)
+      actual = df.selectExpr("RS_ZonalStats(raster, ST_GeomFromWKT('POLYGON ((-78.22106647832458748 37.76411511479908967, -78.20183062098976734 37.72863564460374874, -78.18088490966962922 37.76753482276972562, -78.22106647832458748 37.76411511479908967))'), 1, 'mean', false)").first().get(0)
       assertNull(actual)
     }
 
@@ -1025,7 +1025,7 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
       assertTrue(expected.equals(actual))
 
       // Test with a polygon that does not intersect the raster in lenient mode
-      val actual2 = df.selectExpr("RS_ZonalStatsAll(raster, ST_GeomFromWKT('POLYGON ((-78.22106647832458748 37.76411511479908967, -78.20183062098976734 37.72863564460374874, -78.18088490966962922 37.76753482276972562, -78.22106647832458748 37.76411511479908967))'), 1, false, true)").first().get(0)
+      val actual2 = df.selectExpr("RS_ZonalStatsAll(raster, ST_GeomFromWKT('POLYGON ((-78.22106647832458748 37.76411511479908967, -78.20183062098976734 37.72863564460374874, -78.18088490966962922 37.76753482276972562, -78.22106647832458748 37.76411511479908967))'), 1, false)").first().get(0)
       assertNull(actual2)
     }
 

--- a/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
@@ -990,7 +990,7 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
       assertEquals(92.13277429243035, actual)
 
       // Test with a polygon in EPSG:4326
-      actual = df.selectExpr("RS_ZonalStats(raster, ST_GeomFromWKT('POLYGON ((-77.96672569800863073 37.91971182746296876, -77.9688630154902711 37.89620133516485367, -77.93936803424354309 37.90517806858776595, -77.96672569800863073 37.91971182746296876))'), 1, 'mean', false)").first().get(0)
+      actual = df.selectExpr("RS_ZonalStats(raster, ST_GeomFromWKT('POLYGON ((-77.96672569800863073 37.91971182746296876, -77.9688630154902711 37.89620133516485367, -77.93936803424354309 37.90517806858776595, -77.96672569800863073 37.91971182746296876))'), 1, 'mean', false, true)").first().get(0)
       assertNotNull(actual)
     }
 


### PR DESCRIPTION
This PR depends on https://github.com/apache/sedona/pull/1256

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-506. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Add an optional `lenient` parameter to `RS_ZonalStats` and `RS_ZonalStatsAll`. The default value is `true`. When `lenient` is set to `true`, zonal stats functions won't raise exceptions when the ROI does not intersect with the raster, and return null in such cases.

## How was this patch tested?

Add tests for lenient mode.

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation update.

