### PR TITLE
[SEDONA-650] keep fiona version below 1.10.0

### DIFF
--- a/python/Pipfile
+++ b/python/Pipfile
@@ -14,6 +14,9 @@ pytest-cov = "*"
 pandas="<=1.5.3"
 numpy="<2"
 geopandas="*"
+# https://stackoverflow.com/questions/78949093/how-to-resolve-attributeerror-module-fiona-has-no-attribute-path
+# cannot set geopandas>=0.14.4 since it doesn't support python 3.8, so we pin fiona to <1.10.0
+fiona="<1.10.0"
 shapely=">=1.7.0"
 pyspark=">=2.3.0"
 attrs="*"


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-650. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?
fixing the fiona version so that the integration between geopandas and fiona is not broken in python 3.8

## How was this patch tested?
unit tests. They detected this issue originally as well.

## Did this PR include necessary documentation updates?
- No, this PR does not affect any public API so no need to change the documentation.
