### PR TITLE
[DOCS] Enable markdownlint rule `MD051`

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -50,6 +50,3 @@ MD045: false
 
 # code-block-style - Code block style
 MD046: false
-
-# link-fragments - Link fragments should be valid
-MD051: false

--- a/docs/api/flink/Constructor.md
+++ b/docs/api/flink/Constructor.md
@@ -167,7 +167,7 @@ LINESTRING (-71.1663 42.2614, -71.1667 42.2616)
 
 ## ST_GeomFromText
 
-Introduction: Construct a Geometry from WKT. Alias of  [ST_GeomFromWKT](#ST_GeomFromWKT)
+Introduction: Construct a Geometry from WKT. Alias of  [ST_GeomFromWKT](#st_geomfromwkt)
 
 Format:
 `ST_GeomFromText (Wkt: String)`
@@ -277,7 +277,7 @@ LINESTRING (1 2, 3 4)
 
 ## ST_LineStringFromText
 
-Introduction: Construct a LineString from Text, delimited by Delimiter (Optional). Alias of  [ST_LineFromText](#ST_LineFromText)
+Introduction: Construct a LineString from Text, delimited by Delimiter (Optional). Alias of  [ST_LineFromText](#st_linefromtext)
 
 Format: `ST_LineStringFromText (Text: String, Delimiter: Char)`
 

--- a/docs/api/flink/Function.md
+++ b/docs/api/flink/Function.md
@@ -305,7 +305,7 @@ Introduction: Return the Extended Well-Known Text representation of a geometry.
 EWKT is an extended version of WKT which includes the SRID of the geometry.
 The format originated in PostGIS but is supported by many GIS tools.
 If the geometry is lacking SRID a WKT format is produced.
-[See ST_SetSRID](#ST_SetSRID)
+[See ST_SetSRID](#st_setsrid)
 It will support M coordinate if present since v1.5.0.
 
 Format: `ST_AsEWKT (A: Geometry)`

--- a/docs/api/sql/Constructor.md
+++ b/docs/api/sql/Constructor.md
@@ -216,7 +216,7 @@ LINESTRING (-71.1663 42.2614, -71.1667 42.2616)
 
 ## ST_GeomFromText
 
-Introduction: Construct a Geometry from WKT. If SRID is not set, it defaults to 0 (unknown). Alias of [ST_GeomFromWKT](#ST_GeomFromWKT)
+Introduction: Construct a Geometry from WKT. If SRID is not set, it defaults to 0 (unknown). Alias of [ST_GeomFromWKT](#st_geomfromwkt)
 
 Format:
 

--- a/docs/api/sql/Function.md
+++ b/docs/api/sql/Function.md
@@ -274,7 +274,7 @@ Introduction: Return the Extended Well-Known Binary representation of a geometry
 EWKB is an extended version of WKB which includes the SRID of the geometry.
 The format originated in PostGIS but is supported by many GIS tools.
 If the geometry is lacking SRID a WKB format is produced.
-[See ST_SetSRID](#ST_SetSRID)
+[See ST_SetSRID](#st_setsrid)
 It will ignore the M coordinate if present.
 
 Format: `ST_AsEWKB (A: Geometry)`
@@ -299,7 +299,7 @@ Introduction: Return the Extended Well-Known Text representation of a geometry.
 EWKT is an extended version of WKT which includes the SRID of the geometry.
 The format originated in PostGIS but is supported by many GIS tools.
 If the geometry is lacking SRID a WKT format is produced.
-[See ST_SetSRID](#ST_SetSRID)
+[See ST_SetSRID](#st_setsrid)
 It will support M coordinate if present since v1.5.0.
 
 Format: `ST_AsEWKT (A: Geometry)`

--- a/docs/tutorial/rdd.md
+++ b/docs/tutorial/rdd.md
@@ -937,9 +937,9 @@ Distance join can only accept `COVERED_BY` and `INTERSECTS` as spatial predicate
 
 The details of spatial partitioning in join query is [here](#use-spatial-partitioning).
 
-The details of using spatial indexes in join query is [here](#use-spatial-indexes_2).
+The details of using spatial indexes in join query is [here](#use-spatial-indexes-2).
 
-The output format of the distance join query is [here](#output-format_2).
+The output format of the distance join query is [here](#output-format-2).
 
 !!!note
 	Distance join query is equal to the following query in Spatial SQL:


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- No, this is a documentation update. The PR name follows the format `[DOCS] my subject`.

## What changes were proposed in this PR?

Now testing for `MD051` -  Link fragments should be valid.

https://github.com/DavidAnson/markdownlint/blob/main/doc/md051.md

## How was this patch tested?

`pre-commit run --all-files`

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
