### PR TITLE
[SEDONA-694] Use apache-sedona instead of sedona when referring to pypi Sedona

### DIFF
--- a/docs/tutorial/sql.md
+++ b/docs/tutorial/sql.md
@@ -1091,7 +1091,7 @@ SedonaPyDeck exposes APIs to create interactive map visualizations using [pydeck
 !!!Note
 	To use SedonaPyDeck, install sedona with the `pydeck-map` extra:
 	```
-	pip install sedona[pydeck-map]
+	pip install apache-sedona[pydeck-map]
 	```
 
 The following tutorial showcases the various maps that can be created using SedonaPyDeck, the datasets used to create these maps are publicly available.
@@ -1168,7 +1168,7 @@ SedonaKepler exposes APIs to create interactive and customizable map visualizati
 !!!Note
 	To use SedonaKepler, install sedona with the `kepler-map` extra:
 	```
-	pip install sedona[kepler-map]
+	pip install apache-sedona[kepler-map]
 	```
 
 This tutorial showcases how simple it is to instantly visualize geospatial data using SedonaKepler.

--- a/python/sedona/maps/SedonaKepler.py
+++ b/python/sedona/maps/SedonaKepler.py
@@ -34,7 +34,7 @@ class SedonaKepler:
         try:
             from keplergl import KeplerGl
         except ImportError:
-            msg = "Install sedona[kepler-map] to convert sedona dataframes to kepler maps."
+            msg = "Install apache-sedona[kepler-map] to convert sedona dataframes to kepler maps."
             raise ImportError(msg) from None
 
         kepler_map = KeplerGl()

--- a/python/sedona/maps/SedonaMapUtils.py
+++ b/python/sedona/maps/SedonaMapUtils.py
@@ -42,7 +42,7 @@ class SedonaMapUtils:
         try:
             import geopandas as gpd
         except ImportError:
-            msg = "GeoPandas is missing. You can install it manually or via sedona[kepler-map] or sedona[pydeck-map]."
+            msg = "GeoPandas is missing. You can install it manually or via apache-sedona[kepler-map] or apache-sedona[pydeck-map]."
             raise ImportError(msg) from None
         geo_df = gpd.GeoDataFrame(pandas_df, geometry=geometry_col)
         if geometry_col != "geometry" and rename is True:

--- a/python/sedona/maps/SedonaPyDeck.py
+++ b/python/sedona/maps/SedonaPyDeck.py
@@ -385,7 +385,7 @@ def _try_import_pydeck() -> ModuleType:
         import pydeck as pdk
 
     except ImportError:
-        msg = "Install sedona[pydeck-map] to convert sedona dataframes to pydeck maps."
+        msg = "Install apache-sedona[pydeck-map] to convert sedona dataframes to pydeck maps."
         raise ImportError(msg) from None
 
     return pdk


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-XXX. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Documentation or error messages that refer to `sedona[optional-extra]` were updated to `apache-sedona[optional-extra]`.

## How was this patch tested?

These changes are in error messages that were not tested.

## Did this PR include necessary documentation updates?

- Yes, I have only updated the documentation.
