### PR TITLE
[CI] Add pre-commit hook `gitleaks` to detect and prevent hardcoded secrets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,10 @@ repos:
         description: Check spelling with codespell
         args: [--ignore-words=.github/linters/codespell.txt]
         exclude: ^docs/image|^spark/common/src/test/resources|^docs/usecases|^tools/maven/scalafmt
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.20.1
+    hooks:
+      - id: gitleaks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:


### PR DESCRIPTION
https://github.com/gitleaks/gitleaks

Adding another check/test to our pre-commit framework.

gitleaks is a popular tool that helps with security.



## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-XXX. The PR name follows the format `[SEDONA-XXX] my subject`.

- No, this is a documentation update. The PR name follows the format `[DOCS] my subject`.


## What changes were proposed in this PR?

Added another pre-commit hook for testing.

## How was this patch tested?

Ran locally `pre-commit run --all-files`

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
