### PR TITLE
[SEDONA-552] Enable Python lint rule `E741`

### DIFF
--- a/.github/linters/ruff.toml
+++ b/.github/linters/ruff.toml
@@ -40,7 +40,7 @@ target-version = "py38"
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
 select = ["E4", "E7", "E9", "F"]
-ignore = ["E721", "E722", "E731", "E741", "F401", "F402", "F403", "F405", "F811", "F821", "F822", "F841", "F901"]
+ignore = ["E721", "E722", "E731", "F401", "F402", "F403", "F405", "F811", "F821", "F822", "F841", "F901"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]

--- a/python/sedona/utils/geometry_serde_general.py
+++ b/python/sedona/utils/geometry_serde_general.py
@@ -379,11 +379,11 @@ def serialize_multi_linestring(geom: MultiLineString) -> bytes:
 
     coord_type = CoordinateType.type_of(geom)
     lines = [[list(coord) for coord in ls.coords] for ls in linestrings]
-    line_lengths = [len(l) for l in lines]
+    line_lengths = [len(line) for line in lines]
     num_coords = sum(line_lengths)
 
     header = generate_header_bytes(GeometryTypeID.MULTILINESTRING, coord_type, num_coords)
-    coord_data = array.array('d', [c for l in lines for coord in l for c in coord]).tobytes()
+    coord_data = array.array('d', [c for line in lines for coord in line for c in coord]).tobytes()
     num_lines = struct.pack('i', len(lines))
     structure_data = array.array('i', line_lengths).tobytes()
 


### PR DESCRIPTION
E741 - Do not use variables named 'I', 'O', or 'l'

https://www.flake8rules.com/rules/E741.html



## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-552. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Cleaned up the Python code

## How was this patch tested?

`pre-commit run --all-files`

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
