### PR TITLE
[SEDONA-546] Python linting enable rule `E712`

### DIFF
--- a/.github/linters/ruff.toml
+++ b/.github/linters/ruff.toml
@@ -40,7 +40,7 @@ target-version = "py38"
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
 select = ["E4", "E7", "E9", "F"]
-ignore = ["E712", "E721", "E722", "E731", "E741", "F401", "F402", "F403", "F405", "F811", "F821", "F822", "F841", "F901"]
+ignore = ["E721", "E722", "E731", "E741", "F401", "F402", "F403", "F405", "F811", "F821", "F822", "F841", "F901"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     rev: v0.4.2
     hooks:
       - id: ruff
-        args: [--config=.github/linters/ruff.toml]
+        args: [--config=.github/linters/ruff.toml, --fix]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:

--- a/python/tests/maps/test_sedonapydeck.py
+++ b/python/tests/maps/test_sedonapydeck.py
@@ -109,7 +109,7 @@ class TestVisualization(TestBase):
 
         p_map = pdk.Deck(layers=[layer])
         sedona_pydeck_map = SedonaPyDeck.create_scatterplot_map(df=chicago_crimes_df)
-        assert self.isMapEqual(sedona_map=sedona_pydeck_map, pydeck_map=p_map) == True
+        assert self.isMapEqual(sedona_map=sedona_pydeck_map, pydeck_map=p_map)
 
     def testHeatmap(self):
         chicago_crimes_csv_df = self.spark.read.format("csv"). \
@@ -144,7 +144,7 @@ class TestVisualization(TestBase):
 
         p_map = pdk.Deck(layers=[layer])
         sedona_pydeck_map = SedonaPyDeck.create_heatmap(df=chicago_crimes_df)
-        assert self.isMapEqual(sedona_map=sedona_pydeck_map, pydeck_map=p_map) == True
+        assert self.isMapEqual(sedona_map=sedona_pydeck_map, pydeck_map=p_map)
 
     def isMapEqual(self, pydeck_map, sedona_map):
         sedona_dict = json.loads(sedona_map.to_json())

--- a/python/tests/sql/test_function.py
+++ b/python/tests/sql/test_function.py
@@ -844,10 +844,10 @@ class TestPredicateJoin(TestBase):
 
     def test_isPolygonCW(self):
         actual = self.spark.sql("SELECT ST_IsPolygonCW(ST_GeomFromWKT('POLYGON ((20 35, 10 30, 10 10, 30 5, 45 20, 20 35),(30 20, 20 15, 20 25, 30 20))'))").take(1)[0][0]
-        assert actual == False
+        assert not actual
 
         actual = self.spark.sql("SELECT ST_IsPolygonCW(ST_GeomFromWKT('POLYGON ((20 35, 45 20, 30 5, 10 10, 10 30, 20 35), (30 20, 20 25, 20 15, 30 20))'))").take(1)[0][0]
-        assert actual == True
+        assert actual
 
     def test_st_is_ring(self):
         result_and_expected = [
@@ -862,10 +862,10 @@ class TestPredicateJoin(TestBase):
 
     def test_isPolygonCCW(self):
         actual = self.spark.sql("SELECT ST_IsPolygonCCW(ST_GeomFromWKT('POLYGON ((20 35, 10 30, 10 10, 30 5, 45 20, 20 35),(30 20, 20 15, 20 25, 30 20))'))").take(1)[0][0]
-        assert actual == True
+        assert actual
 
         actual = self.spark.sql("SELECT ST_IsPolygonCCW(ST_GeomFromWKT('POLYGON ((20 35, 45 20, 30 5, 10 10, 10 30, 20 35), (30 20, 20 25, 20 15, 30 20))'))").take(1)[0][0]
-        assert actual == False
+        assert not actual
 
     def test_forcePolygonCCW(self):
         actualDf = self.spark.sql(


### PR DESCRIPTION
Comparison to true should be 'if cond is true:' or 'if cond:'.

https://www.flake8rules.com/rules/E712.html

https://peps.python.org/pep-0008/#programming-recommendations

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-546. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Standardized the Python code for best practice.

## How was this patch tested?

Ran  `pre-commit run --all-files`

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
