### PR TITLE
[SEDONA-511] Fix reading/writing geoparquet metadata for snake_case or camelCase column names

### DIFF
--- a/spark/common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/GeoParquetMetaData.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/GeoParquetMetaData.scala
@@ -14,7 +14,8 @@
 package org.apache.spark.sql.execution.datasources.parquet
 
 import org.json4s.jackson.JsonMethods.parse
-import org.json4s.{JNothing, JNull, JValue}
+import org.json4s.jackson.compactJson
+import org.json4s.{DefaultFormats, Extraction, JField, JNothing, JNull, JObject, JValue}
 
 /**
  * A case class that holds the metadata of geometry column in GeoParquet metadata
@@ -62,14 +63,31 @@ object GeoParquetMetaData {
       implicit val formats: org.json4s.Formats = org.json4s.DefaultFormats
       val geoObject = parse(geo)
       val metadata = geoObject.camelizeKeys.extract[GeoParquetMetaData]
-      metadata.copy(columns = metadata.columns.map { case (name, column) =>
+      val columns = (geoObject \ "columns").extract[Map[String, JValue]].map { case (name, columnObject) =>
+        val fieldMetadata = columnObject.camelizeKeys.extract[GeometryFieldMetaData]
         // Postprocess to distinguish between null (JNull) and missing field (JNothing).
-        geoObject \ "columns" \ name \ "crs" match {
-          case JNothing => name -> column.copy(crs = None)
-          case JNull => name -> column.copy(crs = Some(JNull))
-          case _ => name -> column
+        columnObject \ "crs" match {
+          case JNothing => name -> fieldMetadata.copy(crs = None)
+          case JNull => name -> fieldMetadata.copy(crs = Some(JNull))
+          case _ => name -> fieldMetadata
         }
-      })
+      }
+      metadata.copy(columns = columns)
     }
+  }
+
+  def toJson(geoParquetMetadata: GeoParquetMetaData): String = {
+    implicit val formats: org.json4s.Formats = DefaultFormats
+    val geoObject = Extraction.decompose(geoParquetMetadata)
+
+    // Make sure that the keys of columns are not transformed to camel case, so we use the columns map with
+    // original keys to replace the transformed columns map.
+    val columnsMap = (geoObject \ "columns").extract[Map[String, JValue]].map { case (name, columnObject) =>
+      name -> columnObject.underscoreKeys
+    }
+    val serializedGeoObject = geoObject.underscoreKeys transformField {
+      case JField("columns", _) => JField("columns", JObject(columnsMap.toList))
+    }
+    compactJson(serializedGeoObject)
   }
 }

--- a/spark/spark-3.0/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/GeoParquetWriteSupport.scala
+++ b/spark/spark-3.0/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/GeoParquetWriteSupport.scala
@@ -201,8 +201,7 @@ class GeoParquetWriteSupport extends WriteSupport[InternalRow] with Logging {
         columnName -> GeometryFieldMetaData("WKB", geometryTypes, bbox, crs)
       }.toMap
       val geoParquetMetadata = GeoParquetMetaData(geoParquetVersion, primaryColumn, columns)
-      implicit val formats: org.json4s.Formats = DefaultFormats
-      val geoParquetMetadataJson = compactJson(Extraction.decompose(geoParquetMetadata).underscoreKeys)
+      val geoParquetMetadataJson = GeoParquetMetaData.toJson(geoParquetMetadata)
       metadata.put("geo", geoParquetMetadataJson)
     }
     new FinalizedWriteContext(metadata)

--- a/spark/spark-3.4/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/GeoParquetWriteSupport.scala
+++ b/spark/spark-3.4/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/GeoParquetWriteSupport.scala
@@ -201,8 +201,7 @@ class GeoParquetWriteSupport extends WriteSupport[InternalRow] with Logging {
         columnName -> GeometryFieldMetaData("WKB", geometryTypes, bbox, crs)
       }.toMap
       val geoParquetMetadata = GeoParquetMetaData(geoParquetVersion, primaryColumn, columns)
-      implicit val formats: org.json4s.Formats = DefaultFormats
-      val geoParquetMetadataJson = compactJson(Extraction.decompose(geoParquetMetadata).underscoreKeys)
+      val geoParquetMetadataJson = GeoParquetMetaData.toJson(geoParquetMetadata)
       metadata.put("geo", geoParquetMetadataJson)
     }
     new FinalizedWriteContext(metadata)

--- a/spark/spark-3.5/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/GeoParquetWriteSupport.scala
+++ b/spark/spark-3.5/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/GeoParquetWriteSupport.scala
@@ -201,8 +201,7 @@ class GeoParquetWriteSupport extends WriteSupport[InternalRow] with Logging {
         columnName -> GeometryFieldMetaData("WKB", geometryTypes, bbox, crs)
       }.toMap
       val geoParquetMetadata = GeoParquetMetaData(geoParquetVersion, primaryColumn, columns)
-      implicit val formats: org.json4s.Formats = DefaultFormats
-      val geoParquetMetadataJson = compactJson(Extraction.decompose(geoParquetMetadata).underscoreKeys)
+      val geoParquetMetadataJson = GeoParquetMetaData.toJson(geoParquetMetadata)
       metadata.put("geo", geoParquetMetadataJson)
     }
     new FinalizedWriteContext(metadata)


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-511. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

The current GeoParquet implementation converts the geo metadata to camel or underscore style during parsing and serialization, and it introduces consistency issues with the schema of the parquet files. This patch resolves this issue by skipping the style conversion for column names. Now it should work correctly with geometry column names such as `geom_column` or `geomColumn`.

## How was this patch tested?

Added tests for geoparquet and geoparquet.metadata data source.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
