### PR TITLE
[SEDONA-609] Pin numpy to v1

### DIFF
--- a/docker/sedona-spark-jupyterlab/requirements.txt
+++ b/docker/sedona-spark-jupyterlab/requirements.txt
@@ -11,3 +11,4 @@ jupyterlab-widgets==1.1.7
 keplergl==0.3.2
 matplotlib
 pydeck==0.8.0
+numpy<2


### PR DESCRIPTION
Resolves #1572

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-609. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Use numpy v1 inside container to prevent issues with (geo)pandas, see https://github.com/apache/sedona/issues/1572

## How was this patch tested?

Built image and ran `python3 -c 'import pandas as pd'`.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
