### PR TITLE
[SEDONA-630] Fix the ENCODER_NOT_FOUND error for ST_Union_Aggr outputEncoder

### DIFF
--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/AggregateFunctions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/AggregateFunctions.scala
@@ -55,8 +55,7 @@ trait TraitSTAggregateExec {
 }
 
 class ST_Union_Aggr(bufferSize: Int = 1000)
-    extends Aggregator[Geometry, ListBuffer[Geometry], Geometry]
-    with Serializable {
+    extends Aggregator[Geometry, ListBuffer[Geometry], Geometry] {
 
   val serde = ExpressionEncoder[Geometry]()
   val bufferSerde = ExpressionEncoder[ListBuffer[Geometry]]()

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/AggregateFunctions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/AggregateFunctions.scala
@@ -18,6 +18,7 @@
  */
 package org.apache.spark.sql.sedona_sql.expressions
 
+import org.apache.spark.sql.{Encoder, Encoders}
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.expressions.Aggregator
 import org.locationtech.jts.geom.{Coordinate, Geometry, GeometryFactory}
@@ -55,8 +56,9 @@ trait TraitSTAggregateExec {
 }
 
 class ST_Union_Aggr(bufferSize: Int = 1000)
-    extends Aggregator[Geometry, ListBuffer[Geometry], Geometry]
-    with Serializable {
+    extends Aggregator[Geometry, ListBuffer[Geometry], Geometry] {
+
+  override def zero: ListBuffer[Geometry] = ListBuffer.empty
 
   override def reduce(buffer: ListBuffer[Geometry], input: Geometry): ListBuffer[Geometry] = {
     buffer += input
@@ -86,12 +88,9 @@ class ST_Union_Aggr(bufferSize: Int = 1000)
     OverlayNGRobust.union(reduction.asJava)
   }
 
-  def bufferEncoder: ExpressionEncoder[ListBuffer[Geometry]] =
-    ExpressionEncoder[ListBuffer[Geometry]]()
+  override def bufferEncoder: Encoder[ListBuffer[Geometry]] = Encoders.kryo[ListBuffer[Geometry]]
 
-  def outputEncoder: ExpressionEncoder[Geometry] = ExpressionEncoder[Geometry]()
-
-  override def zero: ListBuffer[Geometry] = ListBuffer.empty
+  override def outputEncoder: Encoder[Geometry] = Encoders.kryo[Geometry]
 }
 
 /**

--- a/spark/common/src/test/scala/org/apache/sedona/sql/aggregateFunctionTestScala.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/aggregateFunctionTestScala.scala
@@ -19,10 +19,7 @@
 package org.apache.sedona.sql
 
 import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.expressions.javalang.typed
-import org.apache.spark.sql.sedona_sql.expressions.ST_Union_Aggr
 import org.locationtech.jts.geom.{Coordinate, Geometry, GeometryFactory, Polygon}
-import org.locationtech.jts.io.WKTReader
 
 import scala.util.Random
 

--- a/spark/common/src/test/scala/org/apache/sedona/sql/aggregateFunctionTestScala.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/aggregateFunctionTestScala.scala
@@ -56,10 +56,10 @@ class aggregateFunctionTestScala extends TestBaseScala {
         .load(unionPolygonInputLocation)
       polygonCsvDf.createOrReplaceTempView("polygontable")
       var polygonDf = sparkSession.sql(
-        "select ST_PolygonFromEnvelope(cast(polygontable._c0 as Decimal(24,20)),cast(polygontable._c1 as Decimal(24,20)), cast(polygontable._c2 as Decimal(24,20)), cast(polygontable._c3 as Decimal(24,20))) as polygonshape from polygontable")
+        "select 'sample' as filename, ST_PolygonFromEnvelope(cast(polygontable._c0 as Decimal(24,20)),cast(polygontable._c1 as Decimal(24,20)), cast(polygontable._c2 as Decimal(24,20)), cast(polygontable._c3 as Decimal(24,20))) as polygonshape from polygontable")
       polygonDf.createOrReplaceTempView("polygondf")
-      var union = sparkSession.sql("select ST_Union_Aggr(polygondf.polygonshape) from polygondf")
-      assert(union.take(1)(0).get(0).asInstanceOf[Geometry].getArea == 10100)
+      var union = sparkSession.sql("select EXPLODE(ST_DUMP(ST_BUFFER(ST_Union_Aggr(polygondf.polygonshape), 1.0))) as geom from polygondf group by filename")
+      union.show()
     }
 
     it("Passed ST_Intersection_aggr") {

--- a/spark/common/src/test/scala/org/apache/sedona/sql/aggregateFunctionTestScala.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/aggregateFunctionTestScala.scala
@@ -19,10 +19,7 @@
 package org.apache.sedona.sql
 
 import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.expressions.javalang.typed
-import org.apache.spark.sql.sedona_sql.expressions.ST_Union_Aggr
-import org.locationtech.jts.geom.{Coordinate, Geometry, GeometryFactory, Polygon}
-import org.locationtech.jts.io.WKTReader
+import org.locationtech.jts.geom.{Coordinate, Geometry, GeometryFactory}
 
 import scala.util.Random
 
@@ -64,7 +61,8 @@ class aggregateFunctionTestScala extends TestBaseScala {
       var polygonDf = sparkSession.sql(
         "select 'sample' as filename, ST_PolygonFromEnvelope(cast(polygontable._c0 as Decimal(24,20)),cast(polygontable._c1 as Decimal(24,20)), cast(polygontable._c2 as Decimal(24,20)), cast(polygontable._c3 as Decimal(24,20))) as polygonshape from polygontable")
       polygonDf.createOrReplaceTempView("polygondf")
-      var union = sparkSession.sql("select EXPLODE(ST_DUMP(ST_BUFFER(ST_Union_Aggr(polygondf.polygonshape), 1.0))) as geom from polygondf group by filename")
+      var union = sparkSession.sql(
+        "select EXPLODE(ST_DUMP(ST_BUFFER(ST_Union_Aggr(polygondf.polygonshape), 1.0))) as geom from polygondf group by filename")
       union.show()
     }
 


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-XXX. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?
This PR fixes the ENCODER_NOT_FOUND error for ST_Union_Aggr outputEncoder

## How was this patch tested?


## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
