### PR TITLE
[SEDONA-651] Add spark prefix to all sedona spark config

### DIFF
--- a/docs/api/sql/Parameter.md
+++ b/docs/api/sql/Parameter.md
@@ -25,6 +25,16 @@ println(sedonaConf)
 sparkSession.conf.set("sedona.global.index","false")
 ```
 
+In addition, you can also add `spark` prefix to the parameter name, for example:
+
+```scala
+sparkSession.conf.set("spark.sedona.global.index","false")
+```
+
+However, any parameter set through `spark` prefix will be honored by Spark, which means you can set these parameters before hand via `spark-defaults.conf` or Spark on Kubernetes configuration.
+
+If you set the same parameter through both `sedona` and `spark.sedona` prefixes, the parameter set through `sedona` prefix will override the parameter set through `spark.sedona` prefix.
+
 ## Explanation
 
 * sedona.global.index


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-651. The PR name follows the format `[SEDONA-651] my subject`.

## What changes were proposed in this PR?

Add the `spark` prefix to all existing configs and allow them to co-exist in the config.

Users can set via both methods `sedona.` or `spark.sedona.` but when both options present, the parameter set through `sedona` prefix will override the parameter set through `spark.sedona` prefix.


## How was this patch tested?

Passed existing tests

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.