### PR TITLE
[SEDONA-665] Ping rasterio version to < 1.4.0 in Docker

### DIFF
--- a/docker/sedona-spark-jupyterlab/requirements.txt
+++ b/docker/sedona-spark-jupyterlab/requirements.txt
@@ -4,6 +4,7 @@ fiona==1.8.22
 pandas==1.5.3
 shapely==2.0.4
 geopandas==0.14.4
+rasterio==1.3.11
 ipykernel
 ipywidgets
 jupyterlab==3.6.4

--- a/docker/sedona-spark-jupyterlab/sedona-jupyterlab.dockerfile
+++ b/docker/sedona-spark-jupyterlab/sedona-jupyterlab.dockerfile
@@ -45,11 +45,12 @@ COPY ./ ${SEDONA_HOME}/
 RUN chmod +x ${SEDONA_HOME}/docker/spark.sh
 RUN chmod +x ${SEDONA_HOME}/docker/sedona.sh
 RUN ${SEDONA_HOME}/docker/spark.sh ${spark_version} ${hadoop_version} ${hadoop_s3_version} ${aws_sdk_version} ${spark_xml_version}
-RUN ${SEDONA_HOME}/docker/sedona.sh ${sedona_version} ${geotools_wrapper_version} ${spark_version} ${spark_extension_version}
 
 # Install Python dependencies
 COPY docker/sedona-spark-jupyterlab/requirements.txt /opt/requirements.txt
 RUN pip3 install -r /opt/requirements.txt
+
+RUN ${SEDONA_HOME}/docker/sedona.sh ${sedona_version} ${geotools_wrapper_version} ${spark_version} ${spark_extension_version}
 
 COPY docs/usecases/*.ipynb /opt/workspace/examples/
 COPY docs/usecases/*.py /opt/workspace/examples/


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-665. The PR name follows the format `[SEDONA-665] my subject`.


## What changes were proposed in this PR?

Ping rasterio version to < 1.4.0 in Docker.

Ubuntu 22.04 comes with GDAL 3.4.1 but rasterio 1.4.0+ requires GDAL 3.5. This leads to the failure of recent docker build.

## How was this patch tested?

Passed local tests

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
