### PR TITLE
[SEDONA-560] Properly handle dataframes containing 0 partitions when running spatial join

### DIFF
--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/TraitJoinQueryBase.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/TraitJoinQueryBase.scala
@@ -96,7 +96,7 @@ trait TraitJoinQueryBase {
 
   def doSpatialPartitioning(dominantShapes: SpatialRDD[Geometry], followerShapes: SpatialRDD[Geometry],
                             numPartitions: Integer, sedonaConf: SedonaConf): Unit = {
-    if (dominantShapes.approximateTotalCount > 0) {
+    if (dominantShapes.approximateTotalCount > 0 && numPartitions > 0) {
       dominantShapes.spatialPartitioning(sedonaConf.getJoinGridType, numPartitions)
       followerShapes.spatialPartitioning(dominantShapes.getPartitioner)
     }

--- a/spark/common/src/test/scala/org/apache/sedona/sql/TestBaseScala.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/TestBaseScala.scala
@@ -143,6 +143,19 @@ trait TestBaseScala extends FunSpec with BeforeAndAfterAll {
     }
   }
 
+  def withConf[T](conf: Map[String, String])(f: => T): T = {
+    val oldConf = conf.values.map(key => key -> sparkSession.conf.getOption(key))
+    conf.foreach{ case (key, value) => sparkSession.conf.set(key, value) }
+    try {
+      f
+    } finally {
+      oldConf.foreach { case (key, value) => value match {
+        case Some(v) => sparkSession.conf.set(key, v)
+        case None => sparkSession.conf.unset(key)
+      }}
+    }
+  }
+
   protected def bruteForceDistanceJoinCountSpheroid(sampleCount:Int, distance: Double): Int = {
     val input = buildPointLonLatDf.limit(sampleCount).collect()
     input.map(row => {


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-560. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Spatial join involving dataframes containing 0 partitions may fail. This is because of the inappropriate handling of such edge cases. This PR resolves such problems.

We've also refactored the code for setting up environments to run spatial join tests to be more compact and readable.

## How was this patch tested?

Add new tests.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
