### PR TITLE
[CI] Fix the r-lib action permission issue

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,12 +36,12 @@ jobs:
       - run: pip install mkdocs-git-revision-date-localized-plugin
       - run: pip install mike
       - run: sudo apt update
-      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r@v2.9.0
         with:
           r-version: release
           use-public-rspm: true
       - name: Query R dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2
+        uses: r-lib/actions/setup-r-dependencies@v2.9.0
         with:
           cache: true
           extra-packages: |

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -60,12 +60,12 @@ jobs:
           sudo apt-get -y remove --purge default-jdk adoptopenjdk-11-hotspot || :
         shell: bash
       - uses: actions/checkout@v4
-      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r@v2.9.0
         with:
           r-version: ${{ matrix.r }}
           use-public-rspm: true
       - name: Query R dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2
+        uses: r-lib/actions/setup-r-dependencies@v2.9.0
         with:
           cache: true
           extra-packages: |
@@ -73,7 +73,7 @@ jobs:
             any::rcmdcheck
           working-directory : './R'
       - name: Build and check R package
-        uses: r-lib/actions/check-r-package@v2
+        uses: r-lib/actions/check-r-package@v2.9.0
         with:
           build_args: 'c("--no-build-vignettes", "--no-manual")'
           args: 'c("--no-build-vignettes", "--no-manual", "--no-tests")'


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- NO. This is a CI update.


## What changes were proposed in this PR?

r-lib/actions introduces 2.10.0 which is a breaking change to our R github action: https://github.com/r-lib/actions/tags

This new version requires quarto GitHub action which is not allowed in ASF repo. See [the commit](https://github.com/r-lib/actions/pull/895)

This PR is to pin the r action to a specific version `2.9.0`

## How was this patch tested?


## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
