### PR TITLE
[SEDONA-507] RS_AsImage and RS_AsPNG could properly handle non-integral band data

### DIFF
--- a/common/src/test/java/org/apache/sedona/common/raster/RasterOutputTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterOutputTest.java
@@ -50,7 +50,7 @@ public class RasterOutputTest
         GridCoverage2D raster = RasterConstructors.makeNonEmptyRaster(1, "d", 5, 5, 1, 1, 1, 1, 0, 0, 4326, new double[][] {bandData});
 
         String resultRaw = RasterOutputs.asBase64(raster);
-        assertTrue(resultRaw.startsWith("TU0AKgAAAAgADQEAAAMAAAABAAUAAAEBAAMAAAABAAUAAAECA"));
+        assertTrue(resultRaw.startsWith("iVBORw0KGgoAAAANSUhEUgAAAAUAAAA"));
     }
 
     @Test
@@ -211,5 +211,27 @@ public class RasterOutputTest
         assertTrue(htmlString.endsWith(expectedEnd));
     }
 
-
+    @Test
+    public void testAsImageVariousBandDataType() throws IOException, FactoryException {
+        String[] dataTypes = {"b", "d", "f", "i", "s", "us"};
+        int width = 100;
+        int height = 100;
+        for (String dataType : dataTypes) {
+            for (int numBands = 1; numBands < 5; numBands++) {
+                GridCoverage2D testRaster = RasterConstructors.makeEmptyRaster(numBands, dataType, width, height, 0, 0, 1, -1, 0, 0, 0);
+                double[] bandValues = new double[width * height];
+                for (int k = 0; k < numBands; k++) {
+                    for (int i = 0; i < bandValues.length; i++) {
+                        bandValues[i] = k + i;
+                    }
+                    testRaster = MapAlgebra.addBandFromArray(testRaster, bandValues, k + 1);
+                }
+                String htmlString = RasterOutputs.createHTMLString(testRaster, 50);
+                String expectedStart = "<img src=\"data:image/png;base64,iVBORw0K";
+                String expectedEnd = "width=\"50\" />";
+                assertTrue(htmlString.startsWith(expectedStart));
+                assertTrue(htmlString.endsWith(expectedEnd));
+            }
+        }
+    }
 }

--- a/docs/api/sql/Raster-visualizer.md
+++ b/docs/api/sql/Raster-visualizer.md
@@ -11,7 +11,11 @@ Introduction: Returns a base64 encoded string of the given raster. If the dataty
 !!!Warning
     This is not recommended for large files.
 
-Format: `RS_AsBase64(raster: Raster)`
+Format:
+
+`RS_AsBase64(raster: Raster, maxWidth: Integer)`
+
+`RS_AsBase64(raster: Raster)`
 
 Since: `v1.5.0`
 
@@ -54,8 +58,8 @@ Output:
 Example:
 
 ```python
-df = sedona.read.format('binaryFile').load(DATA_DIR + 'raster.tiff').selectExpr(\"RS_FromGeoTiff(content) as raster\")
-htmlDF = df.selectExpr(\"RS_AsImage(raster, 500) as raster_image\")
+df = sedona.read.format('binaryFile').load(DATA_DIR + 'raster.tiff').selectExpr("RS_FromGeoTiff(content) as raster")
+htmlDF = df.selectExpr("RS_AsImage(raster, 500) as raster_image")
 SedonaUtils.display_image(htmlDF)
 ```
 

--- a/docs/api/sql/Raster-writer.md
+++ b/docs/api/sql/Raster-writer.md
@@ -107,7 +107,11 @@ Introduction: Returns a PNG byte array, that can be written to raster files as P
 !!!Note
 	Raster that have float or double values will result in an empty byte array. PNG only accepts Integer values, if you want to write your raster to an image file, please refer to [RS_AsGeoTiff](#rs_asgeotiff).
 
-Format: `RS_AsPNG(raster: Raster)`
+Format:
+
+`RS_AsPNG(raster: Raster, maxWidth: Integer)`
+
+`RS_AsPNG(raster: Raster)`
 
 Since: `v1.5.0`
 

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterOutputs.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterOutputs.scala
@@ -39,13 +39,15 @@ case class RS_AsArcGrid(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_AsPNG(inputExpressions: Seq[Expression]) extends InferredExpression(RasterOutputs.asPNG _) {
+case class RS_AsPNG(inputExpressions: Seq[Expression]) extends InferredExpression(
+  inferrableFunction1(RasterOutputs.asPNG), inferrableFunction2(RasterOutputs.asPNG)) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_AsBase64(inputExpressions: Seq[Expression]) extends InferredExpression(RasterOutputs.asBase64 _) {
+case class RS_AsBase64(inputExpressions: Seq[Expression]) extends InferredExpression(
+  inferrableFunction1(RasterOutputs.asBase64), inferrableFunction2(RasterOutputs.asBase64)) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-507. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

RS_AsImage only produces PNG images for rasters with integral band data, and produces TIFF images for rasters with floating point band data. TIFF cannot be displayed on many mainstream browsers, so we should not use TIFF to visualize rasters.

This PR make RS_AsPNG work for all types of band data, so that RS_AsImage won't produce TIFF base64 output.

* If the band data type is byte, we try converting it to PNG directly. This will preserve the original color of the raster if the raster is RGB or using a color table
* If the raster has one single band, we normalize the band data to 0~255 and generate a grayscale image, with nodata pixels masked as transparent
* Otherwise we use the color model to translate pixel values to RGB value, and generate an RGB image.

## How was this patch tested?

* Tested locally on various rasters to make sure that they are displayed properly.
* Added a smoke test to make sure that it does not break when processing rasters with various band data types

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
