### PR TITLE
[SEDONA-558] Fix and improve SedonaPyDeck behavior

### DIFF
--- a/docs/api/sql/Visualization_SedonaPyDeck.md
+++ b/docs/api/sql/Visualization_SedonaPyDeck.md
@@ -28,8 +28,8 @@ The parameter `line_color` can be given a list of RGB/RGBA values, or a string t
 
 The parameter `elevation_col` can be given a static elevation or elevation based on column values like `fill_color`, this only works for the polygon geometries in the map.
 
-Optionally, parameters `initial_view_state`, `map_style`, `map_provider` can be passed to configure the map as per user's liking.
-More details on the parameters and their default values can be found on the pydeck website as well by deck.gl [here](https://github.com/visgl/deck.gl/blob/8.9-release/docs/api-reference/layers/geojson-layer.md)
+Optionally, parameters `initial_view_state`, `map_style`, `map_provider`, `api_keys` can be passed to configure the map as per user's liking.
+More details on the parameters and their default values can be found on the PyDeck website as well by deck.gl [here](https://github.com/visgl/deck.gl/blob/8.9-release/docs/api-reference/layers/geojson-layer.md)
 
 ### **Choropleth Map**
 
@@ -53,8 +53,8 @@ SedonaPyDeck then creates a default color scheme based on the values of the colu
 
 The parameter `elevation_col` can be given a numeric or a string value (containing the column with/without operations on it) to set a 3D elevation to the plotted polygons if any.
 
-Optionally, parameters `initial_view_state`, `map_style`, `map_provider` can be passed to configure the map as per user's liking.
-More details on the parameters and their default values can be found on the pydeck website.
+Optionally, parameters `initial_view_state`, `map_style`, `map_provider`, `api_keys` can be passed to configure the map as per user's liking.
+More details on the parameters and their default values can be found on the PyDeck website.
 
 ### **Scatterplot**
 
@@ -72,8 +72,8 @@ The parameter `radius_max_pixels` can be given a numeric value that would set th
 
 The parameter `radius_scale` can be given a numeric value that sets a global radius multiplier for all points.
 
-Optionally, parameters `initial_view_state`, `map_style`, `map_provider` can be passed to configure the map as per user's liking.
-More details on the parameters and their default values can be found on the pydeck website as well by deck.gl [here](https://github.com/visgl/deck.gl/blob/8.9-release/docs/api-reference/layers/scatterplot-layer.md)
+Optionally, parameters `initial_view_state`, `map_style`, `map_provider`, `api_keys` can be passed to configure the map as per user's liking.
+More details on the parameters and their default values can be found on the PyDeck website as well by deck.gl [here](https://github.com/visgl/deck.gl/blob/8.9-release/docs/api-reference/layers/scatterplot-layer.md)
 
 ### **Heatmap**
 
@@ -91,5 +91,5 @@ By default, SedonaPyDeck assigns a weight of 1 to each point
 The parameter `aggregation` can be used to define aggregation strategy to use when aggregating heatmap to a lower resolution (zooming out).
 One of "MEAN" or "SUM" can be provided. By default, SedonaPyDeck uses "MEAN" as the aggregation strategy.
 
-Optionally, parameters `initial_view_state`, `map_style`, `map_provider` can be passed to configure the map as per user's liking.
-More details on the parameters and their default values can be found on the pydeck website as well by deck.gl [here](https://github.com/visgl/deck.gl/blob/8.9-release/docs/api-reference/aggregation-layers/heatmap-layer.md)
+Optionally, parameters `initial_view_state`, `map_style`, `map_provider`, `api_keys` can be passed to configure the map as per user's liking.
+More details on the parameters and their default values can be found on the PyDeck website as well by deck.gl [here](https://github.com/visgl/deck.gl/blob/8.9-release/docs/api-reference/aggregation-layers/heatmap-layer.md)

--- a/docs/api/sql/Visualization_SedonaPyDeck.md
+++ b/docs/api/sql/Visualization_SedonaPyDeck.md
@@ -12,6 +12,11 @@ Alternatively it can also be imported using:
 from sedona.maps.SedonaPyDeck import SedonaPyDeck
 ```
 
+!!!Note
+    For more information on the optional parameters please visit [PyDeck docs](https://deckgl.readthedocs.io/en/latest/deck.html).
+
+    SedonaPyDeck assumes the map provider to be Mapbox when user selects 'salellite' option for `map_style`.
+
 Following are details on all the APIs exposed via SedonaPyDeck:
 
 ### **Geometry Map**
@@ -19,7 +24,7 @@ Following are details on all the APIs exposed via SedonaPyDeck:
 ```python
 def create_geometry_map(df, fill_color="[85, 183, 177, 255]", line_color="[85, 183, 177, 255]",
                    elevation_col=0, initial_view_state=None,
-                   map_style=None, map_provider=None):
+                   map_style=None, map_provider=None, api_keys=None):
 ```
 
 The parameter `fill_color` can be given a list of RGB/RGBA values, or a string that contains RGB/RGBA values based on a column, and is used to color polygons or point geometries in the map
@@ -35,7 +40,7 @@ More details on the parameters and their default values can be found on the PyDe
 
 ```python
 def create_choropleth_map(df, fill_color=None, plot_col=None, initial_view_state=None, map_style=None,
-						  map_provider=None, elevation_col=0)
+						  map_provider=None, api_keys=None, elevation_col=0)
 ```
 
 The parameter `fill_color` can be given a list of RGB/RGBA values, or a string that contains RGB/RGBA values based on a column.
@@ -59,7 +64,8 @@ More details on the parameters and their default values can be found on the PyDe
 ### **Scatterplot**
 
 ```python
-def create_scatterplot_map(df, fill_color="[255, 140, 0]", radius_col=1, radius_min_pixels = 1, radius_max_pixels = 10, radius_scale=1, initial_view_state=None, map_style=None, map_provider=None)
+def create_scatterplot_map(df, fill_color="[255, 140, 0]", radius_col=1, radius_min_pixels = 1, radius_max_pixels = 10, radius_scale=1, initial_view_state=None,
+                           map_style=None, map_provider=None, api_keys=None)
 ```
 
 The parameter `fill_color` can be given a list of RGB/RGBA values, or a string that contains RGB/RGBA values based on a column.
@@ -79,7 +85,7 @@ More details on the parameters and their default values can be found on the PyDe
 
 ```python
 def create_heatmap(df, color_range=None, weight=1, aggregation="SUM", initial_view_state=None, map_style=None,
-                map_provider=None)
+                map_provider=None, api_keys=None)
 ```
 
 The parameter `color_range` can be optionally given a list of RGB values, SedonaPyDeck by default uses `6-class YlOrRd` as color_range.

--- a/python/sedona/maps/SedonaPyDeck.py
+++ b/python/sedona/maps/SedonaPyDeck.py
@@ -24,7 +24,7 @@ class SedonaPyDeck:
     # User Facing APIs
     @classmethod
     def create_choropleth_map(cls, df, fill_color=None, plot_col=None, initial_view_state=None, map_style=None,
-                              map_provider=None, elevation_col=0):
+                              map_provider=None, elevation_col=0, api_keys=None):
         """
         Create a pydeck map with a choropleth layer added
         :param elevation_col: Optional elevation for the polygons
@@ -35,6 +35,7 @@ class SedonaPyDeck:
         :param initial_view_state:
         :param map_style:
         :param map_provider:
+        :param api_keys: Optional dictionary of API keys for Map providers
         :return: A pydeck Map object with choropleth layer added:
         """
         pdk = _try_import_pydeck()
@@ -61,14 +62,13 @@ class SedonaPyDeck:
             pickable=True
         )
 
-        map_ = pdk.Deck(layers=[choropleth_layer], initial_view_state=initial_view_state)
-        SedonaPyDeck._set_optional_parameters_(p_map=map_, map_style=map_style, map_provider=map_provider)
-        return map_
+        return SedonaPyDeck._create_map_obj(layer=choropleth_layer, initial_view_state=initial_view_state, map_style=map_style,
+                                            map_provider=map_provider, api_keys=api_keys)
 
     @classmethod
     def create_geometry_map(cls, df, fill_color="[85, 183, 177, 255]", line_color="[85, 183, 177, 255]",
                             elevation_col=0, initial_view_state=None,
-                            map_style=None, map_provider=None):
+                            map_style=None, map_provider=None, api_keys=None):
         """
         Create a pydeck map with a GeoJsonLayer added for plotting given geometries.
         :param line_color:
@@ -78,6 +78,7 @@ class SedonaPyDeck:
         :param initial_view_state: optional initial view state of the pydeck map
         :param map_style: optional map_style of the pydeck map
         :param map_provider: optional map_provider of the pydeck map
+        :param api_keys: Optional dictionary of API keys for Map providers
         :return: A pydeck map with a GeoJsonLayer map added
         """
         pdk = _try_import_pydeck()
@@ -98,14 +99,14 @@ class SedonaPyDeck:
 
         if elevation_col != 0 and geom_type == "Polygon":
             initial_view_state.pitch = 45  # If polygons are elevated, change the pitch to visualize the elevation better
-        map_ = pdk.Deck(layers=[layer], map_style='dark', initial_view_state=initial_view_state)
-        SedonaPyDeck._set_optional_parameters_(p_map=map_, map_style=map_style, map_provider=map_provider)
-        return map_
+
+        return SedonaPyDeck._create_map_obj(layer=layer, initial_view_state=initial_view_state, map_style=map_style,
+                                            map_provider=map_provider, api_keys=api_keys)
 
     @classmethod
     def create_scatterplot_map(cls, df, fill_color="[255, 140, 0]", radius_col=1, radius_min_pixels=1,
                                radius_max_pixels=10, radius_scale=1, initial_view_state=None, map_style=None,
-                               map_provider=None):
+                               map_provider=None, api_keys=None):
         """
         Create a pydeck map with a scatterplot layer
         :param radius_scale:
@@ -117,6 +118,7 @@ class SedonaPyDeck:
         :param initial_view_state: optional initial view state of a pydeck map
         :param map_style: optional map_style to be added to the pydeck map
         :param map_provider: optional map_provider to be added to the pydeck map
+        :param api_keys: Optional dictionary of API keys for Map providers
         :return: A pydeck map object with a scatterplot layer added
         """
         pdk = _try_import_pydeck()
@@ -139,13 +141,12 @@ class SedonaPyDeck:
         if initial_view_state is None:
             initial_view_state = pdk.data_utils.compute_view(gdf['coordinate_array_sedona'])
 
-        map_ = pdk.Deck(layers=[layer], initial_view_state=initial_view_state)
-        SedonaPyDeck._set_optional_parameters_(p_map=map_, map_style=map_style, map_provider=map_provider)
-        return map_
+        return SedonaPyDeck._create_map_obj(layer=layer, initial_view_state=initial_view_state, map_style=map_style,
+                                            map_provider=map_provider, api_keys=api_keys)
 
     @classmethod
     def create_heatmap(cls, df, color_range=None, weight=1, aggregation="SUM", initial_view_state=None, map_style=None,
-                       map_provider=None):
+                       map_provider=None, api_keys=None):
         """
         Create a pydeck map with a heatmap layer added
         :param df: SedonaDataFrame to be used to plot the heatmap
@@ -155,6 +156,7 @@ class SedonaPyDeck:
         :param initial_view_state: Optional initial view state of the pydeck map
         :param map_style: Optional map_style of the pydeck map
         :param map_provider: Optional map_provider for the pydeck map
+        :param api_keys: Optional dictionary of API keys for Map providers
         :return: A pydeck map with a heatmap layer added
         """
         pdk = _try_import_pydeck()
@@ -186,10 +188,8 @@ class SedonaPyDeck:
         if initial_view_state is None:
             initial_view_state = pdk.data_utils.compute_view(gdf['coordinate_array_sedona'])
 
-        map_ = pdk.Deck(layers=[layer], initial_view_state=initial_view_state)
-        SedonaPyDeck._set_optional_parameters_(p_map=map_, map_style=map_style, map_provider=map_provider)
-
-        return map_
+        return SedonaPyDeck._create_map_obj(layer=layer, initial_view_state=initial_view_state, map_style=map_style,
+                                            map_provider=map_provider, api_keys=api_keys)
 
     @classmethod
     def _prepare_df_(cls, df, add_coords=False, geometry_col=None):
@@ -206,21 +206,6 @@ class SedonaPyDeck:
             SedonaPyDeck._create_coord_column_(gdf=gdf, geometry_col=geometry_col)
         return gdf
 
-    # Utility APIs specific to SedonaPyDeck
-    @classmethod
-    def _set_optional_parameters_(cls, p_map, map_style, map_provider):
-        """
-        Set optional parameters to a given pydeck map
-        (Parameters are self-explanatory for a pydeck map)
-        :param p_map:
-        :param map_style:
-        :param map_provider:
-        """
-        if map_style is not None:
-            p_map.map_style = map_style
-
-        if map_provider is not None:
-            p_map.map_provider = map_provider
 
     @classmethod
     def _create_default_fill_color_(cls, gdf, plot_col):
@@ -261,6 +246,27 @@ class SedonaPyDeck:
         )
 
         return layer
+
+    # creates the final map object and handles the parameters for pydeck
+    @classmethod
+    def _create_map_obj(cls, layer, initial_view_state, map_style, map_provider, api_keys):
+        pdk = _try_import_pydeck()
+
+        if map_provider is None:
+            map_provider = 'carto'
+
+        if map_style is None:
+            map_style = 'dark'
+
+        # Default to mapbox if user selects 'satellite' map_style as pydeck uses mapbox and google maps for satellite basemap
+        if map_style == 'satellite' and map_provider != 'google_maps':
+            map_provider = 'mapbox'
+
+        if api_keys is not None:
+            api_keys = api_keys
+
+        return pdk.Deck(layers=[layer], initial_view_state=initial_view_state, map_style=map_style,
+                        map_provider=map_provider, api_keys=api_keys)
 
 
 def _try_import_pydeck() -> ModuleType:

--- a/python/sedona/sql/st_constructors.py
+++ b/python/sedona/sql/st_constructors.py
@@ -84,7 +84,7 @@ def ST_GeomFromKML(kml_string: ColumnOrName) -> Column:
 
 
 @validate_argument_types
-def ST_GeomFromText(wkt: ColumnOrName) -> Column:
+def ST_GeomFromText(wkt: ColumnOrName, srid: Optional[ColumnOrNameOrNumber] = None) -> Column:
     """Generate a geometry column from a Well-Known Text (WKT) string column.
     This is an alias of ST_GeomFromWKT.
 
@@ -93,7 +93,9 @@ def ST_GeomFromText(wkt: ColumnOrName) -> Column:
     :return: Geometry column representing the WKT string.
     :rtype: Column
     """
-    return _call_constructor_function("ST_GeomFromText", wkt)
+    args = (wkt) if srid is None else (wkt, srid)
+
+    return _call_constructor_function("ST_GeomFromText", args)
 
 
 @validate_argument_types
@@ -109,7 +111,7 @@ def ST_GeomFromWKB(wkb: ColumnOrName) -> Column:
 
 
 @validate_argument_types
-def ST_GeomFromWKT(wkt: ColumnOrName) -> Column:
+def ST_GeomFromWKT(wkt: ColumnOrName, srid: Optional[ColumnOrNameOrNumber] = None) -> Column:
     """Generate a geometry column from a Well-Known Text (WKT) string column.
     This is an alias of ST_GeomFromText.
 
@@ -118,7 +120,9 @@ def ST_GeomFromWKT(wkt: ColumnOrName) -> Column:
     :return: Geometry column representing the WKT string.
     :rtype: Column
     """
-    return _call_constructor_function("ST_GeomFromWKT", wkt)
+    args = (wkt) if srid is None else (wkt, srid)
+
+    return _call_constructor_function("ST_GeomFromWKT", args)
 
 @validate_argument_types
 def ST_GeomFromEWKT(ewkt: ColumnOrName) -> Column:
@@ -261,7 +265,7 @@ def ST_PolygonFromText(coords: ColumnOrName, delimiter: ColumnOrName) -> Column:
     return _call_constructor_function("ST_PolygonFromText", (coords, delimiter))
 
 @validate_argument_types
-def ST_MPolyFromText(wkt: ColumnOrName) -> Column:
+def ST_MPolyFromText(wkt: ColumnOrName, srid: Optional[ColumnOrNameOrNumber] = None) -> Column:
     """Generate multiPolygon geometry from a multiPolygon WKT representation.
 
     :param wkt: multiPolygon WKT string column to generate from.
@@ -269,10 +273,12 @@ def ST_MPolyFromText(wkt: ColumnOrName) -> Column:
     :return: multiPolygon geometry generated from the wkt column.
     :rtype: Column
     """
-    return _call_constructor_function("ST_MPolyFromText", wkt)
+    args = (wkt) if srid is None else (wkt, srid)
+
+    return _call_constructor_function("ST_MPolyFromText", args)
 
 @validate_argument_types
-def ST_MLineFromText(wkt: ColumnOrName) -> Column:
+def ST_MLineFromText(wkt: ColumnOrName, srid: Optional[ColumnOrNameOrNumber] = None) -> Column:
     """Generate multiLineString geometry from a multiLineString WKT representation.
 
     :param wkt: multiLineString WKT string column to generate from.
@@ -280,4 +286,6 @@ def ST_MLineFromText(wkt: ColumnOrName) -> Column:
     :return: multiLineString geometry generated from the wkt column.
     :rtype: Column
     """
-    return _call_constructor_function("ST_MLineFromText", wkt)
+    args = (wkt) if srid is None else (wkt, srid)
+
+    return _call_constructor_function("ST_MLineFromText", args)

--- a/python/tests/maps/test_sedonapydeck.py
+++ b/python/tests/maps/test_sedonapydeck.py
@@ -49,8 +49,8 @@ class TestVisualization(TestBase):
             get_elevation=0,
             pickable=True
         )
-        p_map = pdk.Deck(layers=[choropleth_layer])
-        sedona_pydeck_map = SedonaPyDeck.create_choropleth_map(df=buildings_df, plot_col='confidence')
+        p_map = pdk.Deck(layers=[choropleth_layer], map_style='satellite', map_provider='mapbox')
+        sedona_pydeck_map = SedonaPyDeck.create_choropleth_map(df=buildings_df, plot_col='confidence', map_style='satellite')
         res = self.isMapEqual(sedona_map=sedona_pydeck_map, pydeck_map=p_map)
         assert res is True
 
@@ -142,8 +142,8 @@ class TestVisualization(TestBase):
             get_weight=1
         )
 
-        p_map = pdk.Deck(layers=[layer])
-        sedona_pydeck_map = SedonaPyDeck.create_heatmap(df=chicago_crimes_df)
+        p_map = pdk.Deck(layers=[layer], map_style='satellite', map_provider='mapbox')
+        sedona_pydeck_map = SedonaPyDeck.create_heatmap(df=chicago_crimes_df, map_style='satellite')
         assert self.isMapEqual(sedona_map=sedona_pydeck_map, pydeck_map=p_map)
 
     def isMapEqual(self, pydeck_map, sedona_map):

--- a/python/tests/maps/test_sedonapydeck.py
+++ b/python/tests/maps/test_sedonapydeck.py
@@ -107,8 +107,8 @@ class TestVisualization(TestBase):
             radius_scale=1
         )
 
-        p_map = pdk.Deck(layers=[layer])
-        sedona_pydeck_map = SedonaPyDeck.create_scatterplot_map(df=chicago_crimes_df)
+        p_map = pdk.Deck(layers=[layer], map_style='satellite', map_provider='google_maps')
+        sedona_pydeck_map = SedonaPyDeck.create_scatterplot_map(df=chicago_crimes_df, map_style='satellite', map_provider='google_maps')
         assert self.isMapEqual(sedona_map=sedona_pydeck_map, pydeck_map=p_map)
 
     def testHeatmap(self):

--- a/python/tests/sql/test_dataframe_api.py
+++ b/python/tests/sql/test_dataframe_api.py
@@ -43,12 +43,20 @@ test_configurations = [
     (stc.ST_GeomFromGML, ("gml",), "constructor", "", "LINESTRING (-71.16 42.25, -71.17 42.25, -71.18 42.25)"),
     (stc.ST_GeomFromKML, ("kml",), "constructor", "", "LINESTRING (-71.16 42.26, -71.17 42.26)"),
     (stc.ST_GeomFromText, ("wkt",), "linestring_wkt", "", "LINESTRING (1 2, 3 4)"),
+    (stc.ST_GeomFromText, ("wkt",4326), "linestring_wkt", "", "LINESTRING (1 2, 3 4)"),
     (stc.ST_GeomFromWKB, ("wkb",), "constructor", "ST_ReducePrecision(geom, 2)", "LINESTRING (-2.1 -0.35, -1.5 -0.67)"),
     (stc.ST_GeomFromWKT, ("wkt",), "linestring_wkt", "", "LINESTRING (1 2, 3 4)"),
+    (stc.ST_GeomFromWKT, ("wkt",4326), "linestring_wkt", "", "LINESTRING (1 2, 3 4)"),
     (stc.ST_GeomFromEWKT, ("ewkt",), "linestring_ewkt", "", "LINESTRING (1 2, 3 4)"),
     (stc.ST_LineFromText, ("wkt",), "linestring_wkt", "", "LINESTRING (1 2, 3 4)"),
     (stc.ST_LineStringFromText, ("multiple_point", lambda: f.lit(',')), "constructor", "", "LINESTRING (0 0, 1 0, 1 1, 0 0)"),
     (stc.ST_Point, ("x", "y"), "constructor", "", "POINT (0 1)"),
+    (stc.ST_PointZ, ("x", "y", "z", 4326), "constructor", "", "POINT Z (0 1 2)"),
+    (stc.ST_PointZ, ("x", "y", "z"), "constructor", "", "POINT Z (0 1 2)"),
+    (stc.ST_MPolyFromText, ("mpoly",), "constructor", "" , "MULTIPOLYGON (((0 0, 20 0, 20 20, 0 20, 0 0), (5 5, 5 7, 7 7, 7 5, 5 5)))"),
+    (stc.ST_MPolyFromText, ("mpoly", 4326), "constructor", "" , "MULTIPOLYGON (((0 0, 20 0, 20 20, 0 20, 0 0), (5 5, 5 7, 7 7, 7 5, 5 5)))"),
+    (stc.ST_MLineFromText, ("mline", ), "constructor", "" , "MULTILINESTRING ((1 2, 3 4), (4 5, 6 7))"),
+    (stc.ST_MLineFromText, ("mline", 4326), "constructor", "" , "MULTILINESTRING ((1 2, 3 4), (4 5, 6 7))"),
     (stc.ST_PointFromText, ("single_point", lambda: f.lit(',')), "constructor", "", "POINT (0 1)"),
     (stc.ST_MakePoint, ("x", "y", "z"), "constructor", "", "POINT Z (0 1 2)"),
     (stc.ST_PolygonFromEnvelope, ("minx", "miny", "maxx", "maxy"), "min_max_x_y", "", "POLYGON ((0 1, 0 3, 2 3, 2 1, 0 1))"),
@@ -382,6 +390,8 @@ class TestDataFrameAPI(TestBase):
     @pytest.fixture
     def base_df(self, request):
         wkb = '0102000000020000000000000084d600c00000000080b5d6bf00000060e1eff7bf00000080075de5bf'
+        mpoly = 'MULTIPOLYGON(((0 0 ,20 0 ,20 20 ,0 20 ,0 0 ),(5 5 ,5 7 ,7 7 ,7 5 ,5 5)))'
+        mline = 'MULTILINESTRING((1 2, 3 4), (4 5, 6 7))'
         geojson = "{ \"type\": \"Feature\", \"properties\": { \"prop\": \"01\" }, \"geometry\": { \"type\": \"Point\", \"coordinates\": [ 0.0, 1.0 ] }},"
         gml_string = "<gml:LineString srsName=\"EPSG:4269\"><gml:coordinates>-71.16,42.25 -71.17,42.25 -71.18,42.25</gml:coordinates></gml:LineString>"
         kml_string = "<LineString><coordinates>-71.16,42.26 -71.17,42.26</coordinates></LineString>"
@@ -394,6 +404,8 @@ class TestDataFrameAPI(TestBase):
                 "'0.0,1.0' AS single_point",
                 "'0.0,0.0,1.0,0.0,1.0,1.0,0.0,0.0' AS multiple_point",
                 f"X'{wkb}' AS wkb",
+                f"'{mpoly}' AS mpoly",
+                f"'{mline}' AS mline",
                 f"'{geojson}' AS geojson",
                 "'s00twy01mt' AS geohash",
                 f"'{gml_string}' AS gml",


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-558. The PR name follows the format `[SEDONA-XXX] my subject`

## Description

### Current implementation

- Adds the optional parameters `map_style`, and `map_provider` as data members to the pdk map object. 

     eg: map_p.map_style = map_style

- The current behavior of PyDeck doesn't update the map object with the additional configuration added via data members.

### Behavior of PyDeck

- The default `map_style` is 'dark' and `map_provider` is 'carto'. If you configure `map_style` to 'satellite' it will not change the `map_provider` to Mapbox or Google Maps API. 


## What changes were proposed in this PR?

- Expose `api_key` parameter of PyDeck
- Create a new method to create the PyDeck object to handle the default behavior of PyDeck.
- Default to Mapbox map provider if the `map_style` is set to 'satellite' and if `map_provider` is Carto (the default).

## How was this patch tested?

- Passed existing tests.

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.