### PR TITLE
[DOCS] Standardize Javadoc comments for links

### DIFF
--- a/spark/common/src/main/java/org/apache/sedona/core/spatialPartitioning/KDB.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/spatialPartitioning/KDB.java
@@ -33,7 +33,10 @@ import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Point;
 import scala.Tuple2;
 
-/** see https://en.wikipedia.org/wiki/K-D-B-tree */
+/**
+ * see <a
+ * href="https://en.wikipedia.org/wiki/K-D-B-tree">https://en.wikipedia.org/wiki/K-D-B-tree</a>
+ */
 public class KDB extends PartitioningUtils implements Serializable {
 
   private final int maxItemsPerNode;

--- a/spark/common/src/test/java/org/apache/sedona/core/spatialOperator/JoinQueryDeduplicationTest.java
+++ b/spark/common/src/test/java/org/apache/sedona/core/spatialOperator/JoinQueryDeduplicationTest.java
@@ -43,7 +43,10 @@ public class JoinQueryDeduplicationTest extends TestBase {
     sc.stop();
   }
 
-  /** See https://issues.apache.org/jira/browse/SEDONA-233 */
+  /**
+   * See <a
+   * href="https://issues.apache.org/jira/browse/SEDONA-233">https://issues.apache.org/jira/browse/SEDONA-233</a>
+   */
   @Test
   public void testDeduplication() throws Exception {
     SpatialRDD<Geometry> leftRDD = new SpatialRDD<>();


### PR DESCRIPTION
https://stackoverflow.com/questions/1082050/linking-to-an-external-url-in-javadoc

Was using IntelliJ IDE and these minor Javadoc issues were listed.

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- No:
  - this is a documentation update. The PR name follows the format `[DOCS] my subject`

## What changes were proposed in this PR?

Small clean up of Javadoc comments.

## How was this patch tested?


## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
