### PR TITLE
[DOCS] Label the `binder` directory with the PR labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,6 +5,12 @@ root:
           - any-glob-to-any-file:
               - '*'
 
+binder:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file:
+              - binder/**/*
+
 docs:
   - any:
       - changed-files:


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- No, this is a documentation update. The PR name follows the format `[DOCS] my subject`.

## What changes were proposed in this PR?

Labels the `binder` folder.  Best to have all files and folders labeled.

To complete this PR we need to add the new label for `binder` on the repo issues page:

https://github.com/apache/sedona/labels

## How was this patch tested?

Ran locally:

`pre-commit run --all-files`

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
