### PR TITLE
[SEDONA-605] Fix rasterization when useGeometryExtent=false

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/raster/RasterConstructors.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterConstructors.java
@@ -178,29 +178,19 @@ public class RasterConstructors
 
         Envelope2D bound = null;
 
+        int width, height;
         if (useGeometryExtent) {
             bound = JTS.getEnvelope2D(geom.getEnvelopeInternal(), raster.getCoordinateReferenceSystem2D());
+            double scaleX = Math.abs(metadata[4]), scaleY = Math.abs(metadata[5]);
+            width = Math.max((int) Math.ceil(bound.getWidth() / scaleX), 1);
+            height = Math.max((int) Math.ceil(bound.getHeight() / scaleY), 1);
+            bound = new Envelope2D(bound.getCoordinateReferenceSystem(), bound.getMinX(), bound.getMinY(), width * scaleX, height * scaleY);
         } else {
             ReferencedEnvelope envelope = ReferencedEnvelope.create(raster.getEnvelope(), raster.getCoordinateReferenceSystem());
             bound = JTS.getEnvelope2D(envelope, raster.getCoordinateReferenceSystem2D());
-        }
-
-        double scaleX = Math.abs(metadata[4]), scaleY = Math.abs(metadata[5]);
-        int width = (int) bound.getWidth(), height = (int) bound.getHeight();
-        if (width == 0 && height == 0) {
-            bound = new Envelope2D(bound.getCoordinateReferenceSystem(), bound.getCenterX() - scaleX * 0.5, bound.getCenterY() - scaleY * 0.5, scaleX, scaleY);
-            width = 1;
-            height = 1;
-        } else if (height == 0) {
-            bound = new Envelope2D(bound.getCoordinateReferenceSystem(), bound.getCenterX() - scaleX * 0.5, bound.getCenterY() - scaleY * 0.5, width, scaleY);
-            height = 1;
-        } else if (width == 0) {
-            bound = new Envelope2D(bound.getCoordinateReferenceSystem(), bound.getCenterX() - scaleX * 0.5, bound.getCenterY() - scaleY * 0.5, scaleX, height);
-            width = 1;
-        } else {
-            // To preserve scale of reference raster
-            width = (int) (width / scaleX);
-            height = (int) (height / scaleY);
+            GridEnvelope2D gridRange = raster.getGridGeometry().getGridRange2D();
+            width = gridRange.width;
+            height = gridRange.height;
         }
 
         VectorToRasterProcess rasterProcess = new VectorToRasterProcess();

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterBandAccessorsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterBandAccessorsTest.java
@@ -86,11 +86,11 @@ public class RasterBandAccessorsTest extends RasterTestBase {
         Geometry geom = Constructors.geomFromWKT(polygon, RasterAccessors.srid(raster));
 
         double actual = RasterBandAccessors.getZonalStats(raster, geom, 1, "sum", false);
-        double expected = 1.0690406E7;
+        double expected = 1.0719726E7;
         assertEquals(expected, actual, 0d);
 
         actual = RasterBandAccessors.getZonalStats(raster, geom, 2, "mean", false);
-        expected = 220.6062;
+        expected = 220.7527;
         assertEquals(expected, actual, FP_TOLERANCE);
 
         actual = RasterBandAccessors.getZonalStats(raster, geom, 1, "count");
@@ -98,7 +98,7 @@ public class RasterBandAccessorsTest extends RasterTestBase {
         assertEquals(expected, actual, 0.1d);
 
         actual = RasterBandAccessors.getZonalStats(raster, geom, 3, "variance", false);
-        expected = 13554.5057;
+        expected = 13549.6263;
         assertEquals(expected, actual, FP_TOLERANCE);
 
         actual = RasterBandAccessors.getZonalStats(raster, geom, "max");
@@ -110,7 +110,7 @@ public class RasterBandAccessorsTest extends RasterTestBase {
         assertEquals(expected, actual, 1E-1);
 
         actual = RasterBandAccessors.getZonalStats(raster, geom, 1, "sd", false);
-        expected = 92.1327;
+        expected = 92.1500;
         assertEquals(expected, actual, FP_TOLERANCE);
 
         geom = Constructors.geomFromWKT("POLYGON ((-77.96672569800863073 37.91971182746296876, -77.9688630154902711 37.89620133516485367, -77.93936803424354309 37.90517806858776595, -77.96672569800863073 37.91971182746296876))", 0);
@@ -166,7 +166,7 @@ public class RasterBandAccessorsTest extends RasterTestBase {
         Geometry geom = Constructors.geomFromWKT(polygon, 3857);
 
         double[] actual = RasterBandAccessors.getZonalStatsAll(raster, geom, 1, false);
-        double[] expected = new double[] {184792.0, 1.0690406E7, 57.8510, 0.0, 0.0, 92.1327, 8488.4480, 0.0, 255.0};
+        double[] expected = new double[] {184792.0, 1.0719726E7, 58.00968656653401, 0.0, 0.0, 92.15004748703687, 8491.631251863151, 0.0, 255.0};
         assertArrayEquals(expected, actual, FP_TOLERANCE);
 
         geom = Constructors.geomFromWKT("POLYGON ((-77.96672569800863073 37.91971182746296876, -77.9688630154902711 37.89620133516485367, -77.93936803424354309 37.90517806858776595, -77.96672569800863073 37.91971182746296876))", 0);

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterConstructorsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterConstructorsTest.java
@@ -77,48 +77,48 @@ public class RasterConstructorsTest
         Geometry geom = Constructors.geomFromWKT("POLYGON((15 15, 18 20, 15 24, 24 25, 15 15))", 0);
         GridCoverage2D rasterized = RasterConstructors.asRaster(geom, raster, "d", 3093151, 3d);
         double[] actual = MapAlgebra.bandAsArray(rasterized, 1);
-        double[] expected = new double[] {3093151.0, 3093151.0, 3093151.0, 0.0, 0.0, 3093151.0, 0.0, 0.0, 0.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+        double[] expected = new double[] {3093151.0, 3093151.0, 3093151.0, 3093151.0, 0.0, 0.0, 3093151.0, 3093151.0, 0.0, 0.0, 0.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
         assertArrayEquals(expected, actual, 0.1d);
 
         rasterized = RasterConstructors.asRaster(geom, raster, "d");
         actual = MapAlgebra.bandAsArray(rasterized, 1);
-        expected = new double[] {1.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+        expected = new double[] {1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
         assertArrayEquals(expected, actual, 0.1d);
 
         // MultiPolygon
         geom = Constructors.geomFromWKT("MULTIPOLYGON (((15 15, 1.5 5.5, 3.5 5.5, 3.5 1.5, 15 15)), ((4.4 2.4, 4.4 6.4, 6.4 6.4, 6.4 2.4, 4.4 2.4)))", 0);
         rasterized = RasterConstructors.asRaster(geom, raster, "d", 3093151, 3d);
         actual = MapAlgebra.bandAsArray(rasterized, 1);
-        expected = new double[] {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 3093151.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+        expected = new double[] {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3093151.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 3093151.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
         assertArrayEquals(expected, actual, 0.1d);
 
         rasterized = RasterConstructors.asRaster(geom, raster, "d");
         actual = MapAlgebra.bandAsArray(rasterized, 1);
-        expected = new double[] {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+        expected = new double[] {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
         assertArrayEquals(expected, actual, 0.1d);
 
         // MultiLineString
         geom = Constructors.geomFromWKT("MULTILINESTRING ((5 5, 10 10), (10 10, 15 15, 20 20))", 0);
         rasterized = RasterConstructors.asRaster(geom, raster, "d", 3093151, 3d);
         actual = MapAlgebra.bandAsArray(rasterized, 1);
-        expected = new double[] {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+        expected = new double[] {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3093151.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
         assertArrayEquals(expected, actual, 0.1d);
 
         rasterized = RasterConstructors.asRaster(geom, raster, "d");
         actual = MapAlgebra.bandAsArray(rasterized, 1);
-        expected = new double[] {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+        expected = new double[] {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
         assertArrayEquals(expected, actual, 0.1d);
 
         // LinearRing
         geom = Constructors.geomFromWKT("LINEARRING (10 10, 18 20, 15 24, 24 25, 10 10)", 0);
         rasterized = RasterConstructors.asRaster(geom, raster, "d", 3093151, 3d);
         actual = MapAlgebra.bandAsArray(rasterized, 1);
-        expected = new double[] {0.0, 0.0, 3093151.0, 3093151.0, 3093151.0, 3093151.0, 3093151.0, 0.0, 0.0, 0.0, 3093151.0, 0.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+        expected = new double[] {0.0, 0.0, 0.0, 0.0, 3093151.0, 3093151.0, 3093151.0, 0.0, 0.0, 3093151.0, 3093151.0, 0.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 3093151.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3093151.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
         assertArrayEquals(expected, actual, 0.1d);
 
         rasterized = RasterConstructors.asRaster(geom, raster, "d");
         actual = MapAlgebra.bandAsArray(rasterized, 1);
-        expected = new double[] {0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+        expected = new double[] {0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
         assertArrayEquals(expected, actual, 0.1d);
 
         // MultiPoints
@@ -153,14 +153,14 @@ public class RasterConstructorsTest
         Geometry geom = Constructors.geomFromEWKT("LINESTRING(1 1, 2 1, 10 1)");
         GridCoverage2D rasterized = RasterConstructors.asRaster(geom, raster, "d", 3093151, 0d);
         double[] actual = MapAlgebra.bandAsArray(rasterized, 1);
-        double[] expected = new double[] {3093151.0, 3093151.0, 3093151.0, 3093151.0, 3093151.0, 3093151.0, 0.0, 0.0, 0.0};
+        double[] expected = new double[] {3093151.0, 3093151.0, 3093151.0, 3093151.0, 3093151.0};
         assertArrayEquals(expected, actual, 0.1d);
 
         // Vertical LineString
         geom = Constructors.geomFromEWKT("LINESTRING(1 1, 1 2, 1 10)");
         rasterized = RasterConstructors.asRaster(geom, raster, "d", 3093151, 0d);
         actual = MapAlgebra.bandAsArray(rasterized, 1);
-        expected = new double[] {0.0, 0.0, 0.0, 3093151.0, 3093151.0, 3093151.0, 3093151.0, 3093151.0, 3093151.0};
+        expected = new double[] {3093151.0, 3093151.0, 3093151.0, 3093151.0, 3093151.0};
         assertArrayEquals(expected, actual, 0.1d);
     }
 
@@ -171,12 +171,12 @@ public class RasterConstructorsTest
         Geometry geom = Constructors.geomFromWKT("POLYGON((1.5 1.5, 3.8 3.0, 4.5 4.4, 3.4 3.5, 1.5 1.5))", 0);
         GridCoverage2D rasterized = RasterConstructors.asRaster(geom, raster, "d", 612028, 5d);
         double[] actual = Arrays.stream(MapAlgebra.bandAsArray(rasterized, 1)).toArray();
-        double[] expected = new double[] {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 612028.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 612028.0, 612028.0, 612028.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 612028.0, 612028.0, 612028.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 612028.0, 612028.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 612028.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 612028.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+        double[] expected = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 612028.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 612028.0, 612028.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 612028.0, 612028.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 612028.0, 612028.0, 612028.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 612028.0, 612028.0, 612028.0, 612028.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 612028.0, 612028.0, 612028.0, 612028.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 612028.0, 612028.0, 612028.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 612028.0, 612028.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 612028.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 612028.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
         assertArrayEquals(expected, actual, 0.1d);
 
         rasterized = RasterConstructors.asRaster(geom, raster, "d", 5484);
         actual = Arrays.stream(MapAlgebra.bandAsArray(rasterized, 1)).toArray();
-        expected = new double[] {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 5484.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 5484.0, 5484.0, 5484.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 5484.0, 5484.0, 5484.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 5484.0, 5484.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 5484.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 5484.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+        expected = new double[] {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 5484.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 5484.0, 5484.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 5484.0, 5484.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 5484.0, 5484.0, 5484.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 5484.0, 5484.0, 5484.0, 5484.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 5484.0, 5484.0, 5484.0, 5484.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 5484.0, 5484.0, 5484.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 5484.0, 5484.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 5484.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 5484.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
         assertArrayEquals(expected, actual, 0.1d);
     }
 
@@ -193,6 +193,21 @@ public class RasterConstructorsTest
         int heightActual = RasterAccessors.getHeight(rasterized);
         int heightExpected = RasterAccessors.getHeight(raster);
         assertEquals(heightExpected, heightActual);
+    }
+
+    @Test
+    public void testAsRasterWithRasterExtent2() throws FactoryException, ParseException {
+        GridCoverage2D raster = RasterConstructors.makeEmptyRaster(1, 5, 5, 0, 0.5, 0.1, -0.1, 0, 0, 4326);
+        Geometry geom = Constructors.geomFromWKT("POLYGON((0.1 0.1, 0.1 0.4, 0.4 0.4, 0.4 0.1, 0.1 0.1))", 0);
+        GridCoverage2D rasterized = RasterConstructors.asRasterWithRasterExtent(geom, raster, "d", 100d, 0d);
+        assertEquals(0, rasterized.getEnvelope2D().x, 1e-6);
+        assertEquals(0, rasterized.getEnvelope2D().y, 1e-6);
+        assertEquals(0.5, rasterized.getEnvelope2D().width, 1e-6);
+        assertEquals(0.5, rasterized.getEnvelope2D().height, 1e-6);
+        assertEquals(5, RasterAccessors.getWidth(rasterized));
+        assertEquals(5, RasterAccessors.getHeight(rasterized));
+        double sum = Arrays.stream(MapAlgebra.bandAsArray(rasterized, 1)).sum();
+        assertEquals(900, sum, 1e-6);  // Covers 3x3 grid
     }
 
     @Test

--- a/spark/common/src/test/scala/org/apache/sedona/sql/rasterIOTest.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/rasterIOTest.scala
@@ -76,17 +76,17 @@ class rasterIOTest extends TestBaseScala with BeforeAndAfter with GivenWhenThen 
       var df = sparkSession.sql("SELECT RS_MakeEmptyRaster(2, 255, 255, 3, -215, 2, -2, 0, 0, 4326) as raster, ST_GeomFromWKT('POLYGON((15 15, 18 20, 15 24, 24 25, 15 15))') as geom")
       var rasterized = df.selectExpr("RS_AsRaster(geom, raster, 'd', 255, 0d) as rasterized")
       var actual = rasterized.selectExpr("RS_BandAsArray(rasterized, 1)").first().getSeq(0).mkString("Array(", ", ", ")")
-      var expected = "Array(255.0, 255.0, 255.0, 0.0, 0.0, 255.0, 0.0, 0.0, 0.0, 255.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)"
+      var expected = "Array(255.0, 255.0, 255.0, 255.0, 0.0, 0.0, 255.0, 255.0, 0.0, 0.0, 0.0, 255.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)"
       assertEquals(expected, actual)
 
       rasterized = df.selectExpr("RS_AsRaster(geom, raster, 'd', 3093151) as rasterized")
       actual = rasterized.selectExpr("RS_BandAsArray(rasterized, 1)").first().getSeq(0).mkString("Array(", ", ", ")")
-      expected = "Array(3093151.0, 3093151.0, 3093151.0, 0.0, 0.0, 3093151.0, 0.0, 0.0, 0.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)"
+      expected = "Array(3093151.0, 3093151.0, 3093151.0, 3093151.0, 0.0, 0.0, 3093151.0, 3093151.0, 0.0, 0.0, 0.0, 3093151.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)"
       assertEquals(expected, actual)
 
       rasterized = df.selectExpr("RS_AsRaster(geom, raster, 'd') as rasterized")
       actual = rasterized.selectExpr("RS_BandAsArray(rasterized, 1)").first().getSeq(0).mkString("Array(", ", ", ")")
-      expected = "Array(1.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)"
+      expected = "Array(1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)"
       assertEquals(expected, actual)
     }
 
@@ -94,12 +94,12 @@ class rasterIOTest extends TestBaseScala with BeforeAndAfter with GivenWhenThen 
       var df = sparkSession.sql("SELECT RS_MakeEmptyRaster(2, 255, 255, 3, -215, 2, -2, 0, 0, 4326) as raster, ST_GeomFromWKT('LINESTRING(1 1, 2 1, 10 1)') as geom")
       var rasterized = df.selectExpr("RS_AsRaster(geom, raster, 'd', 255, 0d) as rasterized")
       var actual = rasterized.selectExpr("RS_BandAsArray(rasterized, 1)").first().getSeq(0).mkString("Array(", ", ", ")")
-      var expected = "Array(255.0, 255.0, 255.0, 255.0, 255.0, 255.0, 0.0, 0.0, 0.0)"
+      var expected = "Array(255.0, 255.0, 255.0, 255.0, 255.0)"
       assertEquals(expected, actual)
 
       rasterized = df.selectExpr("RS_AsRaster(ST_GeomFromWKT('LINESTRING(1 1, 1 2, 1 10)'), raster, 'd', 255, 0d) as rasterized")
       actual = rasterized.selectExpr("RS_BandAsArray(rasterized, 1)").first().getSeq(0).mkString("Array(", ", ", ")")
-      expected = "Array(0.0, 0.0, 0.0, 255.0, 255.0, 255.0, 255.0, 255.0, 255.0)"
+      expected = "Array(255.0, 255.0, 255.0, 255.0, 255.0)"
       assertEquals(expected, actual)
     }
 

--- a/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
@@ -1169,19 +1169,19 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
       var df = sparkSession.read.format("binaryFile").load(resourceFolder + "raster_geotiff_color/FAA_UTM18N_NAD83.tif")
       df = df.selectExpr("RS_FromGeoTiff(content) as raster", "ST_GeomFromWKT('POLYGON ((236722 4204770, 243900 4204770, 243900 4197590, 221170 4197590, 236722 4204770))', 26918) as geom")
       var actual = df.selectExpr("RS_ZonalStats(raster, geom, 1, 'sum', true)").first().get(0)
-      assertEquals(1.0690406E7, actual)
+      assertEquals(1.0719726E7, actual)
 
       actual = df.selectExpr("RS_ZonalStats(raster, geom, 1, 'count', false)").first().get(0)
       assertEquals(184792.0, actual)
 
       actual = df.selectExpr("RS_ZonalStats(raster, geom, 1, 'mean', false)").first().get(0)
-      assertEquals(57.851021689230684, actual)
+      assertEquals(58.00968656653401, actual)
 
       actual = df.selectExpr("RS_ZonalStats(raster, geom, 1, 'variance')").first().get(0)
-      assertEquals(8488.448098819916, actual)
+      assertEquals(8491.631251863151, actual)
 
       actual = df.selectExpr("RS_ZonalStats(raster, geom, 'sd')").first().get(0)
-      assertEquals(92.13277429243035, actual)
+      assertEquals(92.15004748703687, actual)
 
       // Test with a polygon in EPSG:4326
       actual = df.selectExpr("RS_ZonalStats(raster, ST_GeomFromWKT('POLYGON ((-77.96672569800863073 37.91971182746296876, -77.9688630154902711 37.89620133516485367, -77.93936803424354309 37.90517806858776595, -77.96672569800863073 37.91971182746296876))'), 1, 'mean', false)").first().get(0)
@@ -1215,7 +1215,7 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
       var df = sparkSession.read.format("binaryFile").load(resourceFolder + "raster_geotiff_color/FAA_UTM18N_NAD83.tif")
       df = df.selectExpr("RS_FromGeoTiff(content) as raster", "ST_GeomFromWKT('POLYGON ((-8673439.6642 4572993.5327, -8673155.5737 4563873.2099, -8701890.3259 4562931.7093, -8682522.8735 4572703.8908, -8673439.6642 4572993.5327))', 3857) as geom")
       val actual = df.selectExpr("RS_ZonalStatsAll(raster, geom, 1, true)").first().get(0)
-      val expected = Seq(184792.0, 1.0690406E7, 57.851021689230684, 0.0, 0.0, 92.13277429243035, 8488.448098819916, 0.0, 255.0)
+      val expected = Seq(184792.0, 1.0719726E7, 58.00968656653401, 0.0, 0.0, 92.15004748703687, 8491.631251863151, 0.0, 255.0)
       assertTrue(expected.equals(actual))
 
       // Test with a polygon that does not intersect the raster in lenient mode


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-605. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Fix the code to compute the width and height of the rasterization result. Please refer to the JIRA ticket for a detailed explanation of this problem.

This patch fixes `RS_AsRaster`, `RS_ZonalStats` and `RS_ZonalStatsAll`.

## How was this patch tested?

Add new tests for RS_AsRaster, updated assertions for existing RS_AsRaster and zonal stats tests since the bound and width/height will be slightly different from before.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
