### PR TITLE
[SEDONA-678] Fix ST_Length and ST_Length2D behavior

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/Functions.java
+++ b/common/src/main/java/org/apache/sedona/common/Functions.java
@@ -457,8 +457,26 @@ public class Functions {
     return new Distance3DOp(left, right).distance();
   }
 
-  public static double length(Geometry geometry) {
+  public static double baseLength(Geometry geometry) {
     return geometry.getLength();
+  }
+
+  public static double length(Geometry geometry) {
+    String geomType = geometry.getGeometryType();
+    if (geomType.equalsIgnoreCase(Geometry.TYPENAME_LINESTRING)
+        || geomType.equalsIgnoreCase(Geometry.TYPENAME_POINT)
+        || geomType.equalsIgnoreCase(Geometry.TYPENAME_MULTIPOINT)
+        || geomType.equalsIgnoreCase(Geometry.TYPENAME_MULTILINESTRING)) {
+      return baseLength(geometry);
+    } else if (geomType.equalsIgnoreCase(Geometry.TYPENAME_GEOMETRYCOLLECTION)) {
+      double length = 0;
+      for (int i = 0; i < geometry.getNumGeometries(); i++) {
+        length += length(geometry.getGeometryN(i));
+      }
+      return length;
+    } else {
+      return 0;
+    }
   }
 
   public static Geometry normalize(Geometry geometry) {
@@ -1122,7 +1140,7 @@ public class Functions {
     if (use_spheroid) {
       return Spheroid.length(geometry);
     } else {
-      return length(geometry);
+      return baseLength(geometry);
     }
   }
 

--- a/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
@@ -1687,6 +1687,30 @@ public class FunctionsTest extends TestBase {
   }
 
   @Test
+  public void length() {
+    Point point = GEOMETRY_FACTORY.createPoint(new Coordinate(90, 0));
+    assertEquals(0, Functions.length(point), FP_TOLERANCE2);
+
+    LineString line = GEOMETRY_FACTORY.createLineString(coordArray(0, 0, 90, 0));
+    assertEquals(90.0, Functions.length(line), FP_TOLERANCE2);
+
+    Polygon polygon = GEOMETRY_FACTORY.createPolygon(coordArray(0, 0, 90, 0, 0, 0));
+    assertEquals(0.0, Functions.length(polygon), FP_TOLERANCE2);
+
+    MultiPoint multiPoint = GEOMETRY_FACTORY.createMultiPoint(new Point[] {point, point});
+    assertEquals(0, Functions.length(multiPoint), FP_TOLERANCE2);
+
+    MultiLineString multiLineString =
+        GEOMETRY_FACTORY.createMultiLineString(new LineString[] {line, line});
+    assertEquals(180.0, Functions.length(multiLineString), FP_TOLERANCE2);
+
+    GeometryCollection geometryCollection =
+        GEOMETRY_FACTORY.createGeometryCollection(
+            new Geometry[] {point, line, multiLineString, polygon});
+    assertEquals(270.0, Functions.length(geometryCollection), FP_TOLERANCE2);
+  }
+
+  @Test
   public void spheroidLength() throws ParseException {
     Point point = GEOMETRY_FACTORY.createPoint(new Coordinate(90, 0));
     assertEquals(0, Spheroid.length(point), FP_TOLERANCE2);

--- a/docs/api/flink/Function.md
+++ b/docs/api/flink/Function.md
@@ -2344,6 +2344,9 @@ false
 
 Introduction: Returns the perimeter of A.
 
+!!!Warning
+    Since `v1.7.0`, this function only supports LineString, MultiLineString, and GeometryCollections containing linear geometries. Use [ST_Perimeter](#st_perimeter) for polygons.
+
 Format: `ST_Length (A: Geometry)`
 
 Since: `v1.3.0`
@@ -2363,6 +2366,9 @@ Output:
 ## ST_Length2D
 
 Introduction: Returns the perimeter of A. This function is an alias of [ST_Length](#st_length).
+
+!!!Warning
+    Since `v1.7.0`, this function only supports LineString, MultiLineString, and GeometryCollections containing linear geometries. Use [ST_Perimeter](#st_perimeter) for polygons.
 
 Format: ST_Length2D (A:geometry)
 

--- a/docs/api/snowflake/vector-data/Function.md
+++ b/docs/api/snowflake/vector-data/Function.md
@@ -1706,6 +1706,9 @@ gid  |                  validity_info
 
 Introduction: Returns the perimeter of A.
 
+!!!Warning
+    This function only supports LineString, MultiLineString, and GeometryCollections containing linear geometries. Use [ST_Perimeter](#st_perimeter) for polygons.
+
 Format: ST_Length (A:geometry)
 
 SQL example:
@@ -1718,6 +1721,9 @@ FROM polygondf
 ## ST_Length2D
 
 Introduction: Returns the perimeter of A. This function is an alias of [ST_Length](#st_length).
+
+!!!Warning
+    This function only supports LineString, MultiLineString, and GeometryCollections containing linear geometries. Use [ST_Perimeter](#st_perimeter) for polygons.
 
 Format: ST_Length2D (A:geometry)
 

--- a/docs/api/sql/Function.md
+++ b/docs/api/sql/Function.md
@@ -2389,6 +2389,9 @@ false
 
 Introduction: Returns the perimeter of A.
 
+!!!Warning
+    Since `v1.7.0`, this function only supports LineString, MultiLineString, and GeometryCollections containing linear geometries. Use [ST_Perimeter](#st_perimeter) for polygons.
+
 Format: `ST_Length (A: Geometry)`
 
 Since: `v1.0.0`
@@ -2408,6 +2411,9 @@ Output:
 ## ST_Length2D
 
 Introduction: Returns the perimeter of A. This function is an alias of [ST_Length](#st_length).
+
+!!!Warning
+    Since `v1.7.0`, this function only supports LineString, MultiLineString, and GeometryCollections containing linear geometries. Use [ST_Perimeter](#st_perimeter) for polygons.
 
 Format: ST_Length2D (A:geometry)
 

--- a/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
@@ -632,23 +632,24 @@ public class FunctionTest extends TestBase {
 
   @Test
   public void testLength() {
-    Table polygonTable = createPolygonTable(1);
+    Table polygonTable = createLineStringTable(1);
     Table resultTable =
-        polygonTable.select(call(Functions.ST_Length.class.getSimpleName(), $(polygonColNames[0])));
+        polygonTable.select(
+            call(Functions.ST_Length.class.getSimpleName(), $(linestringColNames[0])));
     assertNotNull(first(resultTable).getField(0));
     double result = (double) first(resultTable).getField(0);
-    assertEquals(4, result, 0);
+    assertEquals(1.4142135623730951, result, FP_TOLERANCE);
   }
 
   @Test
   public void testLength2D() {
-    Table polygonTable = createPolygonTable(1);
+    Table polygonTable = createLineStringTable(1);
     Table resultTable =
         polygonTable.select(
-            call(Functions.ST_Length2D.class.getSimpleName(), $(polygonColNames[0])));
+            call(Functions.ST_Length2D.class.getSimpleName(), $(linestringColNames[0])));
     assertNotNull(first(resultTable).getField(0));
     double result = (double) first(resultTable).getField(0);
-    assertEquals(4, result, 0);
+    assertEquals(1.4142135623730951, result, FP_TOLERANCE);
   }
 
   @Test

--- a/python/tests/sql/test_function.py
+++ b/python/tests/sql/test_function.py
@@ -274,18 +274,16 @@ class TestPredicateJoin(TestBase):
         )
 
         polygon_wkt_df.createOrReplaceTempView("polygontable")
-        polygon_wkt_df.show()
 
         polygon_df = self.spark.sql(
             "select ST_GeomFromWKT(polygontable._c0) as countyshape from polygontable"
         )
         polygon_df.createOrReplaceTempView("polygondf")
-        polygon_df.show()
 
         function_df = self.spark.sql(
             "select ST_Length(polygondf.countyshape) from polygondf"
         )
-        function_df.show()
+        assert function_df.take(1)[0][0] == 0.0
 
     def test_st_length2d(self):
         polygon_wkt_df = (
@@ -305,7 +303,7 @@ class TestPredicateJoin(TestBase):
         function_df = self.spark.sql(
             "select ST_Length2D(polygondf.countyshape) from polygondf"
         )
-        assert function_df.take(1)[0][0] == 1.6244272911181594
+        assert function_df.take(1)[0][0] == 0.0
 
     def test_st_area(self):
         polygon_wkt_df = (

--- a/python/tests/streaming/spark/test_constructor_functions.py
+++ b/python/tests/streaming/spark/test_constructor_functions.py
@@ -92,7 +92,7 @@ SEDONA_LISTED_SQL_FUNCTIONS = [
         SuiteContainer.empty()
         .with_function_name("ST_LENGTH")
         .with_arguments(
-            ["ST_GeomFromText('POLYGON ((21 52, 21 53, 22 53, 22 52, 21 52))')"]
+            ["ST_GeomFromText('LINESTRING (21 52, 21 53, 22 53, 22 52, 21 52)')"]
         )
         .with_expected_result(4.0)
     ),


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-678. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

- Removes support for polygonal geometries in ST_Length and ST_Length2D
- ST_Perimeter is for Polygonal geometries.

## How was this patch tested?

- Passed CI

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.
