### PR TITLE
[SEDONA-638] Submit telemetry asynchronously without blocking the initialization of SedonaContext

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/utils/TelemetryCollector.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/TelemetryCollector.java
@@ -21,14 +21,18 @@ package org.apache.sedona.common.utils;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class TelemetryCollector {
 
   private static final String BASE_URL = "https://sedona.gateway.scarf.sh/packages/";
+  private static final AtomicBoolean telemetrySubmitted = new AtomicBoolean(false);
 
   public static String send(String engineName, String language) {
-    HttpURLConnection conn = null;
-    String telemetrySubmitted = "";
+    String telemetrySubmitUrl = "";
+    if (!telemetrySubmitted.compareAndSet(false, true)) {
+      return telemetrySubmitUrl;
+    }
     try {
       String arch = URLEncoder.encode(System.getProperty("os.arch").replaceAll(" ", "_"), "UTF-8");
       String os = URLEncoder.encode(System.getProperty("os.name").replaceAll(" ", "_"), "UTF-8");
@@ -36,7 +40,7 @@ public class TelemetryCollector {
           URLEncoder.encode(System.getProperty("java.version").replaceAll(" ", "_"), "UTF-8");
 
       // Construct URL
-      telemetrySubmitted =
+      telemetrySubmitUrl =
           BASE_URL + language + "/" + engineName + "/" + arch + "/" + os + "/" + jvm;
 
       // Check for user opt-out
@@ -47,26 +51,44 @@ public class TelemetryCollector {
               && System.getProperty("SCARF_NO_ANALYTICS").equals("true")
           || System.getProperty("DO_NOT_TRACK") != null
               && System.getProperty("DO_NOT_TRACK").equals("true")) {
-        return telemetrySubmitted;
+        return telemetrySubmitUrl;
       }
 
-      // Send GET request
-      URL url = new URL(telemetrySubmitted);
-      conn = (HttpURLConnection) url.openConnection();
-      conn.setRequestMethod("GET");
-      conn.connect();
-      int responseCode = conn.getResponseCode();
-      // Optionally check the response for successful execution
-      if (responseCode != 200) {
-        // Silent handling, no output or log
-      }
+      Thread telemetrySubmitThread = createThread(telemetrySubmitUrl);
+      telemetrySubmitThread.start();
     } catch (Exception e) {
       // Silent catch block
-    } finally {
-      if (conn != null) {
-        conn.disconnect();
-      }
     }
-    return telemetrySubmitted;
+    return telemetrySubmitUrl;
+  }
+
+  private static Thread createThread(String telemetrySubmitUrl) {
+    Thread telemetrySubmitThread =
+        new Thread("telemetry-submit-thread") {
+          @Override
+          public void run() {
+            HttpURLConnection conn = null;
+            try {
+              // Send GET request
+              URL url = new URL(telemetrySubmitUrl);
+              conn = (HttpURLConnection) url.openConnection();
+              conn.setRequestMethod("GET");
+              conn.connect();
+              int responseCode = conn.getResponseCode();
+              // Optionally check the response for successful execution
+              if (responseCode != 200) {
+                // Silent handling, no output or log
+              }
+            } catch (Exception e) {
+              // Silent catch block
+            } finally {
+              if (conn != null) {
+                conn.disconnect();
+              }
+            }
+          }
+        };
+    telemetrySubmitThread.setDaemon(true);
+    return telemetrySubmitThread;
   }
 }


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-638. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

The telemetry collector sends requests to the scarf server synchronously, which may block the initialization of SedonaContext when internet access is restricted (see https://github.com/apache/sedona/issues/1512). This PR sends the telemetry requests in a separate thread to avoid blocking the SedonaContext initialization.

## How was this patch tested?

Tested manually. Internet access restriction was simulated using iptables.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
