### PR TITLE
[SEDONA-682] Sedona Spark 3.3 does not compile on Scala 2.13

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -82,6 +82,10 @@ jobs:
             jdk: '11'
             skipTests: ''
           - spark: 3.3.0
+            scala: 2.13.8
+            jdk: '8'
+            skipTests: ''
+          - spark: 3.3.0
             scala: 2.12.15
             jdk: '8'
             skipTests: ''

--- a/spark/spark-3.3/src/main/scala/org/apache/sedona/sql/datasources/geopackage/GeoPackageScanBuilder.scala
+++ b/spark/spark-3.3/src/main/scala/org/apache/sedona/sql/datasources/geopackage/GeoPackageScanBuilder.scala
@@ -18,15 +18,14 @@
  */
 package org.apache.sedona.sql.datasources.geopackage
 
-import org.apache.sedona.sql.datasources.geopackage.model.{GeoPackageLoadOptions, GeoPackageOptions}
+import org.apache.sedona.sql.datasources.geopackage.model.GeoPackageOptions
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connector.read.Scan
-import org.apache.spark.sql.execution.datasources.{InMemoryFileIndex, PartitioningAwareFileIndex}
 import org.apache.spark.sql.execution.datasources.v2.FileScanBuilder
+import org.apache.spark.sql.execution.datasources.{InMemoryFileIndex, PartitioningAwareFileIndex}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
-
-import scala.jdk.CollectionConverters.mapAsScalaMapConverter
+import scala.jdk.CollectionConverters._
 
 class GeoPackageScanBuilder(
     sparkSession: SparkSession,


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-XXX. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Make the source code compile on Spark 3.3 and enable CI to compile it

## How was this patch tested?

Passed local tests

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
