### PR TITLE
[DOCS] Fixed broken link

### DIFF
--- a/latest-snapshot/tutorial/sql/index.html
+++ b/latest-snapshot/tutorial/sql/index.html
@@ -4783,7 +4783,7 @@
 </div>
 </div>
 </div>
-<p>Detailed SedonaSQL APIs are available here: <a href="../../api/sql/Overview/">SedonaSQL API</a>. You can find example county data (i.e., <code>county_small.tsv</code>) in <a href="https://github.com/apache/sedona/tree/master/core/src/test/resources">Sedona GitHub repo</a>.</p>
+<p>Detailed SedonaSQL APIs are available here: <a href="../../api/sql/Overview/">SedonaSQL API</a>. You can find example county data (i.e., <code>county_small.tsv</code>) in <a href="https://github.com/apache/sedona/tree/master/spark/common/src/test/resources">Sedona GitHub repo</a>.</p>
 <h2 id="set-up-dependencies">Set up dependencies<a class="headerlink" href="#set-up-dependencies" title="Permanent link">&para;</a></h2>
 <div class="tabbed-set tabbed-alternate" data-tabs="2:2"><input checked="checked" id="__tabbed_2_1" name="__tabbed_2" type="radio" /><input id="__tabbed_2_2" name="__tabbed_2" type="radio" /><div class="tabbed-labels"><label for="__tabbed_2_1">Scala/Java</label><label for="__tabbed_2_2">Python</label></div>
 <div class="tabbed-content">


### PR DESCRIPTION
Replace the non-existent link https://github.com/apache/sedona/tree/master/core/src/test/resources

with the valid link

https://github.com/apache/sedona/tree/master/spark/common/src/test/resources



## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

- No, I haven't read it.

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-XXX. The PR name follows the format `[SEDONA-XXX] my subject`.

- No, this is a documentation update. The PR name follows the format `[DOCS] my subject`.


## What changes were proposed in this PR?


## How was this patch tested?


## Did this PR include necessary documentation updates?

- Yes, I am adding a new API. I am using the [current SNAPSHOT version number](https://github.com/apache/sedona/blob/99239524f17389fc4ae9548ea88756f8ea538bb9/pom.xml#L29) in `vX.Y.Z` format.
- Yes, I have updated the documentation.
- No, this PR does not affect any public API so no need to change the documentation.
