### PR TITLE
[CI] Remove macos from Docker build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: ['ubuntu-latest', 'macos-12']
+        os: ['ubuntu-latest', 'macos-13']
         spark: ['3.5.1', '3.4.3', '3.3.4']
         include:
           - spark: 3.5.1
@@ -55,6 +55,7 @@ jobs:
       - name: Setup docker (missing on macOS)
         if: runner.os == 'macos'
         run: |
+          brew install --HEAD colima
           brew install docker
           colima start
           DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Setup docker (missing on macOS)
         if: runner.os == 'macos'
         run: |
-          brew install --HEAD colima
+          brew install colima
           brew install docker
           colima start
           DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: ['ubuntu-latest', 'macos-13']
+        os: ['ubuntu-latest']
         spark: ['3.5.1', '3.4.3', '3.3.4']
         include:
           - spark: 3.5.1


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`


## What changes were proposed in this PR?

1. `macos-12` is being deprecated by GitHub and starts to break sometimes: https://github.com/actions/runner-images/issues/10721
2. Recent QEMU release 9.10 breaks the Colima runtime on both macos and macos 13 (see https://github.com/douglascamata/setup-docker-macos-action/issues/37, and https://github.com/douglascamata/setup-docker-macos-action/issues/41).

After numerous attempts, the MacOS build sometimes can finish now but still occasionally crash. Therefore, this PR will remove macos build and we plan to add it back in the future.  

## How was this patch tested?

Passed CI

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
