### PR TITLE
[SEDONA-670] Fix GeoJSON reader for DBR

### DIFF
--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/geojson/GeoJSONFileFormat.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/geojson/GeoJSONFileFormat.scala
@@ -151,8 +151,8 @@ class GeoJSONFileFormat extends TextBasedFileFormat with DataSourceRegister {
         allowArrayAsStructs = true)
       val dataSource = JsonDataSource(parsedOptions)
 
-      dataSource
-        .readFile(broadcastedHadoopConf.value.value, file, parser, actualSchema)
+      SparkCompatUtil
+        .readFile(dataSource, broadcastedHadoopConf.value.value, file, parser, actualSchema)
         .map(row => {
           val newRow = GeoJSONUtils.convertGeoJsonToGeometry(row, alteredSchema)
           newRow


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-670. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

This PR works around an internal method incompatibility between open-source Apache Spark and DBR. The readFile method defined by open-source Apache Spark is:

```scala
def readFile(
  conf: Configuration,
  file: PartitionedFile,
  parser: JacksonParser,
  schema: StructType): Iterator[InternalRow]
```

While this function on DBR takes an extra `Option[_]` parameter:

```scala
def readFile(
  conf: Configuration,
  file: PartitionedFile,
  parser: JacksonParser,
  schema: StructType,
  badRecordsWriter: Option[BadRecordsWriter]): Iterator[InternalRow]
```

We workaround this problem by detecting the number of parameters of the `readFile` function using reflection, and pass the appropriate parameters to them.

## How was this patch tested?

Passing existing tests and manually tested on DBR 15.4 LTS.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
