### PR TITLE
[SEDONA-642] R - Update to jar naming logic

### DIFF
--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: apache.sedona
 Title: R Interface for Apache Sedona
-Version: 1.6.0
+Version: 1.6.0.900
 Authors@R:
     c(person(family = "Apache Sedona",
              role = c("aut", "cre"),

--- a/R/R/dependencies.R
+++ b/R/R/dependencies.R
@@ -18,7 +18,7 @@
 
 spark_dependencies <- function(spark_version, scala_version, ...) {
   if (spark_version[1, 1] == "3") {
-    spark_version <- "3.0"
+    spark_version <- spark_version
     scala_version <- scala_version %||% "2.12"
   } else {
     stop("Unsupported Spark version: ", spark_version)
@@ -42,7 +42,7 @@ spark_dependencies <- function(spark_version, scala_version, ...) {
       ),
       packages
     )
-    cli::cli_alert_info(sprintf("Using Sedona jars versions: %s etc.", packages[1]))
+    cli::cli_alert_info(sprintf("Using Sedona jar version: %s", packages[1]))
   }
 
   spark_dependency(


### PR DESCRIPTION
## What changes were proposed in this PR?
Adapting the package to the split of the shaded vars by version. Before it would always call jar 3.0_2.12, now it gets 3.1, 3.2 etc. accordingly

## How was this patch tested?
Tested locally, R tests and github actions can't capture this because of the development version that is being tested by those

## Did this PR include necessary documentation updates?
- No, this PR does not affect any public API so no need to change the documentation.
