### PR TITLE
[SEDONA-672] Bug fix for ST_LengthSpheroid 

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/sphere/Spheroid.java
+++ b/common/src/main/java/org/apache/sedona/common/sphere/Spheroid.java
@@ -27,6 +27,7 @@ import net.sf.geographiclib.PolygonResult;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.Polygon;
 
 public class Spheroid {
   // Standard EPSG Codes
@@ -79,7 +80,8 @@ public class Spheroid {
    */
   public static double length(Geometry geom) {
     String geomType = geom.getGeometryType();
-    if (geomType.equals("Polygon") || geomType.equals("LineString")) {
+    if (geomType.equals(Geometry.TYPENAME_LINEARRING)
+        || geomType.equals(Geometry.TYPENAME_LINESTRING)) {
       PolygonArea p = new PolygonArea(Geodesic.WGS84, true);
       Coordinate[] coordinates = geom.getCoordinates();
       for (int i = 0; i < coordinates.length; i++) {
@@ -89,9 +91,20 @@ public class Spheroid {
       }
       PolygonResult compute = p.Compute();
       return compute.perimeter;
-    } else if (geomType.equals("MultiPolygon")
-        || geomType.equals("MultiLineString")
-        || geomType.equals("GeometryCollection")) {
+    } else if (geomType.equals(Geometry.TYPENAME_POLYGON)) {
+      Polygon poly = (Polygon) geom;
+      double length = length(poly.getExteriorRing());
+
+      if (poly.getNumInteriorRing() > 0) {
+        for (int i = 0; i < poly.getNumInteriorRing(); i++) {
+          length += length(poly.getInteriorRingN(i));
+        }
+      }
+
+      return length;
+    } else if (geomType.equals(Geometry.TYPENAME_MULTIPOLYGON)
+        || geomType.equals(Geometry.TYPENAME_MULTILINESTRING)
+        || geomType.equals(Geometry.TYPENAME_GEOMETRYCOLLECTION)) {
       double length = 0.0;
       for (int i = 0; i < geom.getNumGeometries(); i++) {
         length += length(geom.getGeometryN(i));

--- a/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
@@ -1614,30 +1614,36 @@ public class FunctionsTest extends TestBase {
   }
 
   @Test
-  public void spheroidLength() {
+  public void spheroidLength() throws ParseException {
     Point point = GEOMETRY_FACTORY.createPoint(new Coordinate(90, 0));
-    assertEquals(0, Spheroid.length(point), 0.1);
+    assertEquals(0, Spheroid.length(point), FP_TOLERANCE2);
 
     LineString line = GEOMETRY_FACTORY.createLineString(coordArray(0, 0, 90, 0));
-    assertEquals(1.0018754171394622E7, Spheroid.length(line), 0.1);
+    assertEquals(1.0018754171394622E7, Spheroid.length(line), FP_TOLERANCE2);
 
     Polygon polygon = GEOMETRY_FACTORY.createPolygon(coordArray(0, 0, 90, 0, 0, 0));
-    assertEquals(2.0037508342789244E7, Spheroid.length(polygon), 0.1);
+    assertEquals(2.0037508342789244E7, Spheroid.length(polygon), FP_TOLERANCE2);
 
     MultiPoint multiPoint = GEOMETRY_FACTORY.createMultiPoint(new Point[] {point, point});
-    assertEquals(0, Spheroid.length(multiPoint), 0.1);
+    assertEquals(0, Spheroid.length(multiPoint), FP_TOLERANCE2);
 
     MultiLineString multiLineString =
         GEOMETRY_FACTORY.createMultiLineString(new LineString[] {line, line});
-    assertEquals(2.0037508342789244E7, Spheroid.length(multiLineString), 0.1);
+    assertEquals(2.0037508342789244E7, Spheroid.length(multiLineString), FP_TOLERANCE2);
 
     MultiPolygon multiPolygon =
         GEOMETRY_FACTORY.createMultiPolygon(new Polygon[] {polygon, polygon});
-    assertEquals(4.007501668557849E7, Spheroid.length(multiPolygon), 0.1);
+    assertEquals(4.007501668557849E7, Spheroid.length(multiPolygon), FP_TOLERANCE2);
 
     GeometryCollection geometryCollection =
         GEOMETRY_FACTORY.createGeometryCollection(new Geometry[] {point, line, multiLineString});
-    assertEquals(3.0056262514183864E7, Spheroid.length(geometryCollection), 0.1);
+    assertEquals(3.0056262514183864E7, Spheroid.length(geometryCollection), FP_TOLERANCE2);
+
+    Geometry polygonWithHole =
+        Constructors.geomFromWKT(
+            "POLYGON((-122.33 47.61, -122.32 47.62, -122.31 47.61, -122.30 47.62, -122.29 47.61, -122.30 47.60, -122.31 47.59, -122.32 47.60, -122.33 47.61), (-122.315 47.605, -122.305 47.615, -122.295 47.605, -122.305 47.595, -122.315 47.605))",
+            4326);
+    assertEquals(16106.506409488933, Spheroid.length(polygonWithHole), FP_TOLERANCE2);
   }
 
   @Test


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-672. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

ST_LengthSpheroid didn't consider Polygons with holes (interior rings). This bug fix addresses that issue.
Eg:

WKT:

```

POLYGON((-122.33 47.61, -122.32 47.62, -122.31 47.61, -122.30 47.62, -122.29 47.61, -122.30 47.60, -122.31 47.59, -122.32 47.60, -122.33 47.61), (-122.315 47.605, -122.305 47.615, -122.295 47.605, -122.305 47.595, -122.315 47.605))

```

old output:                   `17363.913692009628`

output after changes: `16106.506409488933`

## How was this patch tested?

- Passed CI

## Did this PR include necessary documentation updates?

- No, behavior stays the same for this function.