### PR TITLE
[CI] Change command for installing python source package

### DIFF
--- a/.github/workflows/python-extension.yml
+++ b/.github/workflows/python-extension.yml
@@ -72,4 +72,4 @@ jobs:
       run: |
         cd python
         pipenv run python setup.py sdist
-        pipenv run python -m pip install dist/apache-sedona-*.tar.gz
+        pipenv run python -m pip install dist/*sedona-*.tar.gz

--- a/.github/workflows/python-extension.yml
+++ b/.github/workflows/python-extension.yml
@@ -10,6 +10,7 @@ on:
       - 'spark-shaded/**'
       - 'pom.xml'
       - 'python/**'
+      - '.github/workflows/python-extension.yml'
   pull_request:
     branches:
       - '*'
@@ -19,6 +20,7 @@ on:
       - 'spark-shaded/**'
       - 'pom.xml'
       - 'python/**'
+      - '.github/workflows/python-extension.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- No, this is a CI update.

## What changes were proposed in this PR?

The latest version of `setuptools` introduced a [breaking change](https://github.com/pypa/setuptools/issues/4300): the name of sdist package changed from `apache-sedona-*.tar.gz` to `apache_sedona-*.tar.gz`. We have to update the command for installing Python source package to pickup whatever package file setuptools has generated.

## How was this patch tested?

Passing CI

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
