### PR TITLE
[SEDONA-476] Fixed package names of SedonaKepler and SedonaPyDeck; do not require IPython to be installed to `import sedona.spark`

### DIFF
--- a/python/sedona/raster_utils/SedonaUtils.py
+++ b/python/sedona/raster_utils/SedonaUtils.py
@@ -15,9 +15,8 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-from IPython.display import display, HTML
-
 class SedonaUtils:
     @classmethod
     def display_image(cls, df):
+        from IPython.display import display, HTML
         display(HTML(df.toPandas().to_html(escape=False)))

--- a/python/sedona/spark/__init__.py
+++ b/python/sedona/spark/__init__.py
@@ -41,4 +41,5 @@ from sedona.utils import SedonaKryoRegistrator
 from sedona.register import SedonaRegistrator
 from sedona.spark.SedonaContext import SedonaContext
 from sedona.raster_utils.SedonaUtils import SedonaUtils
-from sedona.maps import SedonaKepler, SedonaPyDeck
+from sedona.maps.SedonaKepler import SedonaKepler
+from sedona.maps.SedonaPyDeck import SedonaPyDeck


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-476. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Fix how we import `SedonaKepler` and `SedonaPyDeck` in `sedona/spark/__init__.py`, so that we can call `sedona.spark.SedonaKepler.create_map` after `import sedona.spark`, instead of `sedona.spark.SedonaKepler.SedonaKepler.create_map`.

This PR also contains a fix for https://github.com/apache/sedona/issues/1253, so that `import sedona.spark` won't require IPython to be present.

## How was this patch tested?

Tested manually in a virtual environment.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
