### PR TITLE
[SEDONA-607] Fix error message enhancements for geometry functions

### DIFF
--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Constructors.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Constructors.scala
@@ -160,21 +160,20 @@ case class ST_GeomFromWKB(inputExpressions: Seq[Expression])
   override def nullable: Boolean = true
 
   override def eval(inputRow: InternalRow): Any = {
+    val arg = inputExpressions.head.eval(inputRow)
     try {
-      (inputExpressions.head.eval(inputRow)) match {
-        case (geomString: UTF8String) => {
+      arg match {
+        case geomString: UTF8String =>
           // Parse UTF-8 encoded wkb string
           Constructors.geomFromText(geomString.toString, FileDataSplitter.WKB).toGenericArrayData
-        }
-        case (wkb: Array[Byte]) => {
+        case wkb: Array[Byte] =>
           // convert raw wkb byte array to geometry
           Constructors.geomFromWKB(wkb).toGenericArrayData
-        }
         case null => null
       }
     } catch {
       case e: Exception =>
-        InferredExpression.throwExpressionInferenceException(inputRow, inputExpressions, e)
+        InferredExpression.throwExpressionInferenceException(getClass.getSimpleName, Seq(arg), e)
     }
   }
 
@@ -201,21 +200,20 @@ case class ST_GeomFromEWKB(inputExpressions: Seq[Expression])
   override def nullable: Boolean = true
 
   override def eval(inputRow: InternalRow): Any = {
+    val arg = inputExpressions.head.eval(inputRow)
     try {
-      (inputExpressions.head.eval(inputRow)) match {
-        case (geomString: UTF8String) => {
+      arg match {
+        case geomString: UTF8String =>
           // Parse UTF-8 encoded wkb string
           Constructors.geomFromText(geomString.toString, FileDataSplitter.WKB).toGenericArrayData
-        }
-        case (wkb: Array[Byte]) => {
+        case wkb: Array[Byte] =>
           // convert raw wkb byte array to geometry
           Constructors.geomFromWKB(wkb).toGenericArrayData
-        }
         case null => null
       }
     } catch {
       case e: Exception =>
-        InferredExpression.throwExpressionInferenceException(inputRow, inputExpressions, e)
+        InferredExpression.throwExpressionInferenceException(getClass.getSimpleName, Seq(arg), e)
     }
   }
 
@@ -267,7 +265,10 @@ case class ST_LineFromWKB(inputExpressions: Seq[Expression])
       }
     } catch {
       case e: Exception =>
-        InferredExpression.throwExpressionInferenceException(inputRow, inputExpressions, e)
+        InferredExpression.throwExpressionInferenceException(
+          getClass.getSimpleName,
+          Seq(wkb, srid),
+          e)
     }
   }
 
@@ -321,7 +322,10 @@ case class ST_LinestringFromWKB(inputExpressions: Seq[Expression])
       }
     } catch {
       case e: Exception =>
-        InferredExpression.throwExpressionInferenceException(inputRow, inputExpressions, e)
+        InferredExpression.throwExpressionInferenceException(
+          getClass.getSimpleName,
+          Seq(wkb, srid),
+          e)
     }
   }
 
@@ -375,7 +379,10 @@ case class ST_PointFromWKB(inputExpressions: Seq[Expression])
       }
     } catch {
       case e: Exception =>
-        InferredExpression.throwExpressionInferenceException(inputRow, inputExpressions, e)
+        InferredExpression.throwExpressionInferenceException(
+          getClass.getSimpleName,
+          Seq(wkb, srid),
+          e)
     }
   }
 
@@ -413,7 +420,6 @@ case class ST_GeomFromGeoJSON(inputExpressions: Seq[Expression])
   override def eval(inputRow: InternalRow): Any = {
     val geomString = inputExpressions.head.eval(inputRow).asInstanceOf[UTF8String].toString
     try {
-
       val geometry = Constructors.geomFromText(geomString, FileDataSplitter.GEOJSON)
       // If the user specify a bunch of attributes to go with each geometry, we need to store all of them in this geometry
       if (inputExpressions.length > 1) {
@@ -422,7 +428,10 @@ case class ST_GeomFromGeoJSON(inputExpressions: Seq[Expression])
       GeometrySerializer.serialize(geometry)
     } catch {
       case e: Exception =>
-        InferredExpression.throwExpressionInferenceException(inputRow, inputExpressions, e)
+        InferredExpression.throwExpressionInferenceException(
+          getClass.getSimpleName,
+          Seq(geomString),
+          e)
     }
   }
 

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/InferredExpression.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/InferredExpression.scala
@@ -107,7 +107,10 @@ abstract class InferredExpression(fSeq: InferrableFunction*)
       f.serializer(evaluator(input))
     } catch {
       case e: Exception =>
-        InferredExpression.throwExpressionInferenceException(getClass.getSimpleName, inputArgs, e)
+        InferredExpression.throwExpressionInferenceException(
+          getClass.getSimpleName,
+          inputArgs.toSeq,
+          e)
     } finally {
       inputArgs.clear()
     }
@@ -118,7 +121,10 @@ abstract class InferredExpression(fSeq: InferrableFunction*)
       evaluator(input)
     } catch {
       case e: Exception =>
-        InferredExpression.throwExpressionInferenceException(getClass.getSimpleName, inputArgs, e)
+        InferredExpression.throwExpressionInferenceException(
+          getClass.getSimpleName,
+          inputArgs.toSeq,
+          e)
     } finally {
       inputArgs.clear()
     }

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/InferredExpression.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/InferredExpression.scala
@@ -18,17 +18,19 @@
  */
 package org.apache.spark.sql.sedona_sql.expressions
 
+import org.apache.commons.lang3.StringUtils
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Expression, ImplicitCastInputTypes, Literal}
+import org.apache.spark.sql.catalyst.expressions.{Expression, ImplicitCastInputTypes}
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
 import org.apache.spark.sql.catalyst.util.ArrayData
 import org.apache.spark.sql.sedona_sql.UDT.GeometryUDT
-import org.apache.spark.sql.types.{AbstractDataType, BinaryType, BooleanType, DataType, DataTypes, DoubleType, IntegerType, LongType, StringType, StructField, StructType}
+import org.apache.spark.sql.types.{AbstractDataType, BinaryType, BooleanType, DataType, DataTypes, DoubleType, IntegerType, LongType, StringType}
 import org.apache.spark.unsafe.types.UTF8String
 import org.locationtech.jts.geom.Geometry
 import org.apache.spark.sql.sedona_sql.expressions.implicits._
 
 import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
+import scala.collection.mutable.ArrayBuffer
 import scala.reflect.runtime.universe.TypeTag
 import scala.reflect.runtime.universe.Type
 import scala.reflect.runtime.universe.typeOf
@@ -77,27 +79,37 @@ abstract class InferredExpression(fSeq: InferrableFunction*)
   override def inputTypes: Seq[AbstractDataType] = f.sparkInputTypes
   override def dataType: DataType = f.sparkReturnType
 
-  private lazy val argExtractors: Array[InternalRow => Any] = f.buildExtractors(inputExpressions)
+  private lazy val argExtractors: Array[InternalRow => Any] = buildExtractors(inputExpressions)
   private lazy val evaluator: InternalRow => Any = f.evaluatorBuilder(argExtractors)
 
-  private def findAllLiterals(expression: Expression): Seq[Literal] = {
-    expression match {
-      case lit: Literal => Seq(lit)
-      case _ => expression.children.flatMap(findAllLiterals)
-    }
-  }
+  // Remember input args to generate error messages when exceptions occur. The input arguments are
+  // helpful for troubleshooting the cause of errors.
+  private val inputArgs: ArrayBuffer[AnyRef] = ArrayBuffer.empty[AnyRef]
 
-  private def findAllLiteralsInExpressions(expressions: Seq[Expression]): Seq[String] = {
-    expressions.flatMap(findAllLiterals).map(_.value.toString)
+  private def buildExtractors(expressions: Seq[Expression]): Array[InternalRow => Any] = {
+    f.argExtractorBuilders
+      .zipAll(expressions, null, null)
+      .flatMap {
+        case (null, _) => None
+        case (builder, expr) =>
+          val extractor = builder(expr)
+          Some((input: InternalRow) => {
+            val arg = extractor(input)
+            inputArgs += arg.asInstanceOf[AnyRef]
+            arg
+          })
+      }
+      .toArray
   }
 
   override def eval(input: InternalRow): Any = {
-
     try {
       f.serializer(evaluator(input))
     } catch {
       case e: Exception =>
-        InferredExpression.throwExpressionInferenceException(input, inputExpressions, e)
+        InferredExpression.throwExpressionInferenceException(getClass.getSimpleName, inputArgs, e)
+    } finally {
+      inputArgs.clear()
     }
   }
 
@@ -106,32 +118,29 @@ abstract class InferredExpression(fSeq: InferrableFunction*)
       evaluator(input)
     } catch {
       case e: Exception =>
-        InferredExpression.throwExpressionInferenceException(input, inputExpressions, e)
+        InferredExpression.throwExpressionInferenceException(getClass.getSimpleName, inputArgs, e)
+    } finally {
+      inputArgs.clear()
     }
   }
 }
 
 object InferredExpression {
   def throwExpressionInferenceException(
-      input: InternalRow,
-      inputExpressions: Seq[Expression],
+      name: String,
+      inputArgs: Seq[Any],
       e: Exception): Nothing = {
-    val literalsAsStrings = if (input == null) {
-      // In case no input row is provided, we can't extract literals from the input expressions.
-      inputExpressions.flatMap(findAllLiterals).map(_.value.toString)
+    if (e.isInstanceOf[InferredExpressionException]) {
+      throw e
     } else {
-      Seq.empty[String]
-    }
-    val literalsOrInputString = literalsAsStrings.mkString(", ")
-    throw new InferredExpressionException(
-      s"Exception occurred while evaluating expression - source: [$literalsOrInputString]",
-      e)
-  }
-
-  def findAllLiterals(expression: Expression): Seq[Literal] = {
-    expression match {
-      case lit: Literal => Seq(lit)
-      case _ => expression.children.flatMap(findAllLiterals)
+      val inputsAsStrings = inputArgs.map { arg =>
+        val argStr = if (arg != null) arg.toString else "null"
+        StringUtils.abbreviate(argStr, 5000)
+      }
+      val inputsString = inputsAsStrings.mkString(", ")
+      throw new InferredExpressionException(
+        s"Exception occurred while evaluating expression $name - inputs: [$inputsString]",
+        e)
     }
   }
 }
@@ -301,17 +310,7 @@ case class InferrableFunction(
     sparkReturnType: DataType,
     serializer: Any => Any,
     argExtractorBuilders: Seq[Expression => InternalRow => Any],
-    evaluatorBuilder: Array[InternalRow => Any] => InternalRow => Any) {
-  def buildExtractors(expressions: Seq[Expression]): Array[InternalRow => Any] = {
-    argExtractorBuilders
-      .zipAll(expressions, null, null)
-      .flatMap {
-        case (null, _) => None
-        case (builder, expr) => Some(builder(expr))
-      }
-      .toArray
-  }
-}
+    evaluatorBuilder: Array[InternalRow => Any] => InternalRow => Any)
 
 object InferrableFunction {
 

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Predicates.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Predicates.scala
@@ -55,13 +55,16 @@ abstract class ST_Predicate
       if (rightArray == null) {
         null
       } else {
+        val leftGeometry = GeometrySerializer.deserialize(leftArray)
+        val rightGeometry = GeometrySerializer.deserialize(rightArray)
         try {
-          val leftGeometry = GeometrySerializer.deserialize(leftArray)
-          val rightGeometry = GeometrySerializer.deserialize(rightArray)
           evalGeom(leftGeometry, rightGeometry)
         } catch {
           case e: Exception =>
-            InferredExpression.throwExpressionInferenceException(inputRow, inputExpressions, e)
+            InferredExpression.throwExpressionInferenceException(
+              getClass.getSimpleName,
+              Seq(leftGeometry, rightGeometry),
+              e)
         }
       }
     }

--- a/spark/common/src/test/scala/org/apache/sedona/sql/constructorTestScala.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/constructorTestScala.scala
@@ -216,8 +216,9 @@ class constructorTestScala extends TestBaseScala {
       val thrown = intercept[Exception] {
         sparkSession.sql("SELECT ST_GeomFromWKT('not wkt')").collect()
       }
-      assert(
-        thrown.getMessage == "Exception occurred while evaluating expression - source: [not wkt, 0], cause: Unknown geometry type: NOT (line 1)")
+      assert(thrown.getMessage.contains("ST_GeomFromWKT"))
+      assert(thrown.getMessage.contains("not wkt"))
+      assert(thrown.getMessage.contains("Unknown geometry type"))
     }
 
     it("Passed ST_GeomFromEWKT") {
@@ -246,8 +247,9 @@ class constructorTestScala extends TestBaseScala {
       val thrown = intercept[Exception] {
         sparkSession.sql("SELECT ST_GeomFromEWKT('not wkt')").collect()
       }
-      assert(
-        thrown.getMessage == "Exception occurred while evaluating expression - source: [not wkt], cause: Unknown geometry type: NOT (line 1)")
+      assert(thrown.getMessage.contains("ST_GeomFromEWKT"))
+      assert(thrown.getMessage.contains("not wkt"))
+      assert(thrown.getMessage.contains("Unknown geometry type"))
     }
 
     it("Passed ST_LineFromText") {


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-607. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

This patch is based on https://github.com/apache/sedona/pull/1525, it generates enhanced error messages when the input arguments of geometry functions are not literal. The input arguments may help troubleshoot the cause of the errors.

Note: we originally planned to extract auxiliary fields from input rows and attach them to the error messages, but actually this is hard to implement since we don't know the types of columns that are not part of the function arguments. The error messages will only include arguments passed to the errored functions, including the input geometries. Hopefully this will be good enough for troubleshooting.

## How was this patch tested?

Passing newly added tests.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
