### PR TITLE
[DOCS] Add `pip install mkdocs-jupyter` to setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ checkupdate :
 
 docsinstall :
 	pip install mkdocs
+	pip install mkdocs-jupyter
 	pip install mkdocs-material
 	pip install mkdocs-macros-plugin
 	pip install mkdocs-git-revision-date-localized-plugin

--- a/docs/setup/compile.md
+++ b/docs/setup/compile.md
@@ -144,6 +144,7 @@ In short, you need to run:
 
 ```
 pip install mkdocs
+pip install mkdocs-jupyter
 pip install mkdocs-material
 pip install mkdocs-macros-plugin
 pip install mkdocs-git-revision-date-localized-plugin


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- No, this is a documentation update. The PR name follows the format `[DOCS] my subject`.

## What changes were proposed in this PR?

Added the missing install instructions.

See:

https://github.com/apache/sedona/blob/dc7e5c91c1641edbcdf8bacd3d12a20f14745aca/.github/workflows/docs.yml#L33

## How was this patch tested?

Installed with pip; ran mkdocs serve;

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
