### PR TITLE
[SEDONA-517] RS_MakeRaster

### DIFF
--- a/docs/api/sql/Raster-loader.md
+++ b/docs/api/sql/Raster-loader.md
@@ -165,6 +165,37 @@ Output:
 +------------------------------------------------------------------+
 ```
 
+### RS_MakeRaster
+
+Introduction: Creates a raster from the given array of pixel values. The width, height, geo-reference information, and
+the CRS will be taken from the given reference raster. The data type of the resulting raster will be DOUBLE and the
+number of bands of the resulting raster will be `data.length / (refRaster.width * refRaster.height)`.
+
+Since: `v1.6.0`
+
+Format: `RS_MakeRaster(refRaster: Raster, bandDataType: String, data: ARRAY[Double])`
+
+* refRaster: The reference raster from which the width, height, geo-reference information, and the CRS will be taken.
+* bandDataType: The data type of the bands in the resulting raster. Please refer to the `RS_MakeEmptyRaster` function for the accepted values.
+* data: The array of pixel values. The size of the array cannot be 0, and should be multiple of width * height of the reference raster.
+
+SQL example:
+
+```sql
+WITH r AS (SELECT RS_MakeEmptyRaster(2, 3, 2, 0.0, 0.0, 1.0, -1.0, 0.0, 0.0, 4326) AS rast)
+SELECT RS_AsMatrix(RS_MakeRaster(rast, 'D', ARRAY(1, 2, 3, 4, 5, 6))) FROM r
+```
+
+Output:
+
+```
++------------------------------------------------------------+
+|rs_asmatrix(rs_makeraster(rast, D, array(1, 2, 3, 4, 5, 6)))|
++------------------------------------------------------------+
+||1.0  2.0  3.0|\n|4.0  5.0  6.0|\n                          |
++------------------------------------------------------------+
+```
+
 ### RS_FromNetCDF
 
 Introduction: Returns a raster geometry representing the given record variable short name from a NetCDF file.

--- a/spark/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
+++ b/spark/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
@@ -211,6 +211,7 @@ object Catalog {
     function[RS_FromArcInfoAsciiGrid](),
     function[RS_FromGeoTiff](),
     function[RS_MakeEmptyRaster](),
+    function[RS_MakeRaster](),
     function[RS_Tile](),
     function[RS_TileExplode](),
     function[RS_Envelope](),

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterConstructors.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterConstructors.scala
@@ -69,6 +69,13 @@ case class RS_MakeEmptyRaster(inputExpressions: Seq[Expression])
   }
 }
 
+case class RS_MakeRaster(inputExpressions: Seq[Expression])
+  extends InferredExpression(inferrableFunction3(RasterConstructors.makeNonEmptyRaster)) {
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
+}
+
 case class RS_Tile(inputExpressions: Seq[Expression])
   extends InferredExpression(
     nullTolerantInferrableFunction3(RasterConstructors.rsTile),


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-517. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Add a new raster constructor `RS_MakeRaster` for constructing a raster using specified band data. The width, height, geo-reference information, and CRS will be the same as the given reference raster.

## How was this patch tested?

Add new unit test.

## Did this PR include necessary documentation updates?

- Yes, I am adding a new API. I am using the [current SNAPSHOT version number](https://github.com/apache/sedona/blob/99239524f17389fc4ae9548ea88756f8ea538bb9/pom.xml#L29) in since `vX.Y.Z` format.
