### PR TITLE
[SEDONA-557] Bump Flink from 1.14.x to 1.19.0

### DIFF
--- a/flink/pom.xml
+++ b/flink/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <maven.deploy.skip>${skip.deploy.common.modules}</maven.deploy.skip>
-        <flink.version>1.14.6</flink.version>
+        <flink.version>1.19.0</flink.version>
         <flink.scope>provided</flink.scope>
     </properties>
 
@@ -53,28 +53,21 @@
 <!--        For Flink DataStream API-->
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-streaming-java_${scala.compat.version}</artifactId>
-            <version>${flink.version}</version>
-            <scope>${flink.scope}</scope>
-        </dependency>
-<!--        Flink Kafka connector-->
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-connector-kafka_${scala.compat.version}</artifactId>
+            <artifactId>flink-streaming-java</artifactId>
             <version>${flink.version}</version>
             <scope>${flink.scope}</scope>
         </dependency>
 <!--        For playing flink in IDE-->
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-clients_${scala.compat.version}</artifactId>
+            <artifactId>flink-clients</artifactId>
             <version>${flink.version}</version>
             <scope>${flink.scope}</scope>
         </dependency>
 <!--        For Flink flink api, planner, udf/udt, csv-->
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-table-api-java-bridge_${scala.compat.version}</artifactId>
+            <artifactId>flink-table-api-java-bridge</artifactId>
             <version>${flink.version}</version>
             <scope>${flink.scope}</scope>
         </dependency>
@@ -100,7 +93,7 @@
 <!--        For Flink Web Ui in test-->
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-runtime-web_${scala.compat.version}</artifactId>
+            <artifactId>flink-runtime-web</artifactId>
             <version>${flink.version}</version>
             <scope>test</scope>
         </dependency>

--- a/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
@@ -16,8 +16,6 @@ package org.apache.sedona.flink;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.flink.table.api.Table;
-import org.apache.flink.table.planner.expressions.In;
-import org.apache.sedona.flink.expressions.Constructors;
 import org.apache.sedona.flink.expressions.Functions;
 import org.apache.sedona.flink.expressions.FunctionsGeoTools;
 import org.geotools.referencing.CRS;

--- a/flink/src/test/java/org/apache/sedona/flink/PredicateTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/PredicateTest.java
@@ -13,23 +13,17 @@
  */
 package org.apache.sedona.flink;
 
-import org.apache.calcite.runtime.Geometries;
 import org.apache.flink.table.api.Table;
-import org.apache.sedona.common.utils.GeomUtils;
 import org.apache.sedona.flink.expressions.Predicates;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.geom.GeometryFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.apache.flink.table.api.Expressions.$;
 import static org.apache.flink.table.api.Expressions.call;
-import static org.junit.Assert.assertThrows;
 
 public class PredicateTest extends TestBase{
 
-    private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory();
     @BeforeClass
     public static void onceExecutedBeforeAll() {
         initialize();
@@ -39,8 +33,9 @@ public class PredicateTest extends TestBase{
     public void testIntersects() {
         Table pointTable = createPointTable(testDataSize);
         String polygon = createPolygonWKT(testDataSize).get(0).getField(0).toString();
-        String expr = "ST_Intersects(ST_GeomFromWkt('" + polygon + "'), geom_point)";
-        Table result = pointTable.filter(expr);
+        Table result = pointTable.filter(
+            call("ST_Intersects",
+                call("ST_GeomFromWkt", polygon), $("geom_point")));
         assertEquals(1, count(result));
     }
 
@@ -48,8 +43,9 @@ public class PredicateTest extends TestBase{
     public void testDisjoint() {
         Table pointTable = createPointTable(testDataSize);
         String polygon = createPolygonWKT(testDataSize).get(0).getField(0).toString();
-        String expr = "ST_Disjoint(ST_GeomFromWkt('" + polygon + "'), geom_point)";
-        Table result = pointTable.filter(expr);
+        Table result = pointTable.filter(
+            call("ST_Disjoint",
+                call("ST_GeomFromWkt", polygon), $("geom_point")));
         assertEquals(999, count(result));
     }
 
@@ -57,8 +53,9 @@ public class PredicateTest extends TestBase{
     public void testContains() {
         Table pointTable = createPointTable(testDataSize);
         String polygon = createPolygonWKT(testDataSize).get(0).getField(0).toString();
-        String expr = "ST_Contains(ST_GeomFromWkt('" + polygon + "'), geom_point)";
-        Table result = pointTable.filter(expr);
+        Table result = pointTable.filter(
+            call("ST_Contains",
+                call("ST_GeomFromWkt", polygon), $("geom_point")));
         assertEquals(1, count(result));
     }
 
@@ -66,8 +63,9 @@ public class PredicateTest extends TestBase{
     public void testWithin() {
         Table pointTable = createPointTable(testDataSize);
         String polygon = createPolygonWKT(testDataSize).get(0).getField(0).toString();
-        String expr = "ST_Within(geom_point, ST_GeomFromWkt('" + polygon + "'))";
-        Table result = pointTable.filter(expr);
+        Table result = pointTable.filter(
+            call("ST_Within", $("geom_point"),
+                call("ST_GeomFromWkt", polygon)));
         assertEquals(1, count(result));
     }
 
@@ -75,8 +73,9 @@ public class PredicateTest extends TestBase{
     public void testCovers() {
         Table pointTable = createPointTable(testDataSize);
         String polygon = createPolygonWKT(testDataSize).get(0).getField(0).toString();
-        String expr = "ST_Covers(ST_GeomFromWkt('" + polygon + "'), geom_point)";
-        Table result = pointTable.filter(expr);
+        Table result = pointTable.filter(
+            call("ST_Covers",
+                call("ST_GeomFromWkt", polygon), $("geom_point")));
         assertEquals(1, count(result));
     }
 
@@ -84,8 +83,9 @@ public class PredicateTest extends TestBase{
     public void testCoveredBy() {
         Table pointTable = createPointTable(testDataSize);
         String polygon = createPolygonWKT(testDataSize).get(0).getField(0).toString();
-        String expr = "ST_CoveredBy(geom_point, ST_GeomFromWkt('" + polygon + "'))";
-        Table result = pointTable.filter(expr);
+        Table result = pointTable.filter(
+            call("ST_CoveredBy", $("geom_point"),
+                call("ST_GeomFromWkt", polygon)));
         assertEquals(1, count(result));
     }
 
@@ -109,8 +109,9 @@ public class PredicateTest extends TestBase{
     public void testOrderingEquals() {
         Table lineStringTable = createLineStringTable(testDataSize);
         String lineString = createLineStringWKT(testDataSize).get(0).getField(0).toString();
-        String expr = "ST_OrderingEquals(ST_GeomFromWkt('" + lineString + "'), geom_linestring)";
-        Table result = lineStringTable.filter(expr);
+        Table result = lineStringTable.filter(
+            call("ST_OrderingEquals",
+                call("ST_GeomFromWkt", lineString), $("geom_linestring")));
         assertEquals(1, count(result));
     }
 


### PR DESCRIPTION
This PR bumps Flink from 1.14.6 to 1.19.0 and there are 3 major changes

- Bump Flink to 1.19.0
- Remove useless flink-connector-kafka(for the newer version jackson-bind may break tests)
- Repair tests using deprecated interface

