### PR TITLE
[SEDONA-611] Fix writing rasters to S3 on EMR

### DIFF
--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/raster/RasterFileFormat.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/raster/RasterFileFormat.scala
@@ -85,7 +85,7 @@ private class RasterFileWriter(
     context: TaskAttemptContext)
     extends OutputWriter {
 
-  private val hfs = FileSystem.newInstance(new Path(savePath).toUri, context.getConfiguration)
+  private val hfs = (new Path(savePath)).getFileSystem(context.getConfiguration)
   private val rasterFieldIndex =
     if (rasterOptions.rasterField.isEmpty) getRasterFieldIndex
     else dataSchema.fieldIndex(rasterOptions.rasterField.get)
@@ -119,9 +119,7 @@ private class RasterFileWriter(
     }
   }
 
-  override def close(): Unit = {
-    hfs.close()
-  }
+  override def close(): Unit = {}
 
   def path(): String = {
     savePath


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-611. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Fix writing rasters to S3 on EMR by re-using the FileSystem object instead of creating new instances. Re-using the FileSystem instance is a common pattern, while creating new FileSystem instances is prone to errors, since some implementations hold transient state required by follow-up operations, and that transient states cannot be accessed by newly created instances.

## How was this patch tested?

Passing existing tests, testing manually on emr-7.1.0.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
