### PR TITLE
[DOCS] State that ST_GeomFromGML only supports GML 1 and GML 2.

### DIFF
--- a/docs/api/flink/Constructor.md
+++ b/docs/api/flink/Constructor.md
@@ -83,6 +83,9 @@ POINT(40.7128 -74.006)
 
 Introduction: Construct a Geometry from GML.
 
+!!!note
+    This function only supports GML1 and GML2. GML3 is not supported.
+
 Format:
 `ST_GeomFromGML (gml: String)`
 

--- a/docs/api/snowflake/vector-data/Constructor.md
+++ b/docs/api/snowflake/vector-data/Constructor.md
@@ -80,6 +80,9 @@ POINT(40.7128 -74.006)
 
 Introduction: Construct a Geometry from GML.
 
+!!!note
+    This function only supports GML1 and GML2. GML3 is not supported.
+
 Format:
 `ST_GeomFromGML (gml:string)`
 

--- a/docs/api/sql/Constructor.md
+++ b/docs/api/sql/Constructor.md
@@ -129,6 +129,9 @@ POINT(40.7128 -74.006)
 
 Introduction: Construct a Geometry from GML.
 
+!!!note
+    This function only supports GML 1 and GML 2. GML 3 is not supported.
+
 Format:
 `ST_GeomFromGML (gml: String)`
 


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)


## Is this PR related to a JIRA ticket?


- No, this is a documentation update. The PR name follows the format `[DOCS] my subject`.


## What changes were proposed in this PR?

Explicitly state that `ST_GeomFromGML` only supports GML 1 and GML 2. GML 3 is not supported

## How was this patch tested?

Viewed locally using `mkdocs serve`.

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.
