### PR TITLE
[SEDONA-621] Remove redundant call to `toString()`

### DIFF
--- a/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
@@ -394,7 +394,7 @@ public class FunctionTest extends TestBase {
     Table table = tableEnv.sqlQuery("SELECT ST_GeomFromWKT('LINESTRING(1 1, 2 2, 3 3)') AS geom");
     table = table.select(call(Functions.ST_GeometryType.class.getSimpleName(), $("geom")));
     String result = (String) first(table).getField(0);
-    assertEquals("ST_LineString", result.toString());
+    assertEquals("ST_LineString", result);
   }
 
   @Test


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-621. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Cleaned up some Java code.

## How was this patch tested?


## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
