### PR TITLE
[SEDONA-549] Fix memory bloat issue of RS_Union_Aggr when working with non-double band data

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/MapAlgebra.java
@@ -78,12 +78,11 @@ public class MapAlgebra
             throw new IllegalArgumentException("Band index is out of bounds. Must be between 1 and " + (numBands + 1) + ")");
         }
 
-        Double[] bandValuesClass = Arrays.stream(bandValues).boxed().toArray(Double[]::new);
         if (bandIndex == numBands + 1) {
-            return RasterUtils.copyRasterAndAppendBand(rasterGeom, bandValuesClass, noDataValue);
+            return RasterUtils.copyRasterAndAppendBand(rasterGeom, bandValues, noDataValue);
         }
         else {
-            return RasterUtils.copyRasterAndReplaceBand(rasterGeom, bandIndex, bandValuesClass, noDataValue, true);
+            return RasterUtils.copyRasterAndReplaceBand(rasterGeom, bandIndex, bandValues, noDataValue, true);
         }
     }
 
@@ -94,12 +93,11 @@ public class MapAlgebra
             throw new IllegalArgumentException("Band index is out of bounds. Must be between 1 and " + (numBands + 1) + ")");
         }
 
-        Double[] bandValuesClass = Arrays.stream(bandValues).boxed().toArray(Double[]::new);
         if (bandIndex == numBands + 1) {
-            return RasterUtils.copyRasterAndAppendBand(rasterGeom, bandValuesClass);
+            return RasterUtils.copyRasterAndAppendBand(rasterGeom, bandValues);
         }
         else {
-            return RasterUtils.copyRasterAndReplaceBand(rasterGeom, bandIndex, bandValuesClass);
+            return RasterUtils.copyRasterAndReplaceBand(rasterGeom, bandIndex, bandValues);
         }
     }
 

--- a/common/src/main/java/org/apache/sedona/common/raster/RasterBandEditors.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterBandEditors.java
@@ -135,16 +135,16 @@ public class RasterBandEditors {
         if (RasterUtils.isDataTypeIntegral(dataTypeCode)) {
             int[] bandValues = rasterData.getSamples(0, 0, width, height, fromBand - 1, (int[]) null);
             if (numBands + 1 == toRasterIndex) {
-                return RasterUtils.copyRasterAndAppendBand(toRaster, Arrays.stream(bandValues).boxed().toArray(Integer[]::new), noDataValue);
+                return RasterUtils.copyRasterAndAppendBand(toRaster, bandValues, noDataValue);
             } else {
-                return RasterUtils.copyRasterAndReplaceBand(toRaster, fromBand, Arrays.stream(bandValues).boxed().toArray(Integer[]::new), noDataValue, false);
+                return RasterUtils.copyRasterAndReplaceBand(toRaster, fromBand, bandValues, noDataValue, false);
             }
         } else {
             double[] bandValues = rasterData.getSamples(0, 0, width, height, fromBand - 1, (double[]) null);
             if (numBands + 1 == toRasterIndex) {
-                return RasterUtils.copyRasterAndAppendBand(toRaster, Arrays.stream(bandValues).boxed().toArray(Double[]::new), noDataValue);
+                return RasterUtils.copyRasterAndAppendBand(toRaster, bandValues, noDataValue);
             } else {
-                return RasterUtils.copyRasterAndReplaceBand(toRaster, fromBand, Arrays.stream(bandValues).boxed().toArray(Double[]::new), noDataValue, false);
+                return RasterUtils.copyRasterAndReplaceBand(toRaster, fromBand, bandValues, noDataValue, false);
             }
         }
     }

--- a/common/src/main/java/org/apache/sedona/common/raster/serde/Serde.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/serde/Serde.java
@@ -32,8 +32,6 @@ import org.geotools.api.referencing.operation.MathTransform;
 
 import javax.media.jai.RenderedImageAdapter;
 import java.awt.image.RenderedImage;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.URI;
@@ -178,22 +176,4 @@ public class Serde {
             return state.restore();
         }
     }
-
-    public static byte[] serializeGridSampleDimension(GridSampleDimension sampleDimension) {
-        Kryo kryo = kryos.get();
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        Output output = new Output(baos);
-        GridSampleDimensionSerializer serializer = new GridSampleDimensionSerializer();
-        serializer.write(kryo, output, sampleDimension);
-        output.close();
-        return baos.toByteArray();
-    }
-
-    public static GridSampleDimension deserializeGridSampleDimension(byte[] data) {
-        Kryo kryo = kryos.get();
-        Input input = new Input(new ByteArrayInputStream(data));
-        GridSampleDimensionSerializer serializer = new GridSampleDimensionSerializer();
-        return serializer.read(kryo, input, GridSampleDimension.class);
-    }
-
 }

--- a/common/src/main/java/org/apache/sedona/common/utils/RasterUtils.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/RasterUtils.java
@@ -556,7 +556,7 @@ public class RasterUtils {
      * @param bandValues
      * @return
      */
-    public static GridCoverage2D copyRasterAndAppendBand(GridCoverage2D gridCoverage2D, Number[] bandValues, Double noDataValue) {
+    public static GridCoverage2D copyRasterAndAppendBand(GridCoverage2D gridCoverage2D, Object bandValues, Double noDataValue) {
         // Get the original image and its properties
         RenderedImage originalImage = gridCoverage2D.getRenderedImage();
         Raster raster = getRaster(originalImage);
@@ -565,17 +565,19 @@ public class RasterUtils {
         // Copy the raster data and append the new band values
         for (int i = 0; i < raster.getWidth(); i++) {
             for (int j = 0; j < raster.getHeight(); j++) {
-                if (bandValues instanceof Double[]) {
+                if (bandValues instanceof double[]) {
+                    double[] values = (double[]) bandValues;
                     double[] pixels = raster.getPixel(i, j, (double[]) null);
                     double[] copiedPixels = new double[pixels.length + 1];
                     System.arraycopy(pixels, 0, copiedPixels, 0, pixels.length);
-                    copiedPixels[pixels.length] = (double) bandValues[j * raster.getWidth() + i];
+                    copiedPixels[pixels.length] = values[j * raster.getWidth() + i];
                     wr.setPixel(i, j, copiedPixels);
-                } else if (bandValues instanceof Integer[]) {
+                } else if (bandValues instanceof int[]) {
+                    int[] values = (int[]) bandValues;
                     int[] pixels = raster.getPixel(i, j, (int[]) null);
                     int[] copiedPixels = new int[pixels.length + 1];
                     System.arraycopy(pixels, 0, copiedPixels, 0, pixels.length);
-                    copiedPixels[pixels.length] = (int) bandValues[j * raster.getWidth() + i];
+                    copiedPixels[pixels.length] = values[j * raster.getWidth() + i];
                     wr.setPixel(i, j, copiedPixels);
                 }
             }
@@ -594,11 +596,11 @@ public class RasterUtils {
         return clone(wr, gridCoverage2D.getGridGeometry(), sampleDimensions, gridCoverage2D, null, true);
     }
 
-    public static GridCoverage2D copyRasterAndAppendBand(GridCoverage2D gridCoverage2D, Number[] bandValues) {
+    public static GridCoverage2D copyRasterAndAppendBand(GridCoverage2D gridCoverage2D, Object bandValues) {
         return copyRasterAndAppendBand(gridCoverage2D, bandValues, null);
     }
 
-    public static GridCoverage2D copyRasterAndReplaceBand(GridCoverage2D gridCoverage2D, int bandIndex, Number[] bandValues, Double noDataValue, boolean removeNoDataIfNull) {
+    public static GridCoverage2D copyRasterAndReplaceBand(GridCoverage2D gridCoverage2D, int bandIndex, Object bandValues, Double noDataValue, boolean removeNoDataIfNull) {
         // Do not allow the band index to be out of bounds
         ensureBand(gridCoverage2D, bandIndex);
         // Get the original image and its properties
@@ -608,13 +610,15 @@ public class RasterUtils {
         // Copy the raster data and replace the band values
         for (int i = 0; i < raster.getWidth(); i++) {
             for (int j = 0; j < raster.getHeight(); j++) {
-                if (bandValues instanceof Double[]) {
+                if (bandValues instanceof double[]) {
+                    double[] values = (double[]) bandValues;
                     double[] bands = raster.getPixel(i, j, (double[]) null);
-                    bands[bandIndex - 1] = (double) bandValues[j * raster.getWidth() + i];
+                    bands[bandIndex - 1] = values[j * raster.getWidth() + i];
                     wr.setPixel(i, j, bands);
-                } else if (bandValues instanceof Integer[]) {
+                } else if (bandValues instanceof int[]) {
+                    int[] values = (int[]) bandValues;
                     int[] bands = raster.getPixel(i, j, (int[]) null);
-                    bands[bandIndex - 1] = (int) bandValues[j * raster.getWidth() + i];
+                    bands[bandIndex - 1] = values[j * raster.getWidth() + i];
                     wr.setPixel(i, j, bands);
                 }
             }
@@ -629,7 +633,7 @@ public class RasterUtils {
         return clone(wr, gridCoverage2D.getGridGeometry(), sampleDimensions, gridCoverage2D, null, true);
     }
 
-    public static GridCoverage2D copyRasterAndReplaceBand(GridCoverage2D gridCoverage2D, int bandIndex, Number[] bandValues) {
+    public static GridCoverage2D copyRasterAndReplaceBand(GridCoverage2D gridCoverage2D, int bandIndex, Object bandValues) {
         return copyRasterAndReplaceBand(gridCoverage2D, bandIndex, bandValues, null, false);
     }
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-XXX. The PR name follows the format `[SEDONA-XXX] my subject`.


## What changes were proposed in this PR?

The current RS_Union_Aggr keeps redundant data within buffers. This PR eliminates them.

We've also removed all the boxing/unboxing of pixel data for RS_AddBand.

## How was this patch tested?

Passing existing tests

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
