### PR TITLE
[SEDONA-700] Fix ST_KNN fails on null and empty geometries

### DIFF
--- a/spark/common/src/main/java/org/apache/sedona/core/spatialPartitioning/quadtree/ExtendedQuadTree.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/spatialPartitioning/quadtree/ExtendedQuadTree.java
@@ -146,8 +146,11 @@ public class ExtendedQuadTree<T> extends PartitioningUtils implements Serializab
 
       final Set<Tuple2<Integer, Geometry>> result = new HashSet<>();
       for (QuadRectangle rectangle : matchedPartitions) {
+        // Ignore null or empty point
+        if (point == null || point.isEmpty()) break;
+
         // For points, make sure to return only one partition
-        if (point != null && !(new HalfOpenRectangle(rectangle.getEnvelope())).contains(point)) {
+        if (!(new HalfOpenRectangle(rectangle.getEnvelope())).contains(point)) {
           continue;
         }
 

--- a/spark/common/src/main/scala/org/apache/sedona/sql/utils/GeometrySerializer.scala
+++ b/spark/common/src/main/scala/org/apache/sedona/sql/utils/GeometrySerializer.scala
@@ -19,7 +19,7 @@
 package org.apache.sedona.sql.utils
 
 import org.apache.sedona.common.geometrySerde
-import org.locationtech.jts.geom.Geometry
+import org.locationtech.jts.geom.{Geometry, GeometryFactory}
 
 /**
  * SerDe using the WKB reader and writer objects
@@ -47,6 +47,9 @@ object GeometrySerializer {
    *   JTS geometry
    */
   def deserialize(value: Array[Byte]): Geometry = {
+    if (value == null) {
+      return new GeometryFactory().createGeometryCollection()
+    }
     geometrySerde.GeometrySerializer.deserialize(value)
   }
 }

--- a/spark/common/src/test/scala/org/apache/sedona/sql/KnnJoinSuite.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/KnnJoinSuite.scala
@@ -443,7 +443,8 @@ class KnnJoinSuite extends TestBaseScala with TableDrivenPropertyChecks {
     }
 
     it("KNN Join with exact algorithms should not fail with null geometries") {
-      val df1 = sparkSession.sql("SELECT ST_GeomFromText(col1) as geom1 from values ('POINT (0.0 0.0)'), (null)")
+      val df1 = sparkSession.sql(
+        "SELECT ST_GeomFromText(col1) as geom1 from values ('POINT (0.0 0.0)'), (null)")
       val df2 = sparkSession.sql("SELECT ST_Point(0.0, 0.0) as geom2")
       df1.cache()
       df2.cache()


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-XXX. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?
This PR fix the bug that when query side dataset contains null or empty geometries, KNN join fails.

## How was this patch tested?
KnnJoinSuite adds two new unit tests

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
