### PR TITLE
[SEDONA-609] Fix python 3.12 build issue caused by binary compatibility issues with numpy 2.0.0

### DIFF
--- a/python/Pipfile
+++ b/python/Pipfile
@@ -12,7 +12,7 @@ pytest-cov = "*"
 
 [packages]
 pandas="<=1.5.3"
-numpy="<=2"
+numpy="<2"
 geopandas="*"
 shapely=">=1.7.0"
 pyspark=">=2.3.0"

--- a/python/Pipfile
+++ b/python/Pipfile
@@ -12,6 +12,7 @@ pytest-cov = "*"
 
 [packages]
 pandas="<=1.5.3"
+numpy="<=2"
 geopandas="*"
 shapely=">=1.7.0"
 pyspark=">=2.3.0"


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-609. The PR name follows the format `[SEDONA-609] my subject`.

## What changes were proposed in this PR?
Numpy 2.0.0 is released as the major release of numpy on June 16, 2024. As of right now, the pandas version still has compatible with numpy 2.0. So, to avoid issues when installing pandas with pip, you should pin numpy < 2.

## How was this patch tested?
All builds should be fixed and run successfully.

## Did this PR include necessary documentation updates?
- No, this PR does not affect any public API so no need to change the documentation.
