### PR TITLE
[DOCS] pre-commit autoupdate; fix Python lint error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         args: [--ignore-words=.github/linters/codespell.txt]
         exclude: ^docs/image|^spark/common/src/test/resources|^docs/usecases|^tools/maven/scalafmt
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.10
+    rev: v0.6.5
     hooks:
       - id: ruff
         args: [--config=.github/linters/ruff.toml, --fix]

--- a/docs/usecases/contrib/PostgresqlConnectionApacheSedona.ipynb
+++ b/docs/usecases/contrib/PostgresqlConnectionApacheSedona.ipynb
@@ -215,11 +215,11 @@
    ],
    "source": [
     "%%timeit\n",
+    "from pandas import DataFrame\n",
     "cursor = connection.cursor()\n",
     "cursor.execute(\"SELECT * FROM clima.t_indices_prec_cpc t Where r100mm > 2000\")\n",
     "names = [ x[0] for x in cursor.description]\n",
     "result = cursor.fetchall()\n",
-    "from pandas import DataFrame\n",
     "df = DataFrame(result, columns=names)"
    ]
   },


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- No, this is a documentation update. The PR name follows the format `[DOCS] my subject`.

## What changes were proposed in this PR?

Updated the pre-commit hooks and fixed a Python lint error.

## How was this patch tested?

First updated the `pre-commit` config and then ran locally:

- `git add .`
- `pre-commit run --all-files`

which produced an error from `ruff` for Python `E402` seen in the image below:

![Screenshot from 2024-09-18 10-50-06](https://github.com/user-attachments/assets/bb2a8ee0-f16a-452f-8795-10a6f1b440ef)

Then fixed the lint error and ran:

- `git add .`
- `pre-commit run --all-files` again

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
