### PR TITLE
[SEDONA-702] Create IndexedGridPartitioner, Support preserveUncontain…

### DIFF
--- a/spark/common/src/main/java/org/apache/sedona/core/spatialPartitioning/EqualPartitioning.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/spatialPartitioning/EqualPartitioning.java
@@ -37,8 +37,19 @@ public class EqualPartitioning implements Serializable {
   /** The grids. */
   List<Envelope> grids = new ArrayList<Envelope>();
 
-  public EqualPartitioning(List<Envelope> grids) {
+  /**
+   * Whether to discard geometries that do not intersect any grid. If true, geometries that are not
+   * contained in a grid are placed into the overflow container.
+   */
+  Boolean preserveUncontainedGeometries;
+
+  public EqualPartitioning(List<Envelope> grids, boolean preserveUncontainedGeometries) {
     this.grids = grids;
+    this.preserveUncontainedGeometries = preserveUncontainedGeometries;
+  }
+
+  public EqualPartitioning(List<Envelope> grids) {
+    this(grids, true);
   }
   /**
    * Instantiates a new equal partitioning.
@@ -105,7 +116,7 @@ public class EqualPartitioning implements Serializable {
       }
     }
 
-    if (!containFlag) {
+    if (!containFlag && preserveUncontainedGeometries) {
       result.add(new Tuple2<>(overflowContainerID, geometry));
     }
 
@@ -133,7 +144,7 @@ public class EqualPartitioning implements Serializable {
       }
     }
 
-    if (!containFlag) {
+    if (!containFlag && preserveUncontainedGeometries) {
       result.add(overflowContainerID);
     }
     return result;

--- a/spark/common/src/main/java/org/apache/sedona/core/spatialPartitioning/FlatGridPartitioner.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/spatialPartitioning/FlatGridPartitioner.java
@@ -28,18 +28,30 @@ import org.locationtech.jts.geom.Geometry;
 import scala.Tuple2;
 
 public class FlatGridPartitioner extends SpatialPartitioner {
-  public FlatGridPartitioner(GridType gridType, List<Envelope> grids) {
+  protected final Boolean preserveUncontainedGeometries;
+
+  public FlatGridPartitioner(
+      GridType gridType, List<Envelope> grids, Boolean preserveUncontainedGeometries) {
     super(gridType, grids);
+    this.preserveUncontainedGeometries = preserveUncontainedGeometries;
+  }
+
+  public FlatGridPartitioner(GridType gridType, List<Envelope> grids) {
+    this(gridType, grids, true);
+  }
+
+  public FlatGridPartitioner(List<Envelope> grids, Boolean preserveUncontainedGeometries) {
+    this(null, grids, preserveUncontainedGeometries);
   }
 
   // For backwards compatibility (see SpatialRDD.spatialPartitioning(otherGrids))
   public FlatGridPartitioner(List<Envelope> grids) {
-    super(null, grids);
+    this(null, grids);
   }
 
   @Override
   public Iterator<Tuple2<Integer, Geometry>> placeObject(Geometry spatialObject) throws Exception {
-    EqualPartitioning partitioning = new EqualPartitioning(grids);
+    EqualPartitioning partitioning = new EqualPartitioning(grids, preserveUncontainedGeometries);
     return partitioning.placeObject(spatialObject);
   }
 
@@ -61,7 +73,7 @@ public class FlatGridPartitioner extends SpatialPartitioner {
 
   @Override
   public int numPartitions() {
-    return grids.size() + 1 /* overflow partition */;
+    return grids.size() + (preserveUncontainedGeometries ? 1 : 0);
   }
 
   @Override

--- a/spark/common/src/main/java/org/apache/sedona/core/spatialPartitioning/IndexedGridPartitioner.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/spatialPartitioning/IndexedGridPartitioner.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.core.spatialPartitioning;
+
+import java.util.*;
+import org.apache.sedona.core.enums.GridType;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.index.strtree.STRtree;
+import scala.Tuple2;
+
+public class IndexedGridPartitioner extends FlatGridPartitioner {
+  private final STRtree index;
+
+  public IndexedGridPartitioner(
+      GridType gridType, List<Envelope> grids, Boolean preserveUncontainedGeometries) {
+    super(gridType, grids, preserveUncontainedGeometries);
+    this.index = new STRtree();
+    for (int i = 0; i < grids.size(); i++) {
+      final Envelope grid = grids.get(i);
+      index.insert(grid, i);
+    }
+    index.build();
+  }
+
+  public IndexedGridPartitioner(GridType gridType, List<Envelope> grids) {
+    this(gridType, grids, false);
+  }
+
+  public IndexedGridPartitioner(List<Envelope> grids, Boolean preserveUncontainedGeometries) {
+    this(null, grids, preserveUncontainedGeometries);
+  }
+
+  public IndexedGridPartitioner(List<Envelope> grids) {
+    this(null, grids);
+  }
+
+  public STRtree getIndex() {
+    return index;
+  }
+
+  @Override
+  public Iterator<Tuple2<Integer, Geometry>> placeObject(Geometry spatialObject) throws Exception {
+    List results = index.query(spatialObject.getEnvelopeInternal());
+    if (preserveUncontainedGeometries) {
+      // borrowed from EqualPartitioning.placeObject
+      final int overflowContainerID = grids.size();
+      final Envelope envelope = spatialObject.getEnvelopeInternal();
+
+      Set<Tuple2<Integer, Geometry>> result = new HashSet();
+      boolean containFlag = false;
+      for (Object queryResult : results) {
+        Integer i = (Integer) queryResult;
+        final Envelope grid = grids.get(i);
+        if (grid.covers(envelope)) {
+          result.add(new Tuple2(i, spatialObject));
+          containFlag = true;
+        } else if (grid.intersects(envelope) || envelope.covers(grid)) {
+          result.add(new Tuple2<>(i, spatialObject));
+        }
+      }
+
+      if (!containFlag) {
+        result.add(new Tuple2<>(overflowContainerID, spatialObject));
+      }
+
+      return result.iterator();
+    } else {
+      return results.stream().map(i -> new Tuple2(i, spatialObject)).iterator();
+    }
+  }
+}

--- a/spark/common/src/test/java/org/apache/sedona/core/spatialPartitioning/IndexedGridPartitionerTest.java
+++ b/spark/common/src/test/java/org/apache/sedona/core/spatialPartitioning/IndexedGridPartitionerTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.core.spatialPartitioning;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import junit.framework.TestCase;
+import org.junit.Assert;
+import org.junit.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import scala.Tuple2;
+
+public class IndexedGridPartitionerTest extends TestCase {
+
+  private List<Envelope> getGrids() {
+    List<Envelope> grids = new ArrayList<>();
+    grids.add(new Envelope(0, 50, 0, 50));
+    grids.add(new Envelope(50, 100, 0, 50));
+    grids.add(new Envelope(0, 50, 50, 100));
+    grids.add(new Envelope(50, 100, 50, 100));
+    return grids;
+  }
+
+  private IndexedGridPartitioner getPartitioner(Boolean preserveUncontainedGeometries) {
+    return new IndexedGridPartitioner(getGrids(), preserveUncontainedGeometries);
+  }
+
+  public void testPlaceObjectPreserveContainedGeometries() throws Exception {
+    IndexedGridPartitioner partitioner = getPartitioner(true);
+    GeometryFactory geometryFactory = new GeometryFactory();
+    Geometry spatialObject = geometryFactory.createPoint(new Coordinate(25, 25));
+    Iterator<Tuple2<Integer, Geometry>> result = partitioner.placeObject(spatialObject);
+
+    List<Tuple2<Integer, Geometry>> resultList = new ArrayList<>();
+    result.forEachRemaining(resultList::add);
+
+    Assert.assertFalse(resultList.isEmpty());
+    Assert.assertEquals(1, resultList.size());
+    Assert.assertEquals(0, (int) resultList.get(0)._1());
+  }
+
+  public void testPlaceObjectDoesntPreserveUncontainedGeometries() throws Exception {
+    IndexedGridPartitioner partitioner = getPartitioner(false);
+    GeometryFactory geometryFactory = new GeometryFactory();
+    Geometry spatialObject = geometryFactory.createPoint(new Coordinate(-25, -25));
+    Iterator<Tuple2<Integer, Geometry>> result = partitioner.placeObject(spatialObject);
+    Assert.assertFalse(result.hasNext());
+  }
+
+  @Test
+  public void testGetGrids() {
+    IndexedGridPartitioner partitioner = getPartitioner(true);
+    Assert.assertEquals(getGrids(), partitioner.getGrids());
+  }
+
+  @Test
+  public void testNumPartitions() {
+    IndexedGridPartitioner partitioner = getPartitioner(true);
+    Assert.assertEquals(5, partitioner.numPartitions());
+
+    partitioner = getPartitioner(false);
+    Assert.assertEquals(4, partitioner.numPartitions());
+  }
+
+  @Test
+  public void testEquals() {
+    IndexedGridPartitioner partitioner = getPartitioner(true);
+    List<Envelope> grids = new ArrayList<>();
+    grids.add(new Envelope(0, 50, 0, 50));
+    grids.add(new Envelope(50, 100, 0, 50));
+    grids.add(new Envelope(0, 50, 50, 100));
+    grids.add(new Envelope(50, 100, 50, 100));
+    IndexedGridPartitioner otherPartitioner = new IndexedGridPartitioner(grids, true);
+    Assert.assertTrue(partitioner.equals(otherPartitioner));
+  }
+}


### PR DESCRIPTION
…edGeometries in *GridPartitioners

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)


## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-702. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?
* Adding an IndexedGridPartitioner class which should perform better than the FlatGridPartitioner in most cases for `placeObject` calls
* adding a `preserveUncontainedGeometries` flag into the GridPartitioner classes to allow callers to configure if geometries that are not contained within any partition should be placed in the overflow partition. 

## How was this patch tested?
Unit Tests added

## Did this PR include necessary documentation updates?
- No, this PR does not affect any public API so no need to change the documentation.

While part of the public Java API, these partitioner classes do not have documentation strings. I have followed this norm by not adding doc strings to the classes. 
