### PR TITLE
[SEDONA-639] Fix GeometrySplitter accuracy issues when splitting LineStrings

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/utils/GeometrySplitter.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/GeometrySplitter.java
@@ -148,19 +148,12 @@ public final class GeometrySplitter {
   }
 
   private MultiLineString splitLinesByLines(Geometry inputLines, Geometry blade) {
-    // compute the intersection of inputLines and blade
-    // and pass back to splitLines to handle as points
-    Geometry intersectionWithBlade = inputLines.intersection(blade);
-
-    if (intersectionWithBlade.isEmpty()) {
-      // blade and inputLines are disjoint so just return the input as a multilinestring
-      return (MultiLineString) ensureMultiGeometryOfDimensionN(inputLines, 1);
-    } else if (intersectionWithBlade.getDimension() != 0) {
-      logger.warn("Colinear sections detected between source and blade geometry. Returned null.");
-      return null;
+    Geometry diff = inputLines.difference(blade);
+    if (diff instanceof MultiLineString) {
+      return (MultiLineString) diff;
+    } else {
+      return geometryFactory.createMultiLineString(new LineString[] {(LineString) inputLines});
     }
-
-    return splitLines(inputLines, intersectionWithBlade);
   }
 
   private MultiPolygon splitPolygonsByLines(Geometry polygons, Geometry blade) {
@@ -197,6 +190,7 @@ public final class GeometrySplitter {
         Iterator<Coordinate> coordIterator =
             getIteratorForSegmentDirection(pointCoords, lineBuilder.getLastCoordinate(), endCoord);
 
+        // line.getPrecisionModel()
         applyCoordsToLineSegment(lineBuilder, coordIterator, endCoord);
       }
 

--- a/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
@@ -33,6 +33,8 @@ import org.geotools.referencing.CRS;
 import org.geotools.referencing.operation.projection.ProjectionException;
 import org.junit.Test;
 import org.locationtech.jts.geom.*;
+import org.locationtech.jts.geom.prep.PreparedGeometry;
+import org.locationtech.jts.geom.prep.PreparedGeometryFactory;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
 import org.locationtech.jts.io.WKTWriter;
@@ -303,6 +305,41 @@ public class FunctionsTest extends TestBase {
     String expectedResult = "MULTILINESTRING ((0 0, 1 1), (1 1, 2 2))";
 
     assertEquals(actualResult, expectedResult);
+  }
+
+  @Test
+  public void splitLineStringFpPrecisionIssue() {
+    LineString lineString =
+        GEOMETRY_FACTORY.createLineString(
+            coordArray(
+                -8.961173822708158, -3.93776773106963, -8.08908227533288, -3.8845245068873444));
+    Polygon polygon =
+        GEOMETRY_FACTORY.createPolygon(
+            coordArray(
+                -6.318936372442209, -6.44985859539768,
+                -8.669092633645995, -3.0659222341103956,
+                -6.264600073171498, -3.075347218794894,
+                -5.3654318906014495, -3.1019726170919877,
+                -5.488002156793005, -5.892626167859213,
+                -6.318936372442209, -6.44985859539768));
+
+    Geometry result = Functions.split(lineString, polygon);
+    assertEquals(2, result.getNumGeometries());
+    assertEquals(lineString.getLength(), result.getLength(), 1e-6);
+  }
+
+  @Test
+  public void tempTest() {
+    LineString lineString =
+        GEOMETRY_FACTORY.createLineString(
+            coordArray(
+                -8.961173822708158, -3.93776773106963, -8.08908227533288, -3.8845245068873444));
+    Point point =
+        GEOMETRY_FACTORY.createPoint(new Coordinate(-8.100103048843774, -3.885197350829553));
+    PreparedGeometryFactory factory = new PreparedGeometryFactory();
+    PreparedGeometry prepLineString = factory.create(lineString);
+    boolean intersects = prepLineString.intersects(point);
+    System.out.println(intersects);
   }
 
   @Test


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-639. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

The algorithm we used before computes the intersection points of the input and the blade and splits the input using the intersection points. The problem is that the intersection point may not perfectly lie on the input LineString due to precision issues of the overlay algorithm, so the input LineString won't be split correctly.

This PR uses a more robust algorithm for splitting LineStrings using LineString blades. It simply computes the difference between the input and blade geometry to derive the split result.

## How was this patch tested?

Pass existing tests and a newly added test.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
