### PR TITLE
[SEDONA-526] Upgrade `actions/setup-java` to `v4`

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -34,8 +34,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@v4
       with:
+        distribution: 'zulu'
         java-version: 11
     - name: Cache Maven packages
       uses: actions/cache@v3

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -31,8 +31,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@v4
       with:
+        distribution: 'zulu'
         java-version: '8'
     - run: sudo apt-get remove scala-library scala
     - run: sudo wget www.scala-lang.org/files/archive/scala-2.12.11.deb

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -78,8 +78,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@v4
       with:
+        distribution: 'zulu'
         java-version: ${{ matrix.jdk }}
     - uses: actions/setup-python@v5
       with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -90,8 +90,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@v4
       with:
+        distribution: 'zulu'
         java-version: '8'
     - uses: actions/setup-python@v5
       with:

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -82,7 +82,7 @@ jobs:
           _R_CHECK_FORCE_SUGGESTS_: false
       - name: Install apache.sedona from source
         run: Rscript -e 'install.packages("./R/", repos = NULL, type = "source")'
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '8'


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-526. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Upgraded to actions/setup-java version 4.

"The major breaking change in V2 is the new mandatory distribution input."

"Use the zulu keyword if you would like to continue using the same distribution as in V1."

https://github.com/actions/setup-java/blob/main/docs/switching-to-v2.md

## How was this patch tested?


## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
