### PR TITLE
[SEDONA-556] Hidden requirement for geopandas in apache-sedona 1.5.2

### DIFF
--- a/python/sedona/maps/SedonaMapUtils.py
+++ b/python/sedona/maps/SedonaMapUtils.py
@@ -15,8 +15,6 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-
-import geopandas as gpd
 import json
 from sedona.sql.types import GeometryType
 
@@ -38,6 +36,11 @@ class SedonaMapUtils:
         pandas_df = df.toPandas()
         if geometry_col is None:  # No geometry column found even after searching schema, return Pandas Dataframe
             return pandas_df
+        try:
+            import geopandas as gpd
+        except ImportError:
+            msg = "GeoPandas is missing. You can install it manually or via sedona[kepler-map] or sedona[pydeck-map]."
+            raise ImportError(msg) from None
         geo_df = gpd.GeoDataFrame(pandas_df, geometry=geometry_col)
         if geometry_col != "geometry" and rename is True:
             geo_df.rename_geometry("geometry", inplace=True)


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-556. The PR name follows the format `[SEDONA-556] my subject`.

## What changes were proposed in this PR?

https://github.com/apache/sedona/pull/1229 tried to eliminate the warning message of KeplerGL and DeckGL. This was done by removing the try-catch of import error message. This try-catch also hides the GeoPandas error accidentally in the past. The removal of this interception hence makes GeoPandas a required dependency.

This PR moves the `import geopandas` statement to the function that actually needs.

## How was this patch tested?

Passed local tests

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
