### PR TITLE
[SEDONA-525] Add two more pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,7 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
+      - id: check-ast
       - id: check-case-conflict
       # - id: check-docstring-first
       # - id: check-executables-have-shebangs
@@ -31,6 +32,8 @@ repos:
       - id: check-vcs-permalinks
       - id: check-xml
       # - id: check-yaml
+      - id: detect-aws-credentials
+        args: [--allow-missing-credentials]
       - id: detect-private-key
       - id: end-of-file-fixer
         exclude: \.svg$|^docs/image|^spark/common/src/test/resources
@@ -38,6 +41,7 @@ repos:
       - id: mixed-line-ending
         exclude: \.csv$
       - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
         exclude: ^docs-overrides/main\.html$|\.Rd$
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.38.0


### PR DESCRIPTION
https://github.com/pre-commit/pre-commit-hooks?tab=readme-ov-file#check-ast

https://github.com/pre-commit/pre-commit-hooks?tab=readme-ov-file#detect-aws-credentials

https://github.com/pre-commit/pre-commit-hooks?tab=readme-ov-file#trailing-whitespace


## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-525. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Added two more hooks to our pre-commit framework.

Standardized the `trailing-whitespace` hook

## How was this patch tested?

Ran locally:

`pre-commit run --all-files`

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
