### PR TITLE
[SEDONA-648] Throw unsupported operation exception when ST_KNN is used as UDF

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/Predicates.java
+++ b/common/src/main/java/org/apache/sedona/common/Predicates.java
@@ -96,12 +96,11 @@ public class Predicates {
   }
 
   public static boolean knn(Geometry leftGeometry, Geometry rightGeometry, int k) {
-    return knn(leftGeometry, rightGeometry, k, false);
+    throw new UnsupportedOperationException("KNN predicate is not supported");
   }
 
   public static boolean knn(
       Geometry leftGeometry, Geometry rightGeometry, int k, boolean useSpheroid) {
-    // This should only be used as a test predicate used with extra join condition
-    return true;
+    throw new UnsupportedOperationException("KNN predicate is not supported");
   }
 }

--- a/spark/common/src/test/scala/org/apache/sedona/sql/KnnJoinSuite.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/KnnJoinSuite.scala
@@ -70,7 +70,7 @@ class KnnJoinSuite extends TestBaseScala with TableDrivenPropertyChecks {
         df,
         numNeighbors = 3,
         useApproximate = false,
-        expressionSize = 5,
+        expressionSize = 4,
         isGeography = true,
         mustInclude = "")
     }
@@ -83,7 +83,7 @@ class KnnJoinSuite extends TestBaseScala with TableDrivenPropertyChecks {
           df,
           numNeighbors = 3,
           useApproximate = true,
-          expressionSize = 5,
+          expressionSize = 4,
           isGeography = false,
           mustInclude = "")
       }
@@ -98,7 +98,7 @@ class KnnJoinSuite extends TestBaseScala with TableDrivenPropertyChecks {
           df,
           numNeighbors = 3,
           useApproximate = true,
-          expressionSize = 5,
+          expressionSize = 4,
           isGeography = false,
           mustInclude = "")
       }
@@ -112,7 +112,7 @@ class KnnJoinSuite extends TestBaseScala with TableDrivenPropertyChecks {
         df,
         numNeighbors = 3,
         useApproximate = true,
-        expressionSize = 5,
+        expressionSize = 4,
         isGeography = false,
         mustInclude = "as int) <= 88))")
     }
@@ -124,7 +124,7 @@ class KnnJoinSuite extends TestBaseScala with TableDrivenPropertyChecks {
         df,
         numNeighbors = 3,
         useApproximate = true,
-        expressionSize = 5,
+        expressionSize = 4,
         isGeography = false,
         mustInclude = "= point))")
     }
@@ -136,7 +136,7 @@ class KnnJoinSuite extends TestBaseScala with TableDrivenPropertyChecks {
         df,
         numNeighbors = 3,
         useApproximate = true,
-        expressionSize = 5,
+        expressionSize = 4,
         isGeography = false,
         mustInclude = "= point))")
     }
@@ -148,7 +148,7 @@ class KnnJoinSuite extends TestBaseScala with TableDrivenPropertyChecks {
         df,
         numNeighbors = 3,
         useApproximate = true,
-        expressionSize = 5,
+        expressionSize = 4,
         isGeography = false,
         mustInclude = "")
     }
@@ -215,6 +215,12 @@ class KnnJoinSuite extends TestBaseScala with TableDrivenPropertyChecks {
       val resultAll = df.collect().sortBy(row => (row.getInt(0), row.getInt(1)))
       resultAll.length should be(8) // 2 queries (filtered out 1) and 4 neighbors each
       resultAll.mkString should be("[2,1][2,5][2,11][2,15][3,3][3,9][3,13][3,19]")
+    }
+
+    it("Should throw KNN predicate is not supported exception") {
+      intercept[Exception] {
+        sparkSession.sql("SELECT ST_KNN(ST_Point(0.0, 0.0), ST_Point(0.0, 0.0), 1)").show()
+      }
     }
   }
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-XXX. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?
This PR prevents users to spark optimizer to use ST_KNN or ST_AKNN is used as UDF.

## How was this patch tested?
KnnJoinSuite

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.
