### PR TITLE
[CI] Enable `yamllint` rules `comments` and `comments-indentation`

### DIFF
--- a/.github/linters/.yaml-lint.yml
+++ b/.github/linters/.yaml-lint.yml
@@ -4,8 +4,6 @@ extends: default
 
 rules:
   colons: disable
-  comments: disable
-  comments-indentation: disable
   document-start: disable
   line-length: disable
   truthy: false

--- a/R/_pkgdown.yml
+++ b/R/_pkgdown.yml
@@ -3,7 +3,7 @@ template:
   bootstrap: 5
   # bootswatch: cosmo
   bslib:
-    #font_scale: 1.1
+    # font_scale: 1.1
     primary: "#ff6e42"
     light: "#ff6e42"
     navbar-light-color: "#fff"
@@ -13,7 +13,7 @@ template:
     # bg: "#fff"
 navbar:
   structure:
-   # left:  [intro, articles, reference, news]
+    # left: [intro, articles, reference, news]
     right: [search, github]
 home:
   sidebar:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -200,7 +200,7 @@ markdown_extensions:
   - pymdownx.tilde
 plugins:
   - search:
-    #prebuild_index: true
+  # prebuild_index: true
   - macros
   - git-revision-date-localized:
       type: datetime


### PR DESCRIPTION
https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.comments

https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.comments_indentation



## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- No.

## What changes were proposed in this PR?

Enabled checking for two more rules for our YAML linter.

## How was this patch tested?

Ran locally: `pre-commit run --all-files`

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
