### PR TITLE
[SEDONA-529] Add basic `EditorConfig` file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# About this file, see:
+#   Website: https://editorconfig.org/
+#   For Emacs users: https://github.com/editorconfig/editorconfig-emacs
+#   For Vim users: https://github.com/editorconfig/editorconfig-vim
+#   For VS Code users: https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig
+
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-529. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

This PR adds a basic `.editorconfig` file.  Most editors / IDEs already have support for editor config.

https://editorconfig.org/

https://github.com/editorconfig/editorconfig/wiki/Projects-Using-EditorConfig

"What is EditorConfig?

EditorConfig helps maintain consistent coding styles for multiple developers working on the same project across various editors and IDEs. The EditorConfig project consists of a file format for defining coding styles and a collection of text editor plugins that enable editors to read the file format and adhere to defined styles. EditorConfig files are easily readable and they work nicely with version control systems."

## How was this patch tested?


## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
