### PR TITLE
[SEDONA-545] Fix importing GeometryType from sedona.spark

### DIFF
--- a/python/sedona/sql/st_functions.py
+++ b/python/sedona/sql/st_functions.py
@@ -2050,4 +2050,4 @@ def ST_Rotate(geometry: ColumnOrName, angle: Union[ColumnOrName, float], originX
 
 # Automatically populate __all__
 __all__ = [name for name, obj in inspect.getmembers(sys.modules[__name__])
-           if inspect.isfunction(obj)]
+           if inspect.isfunction(obj) and name != 'GeometryType']

--- a/python/tests/sql/test_st_function_imports.py
+++ b/python/tests/sql/test_st_function_imports.py
@@ -33,3 +33,8 @@ class TestStFunctionImport(TestBase):
         ST_Point
         ST_Contains
         ST_Envelope_Aggr
+
+    def test_geometry_type_should_be_a_sql_type(self):
+        from sedona.spark import GeometryType
+        from pyspark.sql.types import UserDefinedType
+        assert isinstance(GeometryType(), UserDefinedType)


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-545. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Fix a problem introduced by https://github.com/apache/sedona/pull/1371, `from sedona.spark import GeometryType` imports the GeometryType function defined in st_functions rather than `sedona.sql.types.GeometryType`. 

## How was this patch tested?

Add a new test that imports GeometryType from sedona.spark and verify that it should be a user-defined type.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
