### PR TITLE
[DOCS] Add `codespell` to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,7 @@
 
 [tool.bandit]
 skips = ["B101", "B403", "B405", "B608"]
+
+[tool.codespell]
+ignore-words = '.github/linters/codespell.txt'
+skip = './docs/image,./docs/usecases,./site,./spark/common/src/test/resources,./tools/maven/scalafmt.conf'


### PR DESCRIPTION
https://github.com/codespell-project/codespell?tab=readme-ov-file#using-a-config-file

This file has mainly be added for convenience for when running codespell directly on the repo root.

So if you have codespell installed locally you can run `codespell` and it will use the config settings.


## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- No

## What changes were proposed in this PR?


## How was this patch tested?

Ran `codespell` from the repo root.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
