### PR TITLE
[SEDONA-637] Show spatial filters pushed to GeoParquet scans in the query plan; allow disabling spatial filter pushdown

### DIFF
--- a/docs/api/sql/Optimizer.md
+++ b/docs/api/sql/Optimizer.md
@@ -343,3 +343,5 @@ We can compare the metrics of querying the GeoParquet dataset with or without th
 | Without spatial predicate | With spatial predicate |
 | ----------- | ----------- |
 | ![](../../image/scan-parquet-without-spatial-pred.png) | ![](../../image/scan-parquet-with-spatial-pred.png) |
+
+Spatial predicate push-down to GeoParquet is enabled by default. Users can manually disable it by setting the Spark configuration `spark.sedona.geoparquet.spatialFilterPushDown` to `false`.

--- a/spark/common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/GeoParquetSpatialFilter.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/GeoParquetSpatialFilter.scala
@@ -29,20 +29,25 @@ import org.locationtech.jts.geom.Geometry
  */
 trait GeoParquetSpatialFilter {
   def evaluate(columns: Map[String, GeometryFieldMetaData]): Boolean
+  def simpleString: String
 }
 
 object GeoParquetSpatialFilter {
 
   case class AndFilter(left: GeoParquetSpatialFilter, right: GeoParquetSpatialFilter)
       extends GeoParquetSpatialFilter {
-    override def evaluate(columns: Map[String, GeometryFieldMetaData]): Boolean =
+    override def evaluate(columns: Map[String, GeometryFieldMetaData]): Boolean = {
       left.evaluate(columns) && right.evaluate(columns)
+    }
+
+    override def simpleString: String = s"(${left.simpleString}) AND (${right.simpleString})"
   }
 
   case class OrFilter(left: GeoParquetSpatialFilter, right: GeoParquetSpatialFilter)
       extends GeoParquetSpatialFilter {
     override def evaluate(columns: Map[String, GeometryFieldMetaData]): Boolean =
       left.evaluate(columns) || right.evaluate(columns)
+    override def simpleString: String = s"(${left.simpleString}) OR (${right.simpleString})"
   }
 
   /**
@@ -77,5 +82,6 @@ object GeoParquetSpatialFilter {
         }
       }
     }
+    override def simpleString: String = s"$columnName ${predicateType.name} $queryWindow"
   }
 }

--- a/spark/spark-3.0/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/GeoParquetFileFormat.scala
+++ b/spark/spark-3.0/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/GeoParquetFileFormat.scala
@@ -66,6 +66,14 @@ class GeoParquetFileFormat(val spatialFilter: Option[GeoParquetSpatialFilter])
 
   override def hashCode(): Int = getClass.hashCode()
 
+  override def toString(): String = {
+    // HACK: This is the only place we can inject spatial filter information into the described query plan.
+    // Please see org.apache.spark.sql.execution.DataSourceScanExec#simpleString for more details.
+    "GeoParquet" + spatialFilter
+      .map(filter => " with spatial filter [" + filter.simpleString + "]")
+      .getOrElse("")
+  }
+
   def withSpatialPredicates(spatialFilter: GeoParquetSpatialFilter): GeoParquetFileFormat =
     new GeoParquetFileFormat(Some(spatialFilter))
 

--- a/spark/spark-3.0/src/test/scala/org/apache/sedona/sql/TestBaseScala.scala
+++ b/spark/spark-3.0/src/test/scala/org/apache/sedona/sql/TestBaseScala.scala
@@ -54,4 +54,19 @@ trait TestBaseScala extends FunSpec with BeforeAndAfterAll {
   def loadCsv(path: String): DataFrame = {
     sparkSession.read.format("csv").option("delimiter", ",").option("header", "false").load(path)
   }
+
+  def withConf[T](conf: Map[String, String])(f: => T): T = {
+    val oldConf = conf.keys.map(key => key -> sparkSession.conf.getOption(key))
+    conf.foreach { case (key, value) => sparkSession.conf.set(key, value) }
+    try {
+      f
+    } finally {
+      oldConf.foreach { case (key, value) =>
+        value match {
+          case Some(v) => sparkSession.conf.set(key, v)
+          case None => sparkSession.conf.unset(key)
+        }
+      }
+    }
+  }
 }

--- a/spark/spark-3.4/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/GeoParquetFileFormat.scala
+++ b/spark/spark-3.4/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/GeoParquetFileFormat.scala
@@ -65,6 +65,14 @@ class GeoParquetFileFormat(val spatialFilter: Option[GeoParquetSpatialFilter])
 
   override def hashCode(): Int = getClass.hashCode()
 
+  override def toString(): String = {
+    // HACK: This is the only place we can inject spatial filter information into the described query plan.
+    // Please see org.apache.spark.sql.execution.DataSourceScanExec#simpleString for more details.
+    "GeoParquet" + spatialFilter
+      .map(filter => " with spatial filter [" + filter.simpleString + "]")
+      .getOrElse("")
+  }
+
   def withSpatialPredicates(spatialFilter: GeoParquetSpatialFilter): GeoParquetFileFormat =
     new GeoParquetFileFormat(Some(spatialFilter))
 

--- a/spark/spark-3.4/src/test/scala/org/apache/sedona/sql/TestBaseScala.scala
+++ b/spark/spark-3.4/src/test/scala/org/apache/sedona/sql/TestBaseScala.scala
@@ -54,4 +54,19 @@ trait TestBaseScala extends FunSpec with BeforeAndAfterAll {
   def loadCsv(path: String): DataFrame = {
     sparkSession.read.format("csv").option("delimiter", ",").option("header", "false").load(path)
   }
+
+  def withConf[T](conf: Map[String, String])(f: => T): T = {
+    val oldConf = conf.keys.map(key => key -> sparkSession.conf.getOption(key))
+    conf.foreach { case (key, value) => sparkSession.conf.set(key, value) }
+    try {
+      f
+    } finally {
+      oldConf.foreach { case (key, value) =>
+        value match {
+          case Some(v) => sparkSession.conf.set(key, v)
+          case None => sparkSession.conf.unset(key)
+        }
+      }
+    }
+  }
 }

--- a/spark/spark-3.5/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/GeoParquetFileFormat.scala
+++ b/spark/spark-3.5/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/GeoParquetFileFormat.scala
@@ -64,6 +64,14 @@ class GeoParquetFileFormat(val spatialFilter: Option[GeoParquetSpatialFilter])
 
   override def hashCode(): Int = getClass.hashCode()
 
+  override def toString(): String = {
+    // HACK: This is the only place we can inject spatial filter information into the described query plan.
+    // Please see org.apache.spark.sql.execution.DataSourceScanExec#simpleString for more details.
+    "GeoParquet" + spatialFilter
+      .map(filter => " with spatial filter [" + filter.simpleString + "]")
+      .getOrElse("")
+  }
+
   def withSpatialPredicates(spatialFilter: GeoParquetSpatialFilter): GeoParquetFileFormat =
     new GeoParquetFileFormat(Some(spatialFilter))
 

--- a/spark/spark-3.5/src/test/scala/org/apache/sedona/sql/TestBaseScala.scala
+++ b/spark/spark-3.5/src/test/scala/org/apache/sedona/sql/TestBaseScala.scala
@@ -54,4 +54,19 @@ trait TestBaseScala extends FunSpec with BeforeAndAfterAll {
   def loadCsv(path: String): DataFrame = {
     sparkSession.read.format("csv").option("delimiter", ",").option("header", "false").load(path)
   }
+
+  def withConf[T](conf: Map[String, String])(f: => T): T = {
+    val oldConf = conf.keys.map(key => key -> sparkSession.conf.getOption(key))
+    conf.foreach { case (key, value) => sparkSession.conf.set(key, value) }
+    try {
+      f
+    } finally {
+      oldConf.foreach { case (key, value) =>
+        value match {
+          case Some(v) => sparkSession.conf.set(key, v)
+          case None => sparkSession.conf.unset(key)
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-637. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Spatial filters pushed down to the GeoParquet scan node are visible in the query plan. For example, the following query
```python
df.where("ST_Intersects(geometry, ST_Point(1, 1))").explain()
```

Produces the following query plan
```
== Physical Plan ==
Filter (isnotnull(geometry#218) AND  **org.apache.spark.sql.sedona_sql.expressions.ST_Intersects**  )
+- FileScan geoparquet [id#217L,geometry#218,bbox#219] Batched: false, DataFilters: [isnotnull(geometry#218),  **org.apache.spark.sql.sedona_sql.expressions.ST_Intersects**  ], Format: GeoParquet with spatial filter [geometry INTERSECTS POINT (1 1)], Location: InMemoryFileIndex(1 paths).., PartitionFilters: [], PushedFilters: [IsNotNull(geometry)], ReadSchema: struct<id:bigint,geometry:binary,bbox:struct<xmin:double,ymin:double,xmax:double,ymax:double>>
```

The spatial filters pushed down to GeoParquet scan is shown in `Format: GeoParquet with spatial filter [...]`.

Spatial filter push-down can be manually disabled by configuring the Spark configuration `spark.sedona.geoparquet.spatialFilterPushDown` to `false`:

```
spark.conf.set("spark.sedona.geoparquet.spatialFilterPushDown", "false")
df.where("ST_Intersects(geometry, ST_Point(1, 1))").explain()
```

```
== Physical Plan ==
Filter (isnotnull(geometry#218) AND  **org.apache.spark.sql.sedona_sql.expressions.ST_Intersects**  )
+- FileScan geoparquet [id#217L,geometry#218,bbox#219] Batched: false, DataFilters: [isnotnull(geometry#218),  **org.apache.spark.sql.sedona_sql.expressions.ST_Intersects**  ], Format: GeoParquet, Location: InMemoryFileIndex(1 paths).., PartitionFilters: [], PushedFilters: [IsNotNull(geometry)], ReadSchema: struct<id:bigint,geometry:binary,bbox:struct<xmin:double,ymin:double,xmax:double,ymax:double>>
```

## How was this patch tested?

Pass newly added tests

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.
