### PR TITLE
[SEDONA-550] Remove the version upper bound of Pandas, GeoPandas

### DIFF
--- a/python/Pipfile
+++ b/python/Pipfile
@@ -11,9 +11,8 @@ mkdocs="*"
 pytest-cov = "*"
 
 [packages]
-shapely=">=2.0.0"
-pandas="<=1.3.5"
-geopandas="<=0.10.2"
+geopandas="*"
+shapely=">=1.7.0"
 pyspark=">=2.3.0"
 attrs="*"
 pyarrow="*"

--- a/python/Pipfile
+++ b/python/Pipfile
@@ -11,6 +11,7 @@ mkdocs="*"
 pytest-cov = "*"
 
 [packages]
+pandas="<=1.5.3"
 geopandas="*"
 shapely=">=1.7.0"
 pyspark=">=2.3.0"

--- a/python/setup.py
+++ b/python/setup.py
@@ -55,9 +55,9 @@ setup(
     install_requires=['attrs', "shapely>=1.7.0", "rasterio>=1.2.10"],
     extras_require={
         "spark": ["pyspark>=2.3.0"],
-        "pydeck-map": ["pandas<=1.3.5", "geopandas<=0.10.2", "pydeck==0.8.0"],
-        "kepler-map": ["pandas<=1.3.5", "geopandas<=0.10.2", "keplergl==0.3.2"],
-        "all": ["pyspark>=2.3.0", "pandas<=1.3.5", "geopandas<=0.10.2","pydeck==0.8.0", "keplergl==0.3.2"],
+        "pydeck-map": ["geopandas", "pydeck==0.8.0"],
+        "kepler-map": ["geopandas", "keplergl==0.3.2"],
+        "all": ["pyspark>=2.3.0", "geopandas","pydeck==0.8.0", "keplergl==0.3.2"],
     },
     project_urls={
         'Documentation': 'https://sedona.apache.org',


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-550. The PR name follows the format `[SEDONA-550] my subject`.

## What changes were proposed in this PR?

Updated the following file to remove the upper bound of supported geopandas versions

1. Update `setup.py`
2. Update `Pipfile`

Note: Pandas `2.0` has compatibility issues with some Spark versions. Have to fail back to `1.5.3`

## How was this patch tested?

Pending tests in the CI

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
