### PR TITLE
[CI] Auto add license to Makefiles with pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,15 @@ repos:
     rev: v1.5.5
     hooks:
       - id: insert-license
+        name: Add license for all Makefile files
+        files: ^Makefile$
+        args:
+          - --comment-style
+          - "|#|"
+          - --license-filepath
+          - .github/workflows/license-templates/LICENSE.txt
+          - --fuzzy-match-generates-todo
+      - id: insert-license
         name: Add license for all TOML files
         files: \.toml$
         args:

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 check :
 	pre-commit run --all-files
 .PHONY : check


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- No:
   - this is a CI update. The PR name follows the format `[CI] my subject`


## What changes were proposed in this PR?

Using pre-commit to auto add license headers to all Makefile files.

refs #1657 
refs #1674 
refs #1647 

## How was this patch tested?

Ran `pre-commit run --all-files` before and after the license headers were added.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
