### PR TITLE
[CI] Add pre-commit hook `bandit` to find Python security issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,11 @@ repos:
     hooks:
       - id: isort
         name: isort (python)
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.10
+    hooks:
+      - id: bandit
+        args: ["-c=pyproject.toml", "-r"]
   - repo: https://github.com/codespell-project/codespell
     rev: v2.3.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,5 @@
+[tool.bandit]
+skips = ["B101", "B403", "B405", "B608"]
+
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
https://github.com/PyCQA/bandit

https://bandit.readthedocs.io/en/latest/start.html#version-control-integration

https://bandit.readthedocs.io/en/latest/config.html

This PR is skipping four bandit tests.

https://bandit.readthedocs.io/en/latest/plugins/index.html#complete-test-plugin-listing



## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- No.

## What changes were proposed in this PR?

Added another check/test to our pre-commit framework.

Currently skipping 4 bandit checks and we can address these issues if needed in follow up PRs.

None of the 4 skipped checks were reported as high security.

B608 has been skipped it was reported as a possible medium

https://bandit.readthedocs.io/en/latest/plugins/b608_hardcoded_sql_expressions.html

Automated tools can produce false positives so we need to check each issue manually

## How was this patch tested?

Ran locally: `pre-commit run --all-files`

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
