### PR TITLE
[SEDONA-628] fix python st df function imports from sedona.sql

### DIFF
--- a/python/sedona/sql/__init__.py
+++ b/python/sedona/sql/__init__.py
@@ -14,3 +14,25 @@
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
+import inspect
+import sys
+
+# These allow use to access the __all__
+import sedona.sql.st_aggregates as st_aggregates
+import sedona.sql.st_constructors as st_constructors
+import sedona.sql.st_functions as st_functions
+import sedona.sql.st_predicates as st_predicates
+
+# These bring the contents of the modules into this module
+from sedona.sql.st_aggregates import *
+from sedona.sql.st_constructors import *
+from sedona.sql.st_functions import *
+from sedona.sql.st_predicates import *
+
+__all__ = (
+        [name for name, obj in inspect.getmembers(sys.modules[__name__])]  # get expected values from the modules
+        + st_predicates.__all__
+        + st_constructors.__all__
+        + st_functions.__all__
+        + st_aggregates.__all__
+)

--- a/python/sedona/sql/st_aggregates.py
+++ b/python/sedona/sql/st_aggregates.py
@@ -25,10 +25,6 @@ from sedona.sql.dataframe_api import ColumnOrName, call_sedona_function, validat
 
 _call_aggregate_function = partial(call_sedona_function, "st_aggregates")
 
-# Automatically populate __all__
-__all__ = [name for name, obj in inspect.getmembers(sys.modules[__name__])
-           if inspect.isfunction(obj)]
-
 
 @validate_argument_types
 def ST_Envelope_Aggr(geometry: ColumnOrName) -> Column:
@@ -64,3 +60,8 @@ def ST_Union_Aggr(geometry: ColumnOrName) -> Column:
     :rtype: Column
     """
     return _call_aggregate_function("ST_Union_Aggr", geometry)
+
+
+# Automatically populate __all__
+__all__ = [name for name, obj in inspect.getmembers(sys.modules[__name__])
+           if inspect.isfunction(obj)]

--- a/python/sedona/sql/st_constructors.py
+++ b/python/sedona/sql/st_constructors.py
@@ -25,11 +25,6 @@ from pyspark.sql import Column
 from sedona.sql.dataframe_api import ColumnOrName, ColumnOrNameOrNumber, call_sedona_function, validate_argument_types
 
 
-# Automatically populate __all__
-__all__ = [name for name, obj in inspect.getmembers(sys.modules[__name__])
-           if inspect.isfunction(obj)]
-
-
 _call_constructor_function = partial(call_sedona_function, "st_constructors")
 
 
@@ -454,3 +449,8 @@ def ST_GeomCollFromText(wkt: ColumnOrName, srid: Optional[ColumnOrNameOrNumber] 
     args = (wkt) if srid is None else (wkt, srid)
 
     return _call_constructor_function("ST_GeomCollFromText", args)
+
+
+# Automatically populate __all__
+__all__ = [name for name, obj in inspect.getmembers(sys.modules[__name__])
+           if inspect.isfunction(obj)]

--- a/python/sedona/sql/st_functions.py
+++ b/python/sedona/sql/st_functions.py
@@ -25,11 +25,6 @@ from pyspark.sql import Column
 from sedona.sql.dataframe_api import call_sedona_function, ColumnOrName, ColumnOrNameOrNumber, validate_argument_types
 
 
-# Automatically populate __all__
-__all__ = [name for name, obj in inspect.getmembers(sys.modules[__name__])
-           if inspect.isfunction(obj)]
-
-
 _call_st_function = partial(call_sedona_function, "st_functions")
 
 @validate_argument_types
@@ -2025,3 +2020,8 @@ def ST_Rotate(geometry: ColumnOrName, angle: Union[ColumnOrName, float], originX
         args = (geometry, angle)
 
     return _call_st_function("ST_Rotate", args)
+
+
+# Automatically populate __all__
+__all__ = [name for name, obj in inspect.getmembers(sys.modules[__name__])
+           if inspect.isfunction(obj)]

--- a/python/sedona/sql/st_predicates.py
+++ b/python/sedona/sql/st_predicates.py
@@ -25,11 +25,6 @@ from typing import Union, Optional
 from sedona.sql.dataframe_api import ColumnOrName, call_sedona_function, validate_argument_types
 
 
-# Automatically populate __all__
-__all__ = [name for name, obj in inspect.getmembers(sys.modules[__name__])
-           if inspect.isfunction(obj)]
-
-
 _call_predicate_function = partial(call_sedona_function, "st_predicates")
 
 
@@ -227,3 +222,8 @@ def ST_DWithin(a: ColumnOrName, b: ColumnOrName, distance: Union[ColumnOrName, f
     """
     args = (a, b, distance, use_sphere) if use_sphere is not None else (a, b, distance,)
     return _call_predicate_function("ST_DWithin", args)
+
+
+# Automatically populate __all__
+__all__ = [name for name, obj in inspect.getmembers(sys.modules[__name__])
+           if inspect.isfunction(obj)]

--- a/python/tests/sql/test_st_function_imports.py
+++ b/python/tests/sql/test_st_function_imports.py
@@ -1,0 +1,18 @@
+"""module without top level imports of these names"""
+
+from tests.test_base import TestBase
+
+
+class TestStFunctionImport(TestBase):
+    def test_import(self):
+        from sedona.sql import (
+            ST_Distance,
+            ST_Point,
+            ST_Contains,
+            ST_Envelope_Aggr,
+        )
+
+        ST_Distance
+        ST_Point
+        ST_Contains
+        ST_Envelope_Aggr

--- a/python/tests/sql/test_st_function_imports.py
+++ b/python/tests/sql/test_st_function_imports.py
@@ -1,3 +1,20 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
 """module without top level imports of these names"""
 
 from tests.test_base import TestBase


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)


## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-628. The PR name follows the format `[SEDONA-XXX] my subject`.


## What changes were proposed in this PR?
Bug fix so that importing st dataframe functions works as documented

## How was this patch tested?
added a unit test

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.

Specifically, this change aligns functionality with existing documented API