### PR TITLE
[DOCS] Skip docs deploy on forks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,7 +53,7 @@ jobs:
     - run: mkdocs build
     - run: git fetch origin website --depth=1
     - name: Deploy the doc to the website branch
-      if: ${{ github.event_name != 'pull_request' }}
+      if: ${{ github.event_name != 'pull_request' && github.repository == 'apache/sedona' }}
       run: mike deploy latest-snapshot -b website -p
     - run: mkdir staging
     - run: cp -r site/* staging/


### PR DESCRIPTION
https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution#example-only-run-job-for-specific-repository



## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- No, this is a documentation update. The PR name follows the format `[DOCS] my subject`.

## What changes were proposed in this PR?

When a contributor syncs their fork from the upstream and pushes back to origin master on GitHub the docs build currently fails as seen in the next two links:

https://github.com/jbampton/sedona/actions/runs/8780798846/job/24091461356

https://github.com/furqaankhan/sedona/actions/runs/8725430958/job/23938384642

## How was this patch tested?

Here is an image of the failure:

![Screenshot from 2024-04-22 19-02-05](https://github.com/apache/sedona/assets/418747/4b08b371-079d-4ddd-8121-e017b638c44e)

Probably the worst part about this bug is that you get sent out an email from GitHub about the failing Docs build. 

Just extra email spam like this:

![Screenshot from 2024-04-22 18-38-30](https://github.com/apache/sedona/assets/418747/de8e84ef-1823-4522-bc40-c0b1e852dc56)


## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
