### PR TITLE
[SEDONA-646] Fix DBR compatibility problem for shapefile reader

### DIFF
--- a/spark/spark-3.0/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefilePartition.scala
+++ b/spark/spark-3.0/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefilePartition.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.sql.datasources.shapefile
+
+import org.apache.spark.Partition
+import org.apache.spark.sql.connector.read.InputPartition
+import org.apache.spark.sql.execution.datasources.PartitionedFile
+
+case class ShapefilePartition(index: Int, files: Array[PartitionedFile])
+    extends Partition
+    with InputPartition

--- a/spark/spark-3.0/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefilePartitionReaderFactory.scala
+++ b/spark/spark-3.0/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefilePartitionReaderFactory.scala
@@ -25,7 +25,6 @@ import org.apache.spark.sql.connector.read.PartitionReader
 import org.apache.spark.sql.connector.read.PartitionReaderFactory
 import org.apache.spark.sql.execution.datasources.PartitionedFile
 import org.apache.spark.sql.execution.datasources.v2.PartitionReaderWithPartitionValues
-import org.apache.spark.sql.execution.datasources.FilePartition
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
@@ -58,7 +57,7 @@ case class ShapefilePartitionReaderFactory(
 
   override def createReader(partition: InputPartition): PartitionReader[InternalRow] = {
     partition match {
-      case filePartition: FilePartition => buildReader(filePartition.files)
+      case filePartition: ShapefilePartition => buildReader(filePartition.files)
       case _ =>
         throw new IllegalArgumentException(
           s"Unexpected partition type: ${partition.getClass.getCanonicalName}")

--- a/spark/spark-3.0/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefileScan.scala
+++ b/spark/spark-3.0/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefileScan.scala
@@ -105,7 +105,7 @@ case class ShapefileScan(
         } else false
       }
       if (!hasMissingFiles) {
-        Some(FilePartition(index, group.values.toArray))
+        Some(ShapefilePartition(index, group.values.toArray))
       } else {
         None
       }

--- a/spark/spark-3.1/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefilePartition.scala
+++ b/spark/spark-3.1/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefilePartition.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.sql.datasources.shapefile
+
+import org.apache.spark.Partition
+import org.apache.spark.sql.connector.read.InputPartition
+import org.apache.spark.sql.execution.datasources.PartitionedFile
+
+case class ShapefilePartition(index: Int, files: Array[PartitionedFile])
+    extends Partition
+    with InputPartition

--- a/spark/spark-3.1/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefilePartitionReaderFactory.scala
+++ b/spark/spark-3.1/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefilePartitionReaderFactory.scala
@@ -25,7 +25,6 @@ import org.apache.spark.sql.connector.read.PartitionReader
 import org.apache.spark.sql.connector.read.PartitionReaderFactory
 import org.apache.spark.sql.execution.datasources.PartitionedFile
 import org.apache.spark.sql.execution.datasources.v2.PartitionReaderWithPartitionValues
-import org.apache.spark.sql.execution.datasources.FilePartition
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
@@ -58,7 +57,7 @@ case class ShapefilePartitionReaderFactory(
 
   override def createReader(partition: InputPartition): PartitionReader[InternalRow] = {
     partition match {
-      case filePartition: FilePartition => buildReader(filePartition.files)
+      case filePartition: ShapefilePartition => buildReader(filePartition.files)
       case _ =>
         throw new IllegalArgumentException(
           s"Unexpected partition type: ${partition.getClass.getCanonicalName}")

--- a/spark/spark-3.1/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefileScan.scala
+++ b/spark/spark-3.1/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefileScan.scala
@@ -105,7 +105,7 @@ case class ShapefileScan(
         } else false
       }
       if (!hasMissingFiles) {
-        Some(FilePartition(index, group.values.toArray))
+        Some(ShapefilePartition(index, group.values.toArray))
       } else {
         None
       }

--- a/spark/spark-3.2/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefilePartition.scala
+++ b/spark/spark-3.2/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefilePartition.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.sql.datasources.shapefile
+
+import org.apache.spark.Partition
+import org.apache.spark.sql.connector.read.InputPartition
+import org.apache.spark.sql.execution.datasources.PartitionedFile
+
+case class ShapefilePartition(index: Int, files: Array[PartitionedFile])
+    extends Partition
+    with InputPartition

--- a/spark/spark-3.2/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefilePartitionReaderFactory.scala
+++ b/spark/spark-3.2/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefilePartitionReaderFactory.scala
@@ -25,7 +25,6 @@ import org.apache.spark.sql.connector.read.PartitionReader
 import org.apache.spark.sql.connector.read.PartitionReaderFactory
 import org.apache.spark.sql.execution.datasources.PartitionedFile
 import org.apache.spark.sql.execution.datasources.v2.PartitionReaderWithPartitionValues
-import org.apache.spark.sql.execution.datasources.FilePartition
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
@@ -58,7 +57,7 @@ case class ShapefilePartitionReaderFactory(
 
   override def createReader(partition: InputPartition): PartitionReader[InternalRow] = {
     partition match {
-      case filePartition: FilePartition => buildReader(filePartition.files)
+      case filePartition: ShapefilePartition => buildReader(filePartition.files)
       case _ =>
         throw new IllegalArgumentException(
           s"Unexpected partition type: ${partition.getClass.getCanonicalName}")

--- a/spark/spark-3.2/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefileScan.scala
+++ b/spark/spark-3.2/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefileScan.scala
@@ -105,7 +105,7 @@ case class ShapefileScan(
         } else false
       }
       if (!hasMissingFiles) {
-        Some(FilePartition(index, group.values.toArray))
+        Some(ShapefilePartition(index, group.values.toArray))
       } else {
         None
       }

--- a/spark/spark-3.3/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefilePartition.scala
+++ b/spark/spark-3.3/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefilePartition.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.sql.datasources.shapefile
+
+import org.apache.spark.Partition
+import org.apache.spark.sql.connector.read.InputPartition
+import org.apache.spark.sql.execution.datasources.PartitionedFile
+
+case class ShapefilePartition(index: Int, files: Array[PartitionedFile])
+    extends Partition
+    with InputPartition

--- a/spark/spark-3.3/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefilePartitionReaderFactory.scala
+++ b/spark/spark-3.3/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefilePartitionReaderFactory.scala
@@ -25,7 +25,6 @@ import org.apache.spark.sql.connector.read.PartitionReader
 import org.apache.spark.sql.connector.read.PartitionReaderFactory
 import org.apache.spark.sql.execution.datasources.PartitionedFile
 import org.apache.spark.sql.execution.datasources.v2.PartitionReaderWithPartitionValues
-import org.apache.spark.sql.execution.datasources.FilePartition
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
@@ -58,7 +57,7 @@ case class ShapefilePartitionReaderFactory(
 
   override def createReader(partition: InputPartition): PartitionReader[InternalRow] = {
     partition match {
-      case filePartition: FilePartition => buildReader(filePartition.files)
+      case filePartition: ShapefilePartition => buildReader(filePartition.files)
       case _ =>
         throw new IllegalArgumentException(
           s"Unexpected partition type: ${partition.getClass.getCanonicalName}")

--- a/spark/spark-3.3/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefileScan.scala
+++ b/spark/spark-3.3/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefileScan.scala
@@ -105,7 +105,7 @@ case class ShapefileScan(
         } else false
       }
       if (!hasMissingFiles) {
-        Some(FilePartition(index, group.values.toArray))
+        Some(ShapefilePartition(index, group.values.toArray))
       } else {
         None
       }

--- a/spark/spark-3.4/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefilePartition.scala
+++ b/spark/spark-3.4/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefilePartition.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.sql.datasources.shapefile
+
+import org.apache.spark.Partition
+import org.apache.spark.sql.connector.read.InputPartition
+import org.apache.spark.sql.execution.datasources.PartitionedFile
+
+case class ShapefilePartition(index: Int, files: Array[PartitionedFile])
+    extends Partition
+    with InputPartition

--- a/spark/spark-3.4/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefilePartitionReaderFactory.scala
+++ b/spark/spark-3.4/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefilePartitionReaderFactory.scala
@@ -25,7 +25,6 @@ import org.apache.spark.sql.connector.read.PartitionReader
 import org.apache.spark.sql.connector.read.PartitionReaderFactory
 import org.apache.spark.sql.execution.datasources.PartitionedFile
 import org.apache.spark.sql.execution.datasources.v2.PartitionReaderWithPartitionValues
-import org.apache.spark.sql.execution.datasources.FilePartition
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
@@ -58,7 +57,7 @@ case class ShapefilePartitionReaderFactory(
 
   override def createReader(partition: InputPartition): PartitionReader[InternalRow] = {
     partition match {
-      case filePartition: FilePartition => buildReader(filePartition.files)
+      case filePartition: ShapefilePartition => buildReader(filePartition.files)
       case _ =>
         throw new IllegalArgumentException(
           s"Unexpected partition type: ${partition.getClass.getCanonicalName}")

--- a/spark/spark-3.4/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefileScan.scala
+++ b/spark/spark-3.4/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefileScan.scala
@@ -105,7 +105,7 @@ case class ShapefileScan(
         } else false
       }
       if (!hasMissingFiles) {
-        Some(FilePartition(index, group.values.toArray))
+        Some(ShapefilePartition(index, group.values.toArray))
       } else {
         None
       }

--- a/spark/spark-3.5/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefilePartition.scala
+++ b/spark/spark-3.5/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefilePartition.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.sql.datasources.shapefile
+
+import org.apache.spark.Partition
+import org.apache.spark.sql.connector.read.InputPartition
+import org.apache.spark.sql.execution.datasources.PartitionedFile
+
+case class ShapefilePartition(index: Int, files: Array[PartitionedFile])
+    extends Partition
+    with InputPartition

--- a/spark/spark-3.5/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefilePartitionReaderFactory.scala
+++ b/spark/spark-3.5/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefilePartitionReaderFactory.scala
@@ -25,7 +25,6 @@ import org.apache.spark.sql.connector.read.PartitionReader
 import org.apache.spark.sql.connector.read.PartitionReaderFactory
 import org.apache.spark.sql.execution.datasources.PartitionedFile
 import org.apache.spark.sql.execution.datasources.v2.PartitionReaderWithPartitionValues
-import org.apache.spark.sql.execution.datasources.FilePartition
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
@@ -58,7 +57,7 @@ case class ShapefilePartitionReaderFactory(
 
   override def createReader(partition: InputPartition): PartitionReader[InternalRow] = {
     partition match {
-      case filePartition: FilePartition => buildReader(filePartition.files)
+      case filePartition: ShapefilePartition => buildReader(filePartition.files)
       case _ =>
         throw new IllegalArgumentException(
           s"Unexpected partition type: ${partition.getClass.getCanonicalName}")

--- a/spark/spark-3.5/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefileScan.scala
+++ b/spark/spark-3.5/src/main/scala/org/apache/sedona/sql/datasources/shapefile/ShapefileScan.scala
@@ -105,7 +105,7 @@ case class ShapefileScan(
         } else false
       }
       if (!hasMissingFiles) {
-        Some(FilePartition(index, group.values.toArray))
+        Some(ShapefilePartition(index, group.values.toArray))
       } else {
         None
       }


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-646. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

`org.apache.spark.sql.execution.datasources.FilePartition` on DBR is not binary compatible with the open-source Apache Spark, so we define our own `InputPartition` subclass to get rid of this problem.

## How was this patch tested?

Manually tested on DBR 15.4 LTS.

![image](https://github.com/user-attachments/assets/22a90f63-ecbb-47f9-a9d5-b8775d294e00)

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
