### PR TITLE
[SEDONA-580] New instances of RasterUDT object should equal to the RasterUDT case object

### DIFF
--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/UDT/GeometryUDT.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/UDT/GeometryUDT.scala
@@ -54,7 +54,7 @@ class GeometryUDT extends UserDefinedType[Geometry] {
     case _ => false
   }
 
-  override def hashCode(): Int = super.hashCode()
+  override def hashCode(): Int = userClass.hashCode()
 }
 
 case object GeometryUDT extends org.apache.spark.sql.sedona_sql.UDT.GeometryUDT with scala.Serializable

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/UDT/RasterUDT.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/UDT/RasterUDT.scala
@@ -41,6 +41,13 @@ class RasterUDT extends UserDefinedType[GridCoverage2D] {
   }
 
   override def userClass: Class[GridCoverage2D] = classOf[GridCoverage2D]
+
+  override def equals(other: Any): Boolean = other match {
+    case _: UserDefinedType[_] => other.isInstanceOf[RasterUDT]
+    case _ => false
+  }
+
+  override def hashCode(): Int = userClass.hashCode()
 }
 
 case object RasterUDT extends RasterUDT with Serializable

--- a/spark/common/src/test/scala/org/apache/sedona/sql/GeometryUdtTestScala.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/GeometryUdtTestScala.scala
@@ -58,7 +58,16 @@ class GeometryUdtTestScala extends TestBaseScala with BeforeAndAfter {
     }
 
     it("Case object and new instance should be equals") {
-      assert(GeometryUDT.equals(new GeometryUDT))
+      assert(GeometryUDT == GeometryUDT)
+      val udt = new GeometryUDT
+      assert(udt.equals(udt))
+      assert(udt.equals(GeometryUDT))
+      assert(GeometryUDT.equals(udt))
+    }
+
+    it("hashCode should work correctly") {
+      val udt = new GeometryUDT
+      assert(udt.hashCode() == GeometryUDT.hashCode())
     }
   }
 

--- a/spark/common/src/test/scala/org/apache/sedona/sql/RasterUDTSuite.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/RasterUDTSuite.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.sql
+
+import org.apache.spark.sql.sedona_sql.UDT.RasterUDT
+import org.scalatest.funspec.AnyFunSpec
+
+class RasterUDTSuite extends AnyFunSpec {
+  describe("RasterUDT Test") {
+    it("Case object and new instance should be equals") {
+      assert(RasterUDT == RasterUDT)
+      val udt = new RasterUDT
+      assert(udt.equals(udt))
+      assert(udt.equals(RasterUDT))
+      assert(RasterUDT.equals(udt))
+    }
+
+    it("hashCode should work correctly") {
+      val udt = new RasterUDT
+      assert(udt.hashCode() == RasterUDT.hashCode())
+    }
+  }
+}


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-580. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

* Implement `equals` and `hashCode` for RasterUDT to ensure that newly created instances of RasterUDT class are equal to the RasterUDT case class.
* Fix `hashCode` for GeometryUDT

## How was this patch tested?

Add new tests and manually test on external systems.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
