### PR TITLE
[SEDONA-534] Disable Python warning message of finding jars

### DIFF
--- a/python/sedona/core/jvm/config.py
+++ b/python/sedona/core/jvm/config.py
@@ -187,10 +187,9 @@ class SparkJars:
 
         try:
             used_jar_files = java_spark_conf.get(value)
-        except Py4JJavaError as java_error:
-            error_message = "Failed to get the value of {} from SparkConf: {}".format(
-                value, java_error
-            )
+        except Py4JJavaError:
+            error_message = "Didn't find the value of {} from SparkConf".format(value)
+            logging.info(error_message)
 
         return used_jar_files, error_message
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-534. The PR name follows the format `[SEDONA-534] my subject`.


## What changes were proposed in this PR?

1. Move the error message to info level
2. Stop printing the stackstrace

## How was this patch tested?

Passed local tests

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
