### PR TITLE
[DOCS] Enable markdownlint rule `MD042`

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -48,9 +48,6 @@ MD040: false
 # first-line-heading/first-line-h1 - First line in a file should be a top-level heading
 MD041: false
 
-# no-empty-links - No empty links
-MD042: false
-
 # no-alt-text - Images should have alternate text (alt text)
 MD045: false
 


### PR DESCRIPTION
https://github.com/DavidAnson/markdownlint/blob/main/doc/md042.md



## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- No, this is a documentation update. The PR name follows the format `[DOCS] my subject`.

## What changes were proposed in this PR?

Adds another check or test to our Markdown linting framework.

Just enabled the rule.  Seems we already passed the test.

## How was this patch tested?

`pre-commit run --all-files`

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
