### PR TITLE
[SEDONA-543] Fixes RS_Union_aggr throwing referenceRaster is null error when run on cluster

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/raster/serde/Serde.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/serde/Serde.java
@@ -32,6 +32,8 @@ import org.opengis.referencing.operation.MathTransform;
 
 import javax.media.jai.RenderedImageAdapter;
 import java.awt.image.RenderedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.URI;
@@ -175,5 +177,20 @@ public class Serde {
             state.read(kryo, in);
             return state.restore();
         }
+    }
+
+    public static byte[] serializeGridSampleDimension(GridSampleDimension sampleDimension) {
+        Kryo kryo = kryos.get();
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        Output output = new Output(baos);
+        kryo.writeClassAndObject(output, sampleDimension);
+        output.close();
+        return baos.toByteArray();
+    }
+
+    public static GridSampleDimension deserializeGridSampleDimension(byte[] data) {
+        Kryo kryo = kryos.get();
+        Input input = new Input(new ByteArrayInputStream(data));
+        return (GridSampleDimension) kryo.readClassAndObject(input);
     }
 }

--- a/common/src/main/java/org/apache/sedona/common/raster/serde/Serde.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/serde/Serde.java
@@ -183,7 +183,8 @@ public class Serde {
         Kryo kryo = kryos.get();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         Output output = new Output(baos);
-        kryo.writeClassAndObject(output, sampleDimension);
+        GridSampleDimensionSerializer serializer = new GridSampleDimensionSerializer();
+        serializer.write(kryo, output, sampleDimension);
         output.close();
         return baos.toByteArray();
     }
@@ -191,6 +192,8 @@ public class Serde {
     public static GridSampleDimension deserializeGridSampleDimension(byte[] data) {
         Kryo kryo = kryos.get();
         Input input = new Input(new ByteArrayInputStream(data));
-        return (GridSampleDimension) kryo.readClassAndObject(input);
+        GridSampleDimensionSerializer serializer = new GridSampleDimensionSerializer();
+        return serializer.read(kryo, input, GridSampleDimension.class);
     }
+
 }

--- a/spark/common/src/main/scala/org/apache/sedona/sql/utils/RasterSerializer.scala
+++ b/spark/common/src/main/scala/org/apache/sedona/sql/utils/RasterSerializer.scala
@@ -20,9 +20,7 @@
 package org.apache.sedona.sql.utils
 
 import org.apache.sedona.common.raster.serde.Serde
-import org.geotools.coverage.GridSampleDimension
 import org.geotools.coverage.grid.GridCoverage2D
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
 object RasterSerializer {
   /**
    * Given a raster returns array of bytes
@@ -42,19 +40,5 @@ object RasterSerializer {
    */
   def deserialize(value: Array[Byte]): GridCoverage2D = {
     Serde.deserialize(value);
-  }
-
-  def serializeSampleDimension(sampleDimension: GridSampleDimension): Array[Byte] = {
-    val bos = new ByteArrayOutputStream()
-    val oos = new ObjectOutputStream(bos)
-    oos.writeObject(sampleDimension)
-    oos.flush()
-    bos.toByteArray
-  }
-
-  def deserializeSampleDimension(bytes: Array[Byte]): GridSampleDimension = {
-    val bis = new ByteArrayInputStream(bytes)
-    val ois = new ObjectInputStream(bis)
-    ois.readObject().asInstanceOf[GridSampleDimension]
   }
 }

--- a/spark/common/src/main/scala/org/apache/sedona/sql/utils/RasterSerializer.scala
+++ b/spark/common/src/main/scala/org/apache/sedona/sql/utils/RasterSerializer.scala
@@ -20,8 +20,9 @@
 package org.apache.sedona.sql.utils
 
 import org.apache.sedona.common.raster.serde.Serde
+import org.geotools.coverage.GridSampleDimension
 import org.geotools.coverage.grid.GridCoverage2D
-
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
 object RasterSerializer {
   /**
    * Given a raster returns array of bytes
@@ -41,5 +42,19 @@ object RasterSerializer {
    */
   def deserialize(value: Array[Byte]): GridCoverage2D = {
     Serde.deserialize(value);
+  }
+
+  def serializeSampleDimension(sampleDimension: GridSampleDimension): Array[Byte] = {
+    val bos = new ByteArrayOutputStream()
+    val oos = new ObjectOutputStream(bos)
+    oos.writeObject(sampleDimension)
+    oos.flush()
+    bos.toByteArray
+  }
+
+  def deserializeSampleDimension(bytes: Array[Byte]): GridSampleDimension = {
+    val bis = new ByteArrayInputStream(bytes)
+    val ois = new ObjectInputStream(bis)
+    ois.readObject().asInstanceOf[GridSampleDimension]
   }
 }

--- a/spark/common/src/main/scala/org/apache/sedona/sql/utils/RasterSerializer.scala
+++ b/spark/common/src/main/scala/org/apache/sedona/sql/utils/RasterSerializer.scala
@@ -21,6 +21,7 @@ package org.apache.sedona.sql.utils
 
 import org.apache.sedona.common.raster.serde.Serde
 import org.geotools.coverage.grid.GridCoverage2D
+
 object RasterSerializer {
   /**
    * Given a raster returns array of bytes


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-543. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

- In RS_Union_aggr, moves class level members like `referenceRaster` to data buffer.


## How was this patch tested?

- Passes existing tests


## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
