### PR TITLE
[CI] Upgrade upload-artifact to v4

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -65,7 +65,7 @@ jobs:
           fi
       - run: mkdir staging
       - run: cp -r site/* staging/
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: generated-docs
           path: staging

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -94,7 +94,7 @@ jobs:
       - run: cp spark-shaded/target/sedona-*.jar staging
       - run: |
           [ -d "flink-shaded/target/" ] && cp flink-shaded/target/sedona-*.jar staging 2>/dev/null || true
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: generated-jars ${{ matrix.spark }} ${{ matrix.scala }} ${{ matrix.jdk }}
+          name: generated-jars_spark-${{ matrix.spark }}_scala-${{ matrix.scala }}_jdk-${{ matrix.jdk }}
           path: staging

--- a/.github/workflows/python-wheel.yml
+++ b/.github/workflows/python-wheel.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           platforms: all
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.20.0
+        uses: pypa/cibuildwheel@v2.21.3
         env:
           CIBW_SKIP: 'pp* *musl*'
           CIBW_ARCHS_LINUX: 'x86_64 aarch64'

--- a/.github/workflows/python-wheel.yml
+++ b/.github/workflows/python-wheel.yml
@@ -20,6 +20,7 @@ on:
       - 'spark-shaded/**'
       - 'pom.xml'
       - 'python/**'
+      - '.github/workflows/python-wheel.yml'
 
 jobs:
   build:

--- a/.github/workflows/python-wheel.yml
+++ b/.github/workflows/python-wheel.yml
@@ -46,6 +46,7 @@ jobs:
           CIBW_ARCHS_MACOS: 'x86_64 arm64'
         with:
           package-dir: python
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -122,7 +122,7 @@ jobs:
           cd ./R/tests
           NOT_CRAN='true' Rscript testthat.R
         shell: bash
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: Worker logs


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

> actions/upload-artifact@v3 is scheduled for deprecation on November 30, 2024. [Learn more.](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) Similarly, v1/v2 are scheduled for deprecation on June 30, 2024. Please update your workflow to use v4 of the artifact actions. This deprecation will not impact any existing versions of GitHub Enterprise Server being used by customers.

## What changes were proposed in this PR?

Use upload-artifact v4. The Python cross-platform build code was copied from cibuildwheel github example

## How was this patch tested?


## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
