### PR TITLE
[DOCS] Update mkdocs.yml with code copying feature for website

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -149,6 +149,7 @@ theme:
     - search.highlight
     - search.share
     - navigation.footer
+    - content.code.copy
 extra:
   version:
     provider: mike


### PR DESCRIPTION

Add the following line in features to enable code copying feature:

- content.code.copy

The code sections should have  a copy button as the following attached image.

![code-copying feature](https://github.com/user-attachments/assets/4fd920e3-7018-4291-a5b6-6b26c1d9b55a)


