### PR TITLE
[SEDONA-679] Fix ST_LengthSpheroid behavior

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/Functions.java
+++ b/common/src/main/java/org/apache/sedona/common/Functions.java
@@ -1120,7 +1120,7 @@ public class Functions {
 
   private static double calculateLength(Geometry geometry, boolean use_spheroid) {
     if (use_spheroid) {
-      return Spheroid.length(geometry);
+      return Spheroid.baseLength(geometry);
     } else {
       return length(geometry);
     }

--- a/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
@@ -1695,7 +1695,7 @@ public class FunctionsTest extends TestBase {
     assertEquals(1.0018754171394622E7, Spheroid.length(line), FP_TOLERANCE2);
 
     Polygon polygon = GEOMETRY_FACTORY.createPolygon(coordArray(0, 0, 90, 0, 0, 0));
-    assertEquals(2.0037508342789244E7, Spheroid.length(polygon), FP_TOLERANCE2);
+    assertEquals(0.0, Spheroid.length(polygon), FP_TOLERANCE2);
 
     MultiPoint multiPoint = GEOMETRY_FACTORY.createMultiPoint(new Point[] {point, point});
     assertEquals(0, Spheroid.length(multiPoint), FP_TOLERANCE2);
@@ -1706,17 +1706,44 @@ public class FunctionsTest extends TestBase {
 
     MultiPolygon multiPolygon =
         GEOMETRY_FACTORY.createMultiPolygon(new Polygon[] {polygon, polygon});
-    assertEquals(4.007501668557849E7, Spheroid.length(multiPolygon), FP_TOLERANCE2);
+    assertEquals(0.0, Spheroid.length(multiPolygon), FP_TOLERANCE2);
 
     GeometryCollection geometryCollection =
         GEOMETRY_FACTORY.createGeometryCollection(new Geometry[] {point, line, multiLineString});
     assertEquals(3.0056262514183864E7, Spheroid.length(geometryCollection), FP_TOLERANCE2);
+  }
+
+  @Test
+  public void spheroidBaseLength() throws ParseException {
+    Point point = GEOMETRY_FACTORY.createPoint(new Coordinate(90, 0));
+    assertEquals(0, Spheroid.baseLength(point), FP_TOLERANCE2);
+
+    LineString line = GEOMETRY_FACTORY.createLineString(coordArray(0, 0, 90, 0));
+    assertEquals(1.0018754171394622E7, Spheroid.baseLength(line), FP_TOLERANCE2);
+
+    Polygon polygon = GEOMETRY_FACTORY.createPolygon(coordArray(0, 0, 90, 0, 0, 0));
+    assertEquals(2.0037508342789244E7, Spheroid.baseLength(polygon), FP_TOLERANCE2);
+
+    MultiPoint multiPoint = GEOMETRY_FACTORY.createMultiPoint(new Point[] {point, point});
+    assertEquals(0, Spheroid.baseLength(multiPoint), FP_TOLERANCE2);
+
+    MultiLineString multiLineString =
+        GEOMETRY_FACTORY.createMultiLineString(new LineString[] {line, line});
+    assertEquals(2.0037508342789244E7, Spheroid.baseLength(multiLineString), FP_TOLERANCE2);
+
+    MultiPolygon multiPolygon =
+        GEOMETRY_FACTORY.createMultiPolygon(new Polygon[] {polygon, polygon});
+    assertEquals(4.007501668557849E7, Spheroid.baseLength(multiPolygon), FP_TOLERANCE2);
+
+    GeometryCollection geometryCollection =
+        GEOMETRY_FACTORY.createGeometryCollection(new Geometry[] {point, line, multiLineString});
+    assertEquals(3.0056262514183864E7, Spheroid.baseLength(geometryCollection), FP_TOLERANCE2);
 
     Geometry polygonWithHole =
         Constructors.geomFromWKT(
             "POLYGON((-122.33 47.61, -122.32 47.62, -122.31 47.61, -122.30 47.62, -122.29 47.61, -122.30 47.60, -122.31 47.59, -122.32 47.60, -122.33 47.61), (-122.315 47.605, -122.305 47.615, -122.295 47.605, -122.305 47.595, -122.315 47.605))",
             4326);
-    assertEquals(16106.506409488933, Spheroid.length(polygonWithHole), FP_TOLERANCE2);
+    assertEquals(16106.506409488933, Spheroid.baseLength(polygonWithHole), FP_TOLERANCE2);
   }
 
   @Test

--- a/docs/api/flink/Function.md
+++ b/docs/api/flink/Function.md
@@ -2389,6 +2389,9 @@ Geometry must be in EPSG:4326 (WGS84) projection and must be in ==lon/lat== orde
 !!!note
     By default, this function uses lon/lat order since `v1.5.0`. Before, it used lat/lon order.
 
+!!!Warning
+    Since `v1.7.0`, this function only supports LineString, MultiLineString, and GeometryCollections containing linear geometries. Use [ST_Perimeter](#st_perimeter) for polygons.
+
 Format: `ST_LengthSpheroid (A: Geometry)`
 
 Since: `v1.4.1`
@@ -2396,13 +2399,13 @@ Since: `v1.4.1`
 Example:
 
 ```sql
-SELECT ST_LengthSpheroid(ST_GeomFromWKT('Polygon ((0 0, 90 0, 0 0))'))
+SELECT ST_LengthSpheroid(ST_GeomFromWKT('LINESTRING (0 0, 2 0)'))
 ```
 
 Output:
 
 ```
-20037508.342789244
+222638.98158654713
 ```
 
 ## ST_LineFromMultiPoint

--- a/docs/api/snowflake/vector-data/Function.md
+++ b/docs/api/snowflake/vector-data/Function.md
@@ -1734,15 +1734,22 @@ Introduction: Return the geodesic perimeter of A using WGS84 spheroid. Unit is m
 
 Geometry must be in EPSG:4326 (WGS84) projection and must be in ==lat/lon== order. You can use ==ST_FlipCoordinates== to swap lat and lon.
 
+!!!Warning
+    This function only supports LineString, MultiLineString, and GeometryCollections containing linear geometries. Use [ST_Perimeter](#st_perimeter) for polygons.
+
 Format: `ST_LengthSpheroid (A:geometry)`
 
 SQL example:
 
 ```sql
-SELECT ST_LengthSpheroid(ST_GeomFromWKT('Polygon ((0 0, 0 90, 0 0))'))
+SELECT ST_LengthSpheroid(ST_GeomFromWKT('LINESTRING (0 0, 2 0)'))
 ```
 
-Output: `20037508.342789244`
+Output:
+
+```
+222638.98158654713
+```
 
 ## ST_LineFromMultiPoint
 

--- a/docs/api/sql/Function.md
+++ b/docs/api/sql/Function.md
@@ -2434,6 +2434,9 @@ Geometry must be in EPSG:4326 (WGS84) projection and must be in ==lon/lat== orde
 !!!note
     By default, this function uses lon/lat order since `v1.5.0`. Before, it used lat/lon order.
 
+!!!Warning
+    Since `v1.7.0`, this function only supports LineString, MultiLineString, and GeometryCollections containing linear geometries. Use [ST_Perimeter](#st_perimeter) for polygons.
+
 Format: `ST_LengthSpheroid (A: Geometry)`
 
 Since: `v1.4.1`
@@ -2441,13 +2444,13 @@ Since: `v1.4.1`
 SQL Example
 
 ```sql
-SELECT ST_LengthSpheroid(ST_GeomFromWKT('Polygon ((0 0, 90 0, 0 0))'))
+SELECT ST_LengthSpheroid(ST_GeomFromWKT('LINESTRING (0 0, 2 0)'))
 ```
 
 Output:
 
 ```
-20037508.342789244
+222638.98158654713
 ```
 
 ## ST_LineFromMultiPoint

--- a/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
@@ -654,8 +654,8 @@ public class FunctionTest extends TestBase {
   @Test
   public void testLengthSpheroid() {
     Table tbl =
-        tableEnv.sqlQuery("SELECT ST_LengthSpheroid(ST_GeomFromWKT('Polygon ((0 0, 90 0, 0 0))'))");
-    Double expected = 20037508.342789244;
+        tableEnv.sqlQuery("SELECT ST_LengthSpheroid(ST_GeomFromWKT('LINESTRING (0 0, 2 0)'))");
+    Double expected = 222638.98158654713;
     Double actual = (Double) first(tbl).getField(0);
     assertEquals(expected, actual, 0.1);
   }

--- a/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctions.java
+++ b/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctions.java
@@ -1190,8 +1190,8 @@ public class TestFunctions extends TestBase {
   public void test_ST_LengthSpheroid() {
     registerUDF("ST_LengthSpheroid", byte[].class);
     verifySqlSingleRes(
-        "select sedona.ST_LengthSpheroid(sedona.ST_GeomFromWKT('Polygon ((0 0, 90 0, 0 0))'))",
-        20037508.342789244);
+        "select CEIL(sedona.ST_LengthSpheroid(sedona.ST_GeomFromWKT('LINESTRING (0 0, 2 0)')))",
+            222639.0);
   }
 
   @Test

--- a/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctions.java
+++ b/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctions.java
@@ -1191,7 +1191,7 @@ public class TestFunctions extends TestBase {
     registerUDF("ST_LengthSpheroid", byte[].class);
     verifySqlSingleRes(
         "select CEIL(sedona.ST_LengthSpheroid(sedona.ST_GeomFromWKT('LINESTRING (0 0, 2 0)')))",
-            222639.0);
+        222639.0);
   }
 
   @Test

--- a/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctionsV2.java
+++ b/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctionsV2.java
@@ -1142,8 +1142,7 @@ public class TestFunctionsV2 extends TestBase {
   public void test_ST_LengthSpheroid() {
     registerUDFV2("ST_LengthSpheroid", String.class);
     verifySqlSingleRes(
-        "select CEIL(sedona.ST_LengthSpheroid(ST_GeomFromWKT('LINESTRING (0 0, 2 0)')))",
-            222639.0);
+        "select CEIL(sedona.ST_LengthSpheroid(ST_GeomFromWKT('LINESTRING (0 0, 2 0)')))", 222639.0);
   }
 
   @Test

--- a/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctionsV2.java
+++ b/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctionsV2.java
@@ -1142,8 +1142,8 @@ public class TestFunctionsV2 extends TestBase {
   public void test_ST_LengthSpheroid() {
     registerUDFV2("ST_LengthSpheroid", String.class);
     verifySqlSingleRes(
-        "select sedona.ST_LengthSpheroid(ST_GeomFromWKT('Polygon ((0 0, 90 0, 90 90, 0 90, 0 0))'))",
-        30022685.630020067);
+        "select CEIL(sedona.ST_LengthSpheroid(ST_GeomFromWKT('LINESTRING (0 0, 2 0)')))",
+            222639.0);
   }
 
   @Test

--- a/spark/common/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
@@ -2891,7 +2891,7 @@ class functionTestScala
     val geomTestCases = Map(
       ("'POINT (-0.56 51.3168)'") -> "0.0",
       ("'LineString (0 0, 90 0)'") -> "10018754.17139462",
-      ("'Polygon ((0 0, 90 0, 0 0))'") -> "20037508.34278924")
+      ("'Polygon ((0 0, 90 0, 0 0))'") -> "0.0")
     for (((geom1), expectedResult) <- geomTestCases) {
       val df = sparkSession.sql(
         s"SELECT ST_LengthSpheroid(ST_GeomFromWKT($geom1)), " +


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-679. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

- Removes support for polygonal geometries in ST_Length and ST_Length2D
- ST_Perimeter is for Polygonal geometries.

## How was this patch tested?

- Passed CI

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.