### PR TITLE
[DOCS] Add pre-commit hook `check-docstring-first`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
       - id: check-ast
       - id: check-builtin-literals
       - id: check-case-conflict
-      # - id: check-docstring-first
+      - id: check-docstring-first
       - id: check-executables-have-shebangs
       # - id: check-json
       - id: check-merge-conflict


### PR DESCRIPTION
https://github.com/pre-commit/pre-commit-hooks?tab=readme-ov-file#check-docstring-first


## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- No, this is a documentation update. The PR name follows the format `[DOCS] my subject`.

## What changes were proposed in this PR?

Adds another check/test to our pre-commit framework.

## How was this patch tested?

Ran locally:

`pre-commit run --all-files`

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
