### PR TITLE
[SEDONA-581] SedonaKepler fails to reload if a raster column exists

### DIFF
--- a/python/sedona/maps/SedonaKepler.py
+++ b/python/sedona/maps/SedonaKepler.py
@@ -16,6 +16,7 @@
 #  under the License.
 
 from sedona.maps.SedonaMapUtils import SedonaMapUtils
+from sedona.sql.types import RasterType
 
 
 class SedonaKepler:
@@ -54,5 +55,10 @@ class SedonaKepler:
         :param name: [Optional] Name to assign to the dataframe, default name assigned is 'unnamed'
         :return: Does not return anything, adds df directly to the given map object
         """
+        schema = df.schema
+        for field in schema.fields:
+            if field.dataType == RasterType():
+                df = df.drop(field.name)
+
         geo_df = SedonaMapUtils.__convert_to_gdf_or_pdf__(df)
         kepler_map.add_data(geo_df, name=name)


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-581. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

- Drop the raster column if it exists to prevent serialization errors with Kepler.

## How was this patch tested?

- Add unit tests

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.