### PR TITLE
[SEDONA-684] DBSCAN: allow epsilon = 0

### DIFF
--- a/spark/common/src/main/scala/org/apache/sedona/stats/clustering/DBSCAN.scala
+++ b/spark/common/src/main/scala/org/apache/sedona/stats/clustering/DBSCAN.scala
@@ -141,7 +141,7 @@ object DBSCAN {
       epsilon: Double,
       minPts: Int,
       geometry: String): Unit = {
-    require(epsilon > 0, "epsilon must be greater than 0")
+    require(epsilon >= 0, "epsilon must not be negative")
     require(minPts > 0, "minPts must be greater than 0")
     require(geo_df.columns.contains(geometry), "geometry column not found in dataframe")
     require(


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-684. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?
Allowing epsilon to equal 0 in DBSCAN

## How was this patch tested?
Unit tests

## Did this PR include necessary documentation updates?
- Yes, I have updated the documentation.

These limits are not explicit in the docs so there is no change there. However the error message has been updated in the code. 
