### PR TITLE
[SEDONA-532] Correctly handle complex join conditions

### DIFF
--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/OptimizableJoinCondition.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/OptimizableJoinCondition.scala
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.spark.sql.sedona_sql.strategy.join
+
+import org.apache.spark.sql.catalyst.expressions.{And, Expression, LessThan, LessThanOrEqual, Literal}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.sedona_sql.expressions._
+import org.apache.spark.sql.sedona_sql.expressions.raster.RS_Predicate
+import org.apache.spark.sql.sedona_sql.optimization.ExpressionUtils
+
+case class OptimizableJoinCondition(left: LogicalPlan, right: LogicalPlan) {
+  /**
+   * An extractor that matches expressions that are optimizable join conditions. Join queries with optimizable join
+   * conditions will be executed as a spatial join (RangeJoin or DistanceJoin).
+   * @param expression the join condition
+   * @return an optional tuple containing the spatial predicate and the other predicates
+   */
+  def unapply(expression: Expression): Option[(Expression, Option[Expression])] = {
+    val predicates = ExpressionUtils.splitConjunctivePredicates(expression)
+    val (maybeSpatialPredicate, otherPredicates) = extractFirstOptimizablePredicate(predicates)
+    maybeSpatialPredicate match {
+      case Some(spatialPredicate) =>
+        val other = otherPredicates.reduceOption((l, r) => And(l, r))
+        Some(spatialPredicate, other)
+      case None => None
+    }
+  }
+
+  private def extractFirstOptimizablePredicate(expressions: Seq[Expression]): (Option[Expression], Seq[Expression]) = {
+    expressions match {
+      case Nil => (None, Nil)
+      case head :: tail =>
+        if (isOptimizablePredicate(head)) {
+          (Some(head), tail)
+        } else {
+          val (spatialPredicate, otherPredicates) = extractFirstOptimizablePredicate(tail)
+          (spatialPredicate, head +: otherPredicates)
+        }
+    }
+  }
+
+  private def isOptimizablePredicate(expression: Expression): Boolean = {
+    expression match {
+      case _: ST_Intersects |
+           _: ST_Contains |
+           _: ST_Covers |
+           _: ST_Within |
+           _: ST_CoveredBy |
+           _: ST_Overlaps |
+           _: ST_Touches |
+           _: ST_Equals |
+           _: ST_Crosses |
+           _: RS_Predicate =>
+        val leftShape = expression.children.head
+        val rightShape = expression.children(1)
+        ExpressionUtils.matchExpressionsToPlans(leftShape, rightShape, left, right).isDefined
+
+      case ST_DWithin(Seq(leftShape, rightShape, distance)) =>
+        isDistanceJoinOptimizable(leftShape, rightShape, distance)
+      case ST_DWithin(Seq(leftShape, rightShape, distance, useSpheroid)) =>
+        useSpheroid.isInstanceOf[Literal] && isDistanceJoinOptimizable(leftShape, rightShape, distance)
+
+      case _: LessThan | _: LessThanOrEqual =>
+        val (smaller, larger) = (expression.children.head, expression.children(1))
+        smaller match {
+          case _: ST_Distance |
+               _: ST_DistanceSphere |
+               _: ST_DistanceSpheroid |
+               _: ST_FrechetDistance =>
+            val leftShape = smaller.children.head
+            val rightShape = smaller.children(1)
+            isDistanceJoinOptimizable(leftShape, rightShape, larger)
+
+          case ST_HausdorffDistance(Seq(leftShape, rightShape)) =>
+            isDistanceJoinOptimizable(leftShape, rightShape, larger)
+          case ST_HausdorffDistance(Seq(leftShape, rightShape, densityFrac)) =>
+            isDistanceJoinOptimizable(leftShape, rightShape, larger)
+
+          case _ => false
+        }
+
+      case _ => false
+    }
+  }
+
+  private def isDistanceJoinOptimizable(leftShape: Expression, rightShape: Expression, distance: Expression): Boolean = {
+    ExpressionUtils.matchExpressionsToPlans(leftShape, rightShape, left, right).isDefined &&
+      ExpressionUtils.matchDistanceExpressionToJoinSide(distance, left, right).isDefined
+  }
+}

--- a/spark/common/src/test/scala/org/apache/sedona/sql/SpatialJoinSuite.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/SpatialJoinSuite.scala
@@ -64,7 +64,10 @@ class SpatialJoinSuite extends TestBaseScala with TableDrivenPropertyChecks {
       "ST_Distance(df1.geom, df2.geom) < df1.dist",
       "ST_Distance(df1.geom, df2.geom) < df2.dist",
       "ST_Distance(df2.geom, df1.geom) < df1.dist",
-      "ST_Distance(df2.geom, df1.geom) < df2.dist"
+      "ST_Distance(df2.geom, df1.geom) < df2.dist",
+
+      "1.0 > ST_Distance(df1.geom, df2.geom)",
+      "1.0 >= ST_Distance(df1.geom, df2.geom)"
     )
 
     var spatialJoinPartitionSide = "left"
@@ -242,6 +245,12 @@ class SpatialJoinSuite extends TestBaseScala with TableDrivenPropertyChecks {
           } else {
             (l: Geometry, r: Geometry) => l.distance(r) < 1.0
           }
+        }
+      case _ =>
+        if (udf.contains(">=")) {
+          (l: Geometry, r: Geometry) => l.distance(r) <= 1.0
+        } else {
+          (l: Geometry, r: Geometry) => l.distance(r) < 1.0
         }
     }
     left.flatMap { case (id, geom) =>

--- a/spark/common/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
@@ -685,7 +685,6 @@ class functionTestScala extends TestBaseScala with Matchers with GeometrySample 
       val testtable = sparkSession.sql("select ST_GeomFromWKT('POLYGON ((-3 -3, 3 -3, 3 3, -3 3, -3 -3))') as a,ST_GeomFromWKT('POLYGON ((5 -3, 7 -3, 7 -1, 5 -1, 5 -3))') as b")
       testtable.createOrReplaceTempView("union_table")
       val union = sparkSession.sql("select ST_Union(a,b) from union_table")
-      println(union.take(1)(0).get(0).asInstanceOf[Geometry].toText)
       assert(union.take(1)(0).get(0).asInstanceOf[Geometry].toText.equals("MULTIPOLYGON (((-3 -3, -3 3, 3 3, 3 -3, -3 -3)), ((5 -3, 5 -1, 7 -1, 7 -3, 5 -3)))"))
     }
 
@@ -939,7 +938,6 @@ class functionTestScala extends TestBaseScala with Matchers with GeometrySample 
 
   it("Should pass ST_IsPolygonCW") {
     var actual = sparkSession.sql("SELECT ST_IsPolygonCW(ST_GeomFromWKT('POLYGON ((20 35, 10 30, 10 10, 30 5, 45 20, 20 35),(30 20, 20 15, 20 25, 30 20))'))").first().getBoolean(0)
-    print(actual)
     assert(actual == false)
 
     actual = sparkSession.sql("SELECT ST_IsPolygonCW(ST_GeomFromWKT('POLYGON ((20 35, 45 20, 30 5, 10 10, 10 30, 20 35), (30 20, 20 25, 20 15, 30 20))'))").first().getBoolean(0)


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-532. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Refactored the code for detecting spatial join predicates in join conditions. Now we are capable of handling complex join conditions such as `ST_Intersects(geom1, geom2) AND expr1 AND expr2`.

## How was this patch tested?

Added new tests and manually tested the query mentioned in the JIRA ticket.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
