### PR TITLE
[SEDONA-690] Optimize query side broadcast knn join

### DIFF
--- a/spark/common/src/main/java/org/apache/sedona/core/knnJudgement/EuclideanItemDistance.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/knnJudgement/EuclideanItemDistance.java
@@ -36,4 +36,12 @@ public class EuclideanItemDistance implements ItemDistance {
       return g1.distance(g2);
     }
   }
+
+  public double distance(Geometry geometry1, Geometry geometry2) {
+    if (geometry1 == geometry2) {
+      return Double.MAX_VALUE;
+    } else {
+      return geometry1.distance(geometry2);
+    }
+  }
 }

--- a/spark/common/src/main/java/org/apache/sedona/core/knnJudgement/HaversineItemDistance.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/knnJudgement/HaversineItemDistance.java
@@ -37,4 +37,12 @@ public class HaversineItemDistance implements ItemDistance {
       return Haversine.distance(g1, g2);
     }
   }
+
+  public double distance(Geometry geometry1, Geometry geometry2) {
+    if (geometry1 == geometry2) {
+      return Double.MAX_VALUE;
+    } else {
+      return Haversine.distance(geometry1, geometry2);
+    }
+  }
 }

--- a/spark/common/src/main/java/org/apache/sedona/core/knnJudgement/SpheroidDistance.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/knnJudgement/SpheroidDistance.java
@@ -37,4 +37,12 @@ public class SpheroidDistance implements ItemDistance {
       return Spheroid.distance(g1, g2);
     }
   }
+
+  public double distance(Geometry geometry1, Geometry geometry2) {
+    if (geometry1 == geometry2) {
+      return Double.MAX_VALUE;
+    } else {
+      return Spheroid.distance(geometry1, geometry2);
+    }
+  }
 }

--- a/spark/common/src/main/java/org/apache/sedona/core/wrapper/UniqueGeometry.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/wrapper/UniqueGeometry.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.core.wrapper;
+
+import java.util.UUID;
+import org.apache.commons.lang3.NotImplementedException;
+import org.locationtech.jts.geom.*;
+
+public class UniqueGeometry<T> extends Geometry {
+  private final T originalGeometry;
+  private final String uniqueId;
+
+  public UniqueGeometry(T originalGeometry) {
+    super(new GeometryFactory());
+    this.originalGeometry = originalGeometry;
+    this.uniqueId = UUID.randomUUID().toString();
+  }
+
+  public T getOriginalGeometry() {
+    return originalGeometry;
+  }
+
+  public String getUniqueId() {
+    return uniqueId;
+  }
+
+  @Override
+  public int hashCode() {
+    return uniqueId.hashCode(); // Uniqueness ensured by uniqueId
+  }
+
+  @Override
+  public String getGeometryType() {
+    throw new NotImplementedException("getGeometryType is not implemented.");
+  }
+
+  @Override
+  public Coordinate getCoordinate() {
+    throw new NotImplementedException("getCoordinate is not implemented.");
+  }
+
+  @Override
+  public Coordinate[] getCoordinates() {
+    throw new NotImplementedException("getCoordinates is not implemented.");
+  }
+
+  @Override
+  public int getNumPoints() {
+    throw new NotImplementedException("getNumPoints is not implemented.");
+  }
+
+  @Override
+  public boolean isEmpty() {
+    throw new NotImplementedException("isEmpty is not implemented.");
+  }
+
+  @Override
+  public int getDimension() {
+    throw new NotImplementedException("getDimension is not implemented.");
+  }
+
+  @Override
+  public Geometry getBoundary() {
+    throw new NotImplementedException("getBoundary is not implemented.");
+  }
+
+  @Override
+  public int getBoundaryDimension() {
+    throw new NotImplementedException("getBoundaryDimension is not implemented.");
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if (obj == null || getClass() != obj.getClass()) return false;
+    UniqueGeometry<?> that = (UniqueGeometry<?>) obj;
+    return uniqueId.equals(that.uniqueId);
+  }
+
+  @Override
+  public String toString() {
+    return "UniqueGeometry{"
+        + "originalGeometry="
+        + originalGeometry
+        + ", uniqueId='"
+        + uniqueId
+        + '\''
+        + '}';
+  }
+
+  @Override
+  protected Geometry reverseInternal() {
+    throw new NotImplementedException("reverseInternal is not implemented.");
+  }
+
+  @Override
+  public boolean equalsExact(Geometry geometry, double v) {
+    throw new NotImplementedException("equalsExact is not implemented.");
+  }
+
+  @Override
+  public void apply(CoordinateFilter coordinateFilter) {
+    throw new NotImplementedException("apply(CoordinateFilter) is not implemented.");
+  }
+
+  @Override
+  public void apply(CoordinateSequenceFilter coordinateSequenceFilter) {
+    throw new NotImplementedException("apply(CoordinateSequenceFilter) is not implemented.");
+  }
+
+  @Override
+  public void apply(GeometryFilter geometryFilter) {
+    throw new NotImplementedException("apply(GeometryFilter) is not implemented.");
+  }
+
+  @Override
+  public void apply(GeometryComponentFilter geometryComponentFilter) {
+    throw new NotImplementedException("apply(GeometryComponentFilter) is not implemented.");
+  }
+
+  @Override
+  protected Geometry copyInternal() {
+    throw new NotImplementedException("copyInternal is not implemented.");
+  }
+
+  @Override
+  public void normalize() {
+    throw new NotImplementedException("normalize is not implemented.");
+  }
+
+  @Override
+  protected Envelope computeEnvelopeInternal() {
+    throw new NotImplementedException("computeEnvelopeInternal is not implemented.");
+  }
+
+  @Override
+  protected int compareToSameClass(Object o) {
+    throw new NotImplementedException("compareToSameClass(Object) is not implemented.");
+  }
+
+  @Override
+  protected int compareToSameClass(
+      Object o, CoordinateSequenceComparator coordinateSequenceComparator) {
+    throw new NotImplementedException(
+        "compareToSameClass(Object, CoordinateSequenceComparator) is not implemented.");
+  }
+
+  @Override
+  protected int getTypeCode() {
+    throw new NotImplementedException("getTypeCode is not implemented.");
+  }
+}

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/BroadcastObjectSideKNNJoinExec.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/BroadcastObjectSideKNNJoinExec.scala
@@ -120,7 +120,7 @@ case class BroadcastObjectSideKNNJoinExec(
       sedonaConf: SedonaConf): Unit = {
     require(numPartitions > 0, "The number of partitions must be greater than 0.")
     val kValue: Int = this.k.eval().asInstanceOf[Int]
-    require(kValue > 0, "The number of neighbors must be greater than 0.")
+    require(kValue >= 1, "The number of neighbors (k) must be equal or greater than 1.")
     objectsShapes.setNeighborSampleNumber(kValue)
     broadcastJoin = true
   }

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/BroadcastQuerySideKNNJoinExec.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/BroadcastQuerySideKNNJoinExec.scala
@@ -127,7 +127,7 @@ case class BroadcastQuerySideKNNJoinExec(
       sedonaConf: SedonaConf): Unit = {
     require(numPartitions > 0, "The number of partitions must be greater than 0.")
     val kValue: Int = this.k.eval().asInstanceOf[Int]
-    require(kValue > 0, "The number of neighbors must be greater than 0.")
+    require(kValue >= 1, "The number of neighbors (k) must be equal or greater than 1.")
     objectsShapes.setNeighborSampleNumber(kValue)
 
     val joinPartitions: Integer = numPartitions

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/BroadcastQuerySideKNNJoinExec.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/BroadcastQuerySideKNNJoinExec.scala
@@ -130,19 +130,10 @@ case class BroadcastQuerySideKNNJoinExec(
     require(kValue >= 1, "The number of neighbors (k) must be equal or greater than 1.")
     objectsShapes.setNeighborSampleNumber(kValue)
 
-    val joinPartitions: Integer = numPartitions
-    broadcastJoin = false
-
-    // expand the boundary for partition to include both RDDs
-    objectsShapes.analyze()
-    queryShapes.analyze()
-    objectsShapes.boundaryEnvelope.expandToInclude(queryShapes.boundaryEnvelope)
-
-    objectsShapes.spatialPartitioning(GridType.QUADTREE_RTREE, joinPartitions)
-    queryShapes.spatialPartitioning(
-      objectsShapes.getPartitioner.asInstanceOf[QuadTreeRTPartitioner].nonOverlappedPartitioner())
-
-    objectsShapes.buildIndex(IndexType.RTREE, true)
+    // index the objects on regular partitions (not spatial partitions)
+    // this avoids the cost of spatial partitioning
+    objectsShapes.buildIndex(IndexType.RTREE, false)
+    broadcastJoin = true
   }
 
   /**

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/JoinQueryDetector.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/JoinQueryDetector.scala
@@ -589,7 +589,14 @@ class JoinQueryDetector(sparkSession: SparkSession) extends Strategy {
     val leftShape = children.head
     val rightShape = children.tail.head
 
-    val querySide = getKNNQuerySide(left, leftShape)
+    val querySide = matchExpressionsToPlans(leftShape, rightShape, left, right) match {
+      case Some((_, _, false)) =>
+        LeftSide
+      case Some((_, _, true)) =>
+        RightSide
+      case None =>
+        Nil
+    }
     val objectSidePlan = if (querySide == LeftSide) right else left
 
     checkObjectPlanFilterPushdown(objectSidePlan)
@@ -722,7 +729,14 @@ class JoinQueryDetector(sparkSession: SparkSession) extends Strategy {
         val leftShape = children.head
         val rightShape = children.tail.head
 
-        val querySide = getKNNQuerySide(left, leftShape)
+        val querySide = matchExpressionsToPlans(leftShape, rightShape, left, right) match {
+          case Some((_, _, false)) =>
+            LeftSide
+          case Some((_, _, true)) =>
+            RightSide
+          case None =>
+            Nil
+        }
         val objectSidePlan = if (querySide == LeftSide) right else left
 
         checkObjectPlanFilterPushdown(objectSidePlan)
@@ -862,27 +876,6 @@ class JoinQueryDetector(sparkSession: SparkSession) extends Strategy {
           s"Spatial join for $relationship with arguments not aligned " +
             "with join relations is not supported")
         Nil
-    }
-  }
-
-  /**
-   * Gets the query and object plans based on the left shape.
-   *
-   * This method checks if the left shape is part of the left or right plan and returns the query
-   * and object plans accordingly.
-   *
-   * @param leftShape
-   *   The left shape expression.
-   * @return
-   *   The join side where the left shape is located.
-   */
-  private def getKNNQuerySide(left: LogicalPlan, leftShape: Expression) = {
-    val isLeftQuerySide =
-      left.toString().toLowerCase().contains(leftShape.toString().toLowerCase())
-    if (isLeftQuerySide) {
-      LeftSide
-    } else {
-      RightSide
     }
   }
 

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/JoinQueryDetector.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/JoinQueryDetector.scala
@@ -582,6 +582,10 @@ class JoinQueryDetector(sparkSession: SparkSession) extends Strategy {
       return Nil
     }
 
+    // validate the k value
+    val kValue: Int = distance.eval().asInstanceOf[Int]
+    require(kValue >= 1, "The number of neighbors (k) must be equal or greater than 1.")
+
     val leftShape = children.head
     val rightShape = children.tail.head
 
@@ -711,6 +715,10 @@ class JoinQueryDetector(sparkSession: SparkSession) extends Strategy {
 
     if (spatialPredicate == SpatialPredicate.KNN) {
       {
+        // validate the k value for KNN join
+        val kValue: Int = distance.get.eval().asInstanceOf[Int]
+        require(kValue >= 1, "The number of neighbors (k) must be equal or greater than 1.")
+
         val leftShape = children.head
         val rightShape = children.tail.head
 

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/JoinQueryDetector.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/JoinQueryDetector.scala
@@ -753,7 +753,7 @@ class JoinQueryDetector(sparkSession: SparkSession) extends Strategy {
             k = distance.get,
             useApproximate = false,
             spatialPredicate,
-            isGeography = false,
+            isGeography,
             condition = null,
             extraCondition = None) :: Nil
         } else {
@@ -768,7 +768,7 @@ class JoinQueryDetector(sparkSession: SparkSession) extends Strategy {
             k = distance.get,
             useApproximate = false,
             spatialPredicate,
-            isGeography = false,
+            isGeography,
             condition = null,
             extraCondition = None) :: Nil
         }

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/KNNJoinExec.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/KNNJoinExec.scala
@@ -162,7 +162,7 @@ case class KNNJoinExec(
       sedonaConf: SedonaConf): Unit = {
     require(numPartitions > 0, "The number of partitions must be greater than 0.")
     val kValue: Int = this.k.eval().asInstanceOf[Int]
-    require(kValue > 0, "The number of neighbors must be greater than 0.")
+    require(kValue >= 1, "The number of neighbors (k) must be equal or greater than 1.")
     objectsShapes.setNeighborSampleNumber(kValue)
 
     exactSpatialPartitioning(objectsShapes, queryShapes, numPartitions)


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-XXX. The PR name follows the format `[SEDONA-XXX] my subject`.


## What changes were proposed in this PR?
This PR is to broadcast the query side data to objects and then on the reducing process, group, sort and reduce it to global knn results. We also include an optimization that avoid repartitioning the broadcast side in this task.

## How was this patch tested?
New tests are added to KNNJoinSuit.

## Did this PR include necessary documentation updates?
- No, this PR does not affect any public API so no need to change the documentation.
