### PR TITLE
[SEDONA-561] Fix the examples in the core.showcase package

### DIFF
--- a/spark/common/src/main/java/org/apache/sedona/core/formatMapper/shapefileParser/ShapefileRDD.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/formatMapper/shapefileParser/ShapefileRDD.java
@@ -149,6 +149,9 @@ public class ShapefileRDD
                     throws Exception
             {
                 List<Point> result = new ArrayList<Point>();
+                if (spatialObject == null) {
+                    throw new Exception("[ShapefileRDD] the object is null");
+                }
                 if (spatialObject instanceof MultiPoint) {
                     MultiPoint multiObjects = (MultiPoint) spatialObject;
                     for (int i = 0; i < multiObjects.getNumGeometries(); i++) {
@@ -182,6 +185,9 @@ public class ShapefileRDD
                     throws Exception
             {
                 List<Polygon> result = new ArrayList<Polygon>();
+                if (spatialObject == null) {
+                    throw new Exception("[ShapefileRDD] the object is null");
+                }
                 if (spatialObject instanceof MultiPolygon) {
                     MultiPolygon multiObjects = (MultiPolygon) spatialObject;
                     for (int i = 0; i < multiObjects.getNumGeometries(); i++) {
@@ -215,6 +221,9 @@ public class ShapefileRDD
                     throws Exception
             {
                 List<LineString> result = new ArrayList<LineString>();
+                if (spatialObject == null) {
+                    throw new Exception("[ShapefileRDD] the object is null");
+                }
                 if (spatialObject instanceof MultiLineString) {
                     MultiLineString multiObjects = (MultiLineString) spatialObject;
                     for (int i = 0; i < multiObjects.getNumGeometries(); i++) {

--- a/spark/common/src/main/java/org/apache/sedona/core/showcase/Example.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/showcase/Example.java
@@ -24,7 +24,7 @@ import org.apache.log4j.Logger;
 import org.apache.sedona.common.enums.FileDataSplitter;
 import org.apache.sedona.core.enums.GridType;
 import org.apache.sedona.core.enums.IndexType;
-import org.apache.sedona.core.formatMapper.shapefileParser.ShapefileRDD;
+import org.apache.sedona.core.formatMapper.shapefileParser.ShapefileReader;
 import org.apache.sedona.core.serde.SedonaKryoRegistrator;
 import org.apache.sedona.core.spatialOperator.JoinQuery;
 import org.apache.sedona.core.spatialOperator.KNNQuery;
@@ -40,6 +40,7 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
+import org.apache.sedona.core.spatialRDD.SpatialRDD;
 
 import java.io.Serializable;
 import java.util.List;
@@ -166,13 +167,13 @@ public class Example
         PointRDDSplitter = FileDataSplitter.CSV;
         PointRDDIndexType = IndexType.RTREE;
         PointRDDNumPartitions = 5;
-        PointRDDOffset = 0;
+        PointRDDOffset = 1;
 
         PolygonRDDInputLocation = resourceFolder + "primaryroads-polygon.csv";
         PolygonRDDSplitter = FileDataSplitter.CSV;
         PolygonRDDNumPartitions = 5;
         PolygonRDDStartOffset = 0;
-        PolygonRDDEndOffset = 8;
+        PolygonRDDEndOffset = 9;
 
         geometryFactory = new GeometryFactory();
         kNNQueryPoint = geometryFactory.createPoint(new Coordinate(-84.01, 34.01));
@@ -367,8 +368,8 @@ public class Example
     public static void testLoadShapefileIntoPolygonRDD()
             throws Exception
     {
-        ShapefileRDD shapefileRDD = new ShapefileRDD(sc, ShapeFileInputLocation);
-        PolygonRDD spatialRDD = new PolygonRDD(shapefileRDD.getPolygonRDD());
+        SpatialRDD shapefileRDD = ShapefileReader.readToGeometryRDD(sc, ShapeFileInputLocation);
+        PolygonRDD spatialRDD = new PolygonRDD(shapefileRDD.rawSpatialRDD);
         try {
             RangeQuery.SpatialRangeQuery(spatialRDD, new Envelope(-180, 180, -90, 90), false, false).count();
         }


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-561. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

1. This PR fixed the examples in the core package to use the correct file start/end offsets and to use the latest shapefile RDD loader.
2. It added `null` handling in the format mapper

## How was this patch tested?
Passed existing tests.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
