### PR TITLE
[CI] Add pre-commit hook `requirements-txt-fixer` for Python requirem…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,6 +67,8 @@ repos:
       - id: forbid-submodules
       - id: mixed-line-ending
         exclude: \.csv$
+      - id: requirements-txt-fixer
+        files: ^docker/sedona-spark-jupyterlab/requirements\.txt$
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
         exclude: ^docs-overrides/main\.html$|\.Rd$

--- a/docker/sedona-spark-jupyterlab/requirements.txt
+++ b/docker/sedona-spark-jupyterlab/requirements.txt
@@ -1,8 +1,6 @@
 attrs
 descartes
 fiona==1.8.22
-pandas==1.5.3
-shapely==2.0.4
 geopandas==0.14.4
 ipykernel
 ipywidgets
@@ -10,5 +8,7 @@ jupyterlab==3.6.4
 jupyterlab-widgets==1.1.7
 keplergl==0.3.2
 matplotlib
-pydeck==0.8.0
 numpy<2
+pandas==1.5.3
+pydeck==0.8.0
+shapely==2.0.4


### PR DESCRIPTION
…ents files

https://github.com/pre-commit/pre-commit-hooks?tab=readme-ov-file#requirements-txt-fixer

refs https://github.com/apache/sedona/pull/1418

refs https://github.com/apache/sedona/pull/1349



## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- No.

## What changes were proposed in this PR?

Added another check/test to our pre-commit framework.

## How was this patch tested?

Ran locally: `pre-commit run --all-files`

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
