### PR TITLE
[DOCS] makes top-level navigation persistent as readers scroll, adds …

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -151,6 +151,7 @@ nav:
       - Telemetry: asf/telemetry.md
 repo_url: https://github.com/apache/sedona
 repo_name: apache/sedona
+edit_uri: edit/master/docs/
 theme:
   font: false
   name: 'material'
@@ -165,12 +166,14 @@ theme:
     repo: fontawesome/brands/github
   features:
     - content.code.copy
+    - content.action.edit
     - search.highlight
     - search.share
     - search.suggest
     - navigation.footer
     - navigation.instant
     - navigation.tabs
+    - navigation.tabs.sticky
     - navigation.top
 extra:
   version:


### PR DESCRIPTION
…contribution button

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- No:
  - this is a documentation update. The PR name follows the format `[DOCS] my subject`


## What changes were proposed in this PR?

* `navigation.tabs.sticky` makes top-level navigation persistent as readers scroll
        ![image](https://github.com/user-attachments/assets/f0ceb1b0-6cd4-4602-9b02-b1078c8f0784)


* Setting `edit_uri` and adding `content.action.edit` enables an "Edit this page" button on each page of your MkDocs documentation. This button allows users to easily contribute to your documentation by opening the source file for that page in an online editor.
    ![image](https://github.com/user-attachments/assets/52d2ed06-227c-427f-801a-211e551908db)
    * For example when clicked on the https://sedona.apache.org/latest/setup/emr/ page, readers will be directed to https://github.com/apache/sedona/edit/master/docs/setup/emr.md
       ![image](https://github.com/user-attachments/assets/04b38379-82dd-4383-aa3d-3893755a563f)


## How was this patch tested?

Previewed docs locally

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.
