### PR TITLE
[DOCS] Add two targets to the Makefile for building docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,17 @@ checkinstall :
 checkupdate :
 	pre-commit autoupdate
 .PHONY : checkupdate
+
+docsinstall :
+	pip install mkdocs
+	pip install mkdocs-material
+	pip install mkdocs-macros-plugin
+	pip install mkdocs-git-revision-date-localized-plugin
+	pip install mike
+.PHONY : docsinstall
+
+docsbuild : docsinstall
+	mkdocs build
+	mike deploy --update-aliases latest-snapshot -b website -p
+	mike serve
+.PHONY : docsbuild


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- No, this is a documentation update. The PR name follows the format `[DOCS] my subject`.

## What changes were proposed in this PR?

This PR adds two more Makefile targets.

It makes it much easier to run the commands with the Makefile file

## How was this patch tested?

Ran the Make commands

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
