### PR TITLE
[DOCS] Bump Sedona Python, R and Zeppelin version to 1.7.0

### DIFF
--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: apache.sedona
 Title: R Interface for Apache Sedona
-Version: 1.6.1
+Version: 1.7.0
 Authors@R:
     c(person(family = "Apache Sedona",
              role = c("aut", "cre"),

--- a/R/R/dependencies.R
+++ b/R/R/dependencies.R
@@ -25,7 +25,7 @@ spark_dependencies <- function(spark_version, scala_version, ...) {
   }
 
   packages <- c(
-    "org.datasyslab:geotools-wrapper:1.6.1-28.2"
+    "org.datasyslab:geotools-wrapper:1.7.0-28.5"
   )
   jars <- NULL
 
@@ -38,7 +38,7 @@ spark_dependencies <- function(spark_version, scala_version, ...) {
       paste0(
         "org.apache.sedona:sedona-",
         c("spark-shaded"),
-        sprintf("-%s_%s:1.6.1", spark_version, scala_version)
+        sprintf("-%s_%s:1.7.0", spark_version, scala_version)
       ),
       packages
     )

--- a/python/sedona/version.py
+++ b/python/sedona/version.py
@@ -15,4 +15,4 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-version = "1.6.1"
+version = "1.7.0"

--- a/zeppelin/package.json
+++ b/zeppelin/package.json
@@ -2,7 +2,7 @@
   "name": "apache-sedona",
   "description": "Zeppelin visualization support for Sedona",
   "author": "Apache Sedona, original authors are listed on https://github.com/myuwono/zeppelin-leaflet",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?


- No:
  - this is a documentation update. The PR name follows the format `[DOCS] my subject`


## What changes were proposed in this PR?


## How was this patch tested?

Bump versions to 1.7.0

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
