### PR TITLE
[SEDONA-633,SEDONA-629] Add tileWidth and tileHeight to the result of RS_Metadata, changed the data types of fields of the result struct of RS_Metadata

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/raster/RasterAccessors.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterAccessors.java
@@ -19,6 +19,7 @@
 package org.apache.sedona.common.raster;
 
 import java.awt.geom.Point2D;
+import java.awt.image.RenderedImage;
 import java.util.Arrays;
 import java.util.Set;
 import org.apache.sedona.common.utils.RasterUtils;
@@ -266,6 +267,7 @@ public class RasterAccessors {
     // Get Geo-reference metadata
     GridEnvelope2D gridRange = raster.getGridGeometry().getGridRange2D();
     AffineTransform2D affine = RasterUtils.getGDALAffineTransform(raster);
+    RenderedImage image = raster.getRenderedImage();
 
     // Get the affine parameters
     double upperLeftX = affine.getTranslateX();
@@ -274,6 +276,8 @@ public class RasterAccessors {
     double scaleY = affine.getScaleY();
     double skewX = affine.getShearX();
     double skewY = affine.getShearY();
+    double tileWidth = image.getTileWidth();
+    double tileHeight = image.getTileHeight();
     return new double[] {
       upperLeftX,
       upperLeftY,
@@ -284,7 +288,75 @@ public class RasterAccessors {
       skewX,
       skewY,
       srid(raster),
-      raster.getNumSampleDimensions()
+      raster.getNumSampleDimensions(),
+      tileWidth,
+      tileHeight
     };
+  }
+
+  public static class RasterMetadata {
+    public double upperLeftX;
+    public double upperLeftY;
+    public int gridWidth;
+    public int gridHeight;
+    public double scaleX;
+    public double scaleY;
+    public double skewX;
+    public double skewY;
+    public int srid;
+    public int numBands;
+    public int tileWidth;
+    public int tileHeight;
+
+    public RasterMetadata(
+        double upperLeftX,
+        double upperLeftY,
+        int gridWidth,
+        int gridHeight,
+        double scaleX,
+        double scaleY,
+        double skewX,
+        double skewY,
+        int srid,
+        int numBands,
+        int tileWidth,
+        int tileHeight) {
+      this.upperLeftX = upperLeftX;
+      this.upperLeftY = upperLeftY;
+      this.gridWidth = gridWidth;
+      this.gridHeight = gridHeight;
+      this.scaleX = scaleX;
+      this.scaleY = scaleY;
+      this.skewX = skewX;
+      this.skewY = skewY;
+      this.srid = srid;
+      this.numBands = numBands;
+      this.tileWidth = tileWidth;
+      this.tileHeight = tileHeight;
+    }
+  }
+
+  /**
+   * Returns the metadata of a raster as a {@link RasterMetadata} object.
+   *
+   * @param raster the raster
+   * @return a {@link RasterMetadata} object
+   * @throws FactoryException
+   */
+  public static RasterMetadata rasterMetadata(GridCoverage2D raster) throws FactoryException {
+    double[] meta = metadata(raster);
+    return new RasterMetadata(
+        meta[0],
+        meta[1],
+        (int) meta[2],
+        (int) meta[3],
+        meta[4],
+        meta[5],
+        meta[6],
+        meta[7],
+        (int) meta[8],
+        (int) meta[9],
+        (int) meta[10],
+        (int) meta[11]);
   }
 }

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterAccessorsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterAccessorsTest.java
@@ -379,7 +379,9 @@ public class RasterAccessorsTest extends RasterTestBase {
     assertEquals(0, metadata[7], 1e-9);
     assertEquals(0, metadata[8], 1e-9);
     assertEquals(numBands, metadata[9], 1e-9);
-    assertEquals(10, metadata.length);
+    assertEquals(widthInPixel, metadata[10], 1e-9);
+    assertEquals(heightInPixel, metadata[11], 1e-9);
+    assertEquals(12, metadata.length);
 
     upperLeftX = 5;
     upperLeftY = 6;
@@ -404,8 +406,29 @@ public class RasterAccessorsTest extends RasterTestBase {
     assertEquals(0, metadata[7], 1e-9);
     assertEquals(0, metadata[8], 1e-9);
     assertEquals(numBands, metadata[9], 1e-9);
+    assertEquals(widthInPixel, metadata[10], 1e-9);
+    assertEquals(heightInPixel, metadata[11], 1e-9);
 
-    assertEquals(10, metadata.length);
+    assertEquals(12, metadata.length);
+  }
+
+  @Test
+  public void testMetadataOfTiledRasters() throws IOException, FactoryException {
+    GridCoverage2D raster = rasterFromGeoTiff(resourceFolder + "raster/test1.tiff");
+    double[] metadata = RasterAccessors.metadata(raster);
+    assertEquals(-13095817.809, metadata[0], 0.01);
+    assertEquals(4021262.749, metadata[1], 0.01);
+    assertEquals(512, metadata[2], 1e-9);
+    assertEquals(517, metadata[3], 1e-9);
+    assertEquals(72.328612721326948, metadata[4], 0.001);
+    assertEquals(-72.328612721326948, metadata[5], 0.001);
+    assertEquals(0, metadata[6], 1e-9);
+    assertEquals(0, metadata[7], 1e-9);
+    assertEquals(3857, metadata[8], 1e-9);
+    assertEquals(1, metadata[9], 1e-9);
+    assertEquals(256, metadata[10], 1e-9);
+    assertEquals(256, metadata[11], 1e-9);
+    assertEquals(12, metadata.length);
   }
 
   @Test
@@ -443,6 +466,8 @@ public class RasterAccessorsTest extends RasterTestBase {
     assertEquals(skewY, metadata[7], 1e-9);
     assertEquals(3857, metadata[8], 1e-9);
     assertEquals(numBands, metadata[9], 1e-9);
-    assertEquals(10, metadata.length);
+    assertEquals(widthInPixel, metadata[10], 1e-9);
+    assertEquals(heightInPixel, metadata[11], 1e-9);
+    assertEquals(12, metadata.length);
   }
 }

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterEditorsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterEditorsTest.java
@@ -3600,7 +3600,7 @@ public class RasterEditorsTest extends RasterTestBase {
       -0.33333333333333326, 0.19999999999999996, 6, 5, 1.388888888888889, -1.24, 0, 0, 0, 1
     };
     // verify correct raster geometry
-    for (int i = 0; i < metadata.length; i++) {
+    for (int i = 0; i < expectedMetadata.length; i++) {
       assertEquals(expectedMetadata[i], metadata[i], 1e-6);
     }
 
@@ -3621,7 +3621,7 @@ public class RasterEditorsTest extends RasterTestBase {
           -0.20000000298023224, 0.4000000059604645, 7.0, 5.0, 1.2, -1.4, 0.0, 0.0, 0.0, 1.0
         };
     // verify correct raster geometry
-    for (int i = 0; i < metadata.length; i++) {
+    for (int i = 0; i < expectedMetadata.length; i++) {
       assertEquals(expectedMetadata[i], metadata[i], 1e-6);
     }
   }
@@ -3679,7 +3679,7 @@ public class RasterEditorsTest extends RasterTestBase {
     };
     assertEquals(expectedRes1, res1);
     assertEquals(expectedRes2, res2);
-    for (int i = 0; i < metadata.length; i++) {
+    for (int i = 0; i < expectedMetadata.length; i++) {
       assertEquals(expectedMetadata[i], metadata[i], 1e-6);
     }
 
@@ -3716,7 +3716,7 @@ public class RasterEditorsTest extends RasterTestBase {
         };
     assertEquals(expectedRes1, res1);
     assertEquals(expectedRes2, res2);
-    for (int i = 0; i < metadata.length; i++) {
+    for (int i = 0; i < expectedMetadata.length; i++) {
       assertEquals(expectedMetadata[i], metadata[i], 1e-6);
     }
 
@@ -3749,7 +3749,7 @@ public class RasterEditorsTest extends RasterTestBase {
         };
     assertEquals(expectedRes1, res1);
     assertEquals(expectedRes2, res2);
-    for (int i = 0; i < metadata.length; i++) {
+    for (int i = 0; i < expectedMetadata.length; i++) {
       assertEquals(expectedMetadata[i], metadata[i], 1e-6);
     }
   }
@@ -3772,7 +3772,7 @@ public class RasterEditorsTest extends RasterTestBase {
     double[] metadata = RasterAccessors.metadata(newRaster);
     double[] expectedMetadata = {0, 0, 6, 5, 1.3333333333333333, -1.2, 0, 0, 0, 1};
     // verify correct raster geometry
-    for (int i = 0; i < metadata.length; i++) {
+    for (int i = 0; i < expectedMetadata.length; i++) {
       assertEquals(expectedMetadata[i], metadata[i], 1e-6);
     }
 
@@ -3790,7 +3790,7 @@ public class RasterEditorsTest extends RasterTestBase {
     metadata = RasterAccessors.metadata(newRaster);
     expectedMetadata = new double[] {0, 0, 7, 5, 1.2, -1.4, 0, 0, 0, 1};
     // verify correct raster geometry
-    for (int i = 0; i < metadata.length; i++) {
+    for (int i = 0; i < expectedMetadata.length; i++) {
       assertEquals(expectedMetadata[i], metadata[i], 1e-6);
     }
   }
@@ -3819,7 +3819,7 @@ public class RasterEditorsTest extends RasterTestBase {
       -0.33333333333333326, 0.19999999999999996, 6, 5, 1.388888888888889, -1.24, 0, 0, 0, 1
     };
     // verify correct raster geometry
-    for (int i = 0; i < metadata.length; i++) {
+    for (int i = 0; i < expectedMetadata.length; i++) {
       assertEquals(expectedMetadata[i], metadata[i], 1e-6);
     }
 
@@ -3840,7 +3840,7 @@ public class RasterEditorsTest extends RasterTestBase {
           -0.20000000298023224, 0.4000000059604645, 7.0, 5.0, 1.2, -1.4, 0.0, 0.0, 0.0, 1.0
         };
     // verify correct raster geometry
-    for (int i = 0; i < metadata.length; i++) {
+    for (int i = 0; i < expectedMetadata.length; i++) {
       assertEquals(expectedMetadata[i], metadata[i], 1e-6);
     }
   }
@@ -3868,7 +3868,7 @@ public class RasterEditorsTest extends RasterTestBase {
     double[] metadata = RasterAccessors.metadata(newRaster);
     double[] expectedMetadata = {0, 0, 5, 5, 1.2, -1.2, 0, 0, 0, 1};
     // verify correct raster geometry
-    for (int i = 0; i < metadata.length; i++) {
+    for (int i = 0; i < expectedMetadata.length; i++) {
       assertEquals(expectedMetadata[i], metadata[i], 1e-6);
     }
 
@@ -3885,7 +3885,7 @@ public class RasterEditorsTest extends RasterTestBase {
     assertEquals(expectedRes, res);
     metadata = RasterAccessors.metadata(newRaster);
     // verify correct raster geometry
-    for (int i = 0; i < metadata.length; i++) {
+    for (int i = 0; i < expectedMetadata.length; i++) {
       assertEquals(expectedMetadata[i], metadata[i], 1e-6);
     }
   }

--- a/docs/api/sql/Raster-operators.md
+++ b/docs/api/sql/Raster-operators.md
@@ -1553,8 +1553,14 @@ Introduction: Returns the metadata of the raster as a struct. The struct has the
 - skewY: skew in y direction (rotation y)
 - srid: srid of the raster
 - numSampleDimensions: number of bands
+- tileWidth: (Since `v1.6.1`) width of tiles in the raster
+- tileHeight: (Since `v1.6.1`) height of tiles in the raster
 
 For more information about ScaleX, ScaleY, SkewX, SkewY, please refer to the [Affine Transformations](Raster-affine-transformation.md) section.
+
+`tileWidth` and `tileHeight` are available since `v1.6.1`, they are the dimensions of the tiles in the raster. For example,
+rasters written by `RS_FromGeoTiff` uses the tiling scheme of the loaded GeoTIFF file. For rasters that has only 1 tile,
+`tileWidth` and `tileHeight` will be equal to `gridWidth` and `gridHeight` respectively.
 
 Format: `RS_MetaData (raster: Raster)`
 
@@ -1569,7 +1575,7 @@ SELECT RS_MetaData(raster) FROM raster_table
 Output:
 
 ```
-{-1.3095817809482181E7, 4021262.7487925636, 512.0, 517.0, 72.32861272132695, -72.32861272132695, 0.0, 0.0, 3857.0, 1.0}
+{-1.3095817809482181E7, 4021262.7487925636, 512, 517, 72.32861272132695, -72.32861272132695, 0.0, 0.0, 3857, 1, 256, 256}
 ```
 
 ### RS_NormalizeAll

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterFunctions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterFunctions.scala
@@ -38,14 +38,16 @@ case class RS_Metadata(inputExpressions: Seq[Expression])
     Seq(
       StructField("upperLeftX", DoubleType, nullable = false),
       StructField("upperLeftY", DoubleType, nullable = false),
-      StructField("gridWidth", DoubleType, nullable = false),
-      StructField("gridHeight", DoubleType, nullable = false),
+      StructField("gridWidth", IntegerType, nullable = false),
+      StructField("gridHeight", IntegerType, nullable = false),
       StructField("scaleX", DoubleType, nullable = false),
       StructField("scaleY", DoubleType, nullable = false),
       StructField("skewX", DoubleType, nullable = false),
       StructField("skewY", DoubleType, nullable = false),
-      StructField("srid", DoubleType, nullable = false),
-      StructField("numSampleDimensions", DoubleType, nullable = false)))
+      StructField("srid", IntegerType, nullable = false),
+      StructField("numSampleDimensions", IntegerType, nullable = false),
+      StructField("tileWidth", IntegerType, nullable = false),
+      StructField("tileHeight", IntegerType, nullable = false)))
 
   override def eval(input: InternalRow): Any = {
     // Evaluate the input expressions
@@ -56,10 +58,22 @@ case class RS_Metadata(inputExpressions: Seq[Expression])
       null
     } else {
       // Get the metadata using the Java method
-      val metaData = RasterAccessors.metadata(rasterGeom)
+      val metaData = RasterAccessors.rasterMetadata(rasterGeom)
 
       // Create an InternalRow with the metadata
-      InternalRow.fromSeq(metaData.map(_.asInstanceOf[Any]))
+      InternalRow(
+        metaData.upperLeftX,
+        metaData.upperLeftY,
+        metaData.gridWidth,
+        metaData.gridHeight,
+        metaData.scaleX,
+        metaData.scaleY,
+        metaData.skewX,
+        metaData.skewY,
+        metaData.srid,
+        metaData.numBands,
+        metaData.tileWidth,
+        metaData.tileHeight)
     }
   }
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-633. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

There are 2 changes made to the `RS_Metdata` function:

1. Add `tileWidth` and `tileHeight` fields.
2. Changed the data types of integer fields from DoubleType to IntegerType.

## How was this patch tested?

Pass existing and newly added tests.

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.
