### PR TITLE
[DOCS] Fix Markdown links to also work on GitHub

### DIFF
--- a/docs/api/flink/Function.md
+++ b/docs/api/flink/Function.md
@@ -165,7 +165,7 @@ Computes the angle formed by vectors S1 - E1 and S2 - E2, where S and E denote s
     If a 3D geometry is provided, ST_Angle computes the angle ignoring the z ordinate, equivalent to calling ST_Angle for corresponding 2D geometries.
 
 !!!Tip
-    ST_Angle returns the angle in radian between 0 and 2\Pi. To convert the angle to degrees, use [ST_Degrees](./#st_degrees).
+    ST_Angle returns the angle in radian between 0 and 2\Pi. To convert the angle to degrees, use [ST_Degrees](#st_degrees).
 
 Format: `ST_Angle(p1, p2, p3, p4) | ST_Angle(p1, p2, p3) | ST_Angle(line1, line2)`
 

--- a/docs/api/snowflake/vector-data/Function.md
+++ b/docs/api/snowflake/vector-data/Function.md
@@ -147,7 +147,7 @@ Additionally, if any of the provided geometry is empty, ST_Angle throws an Illeg
     If a 3D geometry is provided, ST_Angle computes the angle ignoring the z ordinate, equivalent to calling ST_Angle for corresponding 2D geometries.
 
 !!!Tip
-    ST_Angle returns the angle in radian between 0 and 2\Pi. To convert the angle to degrees, use [ST_Degrees](./#st_degrees).
+    ST_Angle returns the angle in radian between 0 and 2\Pi. To convert the angle to degrees, use [ST_Degrees](#st_degrees).
 
 Format: `ST_Angle(p1, p2, p3, p4) | ST_Angle(p1, p2, p3) | ST_Angle(line1, line2)`
 

--- a/docs/api/sql/Function.md
+++ b/docs/api/sql/Function.md
@@ -161,7 +161,7 @@ Computes the angle formed by vectors S1 - E1 and S2 - E2, where S and E denote s
     If a 3D geometry is provided, ST_Angle computes the angle ignoring the z ordinate, equivalent to calling ST_Angle for corresponding 2D geometries.
 
 !!!Tip
-    ST_Angle returns the angle in radian between 0 and 2\Pi. To convert the angle to degrees, use [ST_Degrees](./#st_degrees).
+    ST_Angle returns the angle in radian between 0 and 2\Pi. To convert the angle to degrees, use [ST_Degrees](#st_degrees).
 
 Format: `ST_Angle(p1, p2, p3, p4) | ST_Angle(p1, p2, p3) | ST_Angle(line1, line2)`
 

--- a/docs/api/sql/Raster-loader.md
+++ b/docs/api/sql/Raster-loader.md
@@ -208,7 +208,7 @@ This API requires the name of the record variable. It is assumed that a variable
 
 If this assumption does not hold true for your case, you can choose to pass the lonDimensionName and latDimensionName explicitly.
 
-You can use [RS_NetCDFInfo](./#rs_netcdfinfo) to get the details of the passed netCDF file (variables and its dimensions).
+You can use [RS_NetCDFInfo](#rs_netcdfinfo) to get the details of the passed netCDF file (variables and its dimensions).
 
 Format 1: `RS_FromNetCDF(netCDF: ARRAY[Byte], recordVariableName: String)`
 


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- No, this is a documentation update. The PR name follows the format `[DOCS] my subject`.

## What changes were proposed in this PR?

If you go to the next link / page on the GitHub website and see the link `RS_NetCDFInfo` just below you will find after clicking that the link is wrong it jumps away from the page.

https://github.com/apache/sedona/blob/master/docs/api/sql/Raster-loader.md#rs_fromnetcdf

And you can see it working here:

https://github.com/jbampton/sedona/blob/fix-links-to-work-on-github/docs/api/sql/Raster-loader.md#rs_fromnetcdf

Same with the other three links that were fixed.

They all now work on GitHub too.

## How was this patch tested?

Visually and clicked the links on GitHub

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
