### PR TITLE
[SEDONA-632] Use direct committer when writing raster files using `df.write.format("raster")`

### DIFF
--- a/docs/api/sql/Raster-writer.md
+++ b/docs/api/sql/Raster-writer.md
@@ -156,6 +156,9 @@ Available options:
 * pathField
 	* No default value. If you use this option, then the column specified in this option must exist in the DataFrame schema. If this option is not used, each produced raster image will have a random UUID file name.
 	* Allowed values: any column name that indicates the paths of each raster file
+* useDirectCommitter (Since: `v1.6.1`)
+	* Default value: `true`. If set to `true`, the output files will be written directly to the target location. If set to `false`, the output files will be written to a temporary location and finally be committed to their target location. It is usually slower to write large amount of raster files with `useDirectCommitter` set to `false`, especially when writing to object stores such as S3.
+	* Allowed values: `true` or `false`
 
 The schema of the Raster dataframe to be written can be one of the following two schemas:
 

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/raster/RasterOptions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/raster/RasterOptions.scala
@@ -30,4 +30,6 @@ private[io] class RasterOptions(@transient private val parameters: CaseInsensiti
   val rasterPathField = parameters.get("pathField")
   // Column of the raster image itself
   val rasterField = parameters.get("rasterField")
+  // Use direct committer to directly write to the final destination
+  val useDirectCommitter = parameters.getOrElse("useDirectCommitter", "true").toBoolean
 }

--- a/spark/common/src/test/scala/org/apache/sedona/sql/rasterIOTest.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/rasterIOTest.scala
@@ -51,6 +51,7 @@ class rasterIOTest extends TestBaseScala with BeforeAndAfter with GivenWhenThen 
         .option("rasterField", "content")
         .option("fileExtension", ".tiff")
         .option("pathField", "path")
+        .option("useDirectCommitter", "false")
         .mode(SaveMode.Overwrite)
         .save(tempDir + "/raster-written")
       rasterDf = sparkSession.read.format("binaryFile").load(tempDir + "/raster-written/*")


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-632. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Writing large amounts of raster files to distributed file systems or object store is super slow, because the output committer has to move files from temporary locations to their target locations. Users will see all the tasks are completed but the driver is stuck at the committing phase.

This patch an option `useDirectCommitter` to the raster format. By default `useDirectCommitter` is true, and the raster format will use a direct committer that writes raster files to their target locations directly. Users can manually set it to false if they want the original behavior.

## How was this patch tested?

Passing existing tests

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.
