### PR TITLE
[SEDONA-675] Add ST_InterpolatePoint

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/Functions.java
+++ b/common/src/main/java/org/apache/sedona/common/Functions.java
@@ -2379,8 +2379,7 @@ public class Functions {
   }
 
   /**
-   * This function returns the m coordinate of the closest point in a LineString to a Point. If the
-   * LineString does not have M values, it will interpolate the M value.
+   * This function returns the m coordinate of the closest point in a LineString to the specified Point.
    *
    * @param geom1 The LineString (with or without M values) to be evaluated.
    * @param geom2 The Point object to find the closest point to.

--- a/common/src/main/java/org/apache/sedona/common/Functions.java
+++ b/common/src/main/java/org/apache/sedona/common/Functions.java
@@ -2379,7 +2379,8 @@ public class Functions {
   }
 
   /**
-   * This function returns the m coordinate of the closest point in a LineString to the specified Point.
+   * This function returns the m coordinate of the closest point in a LineString to the specified
+   * Point.
    *
    * @param geom1 The LineString (with or without M values) to be evaluated.
    * @param geom2 The Point object to find the closest point to.

--- a/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
@@ -4086,4 +4086,29 @@ public class FunctionsTest extends TestBase {
         "LINESTRING (0 0, -0.8390715290764524 -0.5440211108893698, -0.2950504181870827 -1.383092639965822, 0 0)",
         result);
   }
+
+  @Test
+  public void interpolatePoint() throws ParseException {
+    Geometry line = Constructors.geomFromEWKT("LINESTRING M (0 0 0, 2 0 2, 4 0 4)");
+    Geometry point = Constructors.geomFromEWKT("POINT(1 1)");
+
+    double actual = Functions.interpolatePoint(line, point);
+    double expected = 1.0;
+    assertEquals(expected, actual, 1e-6);
+
+    line = Constructors.geomFromEWKT("LINESTRING M (0 0 0, -2 2 2, -4 4 4)");
+    point = Constructors.geomFromEWKT("POINT(-1 1)");
+    actual = Functions.interpolatePoint(line, point);
+    assertEquals(expected, actual, 1e-6);
+
+    line = Constructors.geomFromEWKT("LINESTRING M (0 0 0, 2 2 2, 4 0 4)");
+    point = Constructors.geomFromEWKT("POINT(2 0)");
+    actual = Functions.interpolatePoint(line, point);
+    assertEquals(expected, actual, 1e-6);
+
+    point = Constructors.geomFromEWKT("POINT(2.5 1)");
+    actual = Functions.interpolatePoint(line, point);
+    expected = 2.75;
+    assertEquals(expected, actual, 1e-6);
+  }
 }

--- a/docs/api/flink/Function.md
+++ b/docs/api/flink/Function.md
@@ -2026,7 +2026,7 @@ Introduction: Returns the interpolated measure value of a linear measured LineSt
 
 Format: `ST_InterpolatePoint(linestringM: Geometry, point: Geometry)`
 
-Since: `v1.6.1`
+Since: `v1.7.0`
 
 SQL Example
 

--- a/docs/api/flink/Function.md
+++ b/docs/api/flink/Function.md
@@ -2017,6 +2017,32 @@ Output:
 LINEARRING (1 1, 2 1, 2 2, 1 2, 1 1)
 ```
 
+## ST_InterpolatePoint
+
+Introduction: Returns the interpolated measure value of a linear measured LineString at the point closest to the specified point.
+
+!!!Note
+    Make sure that both geometries have the same SRID, otherwise the function will throw an IllegalArgumentException.
+
+Format: `ST_InterpolatePoint(linestringM: Geometry, point: Geometry)`
+
+Since: `v1.6.1`
+
+SQL Example
+
+```sql
+SELECT ST_InterpolatePoint(
+    ST_GeomFromWKT("LINESTRING M (0 0 0, 2 0 2, 4 0 4)"),
+    ST_GeomFromWKT("POINT (1 1)")
+    )
+```
+
+Output:
+
+```
+1.0
+```
+
 ## ST_Intersection
 
 Introduction: Return the intersection geometry of A and B

--- a/docs/api/sql/Function.md
+++ b/docs/api/sql/Function.md
@@ -2032,7 +2032,7 @@ Introduction: Returns the interpolated measure value of a linear measured LineSt
 
 Format: `ST_InterpolatePoint(linestringM: Geometry, point: Geometry)`
 
-Since: `v1.6.1`
+Since: `v1.7.0`
 
 SQL Example
 

--- a/docs/api/sql/Function.md
+++ b/docs/api/sql/Function.md
@@ -2023,6 +2023,32 @@ Output:
 LINESTRING (1 1, 2 1, 2 2, 1 2, 1 1)
 ```
 
+## ST_InterpolatePoint
+
+Introduction: Returns the interpolated measure value of a linear measured LineString at the point closest to the specified point.
+
+!!!Note
+    Make sure that both geometries have the same SRID, otherwise the function will throw an IllegalArgumentException.
+
+Format: `ST_InterpolatePoint(linestringM: Geometry, point: Geometry)`
+
+Since: `v1.6.1`
+
+SQL Example
+
+```sql
+SELECT ST_InterpolatePoint(
+    ST_GeomFromWKT("LINESTRING M (0 0 0, 2 0 2, 4 0 4)"),
+    ST_GeomFromWKT("POINT (1 1)")
+    )
+```
+
+Output:
+
+```
+1.0
+```
+
 ## ST_Intersection
 
 Introduction: Return the intersection geometry of A and B

--- a/flink/src/main/java/org/apache/sedona/flink/Catalog.java
+++ b/flink/src/main/java/org/apache/sedona/flink/Catalog.java
@@ -88,6 +88,7 @@ public class Catalog {
       new Functions.ST_DelaunayTriangles(),
       new Functions.ST_EndPoint(),
       new Functions.ST_GeometryType(),
+      new Functions.ST_InterpolatePoint(),
       new Functions.ST_Intersection(),
       new Functions.ST_Length(),
       new Functions.ST_Length2D(),

--- a/flink/src/main/java/org/apache/sedona/flink/expressions/Functions.java
+++ b/flink/src/main/java/org/apache/sedona/flink/expressions/Functions.java
@@ -2068,4 +2068,15 @@ public class Functions {
       return org.apache.sedona.common.Functions.rotate(geom1, angle, originX, originY);
     }
   }
+
+  public static class ST_InterpolatePoint extends ScalarFunction {
+    @DataTypeHint("Double")
+    public double eval(
+        @DataTypeHint(value = "RAW", bridgedTo = Geometry.class) Object o1,
+        @DataTypeHint(value = "RAW", bridgedTo = Geometry.class) Object o2) {
+      Geometry geom1 = (Geometry) o1;
+      Geometry geom2 = (Geometry) o2;
+      return org.apache.sedona.common.Functions.interpolatePoint(geom1, geom2);
+    }
+  }
 }

--- a/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
@@ -2776,4 +2776,71 @@ public class FunctionTest extends TestBase {
         "POLYGON ((0.0700679430157733 0.5247497074078575, 2 0, 1.2974088252118154 1.227340882196042, 2.5247497074078575 1.9299320569842267, 0.5948176504236309 2.454681764392084, 1.2974088252118154 1.227340882196042, 0.0700679430157733 0.5247497074078575))";
     assertEquals(expected, actual);
   }
+
+  @Test
+  public void testInterpolatePoint() {
+    // Create a table with the test geometries
+    Table tbl =
+        tableEnv.sqlQuery(
+            "SELECT "
+                + "ST_GeomFromEWKT('LINESTRING M (0 0 0, 2 0 2, 4 0 4)') AS line1, "
+                + "ST_GeomFromEWKT('POINT(1 1)') AS point1, "
+                + "ST_GeomFromEWKT('LINESTRING M (0 0 0, -2 2 2, -4 4 4)') AS line2, "
+                + "ST_GeomFromEWKT('POINT(-1 1)') AS point2, "
+                + "ST_GeomFromEWKT('LINESTRING M (0 0 0, 2 2 2, 4 0 4)') AS line3, "
+                + "ST_GeomFromEWKT('POINT(2 0)') AS point3, "
+                + "ST_GeomFromEWKT('POINT(2.5 1)') AS point4");
+
+    double actual =
+        (double)
+            first(
+                    tbl.select(
+                            call(
+                                Functions.ST_InterpolatePoint.class.getSimpleName(),
+                                $("line1"),
+                                $("point1")))
+                        .as("result"))
+                .getField(0);
+    double expected = 1.0; // Closest point on line is (1, 0) and interpolated M is 1
+    assertEquals(expected, actual, 1e-6);
+
+    actual =
+        (double)
+            first(
+                    tbl.select(
+                            call(
+                                Functions.ST_InterpolatePoint.class.getSimpleName(),
+                                $("line2"),
+                                $("point2")))
+                        .as("result"))
+                .getField(0);
+    expected = 1.0; // Interpolated M value
+    assertEquals(expected, actual, 1e-6);
+
+    actual =
+        (double)
+            first(
+                    tbl.select(
+                            call(
+                                Functions.ST_InterpolatePoint.class.getSimpleName(),
+                                $("line3"),
+                                $("point3")))
+                        .as("result"))
+                .getField(0);
+    expected = 1.0; // Interpolated M value
+    assertEquals(expected, actual, 1e-6);
+
+    actual =
+        (double)
+            first(
+                    tbl.select(
+                            call(
+                                Functions.ST_InterpolatePoint.class.getSimpleName(),
+                                $("line3"),
+                                $("point4")))
+                        .as("result"))
+                .getField(0);
+    expected = 2.75;
+    assertEquals(expected, actual, 1e-6);
+  }
 }

--- a/python/sedona/sql/st_functions.py
+++ b/python/sedona/sql/st_functions.py
@@ -2392,6 +2392,7 @@ def ST_Rotate(
 
     return _call_st_function("ST_Rotate", args)
 
+
 @validate_argument_types
 def ST_InterpolatePoint(geom1: ColumnOrName, geom2: ColumnOrName) -> Column:
     """Returns the interpolated Measure value at the point on the given linestring M that is closest to the given point.

--- a/python/sedona/sql/st_functions.py
+++ b/python/sedona/sql/st_functions.py
@@ -2392,6 +2392,20 @@ def ST_Rotate(
 
     return _call_st_function("ST_Rotate", args)
 
+@validate_argument_types
+def ST_InterpolatePoint(geom1: ColumnOrName, geom2: ColumnOrName) -> Column:
+    """Returns the interpolated Measure value at the point on the given linestring M that is closest to the given point.
+
+    :param geom1: LineString M Geometry column or name.
+    :type geom1: ColumnOrName
+    :param geom2: Point Geometry column or name.
+    :type geom2: ColumnOrName
+    :rtype: Column
+    """
+
+    args = (geom1, geom2)
+    return _call_st_function("ST_InterpolatePoint", args)
+
 
 # Automatically populate __all__
 __all__ = [

--- a/python/tests/sql/test_dataframe_api.py
+++ b/python/tests/sql/test_dataframe_api.py
@@ -611,6 +611,7 @@ test_configurations = [
         "",
         "POLYGON ((2 0, 1 0, 1 1, 2 1, 2 0))",
     ),
+    (stf.ST_InterpolatePoint, ("linem", "point"), "linestringm_and_point", "", 1.0),
     (stf.ST_IsCollection, ("geom",), "geom_collection", "", True),
     (stf.ST_IsClosed, ("geom",), "closed_linestring_geom", "", True),
     (stf.ST_IsEmpty, ("geom",), "empty_geom", "", True),
@@ -1620,6 +1621,8 @@ class TestDataFrameAPI(TestBase):
             return TestDataFrameAPI.spark.sql(
                 "SELECT ST_GeomFromWKT('GEOMETRYCOLLECTION (LINESTRING (2 0, 2 1, 2 2), LINESTRING (2 2, 2 3, 2 4), LINESTRING (0 2, 1 2, 2 2), LINESTRING (2 2, 3 2, 4 2), LINESTRING (0 2, 1 3, 2 4), LINESTRING (2 4, 3 3, 4 2))') as geom"
             )
+        elif request.param == "linestringm_and_point":
+            return TestDataFrameAPI.spark.sql("SELECT ST_GeomFromWKT('LINESTRING M (0 0 0, 2 0 2, 4 0 4)') as linem, ST_GeomFromWKT('POINT (1 1)') as point")
         raise ValueError(f"Invalid base_df name passed: {request.param}")
 
     def _id_test_configuration(val):

--- a/python/tests/sql/test_dataframe_api.py
+++ b/python/tests/sql/test_dataframe_api.py
@@ -1622,7 +1622,9 @@ class TestDataFrameAPI(TestBase):
                 "SELECT ST_GeomFromWKT('GEOMETRYCOLLECTION (LINESTRING (2 0, 2 1, 2 2), LINESTRING (2 2, 2 3, 2 4), LINESTRING (0 2, 1 2, 2 2), LINESTRING (2 2, 3 2, 4 2), LINESTRING (0 2, 1 3, 2 4), LINESTRING (2 4, 3 3, 4 2))') as geom"
             )
         elif request.param == "linestringm_and_point":
-            return TestDataFrameAPI.spark.sql("SELECT ST_GeomFromWKT('LINESTRING M (0 0 0, 2 0 2, 4 0 4)') as linem, ST_GeomFromWKT('POINT (1 1)') as point")
+            return TestDataFrameAPI.spark.sql(
+                "SELECT ST_GeomFromWKT('LINESTRING M (0 0 0, 2 0 2, 4 0 4)') as linem, ST_GeomFromWKT('POINT (1 1)') as point"
+            )
         raise ValueError(f"Invalid base_df name passed: {request.param}")
 
     def _id_test_configuration(val):

--- a/spark/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
+++ b/spark/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry.FunctionBuilder
 import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression, ExpressionInfo, Literal}
 import org.apache.spark.sql.expressions.Aggregator
-import org.apache.spark.sql.sedona_sql.expressions._
+import org.apache.spark.sql.sedona_sql.expressions.{ST_InterpolatePoint, _}
 import org.apache.spark.sql.sedona_sql.expressions.collect.ST_Collect
 import org.apache.spark.sql.sedona_sql.expressions.raster._
 import org.locationtech.jts.geom.Geometry
@@ -150,6 +150,7 @@ object Catalog {
     function[ST_H3ToGeom](),
     function[ST_H3KRing](),
     function[ST_InteriorRingN](),
+    function[ST_InterpolatePoint](),
     function[ST_Dump](),
     function[ST_DumpPoints](),
     function[ST_IsClosed](),

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
@@ -1765,3 +1765,9 @@ case class ST_Rotate(inputExpressions: Seq[Expression])
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) =
     copy(inputExpressions = newChildren)
 }
+
+case class ST_InterpolatePoint(inputExpressions: Seq[Expression])
+    extends InferredExpression(inferrableFunction2(Functions.interpolatePoint)) {
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) =
+    copy(inputExpressions = newChildren)
+}

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/st_functions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/st_functions.scala
@@ -926,4 +926,10 @@ object st_functions extends DataFrameAPI {
 
   def ST_IsCollection(geometry: String): Column = wrapExpression[ST_IsCollection](geometry)
 
+  def ST_InterpolatePoint(geom1: Column, geom2: Column): Column =
+    wrapExpression[ST_InterpolatePoint](geom1, geom2)
+
+  def ST_InterpolatePoint(geom1: String, geom2: String): Column =
+    wrapExpression[ST_InterpolatePoint](geom1, geom2)
+
 }


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-675. The PR name follows the format `[SEDONA-XXX] my subject`.


## What changes were proposed in this PR?

- This PR implements ST_InterpolatePoint
- ST_InterpolatePoint returns the interpolated measure value of a linear measured LineString at the point closest to the specified point.

## How was this patch tested?

- Passes new and existing tests


## Did this PR include necessary documentation updates?

- Yes, I am adding a new API. I am using the [current SNAPSHOT version number](https://github.com/apache/sedona/blob/99239524f17389fc4ae9548ea88756f8ea538bb9/pom.xml#L29) in `vX.Y.Z` format.
