### PR TITLE
[DOCS] pre-commit: fix the arguments syntax for markdownlint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
       - id: markdownlint
         name: Run markdownlint
         description: Check Markdown files with markdownlint
-        entry: markdownlint -c .github/linters/.markdown-lint.yml .
+        args: [--config=.github/linters/.markdown-lint.yml]
         exclude: ^\.github/.*$
         types: [markdown]
         files: \.(md|mdown|markdown)$


### PR DESCRIPTION
https://github.com/igorshubovych/markdownlint-cli?tab=readme-ov-file#usage

https://github.com/igorshubovych/markdownlint-cli?tab=readme-ov-file#use-with-pre-commit


## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- No, this is a documentation update. The PR name follows the format `[DOCS] my subject`.

## What changes were proposed in this PR?

Fixed the pre-commit syntax for markdownlint

## How was this patch tested?

`pre-commit run --all-files`

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
