### PR TITLE
[SEDONA-624] Bind references in distance expression to relations lazily to avoid exception in query plan canonicalization

### DIFF
--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/DistanceJoinExec.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/DistanceJoinExec.scala
@@ -72,7 +72,7 @@ case class DistanceJoinExec(
     with TraitJoinQueryExec
     with Logging {
 
-  private val boundRadius = if (distanceBoundToLeft) {
+  private lazy val boundRadius = if (distanceBoundToLeft) {
     BindReferences.bindReference(distance, left.output)
   } else {
     BindReferences.bindReference(distance, right.output)


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-624. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

The query plan canonicalization phase creates temporary physical nodes whose attributes cannot be bound to relations, and then calls withNewChildren to replace the bad relations with the correct relations. `DistanceJoinExec` binds distance expression to the relation eagerly, which makes the physical node creation fail. We change the reference binding to be lazily evaluated to get rid of this problem.

## How was this patch tested?

Add new tests that would fail without the fix.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
