### PR TITLE
[SEDONA-704] Add the STAC datasource reader

### DIFF
--- a/docs/api/sql/Stac.md
+++ b/docs/api/sql/Stac.md
@@ -1,0 +1,155 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+The STAC data source allows you to read data from a SpatioTemporal Asset Catalog (STAC) API. The data source supports reading STAC items and collections.
+
+## Usage
+
+To use the STAC data source, you can load a STAC catalog into a Sedona DataFrame using the stac format. The path can be either a local STAC collection JSON file or an HTTP/HTTPS endpoint to retrieve the collection JSON file.
+
+You can load a STAC collection from a local collection file:
+
+```python
+df = sedona.read.format("stac").load("/user/stac_collection.json")
+df.printSchema()
+df.show()
+```
+
+You can load a STAC collection from a s3 collection file object:
+
+```python
+df = sedona.read.format("stac").load("s3a://example.com/stac_bucket/stac_collection.json")
+df.printSchema()
+df.show()
+```
+
+You can also load a STAC collection from an HTTP/HTTPS endpoint:
+
+```python
+df = sedona.read.format("stac").load("https://earth-search.aws.element84.com/v1/collections/sentinel-2-pre-c1-l2a")
+df.printSchema()
+df.show()
+```
+
+output:
+
+```
+root
+ |-- stac_version: string (nullable = false)
+ |-- stac_extensions: array (nullable = true)
+ |    |-- element: string (containsNull = true)
+ |-- type: string (nullable = false)
+ |-- id: string (nullable = false)
+ |-- bbox: array (nullable = true)
+ |    |-- element: double (containsNull = true)
+ |-- geometry: geometry (nullable = true)
+ |-- title: string (nullable = true)
+ |-- description: string (nullable = true)
+ |-- datetime: timestamp (nullable = true)
+ |-- start_datetime: timestamp (nullable = true)
+ |-- end_datetime: timestamp (nullable = true)
+ |-- created: timestamp (nullable = true)
+ |-- updated: timestamp (nullable = true)
+ |-- platform: string (nullable = true)
+ |-- instruments: array (nullable = true)
+ |    |-- element: string (containsNull = true)
+ |-- constellation: string (nullable = true)
+ |-- mission: string (nullable = true)
+ |-- gsd: double (nullable = true)
+ |-- collection: string (nullable = true)
+ |-- links: array (nullable = true)
+ |    |-- element: struct (containsNull = true)
+ |    |    |-- rel: string (nullable = true)
+ |    |    |-- href: string (nullable = true)
+ |    |    |-- type: string (nullable = true)
+ |    |    |-- title: string (nullable = true)
+ |-- assets: map (nullable = true)
+ |    |-- key: string
+ |    |-- value: struct (valueContainsNull = true)
+ |    |    |-- href: string (nullable = true)
+ |    |    |-- type: string (nullable = true)
+ |    |    |-- title: string (nullable = true)
+ |    |    |-- roles: array (nullable = true)
+ |    |    |    |-- element: string (containsNull = true)
+
++------------+--------------------+-------+--------------------+--------------------+--------------------+-----+-----------+--------------------+--------------+------------+--------------------+--------------------+-----------+-----------+-------------+-------+----+--------------------+--------------------+--------------------+
+|stac_version|     stac_extensions|   type|                  id|                bbox|            geometry|title|description|            datetime|start_datetime|end_datetime|             created|             updated|   platform|instruments|constellation|mission| gsd|          collection|               links|              assets|
++------------+--------------------+-------+--------------------+--------------------+--------------------+-----+-----------+--------------------+--------------+------------+--------------------+--------------------+-----------+-----------+-------------+-------+----+--------------------+--------------------+--------------------+
+|       1.0.0|[https://stac-ext...|Feature|S2B_T21NYC_202212...|[-55.202493, 1.71...|POLYGON ((-55.201...| NULL|       NULL|2022-12-05 14:11:...|          NULL|        NULL|2024-05-01 21:13:...|2024-05-01 21:13:...|sentinel-2b|      [msi]|   sentinel-2|   NULL|NULL|sentinel-2-pre-c1...|[{self, https://e...|{red -> {https://...|
+|       1.0.0|[https://stac-ext...|Feature|S2B_T21NZC_202212...|[-54.30394, 1.719...|POLYGON ((-54.302...| NULL|       NULL|2022-12-05 14:11:...|          NULL|        NULL|2024-05-03 00:39:...|2024-05-03 00:39:...|sentinel-2b|      [msi]|   sentinel-2|   NULL|NULL|sentinel-2-pre-c1...|[{self, https://e...|{red -> {https://...|
+|       1.0.0|[https://stac-ext...|Feature|S2B_T22NBH_202212...|[-53.698196, 2.63...|POLYGON ((-53.698...| NULL|       NULL|2022-12-05 14:11:...|          NULL|        NULL|2024-05-03 00:26:...|2024-05-03 00:26:...|sentinel-2b|      [msi]|   sentinel-2|   NULL|NULL|sentinel-2-pre-c1...|[{self, https://e...|{red -> {https://...|
+|       1.0.0|[https://stac-ext...|Feature|S2B_T21NYD_202212...|[-55.201423, 2.62...|POLYGON ((-55.199...| NULL|       NULL|2022-12-05 14:11:...|          NULL|        NULL|2024-05-01 21:10:...|2024-05-01 21:10:...|sentinel-2b|      [msi]|   sentinel-2|   NULL|NULL|sentinel-2-pre-c1...|[{self, https://e...|{red -> {https://...|
+|       1.0.0|[https://stac-ext...|Feature|S2B_T21NZD_202212...|[-54.302336, 2.62...|POLYGON ((-54.299...| NULL|       NULL|2022-12-05 14:11:...|          NULL|        NULL|2024-05-03 00:12:...|2024-05-03 00:12:...|sentinel-2b|      [msi]|   sentinel-2|   NULL|NULL|sentinel-2-pre-c1...|[{self, https://e...|{red -> {https://...|
+|       1.0.0|[https://stac-ext...|Feature|S2B_T22NBJ_202212...|[-53.700535, 2.63...|POLYGON ((-53.700...| NULL|       NULL|2022-12-05 14:11:...|          NULL|        NULL|2024-05-03 00:30:...|2024-05-03 00:30:...|sentinel-2b|      [msi]|   sentinel-2|   NULL|NULL|sentinel-2-pre-c1...|[{self, https://e...|{red -> {https://...|
+|       1.0.0|[https://stac-ext...|Feature|S2B_T21NYE_202212...|[-55.199906, 3.52...|POLYGON ((-55.197...| NULL|       NULL|2022-12-05 14:11:...|          NULL|        NULL|2024-05-01 21:24:...|2024-05-01 21:24:...|sentinel-2b|      [msi]|   sentinel-2|   NULL|NULL|sentinel-2-pre-c1...|[{self, https://e...|{red -> {https://...|
+|       1.0.0|[https://stac-ext...|Feature|S2B_T21NZE_202212...|[-54.300062, 3.52...|POLYGON ((-54.296...| NULL|       NULL|2022-12-05 14:11:...|          NULL|        NULL|2024-05-03 00:14:...|2024-05-03 00:14:...|sentinel-2b|      [msi]|   sentinel-2|   NULL|NULL|sentinel-2-pre-c1...|[{self, https://e...|{red -> {https://...|
+|       1.0.0|[https://stac-ext...|Feature|S2B_T22NBK_202212...|[-53.703548, 3.52...|POLYGON ((-53.703...| NULL|       NULL|2022-12-05 14:11:...|          NULL|        NULL|2024-05-03 00:32:...|2024-05-03 00:32:...|sentinel-2b|      [msi]|   sentinel-2|   NULL|NULL|sentinel-2-pre-c1...|[{self, https://e...|{red -> {https://...|
+|       1.0.0|[https://stac-ext...|Feature|S2B_T21NYF_202212...|[-55.197941, 4.42...|POLYGON ((-55.195...| NULL|       NULL|2022-12-05 14:11:...|          NULL|        NULL|2024-05-01 21:43:...|2024-05-01 21:43:...|sentinel-2b|      [msi]|   sentinel-2|   NULL|NULL|sentinel-2-pre-c1...|[{self, https://e...|{red -> {https://...|
++------------+--------------------+-------+--------------------+--------------------+--------------------+-----+-----------+--------------------+--------------+------------+--------------------+--------------------+-----------+-----------+-------------+-------+----+--------------------+--------------------+--------------------+
+```
+
+# Filter Pushdown
+
+The STAC data source supports predicate pushdown for spatial and temporal filters. The data source can push down spatial and temporal filters to the underlying data source to reduce the amount of data that needs to be read.
+
+## Spatial Filter Pushdown
+
+Spatial filter pushdown allows the data source to apply spatial predicates (e.g., st_contains, st_intersects) directly at the data source level, reducing the amount of data transferred and processed.
+
+## Temporal Filter Pushdown
+
+Temporal filter pushdown allows the data source to apply temporal predicates (e.g., BETWEEN, >=, <=) directly at the data source level, similarly reducing the amount of data transferred and processed.
+
+# Examples
+
+Here are some examples demonstrating how to query a STAC data source that is loaded into a table named `STAC_TABLE`.
+
+## SQL Select Without Filters
+
+```sql
+SELECT id, datetime as dt, geometry, bbox FROM STAC_TABLE
+```
+
+## SQL Select With Temporal Filter
+
+```sql
+  SELECT id, datetime as dt, geometry, bbox
+  FROM STAC_TABLE
+  WHERE datetime BETWEEN '2020-01-01' AND '2020-12-13'
+```
+
+In this example, the data source will push down the temporal filter to the underlying data source.
+
+## SQL Select With Spatial Filter
+
+```sql
+  SELECT id, geometry
+  FROM STAC_TABLE
+  WHERE st_contains(ST_GeomFromText('POLYGON((17 10, 18 10, 18 11, 17 11, 17 10))'), geometry)
+```
+
+In this example, the data source will push down the spatial filter to the underlying data source.
+
+# References
+
+- STAC Specification: https://stacspec.org/
+
+- STAC Browser: https://github.com/radiantearth/stac-browser
+
+- STAC YouTube Video: https://www.youtube.com/watch?v=stac-video

--- a/spark/common/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/spark/common/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -1,3 +1,4 @@
 org.apache.spark.sql.sedona_sql.io.raster.RasterFileFormat
 org.apache.spark.sql.sedona_sql.io.geojson.GeoJSONFileFormat
 org.apache.sedona.sql.datasources.spider.SpiderDataSource
+org.apache.spark.sql.sedona_sql.io.stac.StacDataSource

--- a/spark/common/src/main/scala/org/apache/spark/sql/execution/datasource/stac/TemporalFilter.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/execution/datasource/stac/TemporalFilter.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.spark.sql.execution.datasource.stac
+
+import java.time.LocalDateTime
+
+/* A temporal filter that can be pushed down to the STAC data source.
+ * It wraps a [[TemporalFilter]] and provides a simple string representation.
+ * @param temporalFilter
+ */
+trait TemporalFilter {
+  def evaluate(columns: Map[String, LocalDateTime]): Boolean
+  def simpleString: String
+}
+
+object TemporalFilter {
+
+  case class AndFilter(left: TemporalFilter, right: TemporalFilter) extends TemporalFilter {
+    override def evaluate(columns: Map[String, LocalDateTime]): Boolean = {
+      left.evaluate(columns) && right.evaluate(columns)
+    }
+
+    override def simpleString: String = s"(${left.simpleString}) AND (${right.simpleString})"
+  }
+
+  case class OrFilter(left: TemporalFilter, right: TemporalFilter) extends TemporalFilter {
+    override def evaluate(columns: Map[String, LocalDateTime]): Boolean =
+      left.evaluate(columns) || right.evaluate(columns)
+    override def simpleString: String = s"(${left.simpleString}) OR (${right.simpleString})"
+  }
+
+  case class LessThanFilter(columnName: String, value: LocalDateTime) extends TemporalFilter {
+    override def evaluate(columns: Map[String, LocalDateTime]): Boolean = {
+      columns.get(columnName).exists(_ isBefore value)
+    }
+    override def simpleString: String = s"$columnName < $value"
+  }
+
+  case class GreaterThanFilter(columnName: String, value: LocalDateTime) extends TemporalFilter {
+    override def evaluate(columns: Map[String, LocalDateTime]): Boolean = {
+      columns.get(columnName).exists(_ isAfter value)
+    }
+    override def simpleString: String = s"$columnName > $value"
+  }
+
+  case class EqualFilter(columnName: String, value: LocalDateTime) extends TemporalFilter {
+    override def evaluate(columns: Map[String, LocalDateTime]): Boolean = {
+      columns.get(columnName).exists(_ isEqual value)
+    }
+    override def simpleString: String = s"$columnName = $value"
+  }
+}

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacBatch.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacBatch.scala
@@ -19,7 +19,6 @@
 package org.apache.spark.sql.sedona_sql.io.stac
 
 import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connector.read.{Batch, InputPartition, PartitionReaderFactory}
 import org.apache.spark.sql.execution.datasource.stac.TemporalFilter
 import org.apache.spark.sql.execution.datasources.parquet.{GeoParquetSpatialFilter, GeometryFieldMetaData}
@@ -29,7 +28,7 @@ import org.apache.spark.sql.types.StructType
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatterBuilder
 import java.time.temporal.ChronoField
-import scala.jdk.CollectionConverters.asScalaIteratorConverter
+import scala.jdk.CollectionConverters._
 
 /**
  * The `StacBatch` class represents a batch of partitions for reading data in the SpatioTemporal

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacBatch.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacBatch.scala
@@ -1,0 +1,265 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.spark.sql.sedona_sql.io.stac
+
+import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.connector.read.{Batch, InputPartition, PartitionReaderFactory}
+import org.apache.spark.sql.execution.datasource.stac.TemporalFilter
+import org.apache.spark.sql.execution.datasources.parquet.{GeoParquetSpatialFilter, GeometryFieldMetaData}
+import org.apache.spark.sql.sedona_sql.io.stac.StacUtils.getNumPartitions
+import org.apache.spark.sql.types.StructType
+
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatterBuilder
+import java.time.temporal.ChronoField
+import scala.jdk.CollectionConverters.asScalaIteratorConverter
+
+/**
+ * The `StacBatch` class represents a batch of partitions for reading data in the SpatioTemporal
+ * Asset Catalog (STAC) data source. It implements the `Batch` interface from Apache Spark's data
+ * source API.
+ *
+ * This class provides methods to plan input partitions and create a partition reader factory,
+ * which are necessary for batch data processing.
+ */
+case class StacBatch(
+    stacCollectionUrl: String,
+    stacCollectionJson: String,
+    schema: StructType,
+    opts: Map[String, String],
+    spatialFilter: Option[GeoParquetSpatialFilter],
+    temporalFilter: Option[TemporalFilter])
+    extends Batch {
+
+  val mapper = new ObjectMapper()
+
+  /**
+   * Plans the input partitions for reading data from the STAC data source.
+   *
+   * @return
+   *   An array of input partitions for reading STAC data.
+   */
+  override def planInputPartitions(): Array[InputPartition] = {
+    val stacCollectionBasePath = StacUtils.getStacCollectionBasePath(stacCollectionUrl)
+
+    // Initialize the itemLinks array
+    val itemLinks = scala.collection.mutable.ArrayBuffer[String]()
+
+    // Start the recursive collection of item links
+    collectItemLinks(stacCollectionBasePath, stacCollectionJson, itemLinks)
+
+    // Handle when the number of items is less than 1
+    if (itemLinks.isEmpty) {
+      return Array.empty[InputPartition]
+    }
+
+    val numPartitions = getNumPartitions(
+      itemLinks.length,
+      opts.getOrElse("numPartitions", "-1").toInt,
+      opts.getOrElse("maxPartitionItemFiles", "-1").toInt,
+      opts.getOrElse("defaultParallelism", "1").toInt)
+
+    // Handle when the number of items is less than the number of partitions
+    if (itemLinks.length < numPartitions) {
+      return itemLinks.zipWithIndex.map { case (item, index) =>
+        StacPartition(index, Array(item), new java.util.HashMap[String, String]())
+      }.toArray
+    }
+
+    // Determine how many items to put in each partition
+    val partitionSize = Math.ceil(itemLinks.length.toDouble / numPartitions).toInt
+
+    // Group the item links into partitions
+    itemLinks
+      .grouped(partitionSize)
+      .zipWithIndex
+      .map { case (items, index) =>
+        // Create a StacPartition for each group of items
+        StacPartition(index, items.toArray, new java.util.HashMap[String, String]())
+      }
+      .toArray
+  }
+
+  /**
+   * Recursively processes collections and collects item links.
+   *
+   * @param collectionBasePath
+   *   The base path of the STAC collection.
+   * @param collectionJson
+   *   The JSON string representation of the STAC collection.
+   * @param itemLinks
+   *   The list of item links to populate.
+   */
+  private def collectItemLinks(
+      collectionBasePath: String,
+      collectionJson: String,
+      itemLinks: scala.collection.mutable.ArrayBuffer[String]): Unit = {
+    // Parse the JSON string into a JsonNode (tree representation of JSON)
+    val rootNode: JsonNode = mapper.readTree(collectionJson)
+
+    // Extract item links from the "links" array
+    val linksNode = rootNode.get("links")
+    val iterator = linksNode.elements()
+    while (iterator.hasNext) {
+      val linkNode = iterator.next()
+      val rel = linkNode.get("rel").asText()
+      val href = linkNode.get("href").asText()
+
+      // item links are identified by the "rel" value of "item" or "items"
+      if (rel == "item" || rel == "items") {
+        // need to handle relative paths and local file paths
+        val itemUrl = if (href.startsWith("http") || href.startsWith("file")) {
+          href
+        } else {
+          collectionBasePath + href
+        }
+        itemLinks += itemUrl // Add the item URL to the list
+      } else if (rel == "child") {
+        val childUrl = if (href.startsWith("http") || href.startsWith("file")) {
+          href
+        } else {
+          collectionBasePath + href
+        }
+        // Recursively process the linked collection
+        val linkedCollectionJson = StacUtils.loadStacCollectionToJson(childUrl)
+        val nestedCollectionBasePath = StacUtils.getStacCollectionBasePath(childUrl)
+        val collectionFiltered =
+          filterCollection(linkedCollectionJson, spatialFilter, temporalFilter)
+
+        if (!collectionFiltered) {
+          collectItemLinks(nestedCollectionBasePath, linkedCollectionJson, itemLinks)
+        }
+      }
+    }
+  }
+
+  /**
+   * Filters a collection based on the provided spatial and temporal filters.
+   *
+   * @param collectionJson
+   *   The JSON string representation of the STAC collection.
+   * @param spatialFilter
+   *   The spatial filter to apply to the collection.
+   * @param temporalFilter
+   *   The temporal filter to apply to the collection.
+   * @return
+   *   `true` if the collection is filtered out, `false` otherwise.
+   */
+  def filterCollection(
+      collectionJson: String,
+      spatialFilter: Option[GeoParquetSpatialFilter],
+      temporalFilter: Option[TemporalFilter]): Boolean = {
+
+    val mapper = new ObjectMapper()
+    val rootNode: JsonNode = mapper.readTree(collectionJson)
+
+    // Filter based on spatial extent
+    val spatialFiltered = spatialFilter match {
+      case Some(filter) =>
+        val extentNode = rootNode.path("extent").path("spatial").path("bbox")
+        if (extentNode.isMissingNode) {
+          false
+        } else {
+          val bbox = extentNode
+            .elements()
+            .asScala
+            .map { bboxNode =>
+              val minX = bboxNode.get(0).asDouble()
+              val minY = bboxNode.get(1).asDouble()
+              val maxX = bboxNode.get(2).asDouble()
+              val maxY = bboxNode.get(3).asDouble()
+              (minX, minY, maxX, maxY)
+            }
+            .toList
+
+          !bbox.exists { case (minX, minY, maxX, maxY) =>
+            val geometryTypes = Seq("Polygon")
+            val bbox = Seq(minX, minY, maxX, maxY)
+
+            val geometryFieldMetaData = GeometryFieldMetaData(
+              encoding = "WKB",
+              geometryTypes = geometryTypes,
+              bbox = bbox,
+              crs = None,
+              covering = None)
+
+            filter.evaluate(Map("geometry" -> geometryFieldMetaData))
+          }
+        }
+      case None => false
+    }
+
+    // Filter based on temporal extent
+    val temporalFiltered = temporalFilter match {
+      case Some(filter) =>
+        val extentNode = rootNode.path("extent").path("temporal").path("interval")
+        if (extentNode.isMissingNode) {
+          // if extent is missing, we assume the collection is not filtered
+          true
+        } else {
+          // parse the temporal intervals
+          val formatter = new DateTimeFormatterBuilder()
+            .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
+            .optionalStart()
+            .appendFraction(ChronoField.MILLI_OF_SECOND, 0, 3, true)
+            .optionalEnd()
+            .appendPattern("'Z'")
+            .toFormatter()
+
+          val intervals = extentNode
+            .elements()
+            .asScala
+            .map { intervalNode =>
+              val start = LocalDateTime.parse(intervalNode.get(0).asText(), formatter)
+              val end = LocalDateTime.parse(intervalNode.get(1).asText(), formatter)
+              (start, end)
+            }
+            .toList
+
+          // check if the filter evaluates to true for any of the interval start or end times
+          !intervals.exists { case (start, end) =>
+            filter.evaluate(Map("datetime" -> start)) ||
+            filter.evaluate(Map("datetime" -> end))
+          }
+        }
+      // if the collection is not filtered, return false
+      case None => false
+    }
+
+    spatialFiltered || temporalFiltered
+  }
+
+  /**
+   * Creates a partition reader factory for reading data from the STAC data source.
+   *
+   * @return
+   *   A partition reader factory for reading STAC data.
+   */
+  override def createReaderFactory(): PartitionReaderFactory = { (partition: InputPartition) =>
+    {
+      new StacPartitionReader(
+        partition.asInstanceOf[StacPartition],
+        schema,
+        opts,
+        spatialFilter,
+        temporalFilter)
+    }
+  }
+}

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacDataSource.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacDataSource.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 import java.util
 import java.util.concurrent.ConcurrentHashMap
-import scala.jdk.CollectionConverters.mapAsScalaMapConverter
+import scala.jdk.CollectionConverters._
 
 /**
  * The `StacDataSource` class is responsible for enabling the reading of SpatioTemporal Asset

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacDataSource.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacDataSource.scala
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.spark.sql.sedona_sql.io.stac
+
+import StacUtils.{inferStacSchema, updatePropertiesPromotedSchema}
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.connector.catalog.{Table, TableProvider}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.sedona_sql.UDT.GeometryUDT
+import org.apache.spark.sql.sedona_sql.io.geojson.GeoJSONUtils
+import org.apache.spark.sql.sources.DataSourceRegister
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+import java.util
+import java.util.concurrent.ConcurrentHashMap
+import scala.jdk.CollectionConverters.mapAsScalaMapConverter
+
+/**
+ * The `StacDataSource` class is responsible for enabling the reading of SpatioTemporal Asset
+ * Catalogs (STAC) as tables in Apache Spark. It allows integrating geospatial metadata from local
+ * or remote STAC catalog sources into Spark for processing.
+ *
+ * This class implements Apache Spark's `TableProvider` interface to define how STAC data sources
+ * are converted into Spark tables, and the `DataSourceRegister` interface to provide a custom
+ * short name for easier data source loading.
+ */
+class StacDataSource() extends TableProvider with DataSourceRegister {
+
+  // Cache to store inferred schemas
+  private val schemaCache = new ConcurrentHashMap[Map[String, String], StructType]()
+
+  /**
+   * Returns the short name of this data source, which can be used in Spark SQL queries for
+   * loading the data source. For example:
+   *
+   * `spark.read.format("stac").load(...)`
+   *
+   * @return
+   *   The string identifier for this data source, "stac".
+   */
+  override def shortName(): String = "stac"
+
+  /**
+   * Infers and returns the schema of the STAC data source. This implementation checks if a local
+   * cache of the processed STAC collection exists. If not, it processes the STAC collection and
+   * saves it as a GeoJson file. The schema is then inferred from this GeoJson file.
+   *
+   * @param opts
+   *   Mapping of data source options, which should include either 'url' or 'service'.
+   * @return
+   *   The inferred schema of the STAC data source table.
+   * @throws IllegalArgumentException
+   *   If neither 'url' nor 'service' are provided.
+   */
+  override def inferSchema(opts: CaseInsensitiveStringMap): StructType = {
+    val optsMap = opts.asCaseSensitiveMap().asScala.toMap
+
+    // Check if the schema is already cached
+    val fullSchema = schemaCache.computeIfAbsent(optsMap, _ => inferStacSchema(optsMap))
+    val updatedGeometrySchema = GeoJSONUtils.updateGeometrySchema(fullSchema, GeometryUDT)
+    updatePropertiesPromotedSchema(updatedGeometrySchema)
+  }
+
+  /**
+   * Provides a table implementation for the STAC data source based on the input schema and
+   * configuration properties. This method supports loading STAC catalogs either from a local file
+   * system or from a remote HTTP/HTTPS endpoint.
+   *
+   * @param schema
+   *   The schema of the table, ignored as the schema is pre-defined.
+   * @param partitioning
+   *   Unused, but represents potential transformations (partitioning) in Spark.
+   * @param properties
+   *   A map of properties to configure the data source. Must include either "path" for local file
+   *   access or "service" for HTTP access.
+   * @return
+   *   An instance of `StacTable`, wrapping the parsed STAC catalog JSON data.
+   * @throws IllegalArgumentException
+   *   If neither "url" nor "service" are provided.
+   */
+  override def getTable(
+      schema: StructType,
+      partitioning: Array[Transform],
+      properties: util.Map[String, String]): Table = {
+    val opts = new CaseInsensitiveStringMap(properties)
+
+    val optsMap: Map[String, String] = opts.asCaseSensitiveMap().asScala.toMap ++ Map(
+      "sessionLocalTimeZone" -> SparkSession.active.sessionState.conf.sessionLocalTimeZone,
+      "columnNameOfCorruptRecord" -> SparkSession.active.sessionState.conf.columnNameOfCorruptRecord,
+      "defaultParallelism" -> SparkSession.active.sparkContext.defaultParallelism.toString,
+      "maxPartitionItemFiles" -> SparkSession.active.conf
+        .get("spark.wherobots.stac.load.maxPartitionItemFiles", "0"),
+      "numPartitions" -> SparkSession.active.conf
+        .get("spark.wherobots.stac.load.numPartitions", "-1"))
+    val stacCollectionJsonString = StacUtils.loadStacCollectionToJson(optsMap)
+
+    new StacTable(stacCollectionJson = stacCollectionJsonString, opts = optsMap)
+  }
+}

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacPartition.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacPartition.scala
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.spark.sql.sedona_sql.io.stac
+
+import org.apache.spark.sql.connector.read.InputPartition
+
+case class StacPartition(index: Int, items: Array[String], opts: java.util.Map[String, String])
+    extends InputPartition

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacPartitionReader.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacPartitionReader.scala
@@ -151,30 +151,43 @@ class StacPartitionReader(
   }
 
   /**
-   * Create a PartitionedFile instance using reflection. This is needed to support both Spark 3.3
-   * and below and Spark 3.4 and above.
+   * Create a PartitionedFile instance using reflection. The constructor parameters differ between
+   * these versions, so we need to handle both cases. For Spark 3.4 and below, the constructor has
+   * 7 parameters, while for Spark 3.5 and above, it has 8 parameters. Additionally, the type of
+   * the second parameter may be `SparkPath` in some cases, which requires special handling.
    *
    * @param currentFile
    *   The file to create the PartitionedFile for.
    * @return
    *   The created PartitionedFile instance.
+   * @throws NoSuchMethodException
+   *   If no suitable constructor is found.
    */
   def createPartitionedFile(currentFile: File): PartitionedFile = {
     val partitionedFileClass =
       Class.forName("org.apache.spark.sql.execution.datasources.PartitionedFile")
     val constructors = partitionedFileClass.getConstructors
-    // Spark 3.3 and below have 7 parameters for the constructor
     val constructor = constructors
       .find(_.getParameterCount == 7)
       .getOrElse(
-        // Spark 3.4 and above have 8 parameters for the constructor
         constructors
           .find(_.getParameterCount == 8)
-          .getOrElse(throw new NoSuchMethodException("No constructor with 7 parameters found")))
-    if (constructor.getParameterCount == 7) {
-      // for spark 3.3 and below
-      constructor
-        .newInstance(
+          .getOrElse(
+            throw new NoSuchMethodException("No constructor with 7 or 8 parameters found")))
+
+    val params = if (constructor.getParameterCount == 7) {
+      val secondParamType = constructor.getParameterTypes()(1)
+      if (secondParamType.getName == "org.apache.spark.paths.SparkPath") {
+        Array(
+          null,
+          createSparkPath(currentFile.getPath),
+          java.lang.Long.valueOf(0L),
+          java.lang.Long.valueOf(currentFile.length()),
+          Array.empty[String],
+          java.lang.Long.valueOf(0L),
+          java.lang.Long.valueOf(0L))
+      } else {
+        Array(
           null,
           currentFile.getPath,
           java.lang.Long.valueOf(0L),
@@ -182,24 +195,20 @@ class StacPartitionReader(
           Array.empty[String],
           java.lang.Long.valueOf(0L),
           java.lang.Long.valueOf(0L))
-        .asInstanceOf[PartitionedFile]
-    } else if (constructor.getParameterCount == 8) {
-      // for spark 3.4 and above
-      constructor
-        .newInstance(
-          null,
-          createSparkPath(currentFile.getPath),
-          java.lang.Long.valueOf(0L),
-          java.lang.Long.valueOf(currentFile.length()),
-          Array.empty[String],
-          java.lang.Long.valueOf(0L),
-          java.lang.Long.valueOf(0L),
-          null)
-        .asInstanceOf[PartitionedFile]
+      }
     } else {
-      throw new IllegalArgumentException(
-        "Invalid number of parameters for PartitionedFile constructor")
+      Array(
+        null,
+        createSparkPath(currentFile.getPath),
+        java.lang.Long.valueOf(0L),
+        java.lang.Long.valueOf(currentFile.length()),
+        Array.empty[String],
+        java.lang.Long.valueOf(0L),
+        java.lang.Long.valueOf(0L),
+        null)
     }
+
+    constructor.newInstance(params: _*).asInstanceOf[PartitionedFile]
   }
 
   /**

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacPartitionReader.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacPartitionReader.scala
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.spark.sql.sedona_sql.io.stac
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.apache.hadoop.conf.Configuration
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.json.JSONOptionsInRead
+import org.apache.spark.sql.connector.read.PartitionReader
+import org.apache.spark.sql.execution.datasource.stac.TemporalFilter
+import org.apache.spark.sql.execution.datasources.PartitionedFile
+import org.apache.spark.sql.execution.datasources.json.JsonDataSource
+import org.apache.spark.sql.execution.datasources.parquet.GeoParquetSpatialFilter
+import org.apache.spark.sql.sedona_sql.io.geojson.{GeoJSONUtils, SparkCompatUtil}
+import org.apache.spark.sql.sedona_sql.io.stac.StacUtils.{buildOutDbRasterFields, promotePropertiesToTop}
+import org.apache.spark.sql.types.{StringType, StructType}
+
+import java.io.{File, PrintWriter}
+import java.lang.reflect.Constructor
+import scala.io.Source
+
+class StacPartitionReader(
+    partition: StacPartition,
+    schema: StructType,
+    opts: Map[String, String],
+    spatialFilter: Option[GeoParquetSpatialFilter],
+    temporalFilter: Option[TemporalFilter])
+    extends PartitionReader[InternalRow] {
+
+  private val itemsIterator = partition.items.iterator
+  private var currentItem: String = _
+  private var currentFile: File = _
+  private var featureIterator: Iterator[InternalRow] = Iterator.empty
+  private val mapper = new ObjectMapper()
+
+  override def next(): Boolean = {
+    if (featureIterator.hasNext) {
+      true
+    } else if (itemsIterator.hasNext) {
+      currentItem = itemsIterator.next()
+      if (currentItem.startsWith("http://") || currentItem.startsWith("https://") || currentItem
+          .startsWith("file://")) {
+        val url = new java.net.URL(currentItem)
+
+        // Download the file to a local temp file
+        val tempFile = File.createTempFile("stac_item_", ".json")
+        val writer = new PrintWriter(tempFile)
+        try {
+          val fileContent = Source.fromURL(url).mkString
+          val rootNode = mapper.readTree(fileContent)
+          val nodeType = rootNode.get("type").asText()
+
+          nodeType match {
+            case "Feature" =>
+              // Write the content as a single line JSON
+              val content = mapper.writeValueAsString(rootNode)
+              writer.write(content)
+            case "FeatureCollection" =>
+              // Write each feature in the features array to a multi-line JSON file
+              val features = rootNode.get("features")
+              val featureIterator = features.elements()
+              while (featureIterator.hasNext) {
+                val feature = featureIterator.next()
+                val content = mapper.writeValueAsString(feature)
+                writer.write(content)
+                writer.write("\n")
+              }
+            case _ =>
+              throw new IllegalArgumentException(s"Unsupported type for item: $nodeType")
+          }
+
+        } finally {
+          writer.close()
+        }
+        checkAndDeleteTempFile(currentFile)
+        currentFile = tempFile
+      } else {
+        throw new IllegalArgumentException(s"Unsupported protocol for item: $currentItem")
+      }
+
+      // Parse the current file and extract features
+      featureIterator = if (currentFile.exists()) {
+
+        val parsedOptions = new JSONOptionsInRead(
+          opts,
+          opts.getOrElse("sessionLocalTimeZone", "UTC"),
+          opts.getOrElse("columnNameOfCorruptRecord", "_corrupt_record"))
+        val dataSource = JsonDataSource(parsedOptions)
+
+        val alteredSchema = GeoJSONUtils.updateGeometrySchema(schema, StringType)
+
+        val parser = SparkCompatUtil.constructJacksonParser(
+          alteredSchema,
+          parsedOptions,
+          allowArrayAsStructs = true)
+
+        val rows = SparkCompatUtil
+          .readFile(
+            dataSource,
+            new Configuration(),
+            createPartitionedFile(currentFile),
+            parser,
+            schema)
+
+        rows.map(row => {
+          val geometryConvertedRow = GeoJSONUtils.convertGeoJsonToGeometry(row, alteredSchema)
+          val rasterAddedRow = buildOutDbRasterFields(geometryConvertedRow, alteredSchema)
+          val propertiesPromotedRow = promotePropertiesToTop(rasterAddedRow, alteredSchema)
+          propertiesPromotedRow
+        })
+      } else {
+        Iterator.empty
+      }
+
+      next()
+    } else {
+      false
+    }
+  }
+
+  override def get(): InternalRow = {
+    featureIterator.next()
+  }
+
+  override def close(): Unit = {
+    checkAndDeleteTempFile(currentFile)
+  }
+
+  private def checkAndDeleteTempFile(file: File): Unit = {
+    // Delete the local file if it was downloaded to tmp
+    if (file != null && file.exists() && file.getAbsolutePath.startsWith(
+        System.getProperty("java.io.tmpdir"))) {
+      file.delete()
+    }
+  }
+
+  /**
+   * Create a PartitionedFile instance using reflection. This is needed to support both Spark 3.3
+   * and below and Spark 3.4 and above.
+   *
+   * @param currentFile
+   *   The file to create the PartitionedFile for.
+   * @return
+   *   The created PartitionedFile instance.
+   */
+  def createPartitionedFile(currentFile: File): PartitionedFile = {
+    val partitionedFileClass =
+      Class.forName("org.apache.spark.sql.execution.datasources.PartitionedFile")
+    val constructors = partitionedFileClass.getConstructors
+    // Spark 3.3 and below have 7 parameters for the constructor
+    val constructor = constructors
+      .find(_.getParameterCount == 7)
+      .getOrElse(
+        // Spark 3.4 and above have 8 parameters for the constructor
+        constructors
+          .find(_.getParameterCount == 8)
+          .getOrElse(throw new NoSuchMethodException("No constructor with 7 parameters found")))
+    if (constructor.getParameterCount == 7) {
+      // for spark 3.3 and below
+      constructor
+        .newInstance(
+          null,
+          currentFile.getPath,
+          java.lang.Long.valueOf(0L),
+          java.lang.Long.valueOf(currentFile.length()),
+          Array.empty[String],
+          java.lang.Long.valueOf(0L),
+          java.lang.Long.valueOf(0L))
+        .asInstanceOf[PartitionedFile]
+    } else if (constructor.getParameterCount == 8) {
+      // for spark 3.4 and above
+      constructor
+        .newInstance(
+          null,
+          createSparkPath(currentFile.getPath),
+          java.lang.Long.valueOf(0L),
+          java.lang.Long.valueOf(currentFile.length()),
+          Array.empty[String],
+          java.lang.Long.valueOf(0L),
+          java.lang.Long.valueOf(0L),
+          null)
+        .asInstanceOf[PartitionedFile]
+    } else {
+      throw new IllegalArgumentException(
+        "Invalid number of parameters for PartitionedFile constructor")
+    }
+  }
+
+  /**
+   * Create a SparkPath instance using reflection. This is needed to support both Spark 3.3 and
+   * below and Spark 3.4 and above.
+   *
+   * @param pathString
+   *   The path to create the SparkPath for.
+   * @return
+   *   The created SparkPath instance.
+   */
+  def createSparkPath(pathString: String): Object = {
+    val sparkPathClass = Class.forName("org.apache.spark.paths.SparkPath")
+    val constructor: Constructor[_] = sparkPathClass.getDeclaredConstructor(classOf[String])
+    constructor.setAccessible(true) // Make the private constructor accessible
+    constructor.newInstance(pathString).asInstanceOf[Object]
+  }
+}

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacScan.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacScan.scala
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.spark.sql.sedona_sql.io.stac
+
+import org.apache.spark.sql.connector.read.{Batch, Scan}
+import org.apache.spark.sql.execution.datasource.stac.TemporalFilter
+import org.apache.spark.sql.execution.datasources.parquet.GeoParquetSpatialFilter
+import org.apache.spark.sql.internal.connector.SupportsMetadata
+import org.apache.spark.sql.sedona_sql.io.stac.StacUtils.{getFullCollectionUrl, inferStacSchema}
+import org.apache.spark.sql.types.StructType
+
+class StacScan(stacCollectionJson: String, opts: Map[String, String])
+    extends Scan
+    with SupportsMetadata {
+
+  // The spatial filter to be pushed down to the data source
+  var spatialFilter: Option[GeoParquetSpatialFilter] = None
+
+  // The temporal filter to be pushed down to the data source
+  var temporalFilter: Option[TemporalFilter] = None
+
+  /**
+   * Returns the schema of the data to be read.
+   *
+   * The schema is statically defined in the `StacTable` object.
+   */
+  override def readSchema(): StructType = {
+    val url = opts.get("path")
+    val service = opts.get("service")
+
+    if (url == null && service == null) {
+      throw new IllegalArgumentException("Either 'path' or 'service' must be provided")
+    }
+
+    inferStacSchema(opts)
+  }
+
+  /**
+   * Returns a `Batch` instance for reading the data in batch mode.
+   *
+   * The `StacBatch` class provides the implementation for the batch reading.
+   *
+   * @return
+   *   A `Batch` instance for batch-based data processing.
+   */
+  override def toBatch: Batch = {
+    val stacCollectionUrl = getFullCollectionUrl(opts)
+    StacBatch(
+      stacCollectionUrl,
+      stacCollectionJson,
+      readSchema(),
+      opts,
+      spatialFilter,
+      temporalFilter)
+  }
+
+  /**
+   * Sets the spatial predicates to be pushed down to the data source.
+   *
+   * @param combinedSpatialFilter
+   *   The combined spatial filter to be pushed down.
+   */
+  def setSpatialPredicates(combinedSpatialFilter: GeoParquetSpatialFilter) = {
+    spatialFilter = Some(combinedSpatialFilter)
+  }
+
+  /**
+   * Sets the temporal predicates to be pushed down to the data source.
+   *
+   * @param combineTemporalFilter
+   *   The combined temporal filter to be pushed down.
+   */
+  def setTemporalPredicates(combineTemporalFilter: TemporalFilter) = {
+    temporalFilter = Some(combineTemporalFilter)
+  }
+
+  /**
+   * Returns metadata about the data to be read.
+   *
+   * The metadata includes information about the pushed filters.
+   *
+   * @return
+   *   A map of metadata key-value pairs.
+   */
+  override def getMetaData(): Map[String, String] = {
+    Map(
+      "PushedSpatialFilters" -> spatialFilter.map(_.toString).getOrElse("None"),
+      "PushedTemporalFilters" -> temporalFilter.map(_.toString).getOrElse("None"))
+  }
+
+  /**
+   * Returns a description of the data to be read.
+   *
+   * The description includes the metadata information.
+   *
+   * @return
+   *   A string description of the data to be read.
+   */
+  override def description(): String = {
+    super.description() + " " + getMetaData().mkString(", ")
+  }
+}

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacScanBuilder.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacScanBuilder.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.spark.sql.sedona_sql.io.stac
+
+import org.apache.spark.sql.connector.read.{Scan, ScanBuilder}
+
+/**
+ * The `StacScanBuilder` class represents the builder for creating a `Scan` instance in the
+ * SpatioTemporal Asset Catalog (STAC) data source.
+ *
+ * This class is responsible for assembling the scan operation for reading STAC data. It acts as a
+ * bridge between Spark's data source API and the specific implementation of the STAC data read
+ * operation.
+ */
+class StacScanBuilder(stacCollectionJson: String, opts: Map[String, String]) extends ScanBuilder {
+
+  /**
+   * Builds and returns a `Scan` instance. The `Scan` defines the schema and batch reading methods
+   * for STAC data.
+   *
+   * @return
+   *   A `Scan` instance that defines how to read STAC data.
+   */
+  override def build(): Scan = new StacScan(stacCollectionJson, opts)
+}

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacTable.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacTable.scala
@@ -1,0 +1,261 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.spark.sql.sedona_sql.io.stac
+
+import org.apache.spark.sql.connector.catalog.{SupportsRead, Table, TableCapability}
+import org.apache.spark.sql.connector.read.ScanBuilder
+import org.apache.spark.sql.sedona_sql.UDT.GeometryUDT
+import org.apache.spark.sql.sedona_sql.io.geojson.GeoJSONUtils
+import org.apache.spark.sql.sedona_sql.io.stac.StacUtils.{inferStacSchema, updatePropertiesPromotedSchema}
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * The `StacTable` class represents a table in the SpatioTemporal Asset Catalog (STAC) data
+ * source.
+ *
+ * This class implements the `Table` and `SupportsRead` interfaces to integrate with Apache
+ * Spark's data source API, providing support for reading data from STAC.
+ *
+ * @constructor
+ *   Creates a new instance of the `StacTable` class.
+ */
+class StacTable(stacCollectionJson: String, opts: Map[String, String])
+    extends Table
+    with SupportsRead {
+
+  // Cache to store inferred schemas
+  private val schemaCache = new ConcurrentHashMap[Map[String, String], StructType]()
+
+  /**
+   * Returns the name of the table.
+   *
+   * @return
+   *   The name of the table as a string.
+   */
+  override def name(): String = "stac"
+
+  /**
+   * Defines the schema of the STAC table.
+   *
+   * @return
+   *   The schema as a StructType.
+   */
+  override def schema(): StructType = {
+    // Check if the schema is already cached
+    val fullSchema = schemaCache.computeIfAbsent(opts, _ => inferStacSchema(opts))
+    val updatedGeometrySchema = GeoJSONUtils.updateGeometrySchema(fullSchema, GeometryUDT)
+    updatePropertiesPromotedSchema(updatedGeometrySchema)
+  }
+
+  /**
+   * Indicates the capabilities supported by the STAC table, specifically batch read.
+   *
+   * @return
+   *   A set of table capabilities.
+   */
+  override def capabilities(): java.util.Set[TableCapability] =
+    java.util.EnumSet.of(TableCapability.BATCH_READ)
+
+  /**
+   * Creates a new scan builder for reading data from the STAC table.
+   *
+   * @param options
+   *   The configuration options for the scan.
+   * @return
+   *   A new instance of ScanBuilder.
+   */
+  override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder =
+    new StacScanBuilder(stacCollectionJson, opts)
+}
+
+object StacTable {
+
+  /**
+   * Defines the schema of the STAC table, which supports various fields including collection
+   * information, asset details, geometries, and more. The schema is based on the STAC
+   * specification version 1.1.0.
+   */
+  val SCHEMA_V1_1_0: StructType = StructType(
+    Seq(
+      StructField("stac_version", StringType, nullable = false),
+      StructField("stac_extensions", ArrayType(StringType), nullable = true),
+      StructField("type", StringType, nullable = false),
+      StructField("id", StringType, nullable = false),
+      StructField("bbox", ArrayType(DoubleType), nullable = true),
+      StructField(
+        "geometry",
+        StructType(
+          Seq(
+            StructField("type", StringType, nullable = true),
+            StructField("coordinates", ArrayType(ArrayType(DoubleType)), nullable = true))),
+        nullable = true),
+      StructField(
+        "properties",
+        StructType(Seq(
+          StructField("title", StringType, nullable = true),
+          StructField("description", StringType, nullable = true),
+          StructField("datetime", TimestampType, nullable = true),
+          StructField("start_datetime", TimestampType, nullable = true),
+          StructField("end_datetime", TimestampType, nullable = true),
+          StructField("created", TimestampType, nullable = true),
+          StructField("updated", TimestampType, nullable = true),
+          StructField("platform", StringType, nullable = true),
+          StructField("instruments", ArrayType(StringType), nullable = true),
+          StructField("constellation", StringType, nullable = true),
+          StructField("mission", StringType, nullable = true),
+          StructField("gsd", DoubleType, nullable = true))),
+        nullable = false),
+      StructField("collection", StringType, nullable = true),
+      StructField(
+        "links",
+        ArrayType(StructType(Seq(
+          StructField("rel", StringType, nullable = true),
+          StructField("href", StringType, nullable = true),
+          StructField("type", StringType, nullable = true),
+          StructField("title", StringType, nullable = true)))),
+        nullable = false),
+      StructField(
+        "assets",
+        MapType(
+          StringType,
+          StructType(Seq(
+            StructField("href", StringType, nullable = true),
+            StructField("type", StringType, nullable = true),
+            StructField("title", StringType, nullable = true),
+            StructField("roles", ArrayType(StringType), nullable = true)))),
+        nullable = false)))
+
+  /**
+   * Defines the schema of the STAC table, which supports various fields including collection
+   * information, asset details, geometries, and more. The schema is based on the STAC
+   * specification version 1.0.0.
+   */
+  val SCHEMA_V1_0_0: StructType = StructType(
+    Seq(
+      StructField("stac_version", StringType, nullable = false),
+      StructField("stac_extensions", ArrayType(StringType), nullable = true),
+      StructField("type", StringType, nullable = false),
+      StructField("id", StringType, nullable = false),
+      StructField("bbox", ArrayType(DoubleType), nullable = true),
+      StructField(
+        "geometry",
+        StructType(
+          Seq(
+            StructField("type", StringType, nullable = true),
+            StructField("coordinates", ArrayType(ArrayType(DoubleType)), nullable = true))),
+        nullable = true),
+      StructField(
+        "properties",
+        StructType(Seq(
+          StructField("title", StringType, nullable = true),
+          StructField("description", StringType, nullable = true),
+          StructField("datetime", TimestampType, nullable = true),
+          StructField("start_datetime", TimestampType, nullable = true),
+          StructField("end_datetime", TimestampType, nullable = true),
+          StructField("created", TimestampType, nullable = true),
+          StructField("updated", TimestampType, nullable = true),
+          StructField("platform", StringType, nullable = true),
+          StructField("instruments", ArrayType(StringType), nullable = true),
+          StructField("constellation", StringType, nullable = true),
+          StructField("mission", StringType, nullable = true),
+          StructField("gsd", DoubleType, nullable = true))),
+        nullable = true),
+      StructField("collection", StringType, nullable = true),
+      StructField(
+        "links",
+        ArrayType(StructType(Seq(
+          StructField("rel", StringType, nullable = true),
+          StructField("href", StringType, nullable = true),
+          StructField("type", StringType, nullable = true),
+          StructField("title", StringType, nullable = true)))),
+        nullable = true),
+      StructField(
+        "assets",
+        MapType(
+          StringType,
+          StructType(Seq(
+            StructField("href", StringType, nullable = true),
+            StructField("type", StringType, nullable = true),
+            StructField("title", StringType, nullable = true),
+            StructField("roles", ArrayType(StringType), nullable = true)))),
+        nullable = true)))
+
+  val SCHEMA_GEOPARQUET: StructType = StructType(
+    Seq(
+      StructField("stac_version", StringType, nullable = false),
+      StructField("stac_extensions", ArrayType(StringType), nullable = true),
+      StructField("type", StringType, nullable = false),
+      StructField("id", StringType, nullable = false),
+      StructField("bbox", ArrayType(DoubleType), nullable = true),
+      StructField(
+        "geometry",
+        StructType(
+          Seq(
+            StructField("type", StringType, nullable = true),
+            StructField("coordinates", ArrayType(ArrayType(DoubleType)), nullable = true))),
+        nullable = true),
+      StructField("datetime", TimestampType, nullable = true),
+      StructField("collection", StringType, nullable = true),
+      StructField(
+        "links",
+        ArrayType(StructType(Seq(
+          StructField("rel", StringType, nullable = true),
+          StructField("href", StringType, nullable = true),
+          StructField("type", StringType, nullable = true),
+          StructField("title", StringType, nullable = true)))),
+        nullable = false)))
+
+  def addAssetStruct(schema: StructType, name: String): StructType = {
+    val assetStruct = StructType(
+      Seq(
+        StructField("href", StringType, nullable = true),
+        StructField("roles", ArrayType(StringType), nullable = true),
+        StructField("title", StringType, nullable = true),
+        StructField("type", StringType, nullable = true)))
+
+    val updatedFields = schema.fields.map {
+      case StructField("assets", existingStruct: StructType, nullable, metadata) =>
+        StructField(
+          "assets",
+          StructType(existingStruct.fields :+ StructField(name, assetStruct, nullable = true)),
+          nullable,
+          metadata)
+      case other => other
+    }
+
+    if (!schema.fieldNames.contains("assets")) {
+      StructType(
+        updatedFields :+ StructField(
+          "assets",
+          StructType(Seq(StructField(name, assetStruct, nullable = true))),
+          nullable = true))
+    } else {
+      StructType(updatedFields)
+    }
+  }
+
+  def addAssetsStruct(schema: StructType, names: Array[String]): StructType = {
+    names.foldLeft(schema) { (currentSchema, name) =>
+      addAssetStruct(currentSchema, name)
+    }
+  }
+}

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacUtils.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacUtils.scala
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.spark.sql.sedona_sql.io.stac
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.util.ArrayBasedMapData
+import org.apache.spark.sql.sedona_sql.UDT.RasterUDT
+import org.apache.spark.sql.types.{MapType, StringType, StructField, StructType}
+
+import java.net.URI
+import scala.io.Source
+
+object StacUtils {
+
+  // Function to load JSON from URL or service
+  def loadStacCollectionToJson(opts: Map[String, String]): String = {
+    val urlFull: String = getFullCollectionUrl(opts)
+
+    loadStacCollectionToJson(urlFull)
+  }
+
+  def getFullCollectionUrl(opts: Map[String, String]) = {
+    val url = opts.getOrElse(
+      "path",
+      opts.getOrElse(
+        "service",
+        throw new IllegalArgumentException("Either 'path' or 'service' must be provided")))
+    val urlFinal = if (url.matches("^[a-zA-Z][a-zA-Z0-9+.-]*://.*")) url else s"file://$url"
+    urlFinal
+  }
+
+  // Function to load JSON from URL or service
+  def loadStacCollectionToJson(url: String): String = {
+    if (url.startsWith("s3://") || url.startsWith("s3a://")) {
+      SparkSession.active.read.textFile(url).collect().mkString("\n")
+    } else {
+      Source.fromURL(url).mkString
+    }
+  }
+
+  // Function to get the base URL from the collection URL or service
+  def getStacCollectionBasePath(opts: Map[String, String]): String = {
+    val ref = opts.getOrElse(
+      "path",
+      opts.getOrElse(
+        "service",
+        throw new IllegalArgumentException("Either 'path' or 'service' must be provided")))
+    getStacCollectionBasePath(ref)
+  }
+
+  // Function to get the base URL from the collection URL or service
+  def getStacCollectionBasePath(collectionUrl: String): String = {
+    val urlPattern = "(https?://[^/]+/|http://[^/]+/).*".r
+    val filePattern = "(file:///.*/|/.*/).*".r
+
+    collectionUrl match {
+      case urlPattern(baseUrl) => baseUrl
+      case filePattern(basePath) =>
+        if (basePath.startsWith("file://")) basePath else s"file://$basePath"
+      case _ => throw new IllegalArgumentException(s"Invalid URL or file path: $collectionUrl")
+    }
+  }
+
+  /**
+   * Infer the schema of the STAC data source table.
+   *
+   * This method checks if a cached schema exists for the given data source options. If not, it
+   * processes the STAC collection and saves it as a GeoJson file. The schema is then inferred
+   * from this GeoJson file.
+   *
+   * @param opts
+   *   Mapping of data source options, which should include either 'url' or 'service'.
+   * @return
+   *   The inferred schema of the STAC data source table.
+   * @throws IllegalArgumentException
+   *   If neither 'url' nor 'service' are provided.
+   */
+  def inferStacSchema(opts: Map[String, String]): StructType = {
+    val stacCollectionJsonString = loadStacCollectionToJson(opts)
+
+    // Create the ObjectMapper
+    val mapper = new ObjectMapper()
+    mapper.registerModule(DefaultScalaModule)
+
+    // Parse the STAC collection JSON
+    val collection = mapper.readTree(stacCollectionJsonString)
+
+    // Extract the stac_version
+    val stacVersion = collection.get("stac_version").asText()
+
+    // Return the corresponding schema based on the stac_version
+    stacVersion match {
+      case "1.0.0" => StacTable.SCHEMA_V1_0_0
+      case version if version.matches("1\\.[1-9]\\d*\\.\\d*") => StacTable.SCHEMA_V1_1_0
+      // Add more cases here for other versions if needed
+      case _ => throw new IllegalArgumentException(s"Unsupported STAC version: $stacVersion")
+    }
+  }
+
+  /**
+   * Promote the properties field to the top level of the row.
+   */
+  def promotePropertiesToTop(row: InternalRow, schema: StructType): InternalRow = {
+    val propertiesIndex = schema.fieldIndex("properties")
+    val propertiesStruct = schema("properties").dataType.asInstanceOf[StructType]
+    val propertiesRow = row.getStruct(propertiesIndex, propertiesStruct.fields.length)
+
+    val newValues = schema.fields.zipWithIndex.flatMap {
+      case (field, index) if field.name == "properties" =>
+        propertiesStruct.fields.zipWithIndex.map { case (propField, propIndex) =>
+          propertiesRow.get(propIndex, propField.dataType)
+        }
+      case (_, index) => Seq(row.get(index, schema(index).dataType))
+    }
+
+    InternalRow.fromSeq(newValues)
+  }
+
+  /**
+   * Update the schema to include the promoted properties.
+   *
+   * @param schema
+   *   The schema to update.
+   * @return
+   *   The updated schema.
+   */
+  def updatePropertiesPromotedSchema(schema: StructType): StructType = {
+    val propertiesIndex = schema.fieldIndex("properties")
+    val propertiesStruct = schema("properties").dataType.asInstanceOf[StructType]
+
+    val newFields = schema.fields.flatMap {
+      case StructField("properties", _, _, _) => propertiesStruct.fields
+      case other => Seq(other)
+    }
+
+    StructType(newFields)
+  }
+
+  /**
+   * Builds the output row with the raster field in the assets map.
+   *
+   * @param row
+   *   The input row.
+   * @param schema
+   *   The schema of the input row.
+   * @return
+   *   The output row with the raster field in the assets map.
+   */
+  def buildOutDbRasterFields(row: InternalRow, schema: StructType): InternalRow = {
+    val newValues = new Array[Any](schema.fields.length)
+
+    schema.fields.zipWithIndex.foreach {
+      case (StructField("assets", MapType(StringType, valueType: StructType, _), _, _), index) =>
+        val assetsMap = row.getMap(index)
+        if (assetsMap != null) {
+          val updatedAssets = assetsMap
+            .keyArray()
+            .array
+            .zip(assetsMap.valueArray().array)
+            .map { case (key, value) =>
+              val assetRow = value.asInstanceOf[InternalRow]
+              if (assetRow != null) {
+                key -> assetRow
+              } else {
+                key -> null
+              }
+            }
+            .toMap
+          newValues(index) = ArrayBasedMapData(updatedAssets)
+        } else {
+          newValues(index) = null
+        }
+      case (_, index) =>
+        newValues(index) = row.get(index, schema.fields(index).dataType)
+    }
+
+    InternalRow.fromSeq(newValues)
+  }
+
+  /**
+   * Returns the number of partitions to use for reading the data.
+   *
+   * The number of partitions is determined based on the number of items, the number of partitions
+   * requested, the maximum number of item files per partition, and the default parallelism.
+   *
+   * @param itemCount
+   *   The number of items in the collection.
+   * @param numPartitions
+   *   The number of partitions requested.
+   * @param maxPartitionItemFiles
+   *   The maximum number of item files per partition.
+   * @param defaultParallelism
+   *   The default parallelism.
+   * @return
+   *   The number of partitions to use for reading the data.
+   */
+  def getNumPartitions(
+      itemCount: Int,
+      numPartitions: Int,
+      maxPartitionItemFiles: Int,
+      defaultParallelism: Int): Int = {
+    if (numPartitions > 0) {
+      numPartitions
+    } else {
+      val maxSplitFiles = if (maxPartitionItemFiles > 0) {
+        Math.min(maxPartitionItemFiles, Math.ceil(itemCount.toDouble / defaultParallelism).toInt)
+      } else {
+        Math.ceil(itemCount.toDouble / defaultParallelism).toInt
+      }
+      Math.max(1, Math.ceil(itemCount.toDouble / maxSplitFiles).toInt)
+    }
+  }
+}

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/optimization/SpatialFilterPushDownForGeoParquet.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/optimization/SpatialFilterPushDownForGeoParquet.scala
@@ -92,7 +92,7 @@ class SpatialFilterPushDownForGeoParquet(sparkSession: SparkSession) extends Rul
     lr.relation.isInstanceOf[HadoopFsRelation] &&
       lr.relation.asInstanceOf[HadoopFsRelation].fileFormat.isInstanceOf[GeoParquetFileFormatBase]
 
-  private def translateToGeoParquetSpatialFilters(
+  def translateToGeoParquetSpatialFilters(
       predicates: Seq[Expression]): Seq[GeoParquetSpatialFilter] = {
     val pushableColumn = PushableColumn(nestedPredicatePushdownEnabled = false)
     predicates.flatMap { predicate =>

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/optimization/SpatialTemporalFilterPushDownForStacScan.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/optimization/SpatialTemporalFilterPushDownForStacScan.scala
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.spark.sql.sedona_sql.optimization
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.{And, EqualTo, Expression, GreaterThan, GreaterThanOrEqual, LessThan, LessThanOrEqual, Literal, Or, SubqueryExpression}
+import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan}
+import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.parseColumnPath
+import org.apache.spark.sql.execution.datasource.stac.TemporalFilter
+import org.apache.spark.sql.execution.datasource.stac.TemporalFilter.{AndFilter => TemporalAndFilter}
+import org.apache.spark.sql.execution.datasources.parquet.GeoParquetSpatialFilter.{AndFilter => SpatialAndFilter}
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
+import org.apache.spark.sql.execution.datasources.{DataSourceStrategy, PushableColumn, PushableColumnBase}
+import org.apache.spark.sql.sedona_sql.io.stac.StacScan
+import org.apache.spark.sql.sedona_sql.optimization.ExpressionUtils.splitConjunctivePredicates
+import org.apache.spark.sql.types.TimestampType
+
+import java.time.{Instant, LocalDateTime, ZoneOffset}
+
+/*
+ * This class is responsible for pushing down spatial filters to the STAC data source.
+ * It extends and reuses the `SpatialFilterPushDownForGeoParquet` class, which is responsible for pushing down
+ */
+class SpatialTemporalFilterPushDownForStacScan(sparkSession: SparkSession)
+    extends SpatialFilterPushDownForGeoParquet(sparkSession) {
+
+  /**
+   * Pushes down spatial filters to the STAC data source.
+   *
+   * @param plan
+   *   The logical plan to optimize.
+   * @return
+   *   The optimized logical plan with spatial filters pushed down to the STAC data source.
+   */
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+    val enableSpatialFilterPushDown =
+      sparkSession.conf.get("spark.sedona.stac.spatialFilterPushDown", "true").toBoolean
+    if (!enableSpatialFilterPushDown) plan
+    else {
+      plan transform {
+        case filter @ Filter(condition, lr: DataSourceV2ScanRelation) if isStacScanRelation(lr) =>
+          val filters = splitConjunctivePredicates(condition)
+          val normalizedFilters = DataSourceStrategy.normalizeExprs(filters, lr.output)
+          val (_, normalizedFiltersWithoutSubquery) =
+            normalizedFilters.partition(SubqueryExpression.hasSubquery)
+          // reuse the `translateToGeoParquetSpatialFilters` method from the `SpatialFilterPushDownForGeoParquet` class
+          val spatialFilters =
+            translateToGeoParquetSpatialFilters(normalizedFiltersWithoutSubquery)
+          if (!spatialFilters.isEmpty) {
+            val combinedSpatialFilter = spatialFilters.reduce(SpatialAndFilter)
+            val scan = lr.scan.asInstanceOf[StacScan]
+            // set the spatial predicates in the STAC scan
+            scan.setSpatialPredicates(combinedSpatialFilter)
+            filter.copy()
+          }
+          val temporalFilters =
+            translateToTemporalFilters(normalizedFiltersWithoutSubquery)
+          if (!temporalFilters.isEmpty) {
+            val combinedTemporalFilter = temporalFilters.reduce(TemporalAndFilter)
+            val scan = lr.scan.asInstanceOf[StacScan]
+            // set the spatial predicates in the STAC scan
+            scan.setTemporalPredicates(combinedTemporalFilter)
+            filter.copy()
+          }
+          filter.copy()
+      }
+    }
+  }
+
+  private def isStacScanRelation(lr: DataSourceV2ScanRelation): Boolean =
+    lr.scan.isInstanceOf[StacScan]
+
+  def translateToTemporalFilters(predicates: Seq[Expression]): Seq[TemporalFilter] = {
+    val pushableColumn = PushableColumn(nestedPredicatePushdownEnabled = true)
+    predicates.flatMap { predicate =>
+      translateToTemporalFilter(predicate, pushableColumn)
+    }
+  }
+
+  private def translateToTemporalFilter(
+      predicate: Expression,
+      pushableColumn: PushableColumnBase): Option[TemporalFilter] = {
+    predicate match {
+      case And(left, right) =>
+        val temporalFilterLeft = translateToTemporalFilter(left, pushableColumn)
+        val temporalFilterRight = translateToTemporalFilter(right, pushableColumn)
+        (temporalFilterLeft, temporalFilterRight) match {
+          case (Some(l), Some(r)) => Some(TemporalFilter.AndFilter(l, r))
+          case (Some(l), None) => Some(l)
+          case (None, Some(r)) => Some(r)
+          case _ => None
+        }
+
+      case Or(left, right) =>
+        for {
+          temporalFilterLeft <- translateToTemporalFilter(left, pushableColumn)
+          temporalFilterRight <- translateToTemporalFilter(right, pushableColumn)
+        } yield TemporalFilter.OrFilter(temporalFilterLeft, temporalFilterRight)
+
+      case LessThan(pushableColumn(name), Literal(v, TimestampType)) =>
+        Some(
+          TemporalFilter
+            .LessThanFilter(
+              unquote(name),
+              LocalDateTime
+                .ofInstant(Instant.ofEpochMilli(v.asInstanceOf[Long] / 1000), ZoneOffset.UTC)))
+
+      case LessThanOrEqual(pushableColumn(name), Literal(v, TimestampType)) =>
+        Some(
+          TemporalFilter
+            .LessThanFilter(
+              unquote(name),
+              LocalDateTime
+                .ofInstant(Instant.ofEpochMilli(v.asInstanceOf[Long] / 1000), ZoneOffset.UTC)))
+
+      case GreaterThan(pushableColumn(name), Literal(v, TimestampType)) =>
+        Some(
+          TemporalFilter
+            .GreaterThanFilter(
+              unquote(name),
+              LocalDateTime
+                .ofInstant(Instant.ofEpochMilli(v.asInstanceOf[Long] / 1000), ZoneOffset.UTC)))
+
+      case GreaterThanOrEqual(pushableColumn(name), Literal(v, TimestampType)) =>
+        Some(
+          TemporalFilter
+            .GreaterThanFilter(
+              unquote(name),
+              LocalDateTime
+                .ofInstant(Instant.ofEpochMilli(v.asInstanceOf[Long] / 1000), ZoneOffset.UTC)))
+
+      case EqualTo(pushableColumn(name), Literal(v, TimestampType)) =>
+        Some(
+          TemporalFilter
+            .EqualFilter(
+              unquote(name),
+              LocalDateTime
+                .ofInstant(Instant.ofEpochMilli(v.asInstanceOf[Long] / 1000), ZoneOffset.UTC)))
+
+      case _ => None
+    }
+  }
+
+  private def unquote(name: String): String = {
+    parseColumnPath(name).mkString(".")
+  }
+}

--- a/spark/common/src/test/resources/datasource_stac/collection-items.json
+++ b/spark/common/src/test/resources/datasource_stac/collection-items.json
@@ -1,0 +1,7204 @@
+{
+  "type": "FeatureCollection",
+  "stac_version": "1.0.0",
+  "stac_extensions": [],
+  "context": {
+    "limit": 10,
+    "matched": 21436719,
+    "returned": 10
+  },
+  "numberMatched": 21436719,
+  "numberReturned": 10,
+  "features": [
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "id": "S2B_T28UEC_20250110T120355_L2A",
+      "properties": {
+        "created": "2025-01-10T16:22:52.618Z",
+        "platform": "sentinel-2b",
+        "constellation": "sentinel-2",
+        "instruments": [
+          "msi"
+        ],
+        "eo:cloud_cover": 26.967385,
+        "proj:epsg": 32628,
+        "proj:centroid": {
+          "lat": 52.31849,
+          "lon": -13.53342
+        },
+        "mgrs:utm_zone": 28,
+        "mgrs:latitude_band": "U",
+        "mgrs:grid_square": "EC",
+        "grid:code": "MGRS-28UEC",
+        "view:azimuth": 118.315984493439,
+        "view:incidence_angle": 3.15096590200837,
+        "view:sun_azimuth": 166.250646673544,
+        "view:sun_elevation": 15.2125487342296,
+        "s2:tile_id": "S2B_OPER_MSI_L2A_TL_2BPS_20250110T154043_A040990_T28UEC_N05.11",
+        "s2:degraded_msi_data_percentage": 0.0045,
+        "s2:nodata_pixel_percentage": 99.030858,
+        "s2:saturated_defective_pixel_percentage": 0,
+        "s2:cloud_shadow_percentage": 0,
+        "s2:vegetation_percentage": 0.000342,
+        "s2:not_vegetated_percentage": 0.000342,
+        "s2:water_percentage": 73.031932,
+        "s2:unclassified_percentage": 0,
+        "s2:medium_proba_clouds_percentage": 13.981807,
+        "s2:high_proba_clouds_percentage": 12.049599,
+        "s2:thin_cirrus_percentage": 0.935978,
+        "s2:snow_ice_percentage": 0,
+        "s2:product_type": "S2MSI2A",
+        "s2:processing_baseline": "05.11",
+        "s2:product_uri": "S2B_MSIL2A_20250110T120359_N0511_R066_T28UEC_20250110T154043.SAFE",
+        "s2:generation_time": "2025-01-10T15:40:43.000000Z",
+        "s2:datatake_id": "GS2B_20250110T120359_040990_N05.11",
+        "s2:datatake_type": "INS-NOBS",
+        "s2:datastrip_id": "S2B_OPER_MSI_L2A_DS_2BPS_20250110T154043_S20250110T120355_N05.11",
+        "s2:reflectance_conversion_factor": 1.03425891111326,
+        "datetime": "2025-01-10T12:07:02.966000Z",
+        "earthsearch:payload_id": "roda-sentinel-2-c1-l2a/workflow-sentinel-2-c1-l2a-to-stac/212b523557c5336ebe1c078fc29a2069",
+        "storage:platform": "AWS",
+        "storage:region": "us-west-2",
+        "storage:requester_pays": false,
+        "processing:software": {
+          "sentinel-2-c1-l2a-to-stac": "v2024.02.01"
+        },
+        "updated": "2025-01-10T16:22:52.618Z"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [-13.8282447208263, 52.3446542644649],
+            [-13.7600637715014, 52.3345986073346],
+            [-13.3911071072422, 52.2712256131467],
+            [-13.3886306359678, 52.3394760649279],
+            [-13.8282447208263, 52.3446542644649]
+          ]
+        ]
+      },
+      "links": [
+        {
+          "rel": "self",
+          "type": "application/geo+json",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a/items/S2B_T28UEC_20250110T120355_L2A"
+        },
+        {
+          "rel": "canonical",
+          "href": "s3://e84-earth-search-sentinel-data/sentinel-2-c1-l2a/28/U/EC/2025/1/S2B_T28UEC_20250110T120355_L2A/S2B_T28UEC_20250110T120355_L2A.json",
+          "type": "application/json"
+        },
+        {
+          "rel": "via",
+          "href": "s3://sentinel-s2-l2a/tiles/28/U/EC/2025/1/10/0/metadata.xml",
+          "type": "application/xml",
+          "title": "Granule Metadata in Sinergize RODA Archive"
+        },
+        {
+          "rel": "parent",
+          "type": "application/json",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a"
+        },
+        {
+          "rel": "collection",
+          "type": "application/json",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a"
+        },
+        {
+          "rel": "root",
+          "type": "application/json",
+          "href": "https://earth-search.aws.element84.com/v1"
+        },
+        {
+          "rel": "thumbnail",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a/items/S2B_T28UEC_20250110T120355_L2A/thumbnail"
+        }
+      ],
+      "assets": {
+        "red": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EC/2025/1/S2B_T28UEC_20250110T120355_L2A/B04.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red - 10m",
+          "eo:bands": [
+            {
+              "name": "B04",
+              "common_name": "red",
+              "center_wavelength": 0.665,
+              "full_width_half_max": 0.038
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 499980, 0, -10, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "122032a6cbfd123d742d90e53162ae4660586361a5ef85e13429946aa77953065cf5",
+          "file:size": 2357747,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "green": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EC/2025/1/S2B_T28UEC_20250110T120355_L2A/B03.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Green - 10m",
+          "eo:bands": [
+            {
+              "name": "B03",
+              "common_name": "green",
+              "center_wavelength": 0.56,
+              "full_width_half_max": 0.045
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 499980, 0, -10, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "122033b3a77113b9fa9931115939f8c3738d00a9b73b0e499d23e21da0bef4696be7",
+          "file:size": 2371586,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "blue": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EC/2025/1/S2B_T28UEC_20250110T120355_L2A/B02.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Blue - 10m",
+          "eo:bands": [
+            {
+              "name": "B02",
+              "common_name": "blue",
+              "center_wavelength": 0.49,
+              "full_width_half_max": 0.098
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 499980, 0, -10, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220f68f82bf174b37fc0e5c195c2bb19ed0a2e7d4aa1117636eace4199f49a83845",
+          "file:size": 2396700,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "visual": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EC/2025/1/S2B_T28UEC_20250110T120355_L2A/TCI.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "True color image",
+          "eo:bands": [
+            {
+              "name": "B04",
+              "common_name": "red",
+              "center_wavelength": 0.665,
+              "full_width_half_max": 0.038
+            },
+            {
+              "name": "B03",
+              "common_name": "green",
+              "center_wavelength": 0.56,
+              "full_width_half_max": 0.045
+            },
+            {
+              "name": "B02",
+              "common_name": "blue",
+              "center_wavelength": 0.49,
+              "full_width_half_max": 0.098
+            }
+          ],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 10
+            },
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 10
+            },
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 10
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 499980, 0, -10, 5800020],
+          "file:checksum": "122083fa02d60e11ee92c40028343320794d6b341bfeb88a50b47b317226c3cd45dc",
+          "file:size": 3097977,
+          "roles": [
+            "visual"
+          ]
+        },
+        "nir": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EC/2025/1/S2B_T28UEC_20250110T120355_L2A/B08.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "NIR 1 - 10m",
+          "eo:bands": [
+            {
+              "name": "B08",
+              "common_name": "nir",
+              "center_wavelength": 0.842,
+              "full_width_half_max": 0.145
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 499980, 0, -10, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "122063993cadf2b23b6b877c29387a416c9400d2cbe94092c66dfeea6d6f3851f99c",
+          "file:size": 2368644,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "swir22": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EC/2025/1/S2B_T28UEC_20250110T120355_L2A/B12.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "SWIR 2.2μm - 20m",
+          "eo:bands": [
+            {
+              "name": "B12",
+              "common_name": "swir22",
+              "center_wavelength": 2.19,
+              "full_width_half_max": 0.242
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12208c9c4478d4bbb29ce1fd8b233fec7262d91de3535ab7623dca8821d17ce2b92c",
+          "file:size": 629724,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "rededge2": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EC/2025/1/S2B_T28UEC_20250110T120355_L2A/B06.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red Edge 2 - 20m",
+          "eo:bands": [
+            {
+              "name": "B06",
+              "common_name": "rededge",
+              "center_wavelength": 0.74,
+              "full_width_half_max": 0.018
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12202676f8075b28a063e89a9d461f31f8ac6e9a53e4c54091e218b681c8e74fa41f",
+          "file:size": 638352,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "rededge3": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EC/2025/1/S2B_T28UEC_20250110T120355_L2A/B07.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red Edge 3 - 20m",
+          "eo:bands": [
+            {
+              "name": "B07",
+              "common_name": "rededge",
+              "center_wavelength": 0.783,
+              "full_width_half_max": 0.028
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220d44985e336e4999bc99a3d0d6affd8ea0ce1cf89698fe5727a4495dd43a0664c",
+          "file:size": 639056,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "rededge1": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EC/2025/1/S2B_T28UEC_20250110T120355_L2A/B05.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red Edge 1 - 20m",
+          "eo:bands": [
+            {
+              "name": "B05",
+              "common_name": "rededge",
+              "center_wavelength": 0.704,
+              "full_width_half_max": 0.019
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220f4c994b1ae1c5c8c46d95e862e3888199f703615e01f69b86063885f00bfda19",
+          "file:size": 638484,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "swir16": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EC/2025/1/S2B_T28UEC_20250110T120355_L2A/B11.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "SWIR 1.6μm - 20m",
+          "eo:bands": [
+            {
+              "name": "B11",
+              "common_name": "swir16",
+              "center_wavelength": 1.61,
+              "full_width_half_max": 0.143
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12204553e83bb568a301ed89a19976ce706da96e62da25cd98a30bf47c788c63fdff",
+          "file:size": 626909,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "wvp": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EC/2025/1/S2B_T28UEC_20250110T120355_L2A/WVP.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Water Vapour (WVP)",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "unit": "cm",
+              "scale": 0.001,
+              "offset": 0
+            }
+          ],
+          "file:checksum": "12204701f12f0a40fbe11da4652e3c66a17355edbe9ede6d7cfb6ccbbf2db9aa95cd",
+          "file:size": 98743,
+          "roles": [
+            "data"
+          ]
+        },
+        "nir08": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EC/2025/1/S2B_T28UEC_20250110T120355_L2A/B8A.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "NIR 2 - 20m",
+          "eo:bands": [
+            {
+              "name": "B8A",
+              "common_name": "nir08",
+              "center_wavelength": 0.865,
+              "full_width_half_max": 0.033
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220bf5827bf5efdb2e488c95d707d2f3f56ac524578e6f8b7e0bbff01c2bd051cd0",
+          "file:size": 639283,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "scl": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EC/2025/1/S2B_T28UEC_20250110T120355_L2A/SCL.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Scene classification map (SCL)",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 20
+            }
+          ],
+          "file:checksum": "1220cfbbc94375ef0b9d9c2844eb52cae66a47b996aa960e104edfe170fa07d70897",
+          "file:size": 78184,
+          "roles": [
+            "data"
+          ]
+        },
+        "aot": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EC/2025/1/S2B_T28UEC_20250110T120355_L2A/AOT.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Aerosol optical thickness (AOT)",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.001,
+              "offset": 0
+            }
+          ],
+          "file:checksum": "122075bb84c0519c39937be4e010d502a7973f907792da5c78f0aa0f19e920ae871b",
+          "file:size": 99487,
+          "roles": [
+            "data"
+          ]
+        },
+        "coastal": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EC/2025/1/S2B_T28UEC_20250110T120355_L2A/B01.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Coastal - 60m",
+          "eo:bands": [
+            {
+              "name": "B01",
+              "common_name": "coastal",
+              "center_wavelength": 0.443,
+              "full_width_half_max": 0.027
+            }
+          ],
+          "gsd": 60,
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 499980, 0, -60, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 60,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12205a2e22580d4ee310b6a7ec8b72b7a75b0bfa3b4c46806a7338b3ad03ccdea04a",
+          "file:size": 82752,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "nir09": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EC/2025/1/S2B_T28UEC_20250110T120355_L2A/B09.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "NIR 3 - 60m",
+          "eo:bands": [
+            {
+              "name": "B09",
+              "common_name": "nir09",
+              "center_wavelength": 0.945,
+              "full_width_half_max": 0.026
+            }
+          ],
+          "gsd": 60,
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 499980, 0, -60, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 60,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12203b837e2b511157325bc14d889e3826661156f93ac206408d0b0e442f17cc388e",
+          "file:size": 84972,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "cloud": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EC/2025/1/S2B_T28UEC_20250110T120355_L2A/CLD_20m.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Cloud Probabilities",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 20
+            }
+          ],
+          "file:checksum": "12206f6d9989064b0614512729c79f4292df9c9355550924b42a34703756474e1cf1",
+          "file:size": 120955,
+          "roles": [
+            "data",
+            "cloud"
+          ]
+        },
+        "snow": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EC/2025/1/S2B_T28UEC_20250110T120355_L2A/SNW_20m.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Snow Probabilities",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 20
+            }
+          ],
+          "file:checksum": "1220646fd31cc898948d16da2d3fa3672ec809f579a0181870342d5a73f19cf1db37",
+          "file:size": 53931,
+          "roles": [
+            "data",
+            "snow-ice"
+          ]
+        },
+        "preview": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EC/2025/1/S2B_T28UEC_20250110T120355_L2A/L2A_PVI.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "True color preview",
+          "eo:bands": [
+            {
+              "name": "B04",
+              "common_name": "red",
+              "center_wavelength": 0.665,
+              "full_width_half_max": 0.038
+            },
+            {
+              "name": "B03",
+              "common_name": "green",
+              "center_wavelength": 0.56,
+              "full_width_half_max": 0.045
+            },
+            {
+              "name": "B02",
+              "common_name": "blue",
+              "center_wavelength": 0.49,
+              "full_width_half_max": 0.098
+            }
+          ],
+          "file:checksum": "1220eb97564652f39ae6ab53224b027c7eb549c7de4692cd76cb0805b6c854b28839",
+          "file:size": 8059,
+          "roles": [
+            "overview"
+          ]
+        },
+        "granule_metadata": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EC/2025/1/S2B_T28UEC_20250110T120355_L2A/metadata.xml",
+          "type": "application/xml",
+          "file:checksum": "122054cadc787eb9b6700b86b7275aa389d20aa862537769fcd7bd54be08556d3d01",
+          "file:size": 257414,
+          "roles": [
+            "metadata"
+          ]
+        },
+        "tileinfo_metadata": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EC/2025/1/S2B_T28UEC_20250110T120355_L2A/tileInfo.json",
+          "type": "application/json",
+          "file:checksum": "12200096a9fdb71ede656661a29442dec78f1269d0c233f5bd8ac1a74f14f3e0e484",
+          "file:size": 1581,
+          "roles": [
+            "metadata"
+          ]
+        },
+        "product_metadata": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EC/2025/1/S2B_T28UEC_20250110T120355_L2A/product_metadata.xml",
+          "type": "application/xml",
+          "file:checksum": "1220edf7135e20824122846daebe157b450efaef6c8d92cf2c9a6300f312cd787cca",
+          "file:size": 54686,
+          "roles": [
+            "metadata"
+          ]
+        },
+        "thumbnail": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EC/2025/1/S2B_T28UEC_20250110T120355_L2A/L2A_PVI.jpg",
+          "type": "image/jpeg",
+          "title": "Thumbnail of preview image",
+          "file:checksum": "1220b306fe70acae95183a812673cf9e80ca7056bf626f21271dd471e9cda23dcf26",
+          "file:size": 3156,
+          "roles": [
+            "thumbnail"
+          ]
+        }
+      },
+      "bbox": [-13.828245, 52.271226, -13.388631, 52.344654],
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/file/v2.1.0/schema.json",
+        "https://stac-extensions.github.io/grid/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/mgrs/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sentinel-2/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/storage/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json"
+      ],
+      "collection": "sentinel-2-c1-l2a"
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "id": "S2B_T28UFC_20250110T120355_L2A",
+      "properties": {
+        "created": "2025-01-10T16:24:04.511Z",
+        "platform": "sentinel-2b",
+        "constellation": "sentinel-2",
+        "instruments": [
+          "msi"
+        ],
+        "eo:cloud_cover": 41.692412,
+        "proj:epsg": 32628,
+        "proj:centroid": {
+          "lat": 52.21432,
+          "lon": -12.53367
+        },
+        "mgrs:utm_zone": 28,
+        "mgrs:latitude_band": "U",
+        "mgrs:grid_square": "FC",
+        "grid:code": "MGRS-28UFC",
+        "view:azimuth": 245.523494629745,
+        "view:incidence_angle": 3.70536620607632,
+        "view:sun_azimuth": 167.617359597172,
+        "view:sun_elevation": 15.4317023114617,
+        "s2:tile_id": "S2B_OPER_MSI_L2A_TL_2BPS_20250110T154043_A040990_T28UFC_N05.11",
+        "s2:degraded_msi_data_percentage": 0,
+        "s2:nodata_pixel_percentage": 81.846112,
+        "s2:saturated_defective_pixel_percentage": 0,
+        "s2:cloud_shadow_percentage": 0,
+        "s2:vegetation_percentage": 0.000018,
+        "s2:not_vegetated_percentage": 0,
+        "s2:water_percentage": 58.30757,
+        "s2:unclassified_percentage": 0,
+        "s2:medium_proba_clouds_percentage": 17.302617,
+        "s2:high_proba_clouds_percentage": 22.928596,
+        "s2:thin_cirrus_percentage": 1.4612,
+        "s2:snow_ice_percentage": 0,
+        "s2:product_type": "S2MSI2A",
+        "s2:processing_baseline": "05.11",
+        "s2:product_uri": "S2B_MSIL2A_20250110T120359_N0511_R066_T28UFC_20250110T154043.SAFE",
+        "s2:generation_time": "2025-01-10T15:40:43.000000Z",
+        "s2:datatake_id": "GS2B_20250110T120359_040990_N05.11",
+        "s2:datatake_type": "INS-NOBS",
+        "s2:datastrip_id": "S2B_OPER_MSI_L2A_DS_2BPS_20250110T154043_S20250110T120355_N05.11",
+        "s2:reflectance_conversion_factor": 1.03425891111326,
+        "datetime": "2025-01-10T12:07:01.074000Z",
+        "earthsearch:payload_id": "roda-sentinel-2-c1-l2a/workflow-sentinel-2-c1-l2a-to-stac/8e97d11f28adbcdd059cd9db6b9de885",
+        "storage:platform": "AWS",
+        "storage:region": "us-west-2",
+        "storage:requester_pays": false,
+        "processing:software": {
+          "sentinel-2-c1-l2a-to-stac": "v2024.02.01"
+        },
+        "updated": "2025-01-10T16:24:04.511Z"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [-13.5321014711154, 52.3413459269826],
+            [-13.5336220434666, 52.2953748622493],
+            [-11.9440745611458, 51.9931444540663],
+            [-11.9222573449227, 52.3103583189958],
+            [-13.5321014711154, 52.3413459269826]
+          ]
+        ]
+      },
+      "links": [
+        {
+          "rel": "self",
+          "type": "application/geo+json",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a/items/S2B_T28UFC_20250110T120355_L2A"
+        },
+        {
+          "rel": "canonical",
+          "href": "s3://e84-earth-search-sentinel-data/sentinel-2-c1-l2a/28/U/FC/2025/1/S2B_T28UFC_20250110T120355_L2A/S2B_T28UFC_20250110T120355_L2A.json",
+          "type": "application/json"
+        },
+        {
+          "rel": "via",
+          "href": "s3://sentinel-s2-l2a/tiles/28/U/FC/2025/1/10/0/metadata.xml",
+          "type": "application/xml",
+          "title": "Granule Metadata in Sinergize RODA Archive"
+        },
+        {
+          "rel": "parent",
+          "type": "application/json",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a"
+        },
+        {
+          "rel": "collection",
+          "type": "application/json",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a"
+        },
+        {
+          "rel": "root",
+          "type": "application/json",
+          "href": "https://earth-search.aws.element84.com/v1"
+        },
+        {
+          "rel": "thumbnail",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a/items/S2B_T28UFC_20250110T120355_L2A/thumbnail"
+        }
+      ],
+      "assets": {
+        "red": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/FC/2025/1/S2B_T28UFC_20250110T120355_L2A/B04.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red - 10m",
+          "eo:bands": [
+            {
+              "name": "B04",
+              "common_name": "red",
+              "center_wavelength": 0.665,
+              "full_width_half_max": 0.038
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 600000, 0, -10, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "122035c6d5cbc12a70c69fc6525d5fca8037dff9239727a85394e2f6e31cb50e3cef",
+          "file:size": 37808553,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "green": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/FC/2025/1/S2B_T28UFC_20250110T120355_L2A/B03.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Green - 10m",
+          "eo:bands": [
+            {
+              "name": "B03",
+              "common_name": "green",
+              "center_wavelength": 0.56,
+              "full_width_half_max": 0.045
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 600000, 0, -10, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12201bc6e8ad7c6cbf3ed5ff4b3e6d2e63b98cd5940ff0484c7999003388ecdaeeeb",
+          "file:size": 38001328,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "blue": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/FC/2025/1/S2B_T28UFC_20250110T120355_L2A/B02.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Blue - 10m",
+          "eo:bands": [
+            {
+              "name": "B02",
+              "common_name": "blue",
+              "center_wavelength": 0.49,
+              "full_width_half_max": 0.098
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 600000, 0, -10, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220b3c02b381f6250bde6d1c40512fb5c248739fab60714b0ed457adfe8bc4b2129",
+          "file:size": 38281234,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "visual": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/FC/2025/1/S2B_T28UFC_20250110T120355_L2A/TCI.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "True color image",
+          "eo:bands": [
+            {
+              "name": "B04",
+              "common_name": "red",
+              "center_wavelength": 0.665,
+              "full_width_half_max": 0.038
+            },
+            {
+              "name": "B03",
+              "common_name": "green",
+              "center_wavelength": 0.56,
+              "full_width_half_max": 0.045
+            },
+            {
+              "name": "B02",
+              "common_name": "blue",
+              "center_wavelength": 0.49,
+              "full_width_half_max": 0.098
+            }
+          ],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 10
+            },
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 10
+            },
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 10
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 600000, 0, -10, 5800020],
+          "file:checksum": "12204ff1bdc12c9c16461e1e3a7e17ed3a47bbb0465a1006d2473c4eb341e4232f37",
+          "file:size": 43688315,
+          "roles": [
+            "visual"
+          ]
+        },
+        "nir": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/FC/2025/1/S2B_T28UFC_20250110T120355_L2A/B08.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "NIR 1 - 10m",
+          "eo:bands": [
+            {
+              "name": "B08",
+              "common_name": "nir",
+              "center_wavelength": 0.842,
+              "full_width_half_max": 0.145
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 600000, 0, -10, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220efaaa2b724427b0d9d2a36fde08e20abd94f0dde2c92ebc3cc54b8b818fb3fbd",
+          "file:size": 38093188,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "swir22": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/FC/2025/1/S2B_T28UFC_20250110T120355_L2A/B12.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "SWIR 2.2μm - 20m",
+          "eo:bands": [
+            {
+              "name": "B12",
+              "common_name": "swir22",
+              "center_wavelength": 2.19,
+              "full_width_half_max": 0.242
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 600000, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12208c918c9e07cde5d1a0f7582e66329ed068927ecd5f87359efe22f278a578ecb5",
+          "file:size": 10084992,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "rededge2": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/FC/2025/1/S2B_T28UFC_20250110T120355_L2A/B06.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red Edge 2 - 20m",
+          "eo:bands": [
+            {
+              "name": "B06",
+              "common_name": "rededge",
+              "center_wavelength": 0.74,
+              "full_width_half_max": 0.018
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 600000, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220d6ab4c1b664e7e40d8dbc0b589f967c807f9fdc57a26466472f528976c085874",
+          "file:size": 10346975,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "rededge3": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/FC/2025/1/S2B_T28UFC_20250110T120355_L2A/B07.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red Edge 3 - 20m",
+          "eo:bands": [
+            {
+              "name": "B07",
+              "common_name": "rededge",
+              "center_wavelength": 0.783,
+              "full_width_half_max": 0.028
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 600000, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220c8ca8579f2636deafb9de4798957c6c29d0fa9f7e27161f9e193082951c88c5a",
+          "file:size": 10344767,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "rededge1": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/FC/2025/1/S2B_T28UFC_20250110T120355_L2A/B05.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red Edge 1 - 20m",
+          "eo:bands": [
+            {
+              "name": "B05",
+              "common_name": "rededge",
+              "center_wavelength": 0.704,
+              "full_width_half_max": 0.019
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 600000, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12208ed42d02383e816d27d156887fa8ed671c2da73acc32fb622cc81ef767a5850a",
+          "file:size": 10361731,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "swir16": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/FC/2025/1/S2B_T28UFC_20250110T120355_L2A/B11.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "SWIR 1.6μm - 20m",
+          "eo:bands": [
+            {
+              "name": "B11",
+              "common_name": "swir16",
+              "center_wavelength": 1.61,
+              "full_width_half_max": 0.143
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 600000, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12200ea27f0c2a0293ca9ba18cf9065ed2a3bebe106370a083d0fd5867bbf8069346",
+          "file:size": 10076269,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "wvp": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/FC/2025/1/S2B_T28UFC_20250110T120355_L2A/WVP.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Water Vapour (WVP)",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 600000, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "unit": "cm",
+              "scale": 0.001,
+              "offset": 0
+            }
+          ],
+          "file:checksum": "1220e988a55b07c65489fb136ac2e87c754824341aa39435abf2162336def50a3463",
+          "file:size": 120608,
+          "roles": [
+            "data"
+          ]
+        },
+        "nir08": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/FC/2025/1/S2B_T28UFC_20250110T120355_L2A/B8A.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "NIR 2 - 20m",
+          "eo:bands": [
+            {
+              "name": "B8A",
+              "common_name": "nir08",
+              "center_wavelength": 0.865,
+              "full_width_half_max": 0.033
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 600000, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "122044588afb918873ed2c6a1a7fc302c6227579cec72e71c72444e51ff34089da56",
+          "file:size": 10362876,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "scl": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/FC/2025/1/S2B_T28UFC_20250110T120355_L2A/SCL.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Scene classification map (SCL)",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 600000, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 20
+            }
+          ],
+          "file:checksum": "12206ad27bd37d2e7386ba6d0c2d6b5de04cbb9ad06000cff2a8fa81ce353f0b24c4",
+          "file:size": 420519,
+          "roles": [
+            "data"
+          ]
+        },
+        "aot": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/FC/2025/1/S2B_T28UFC_20250110T120355_L2A/AOT.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Aerosol optical thickness (AOT)",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 600000, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.001,
+              "offset": 0
+            }
+          ],
+          "file:checksum": "1220db700e3012812070a263beea2838d3647844e4bd4234420280942c68b847e492",
+          "file:size": 142297,
+          "roles": [
+            "data"
+          ]
+        },
+        "coastal": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/FC/2025/1/S2B_T28UFC_20250110T120355_L2A/B01.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Coastal - 60m",
+          "eo:bands": [
+            {
+              "name": "B01",
+              "common_name": "coastal",
+              "center_wavelength": 0.443,
+              "full_width_half_max": 0.027
+            }
+          ],
+          "gsd": 60,
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 600000, 0, -60, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 60,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220758926402c8bc702c574e19a3edbdc2a9711017c13e52075afc6cfdddaf2a52e",
+          "file:size": 1206892,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "nir09": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/FC/2025/1/S2B_T28UFC_20250110T120355_L2A/B09.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "NIR 3 - 60m",
+          "eo:bands": [
+            {
+              "name": "B09",
+              "common_name": "nir09",
+              "center_wavelength": 0.945,
+              "full_width_half_max": 0.026
+            }
+          ],
+          "gsd": 60,
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 600000, 0, -60, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 60,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12202747d0e7b18642c93285c3acdd13780ba63fc3937f3ba1456ed9b857566f7181",
+          "file:size": 1261903,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "cloud": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/FC/2025/1/S2B_T28UFC_20250110T120355_L2A/CLD_20m.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Cloud Probabilities",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 600000, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 20
+            }
+          ],
+          "file:checksum": "12205d6e64c391bbe597e37aa0c9b3d5ab81d80390a2fd66ff8d36fc906069df0984",
+          "file:size": 1501376,
+          "roles": [
+            "data",
+            "cloud"
+          ]
+        },
+        "snow": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/FC/2025/1/S2B_T28UFC_20250110T120355_L2A/SNW_20m.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Snow Probabilities",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 600000, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 20
+            }
+          ],
+          "file:checksum": "12202a673ea9c389b334d6a5bbcf6700845107fe73852bf22833c50b53642b9dd49c",
+          "file:size": 53931,
+          "roles": [
+            "data",
+            "snow-ice"
+          ]
+        },
+        "preview": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/FC/2025/1/S2B_T28UFC_20250110T120355_L2A/L2A_PVI.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "True color preview",
+          "eo:bands": [
+            {
+              "name": "B04",
+              "common_name": "red",
+              "center_wavelength": 0.665,
+              "full_width_half_max": 0.038
+            },
+            {
+              "name": "B03",
+              "common_name": "green",
+              "center_wavelength": 0.56,
+              "full_width_half_max": 0.045
+            },
+            {
+              "name": "B02",
+              "common_name": "blue",
+              "center_wavelength": 0.49,
+              "full_width_half_max": 0.098
+            }
+          ],
+          "file:checksum": "1220132208c1e4422dfdde88a04d6f52425c455bef66af0351605e2c05521d1c1b30",
+          "file:size": 57507,
+          "roles": [
+            "overview"
+          ]
+        },
+        "granule_metadata": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/FC/2025/1/S2B_T28UFC_20250110T120355_L2A/metadata.xml",
+          "type": "application/xml",
+          "file:checksum": "1220306690a016b2b6caed07114c113a9b989cb29efb92bda3e31e7ff29c51799fcd",
+          "file:size": 502351,
+          "roles": [
+            "metadata"
+          ]
+        },
+        "tileinfo_metadata": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/FC/2025/1/S2B_T28UFC_20250110T120355_L2A/tileInfo.json",
+          "type": "application/json",
+          "file:checksum": "122051ce84f2407d3a34458f82d94356c968afd65153d5e826278221962d8bbe9b3d",
+          "file:size": 1674,
+          "roles": [
+            "metadata"
+          ]
+        },
+        "product_metadata": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/FC/2025/1/S2B_T28UFC_20250110T120355_L2A/product_metadata.xml",
+          "type": "application/xml",
+          "file:checksum": "1220dce37ab88abf5d29cd31f1753966c4e7bda509523d5ce5cc5e15878cea96c75f",
+          "file:size": 55550,
+          "roles": [
+            "metadata"
+          ]
+        },
+        "thumbnail": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/FC/2025/1/S2B_T28UFC_20250110T120355_L2A/L2A_PVI.jpg",
+          "type": "image/jpeg",
+          "title": "Thumbnail of preview image",
+          "file:checksum": "122094252c5c1668db3d539b946f87167780a67844fe61f32c83baf41c53fae255c8",
+          "file:size": 11406,
+          "roles": [
+            "thumbnail"
+          ]
+        }
+      },
+      "bbox": [-13.533622, 51.993144, -11.922257, 52.341346],
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/file/v2.1.0/schema.json",
+        "https://stac-extensions.github.io/grid/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/mgrs/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sentinel-2/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/storage/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json"
+      ],
+      "collection": "sentinel-2-c1-l2a"
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "id": "S2B_T28UDD_20250110T120355_L2A",
+      "properties": {
+        "created": "2025-01-10T16:23:17.223Z",
+        "platform": "sentinel-2b",
+        "constellation": "sentinel-2",
+        "instruments": [
+          "msi"
+        ],
+        "eo:cloud_cover": 45.573676,
+        "proj:epsg": 32628,
+        "proj:centroid": {
+          "lat": 52.78244,
+          "lon": -14.96778
+        },
+        "mgrs:utm_zone": 28,
+        "mgrs:latitude_band": "U",
+        "mgrs:grid_square": "DD",
+        "grid:code": "MGRS-28UDD",
+        "view:azimuth": 111.363270762582,
+        "view:incidence_angle": 11.2176659476937,
+        "view:sun_azimuth": 164.877643157552,
+        "view:sun_elevation": 14.1102990134553,
+        "s2:tile_id": "S2B_OPER_MSI_L2A_TL_2BPS_20250110T154043_A040990_T28UDD_N05.11",
+        "s2:degraded_msi_data_percentage": 0,
+        "s2:nodata_pixel_percentage": 91.37699,
+        "s2:saturated_defective_pixel_percentage": 0,
+        "s2:cloud_shadow_percentage": 0,
+        "s2:vegetation_percentage": 0.000846,
+        "s2:not_vegetated_percentage": 0,
+        "s2:water_percentage": 54.425478,
+        "s2:unclassified_percentage": 0,
+        "s2:medium_proba_clouds_percentage": 12.064364,
+        "s2:high_proba_clouds_percentage": 32.520658,
+        "s2:thin_cirrus_percentage": 0.988655,
+        "s2:snow_ice_percentage": 0,
+        "s2:product_type": "S2MSI2A",
+        "s2:processing_baseline": "05.11",
+        "s2:product_uri": "S2B_MSIL2A_20250110T120359_N0511_R066_T28UDD_20250110T154043.SAFE",
+        "s2:generation_time": "2025-01-10T15:40:43.000000Z",
+        "s2:datatake_id": "GS2B_20250110T120359_040990_N05.11",
+        "s2:datatake_type": "INS-NOBS",
+        "s2:datastrip_id": "S2B_OPER_MSI_L2A_DS_2BPS_20250110T154043_S20250110T120355_N05.11",
+        "s2:reflectance_conversion_factor": 1.03425891111326,
+        "datetime": "2025-01-10T12:06:59.248000Z",
+        "earthsearch:payload_id": "roda-sentinel-2-c1-l2a/workflow-sentinel-2-c1-l2a-to-stac/af0f2bf0eea44a4ea693a69087331d8e",
+        "storage:platform": "AWS",
+        "storage:region": "us-west-2",
+        "storage:requester_pays": false,
+        "processing:software": {
+          "sentinel-2-c1-l2a-to-stac": "v2024.02.01"
+        },
+        "updated": "2025-01-10T16:23:17.223Z"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [-14.883934957153, 53.249560984131],
+            [-15.191183625645, 52.5424009271242],
+            [-14.8562491296129, 52.4966018865447],
+            [-14.8537381455861, 53.2495277635177],
+            [-14.883934957153, 53.249560984131]
+          ]
+        ]
+      },
+      "links": [
+        {
+          "rel": "self",
+          "type": "application/geo+json",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a/items/S2B_T28UDD_20250110T120355_L2A"
+        },
+        {
+          "rel": "canonical",
+          "href": "s3://e84-earth-search-sentinel-data/sentinel-2-c1-l2a/28/U/DD/2025/1/S2B_T28UDD_20250110T120355_L2A/S2B_T28UDD_20250110T120355_L2A.json",
+          "type": "application/json"
+        },
+        {
+          "rel": "via",
+          "href": "s3://sentinel-s2-l2a/tiles/28/U/DD/2025/1/10/0/metadata.xml",
+          "type": "application/xml",
+          "title": "Granule Metadata in Sinergize RODA Archive"
+        },
+        {
+          "rel": "parent",
+          "type": "application/json",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a"
+        },
+        {
+          "rel": "collection",
+          "type": "application/json",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a"
+        },
+        {
+          "rel": "root",
+          "type": "application/json",
+          "href": "https://earth-search.aws.element84.com/v1"
+        },
+        {
+          "rel": "thumbnail",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a/items/S2B_T28UDD_20250110T120355_L2A/thumbnail"
+        }
+      ],
+      "assets": {
+        "red": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/DD/2025/1/S2B_T28UDD_20250110T120355_L2A/B04.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red - 10m",
+          "eo:bands": [
+            {
+              "name": "B04",
+              "common_name": "red",
+              "center_wavelength": 0.665,
+              "full_width_half_max": 0.038
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 399960, 0, -10, 5900040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "122054a5a778414a5dcf84cedb25f35f7d742e6f7a3a90a39f9f0efb8aa73997ee3d",
+          "file:size": 17308393,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "green": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/DD/2025/1/S2B_T28UDD_20250110T120355_L2A/B03.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Green - 10m",
+          "eo:bands": [
+            {
+              "name": "B03",
+              "common_name": "green",
+              "center_wavelength": 0.56,
+              "full_width_half_max": 0.045
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 399960, 0, -10, 5900040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "122057746c62fa7de4da7c715ed1f9a32daf2a756aeffadb091cd885884fb4bbaa2d",
+          "file:size": 17453898,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "blue": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/DD/2025/1/S2B_T28UDD_20250110T120355_L2A/B02.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Blue - 10m",
+          "eo:bands": [
+            {
+              "name": "B02",
+              "common_name": "blue",
+              "center_wavelength": 0.49,
+              "full_width_half_max": 0.098
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 399960, 0, -10, 5900040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220f66c150b7d0072381550f6daf7bbd2845705d3b7459db07f4c99359e35561598",
+          "file:size": 17687244,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "visual": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/DD/2025/1/S2B_T28UDD_20250110T120355_L2A/TCI.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "True color image",
+          "eo:bands": [
+            {
+              "name": "B04",
+              "common_name": "red",
+              "center_wavelength": 0.665,
+              "full_width_half_max": 0.038
+            },
+            {
+              "name": "B03",
+              "common_name": "green",
+              "center_wavelength": 0.56,
+              "full_width_half_max": 0.045
+            },
+            {
+              "name": "B02",
+              "common_name": "blue",
+              "center_wavelength": 0.49,
+              "full_width_half_max": 0.098
+            }
+          ],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 10
+            },
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 10
+            },
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 10
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 399960, 0, -10, 5900040],
+          "file:checksum": "12201b16ef75a69922ab923ef55e87362bc0e8e12c25aa7131d1db37d20c12978c16",
+          "file:size": 17154534,
+          "roles": [
+            "visual"
+          ]
+        },
+        "nir": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/DD/2025/1/S2B_T28UDD_20250110T120355_L2A/B08.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "NIR 1 - 10m",
+          "eo:bands": [
+            {
+              "name": "B08",
+              "common_name": "nir",
+              "center_wavelength": 0.842,
+              "full_width_half_max": 0.145
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 399960, 0, -10, 5900040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220d6c16cc1335ba85c3cde38b65161d43120f6f210a29e5ac3bd29992f10db0061",
+          "file:size": 17347684,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "swir22": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/DD/2025/1/S2B_T28UDD_20250110T120355_L2A/B12.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "SWIR 2.2μm - 20m",
+          "eo:bands": [
+            {
+              "name": "B12",
+              "common_name": "swir22",
+              "center_wavelength": 2.19,
+              "full_width_half_max": 0.242
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 399960, 0, -20, 5900040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220fadc97c30a1a1471f272b5eb1b62bca1c09a010cc7bf2218a782df05f7844592",
+          "file:size": 4577358,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "rededge2": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/DD/2025/1/S2B_T28UDD_20250110T120355_L2A/B06.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red Edge 2 - 20m",
+          "eo:bands": [
+            {
+              "name": "B06",
+              "common_name": "rededge",
+              "center_wavelength": 0.74,
+              "full_width_half_max": 0.018
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 399960, 0, -20, 5900040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220a79316d379277821cc95628beee1bb62d33db354f26aa7693126d19237dfbc99",
+          "file:size": 4788245,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "rededge3": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/DD/2025/1/S2B_T28UDD_20250110T120355_L2A/B07.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red Edge 3 - 20m",
+          "eo:bands": [
+            {
+              "name": "B07",
+              "common_name": "rededge",
+              "center_wavelength": 0.783,
+              "full_width_half_max": 0.028
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 399960, 0, -20, 5900040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220cad9f61dc28368c2db5efb069e2948bdd433476a4ba1e8744035abe07910d4b7",
+          "file:size": 4801599,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "rededge1": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/DD/2025/1/S2B_T28UDD_20250110T120355_L2A/B05.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red Edge 1 - 20m",
+          "eo:bands": [
+            {
+              "name": "B05",
+              "common_name": "rededge",
+              "center_wavelength": 0.704,
+              "full_width_half_max": 0.019
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 399960, 0, -20, 5900040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220a6c66252a5437bb34de51dcee0552c8c102cbe62839037b7b509bd3d53cb6476",
+          "file:size": 4819787,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "swir16": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/DD/2025/1/S2B_T28UDD_20250110T120355_L2A/B11.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "SWIR 1.6μm - 20m",
+          "eo:bands": [
+            {
+              "name": "B11",
+              "common_name": "swir16",
+              "center_wavelength": 1.61,
+              "full_width_half_max": 0.143
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 399960, 0, -20, 5900040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12209d4fb63d60fdbb1a60cbc1e7489affee9c45556fc06cebbf01bf9c82bfd98f34",
+          "file:size": 4580867,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "wvp": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/DD/2025/1/S2B_T28UDD_20250110T120355_L2A/WVP.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Water Vapour (WVP)",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 399960, 0, -20, 5900040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "unit": "cm",
+              "scale": 0.001,
+              "offset": 0
+            }
+          ],
+          "file:checksum": "122023974cded5bb589228df181ca430c8c9873a298e40e6abeda080b716042c135c",
+          "file:size": 120033,
+          "roles": [
+            "data"
+          ]
+        },
+        "nir08": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/DD/2025/1/S2B_T28UDD_20250110T120355_L2A/B8A.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "NIR 2 - 20m",
+          "eo:bands": [
+            {
+              "name": "B8A",
+              "common_name": "nir08",
+              "center_wavelength": 0.865,
+              "full_width_half_max": 0.033
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 399960, 0, -20, 5900040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220952b926daeefadbbf02d6abb78c13adb3cb6daf998d0ce3ee3932c51fdfa3c07",
+          "file:size": 4791768,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "scl": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/DD/2025/1/S2B_T28UDD_20250110T120355_L2A/SCL.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Scene classification map (SCL)",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 399960, 0, -20, 5900040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 20
+            }
+          ],
+          "file:checksum": "1220a6ef3402bad56ffe7bcfe50f81b1ada6ce752623c3b2437896c5f7abaf52f82a",
+          "file:size": 184466,
+          "roles": [
+            "data"
+          ]
+        },
+        "aot": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/DD/2025/1/S2B_T28UDD_20250110T120355_L2A/AOT.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Aerosol optical thickness (AOT)",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 399960, 0, -20, 5900040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.001,
+              "offset": 0
+            }
+          ],
+          "file:checksum": "12204118b1e0a9d86bfe943e2af1de7e7cbfdde5bce35cd19597d3cad795906ff15a",
+          "file:size": 133584,
+          "roles": [
+            "data"
+          ]
+        },
+        "coastal": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/DD/2025/1/S2B_T28UDD_20250110T120355_L2A/B01.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Coastal - 60m",
+          "eo:bands": [
+            {
+              "name": "B01",
+              "common_name": "coastal",
+              "center_wavelength": 0.443,
+              "full_width_half_max": 0.027
+            }
+          ],
+          "gsd": 60,
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 399960, 0, -60, 5900040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 60,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220c57b36366bb26cff43ba58f29db4d2e7da27ad9793fe9fb1c37c25f1af4af5e4",
+          "file:size": 562940,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "nir09": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/DD/2025/1/S2B_T28UDD_20250110T120355_L2A/B09.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "NIR 3 - 60m",
+          "eo:bands": [
+            {
+              "name": "B09",
+              "common_name": "nir09",
+              "center_wavelength": 0.945,
+              "full_width_half_max": 0.026
+            }
+          ],
+          "gsd": 60,
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 399960, 0, -60, 5900040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 60,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220eeed3e0cebbb75aa936744142ace9c12dd6a82f5ba3acebcde9c97ddbb9f932a",
+          "file:size": 577302,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "cloud": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/DD/2025/1/S2B_T28UDD_20250110T120355_L2A/CLD_20m.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Cloud Probabilities",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 399960, 0, -20, 5900040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 20
+            }
+          ],
+          "file:checksum": "1220410f661fbe8e0a4220db2d2e14d9e8b0d148466c6e42745218e1a82561af8d60",
+          "file:size": 523213,
+          "roles": [
+            "data",
+            "cloud"
+          ]
+        },
+        "snow": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/DD/2025/1/S2B_T28UDD_20250110T120355_L2A/SNW_20m.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Snow Probabilities",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 399960, 0, -20, 5900040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 20
+            }
+          ],
+          "file:checksum": "1220b71d1bd3c5b571cbded0862e4f4785ad1517371019d7a93177f3156c2ecebea7",
+          "file:size": 53931,
+          "roles": [
+            "data",
+            "snow-ice"
+          ]
+        },
+        "preview": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/DD/2025/1/S2B_T28UDD_20250110T120355_L2A/L2A_PVI.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "True color preview",
+          "eo:bands": [
+            {
+              "name": "B04",
+              "common_name": "red",
+              "center_wavelength": 0.665,
+              "full_width_half_max": 0.038
+            },
+            {
+              "name": "B03",
+              "common_name": "green",
+              "center_wavelength": 0.56,
+              "full_width_half_max": 0.045
+            },
+            {
+              "name": "B02",
+              "common_name": "blue",
+              "center_wavelength": 0.49,
+              "full_width_half_max": 0.098
+            }
+          ],
+          "file:checksum": "1220bfa6a79b1279b8892a2a9297157d630645b78a29e97179329fb723a4c9f47654",
+          "file:size": 25349,
+          "roles": [
+            "overview"
+          ]
+        },
+        "granule_metadata": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/DD/2025/1/S2B_T28UDD_20250110T120355_L2A/metadata.xml",
+          "type": "application/xml",
+          "file:checksum": "122011626ced3f3137673cce60b87bcf1a209ad4ac5db04feb55806e90e3ea5f5701",
+          "file:size": 105054,
+          "roles": [
+            "metadata"
+          ]
+        },
+        "tileinfo_metadata": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/DD/2025/1/S2B_T28UDD_20250110T120355_L2A/tileInfo.json",
+          "type": "application/json",
+          "file:checksum": "122083498a89e0c8f200b5222497bad130a56c06ef24ef7c3ba3e236267aa963011b",
+          "file:size": 1535,
+          "roles": [
+            "metadata"
+          ]
+        },
+        "product_metadata": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/DD/2025/1/S2B_T28UDD_20250110T120355_L2A/product_metadata.xml",
+          "type": "application/xml",
+          "file:checksum": "1220007c793944fcc6a5856a609c3d7a90a7981441c0c68bcc8e42d6da314802db15",
+          "file:size": 54651,
+          "roles": [
+            "metadata"
+          ]
+        },
+        "thumbnail": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/DD/2025/1/S2B_T28UDD_20250110T120355_L2A/L2A_PVI.jpg",
+          "type": "image/jpeg",
+          "title": "Thumbnail of preview image",
+          "file:checksum": "1220e9c0f4836898f69022ec8dc67ae68ac26e772723680385d5606261fcff8d3b9a",
+          "file:size": 5672,
+          "roles": [
+            "thumbnail"
+          ]
+        }
+      },
+      "bbox": [-15.191184, 52.496602, -14.853738, 53.249561],
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/file/v2.1.0/schema.json",
+        "https://stac-extensions.github.io/grid/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/mgrs/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sentinel-2/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/storage/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json"
+      ],
+      "collection": "sentinel-2-c1-l2a"
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "id": "S2B_T28UGC_20250110T120355_L2A",
+      "properties": {
+        "created": "2025-01-10T16:24:15.582Z",
+        "platform": "sentinel-2b",
+        "constellation": "sentinel-2",
+        "instruments": [
+          "msi"
+        ],
+        "eo:cloud_cover": 70.551813,
+        "proj:epsg": 32628,
+        "proj:centroid": {
+          "lat": 52.10021,
+          "lon": -11.44977
+        },
+        "mgrs:utm_zone": 28,
+        "mgrs:latitude_band": "U",
+        "mgrs:grid_square": "GC",
+        "grid:code": "MGRS-28UGC",
+        "view:azimuth": 288.991145822068,
+        "view:incidence_angle": 8.88645376535856,
+        "view:sun_azimuth": 168.984702494377,
+        "view:sun_elevation": 15.6474414959517,
+        "s2:tile_id": "S2B_OPER_MSI_L2A_TL_2BPS_20250110T154043_A040990_T28UGC_N05.11",
+        "s2:degraded_msi_data_percentage": 0.0257,
+        "s2:nodata_pixel_percentage": 70.794016,
+        "s2:saturated_defective_pixel_percentage": 0,
+        "s2:cloud_shadow_percentage": 0,
+        "s2:vegetation_percentage": 0.000011,
+        "s2:not_vegetated_percentage": 0.000125,
+        "s2:water_percentage": 29.44805,
+        "s2:unclassified_percentage": 0,
+        "s2:medium_proba_clouds_percentage": 19.48228,
+        "s2:high_proba_clouds_percentage": 50.357151,
+        "s2:thin_cirrus_percentage": 0.712383,
+        "s2:snow_ice_percentage": 0,
+        "s2:product_type": "S2MSI2A",
+        "s2:processing_baseline": "05.11",
+        "s2:product_uri": "S2B_MSIL2A_20250110T120359_N0511_R066_T28UGC_20250110T154043.SAFE",
+        "s2:generation_time": "2025-01-10T15:40:43.000000Z",
+        "s2:datatake_id": "GS2B_20250110T120359_040990_N05.11",
+        "s2:datatake_type": "INS-NOBS",
+        "s2:datastrip_id": "S2B_OPER_MSI_L2A_DS_2BPS_20250110T154043_S20250110T120355_N05.11",
+        "s2:reflectance_conversion_factor": 1.03425891111326,
+        "datetime": "2025-01-10T12:06:59.032000Z",
+        "earthsearch:payload_id": "roda-sentinel-2-c1-l2a/workflow-sentinel-2-c1-l2a-to-stac/b262a7540f8c30c340c7c4d8c2b08a7b",
+        "storage:platform": "AWS",
+        "storage:region": "us-west-2",
+        "storage:requester_pays": false,
+        "processing:software": {
+          "sentinel-2-c1-l2a-to-stac": "v2024.02.01"
+        },
+        "updated": "2025-01-10T16:24:15.582Z"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [-12.0663701781865, 52.3140284614992],
+            [-12.0854674480038, 52.0229565808749],
+            [-11.0571384840821, 51.7940576782695],
+            [-10.8034742021281, 52.2758584353317],
+            [-12.0663701781865, 52.3140284614992]
+          ]
+        ]
+      },
+      "links": [
+        {
+          "rel": "self",
+          "type": "application/geo+json",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a/items/S2B_T28UGC_20250110T120355_L2A"
+        },
+        {
+          "rel": "canonical",
+          "href": "s3://e84-earth-search-sentinel-data/sentinel-2-c1-l2a/28/U/GC/2025/1/S2B_T28UGC_20250110T120355_L2A/S2B_T28UGC_20250110T120355_L2A.json",
+          "type": "application/json"
+        },
+        {
+          "rel": "via",
+          "href": "s3://sentinel-s2-l2a/tiles/28/U/GC/2025/1/10/0/metadata.xml",
+          "type": "application/xml",
+          "title": "Granule Metadata in Sinergize RODA Archive"
+        },
+        {
+          "rel": "parent",
+          "type": "application/json",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a"
+        },
+        {
+          "rel": "collection",
+          "type": "application/json",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a"
+        },
+        {
+          "rel": "root",
+          "type": "application/json",
+          "href": "https://earth-search.aws.element84.com/v1"
+        },
+        {
+          "rel": "thumbnail",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a/items/S2B_T28UGC_20250110T120355_L2A/thumbnail"
+        }
+      ],
+      "assets": {
+        "red": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/GC/2025/1/S2B_T28UGC_20250110T120355_L2A/B04.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red - 10m",
+          "eo:bands": [
+            {
+              "name": "B04",
+              "common_name": "red",
+              "center_wavelength": 0.665,
+              "full_width_half_max": 0.038
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12201cd9c10ddd829fac7b1648dd387ad4fbb1bca16f50c5e3c4fefe23407a9c4011",
+          "file:size": 58207551,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "green": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/GC/2025/1/S2B_T28UGC_20250110T120355_L2A/B03.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Green - 10m",
+          "eo:bands": [
+            {
+              "name": "B03",
+              "common_name": "green",
+              "center_wavelength": 0.56,
+              "full_width_half_max": 0.045
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220451b51412527a211547b7f1fb65618ab70152c0b5876a28710d82c7afb07228e",
+          "file:size": 58118240,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "blue": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/GC/2025/1/S2B_T28UGC_20250110T120355_L2A/B02.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Blue - 10m",
+          "eo:bands": [
+            {
+              "name": "B02",
+              "common_name": "blue",
+              "center_wavelength": 0.49,
+              "full_width_half_max": 0.098
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "122029c3cfa284c85df6ebfaa6b0225ca33c147c2666175b9faab17d726468c25684",
+          "file:size": 58042746,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "visual": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/GC/2025/1/S2B_T28UGC_20250110T120355_L2A/TCI.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "True color image",
+          "eo:bands": [
+            {
+              "name": "B04",
+              "common_name": "red",
+              "center_wavelength": 0.665,
+              "full_width_half_max": 0.038
+            },
+            {
+              "name": "B03",
+              "common_name": "green",
+              "center_wavelength": 0.56,
+              "full_width_half_max": 0.045
+            },
+            {
+              "name": "B02",
+              "common_name": "blue",
+              "center_wavelength": 0.49,
+              "full_width_half_max": 0.098
+            }
+          ],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 10
+            },
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 10
+            },
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 10
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 5800020],
+          "file:checksum": "1220569a22ecc77cb50b68399d0587f0d4b6d7912694d646593166e712e03088fe8a",
+          "file:size": 42064723,
+          "roles": [
+            "visual"
+          ]
+        },
+        "nir": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/GC/2025/1/S2B_T28UGC_20250110T120355_L2A/B08.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "NIR 1 - 10m",
+          "eo:bands": [
+            {
+              "name": "B08",
+              "common_name": "nir",
+              "center_wavelength": 0.842,
+              "full_width_half_max": 0.145
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "122086b8c7c05c080220c58c7837aa5cb177148c998ed3e20bcbc82b5f4483c08de2",
+          "file:size": 58822385,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "swir22": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/GC/2025/1/S2B_T28UGC_20250110T120355_L2A/B12.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "SWIR 2.2μm - 20m",
+          "eo:bands": [
+            {
+              "name": "B12",
+              "common_name": "swir22",
+              "center_wavelength": 2.19,
+              "full_width_half_max": 0.242
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220923638898bfc9c9f7146c955a4a57585779d374044ba21a7158e9810629894c4",
+          "file:size": 16095523,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "rededge2": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/GC/2025/1/S2B_T28UGC_20250110T120355_L2A/B06.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red Edge 2 - 20m",
+          "eo:bands": [
+            {
+              "name": "B06",
+              "common_name": "rededge",
+              "center_wavelength": 0.74,
+              "full_width_half_max": 0.018
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12200d043c3f0dcbee9be9b5e6c1bc5885ecaebb32730b97758c7a058f824b30ae00",
+          "file:size": 17051737,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "rededge3": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/GC/2025/1/S2B_T28UGC_20250110T120355_L2A/B07.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red Edge 3 - 20m",
+          "eo:bands": [
+            {
+              "name": "B07",
+              "common_name": "rededge",
+              "center_wavelength": 0.783,
+              "full_width_half_max": 0.028
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12201496c6d8c6a667ce1068dcb750ce1ac590966a54524102be8fcfa41c1c97b95d",
+          "file:size": 17021702,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "rededge1": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/GC/2025/1/S2B_T28UGC_20250110T120355_L2A/B05.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red Edge 1 - 20m",
+          "eo:bands": [
+            {
+              "name": "B05",
+              "common_name": "rededge",
+              "center_wavelength": 0.704,
+              "full_width_half_max": 0.019
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220943299479e9fc7167e046c58922a0cd43468693b4e14a8086ebba2643c7501a1",
+          "file:size": 17061778,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "swir16": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/GC/2025/1/S2B_T28UGC_20250110T120355_L2A/B11.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "SWIR 1.6μm - 20m",
+          "eo:bands": [
+            {
+              "name": "B11",
+              "common_name": "swir16",
+              "center_wavelength": 1.61,
+              "full_width_half_max": 0.143
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220fa82c7aa49224096f09453a532e579f12fb83c7b57eb5efb3e01d7f86d87309f",
+          "file:size": 16432588,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "wvp": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/GC/2025/1/S2B_T28UGC_20250110T120355_L2A/WVP.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Water Vapour (WVP)",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "unit": "cm",
+              "scale": 0.001,
+              "offset": 0
+            }
+          ],
+          "file:checksum": "1220819c7233d673f986b8d77c116ec375ed68ac1f9d11665a3edfe513c73d26805e",
+          "file:size": 133428,
+          "roles": [
+            "data"
+          ]
+        },
+        "nir08": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/GC/2025/1/S2B_T28UGC_20250110T120355_L2A/B8A.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "NIR 2 - 20m",
+          "eo:bands": [
+            {
+              "name": "B8A",
+              "common_name": "nir08",
+              "center_wavelength": 0.865,
+              "full_width_half_max": 0.033
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "122008817be7d0e498c3ca35dc04ec5299db2f686150c71ac4e4d6c2219896656f68",
+          "file:size": 17052752,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "scl": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/GC/2025/1/S2B_T28UGC_20250110T120355_L2A/SCL.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Scene classification map (SCL)",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 20
+            }
+          ],
+          "file:checksum": "12201be991eef66b3ee9fb9993040702d74dc890ee3bc5f13767c779dfbbe49f3004",
+          "file:size": 645587,
+          "roles": [
+            "data"
+          ]
+        },
+        "aot": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/GC/2025/1/S2B_T28UGC_20250110T120355_L2A/AOT.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Aerosol optical thickness (AOT)",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.001,
+              "offset": 0
+            }
+          ],
+          "file:checksum": "1220633bfaa1c34b320443dbb216a3479c1e75b634b9785145005de6cf6130d864b9",
+          "file:size": 201548,
+          "roles": [
+            "data"
+          ]
+        },
+        "coastal": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/GC/2025/1/S2B_T28UGC_20250110T120355_L2A/B01.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Coastal - 60m",
+          "eo:bands": [
+            {
+              "name": "B01",
+              "common_name": "coastal",
+              "center_wavelength": 0.443,
+              "full_width_half_max": 0.027
+            }
+          ],
+          "gsd": 60,
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 60,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12207141b1f48d8faf012d0acb1beebbf23b5c3df7c4b9a167d8d73ef7d15ebff353",
+          "file:size": 2012692,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "nir09": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/GC/2025/1/S2B_T28UGC_20250110T120355_L2A/B09.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "NIR 3 - 60m",
+          "eo:bands": [
+            {
+              "name": "B09",
+              "common_name": "nir09",
+              "center_wavelength": 0.945,
+              "full_width_half_max": 0.026
+            }
+          ],
+          "gsd": 60,
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 60,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12202e70675c4b9ab5a47692cd176acea1f68e5d1c435edda8e5c97c66bb775ddb0d",
+          "file:size": 2032167,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "cloud": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/GC/2025/1/S2B_T28UGC_20250110T120355_L2A/CLD_20m.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Cloud Probabilities",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 20
+            }
+          ],
+          "file:checksum": "1220f14c816e5e28cba274f817a6a1a078ca93a33b79f8c6b5d2805f13f302df01a6",
+          "file:size": 2676520,
+          "roles": [
+            "data",
+            "cloud"
+          ]
+        },
+        "snow": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/GC/2025/1/S2B_T28UGC_20250110T120355_L2A/SNW_20m.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Snow Probabilities",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 20
+            }
+          ],
+          "file:checksum": "122074b684a20156d8958e2cc54b9b3740f5217f825466c66d10e8df379e946e5a96",
+          "file:size": 53931,
+          "roles": [
+            "data",
+            "snow-ice"
+          ]
+        },
+        "preview": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/GC/2025/1/S2B_T28UGC_20250110T120355_L2A/L2A_PVI.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "True color preview",
+          "eo:bands": [
+            {
+              "name": "B04",
+              "common_name": "red",
+              "center_wavelength": 0.665,
+              "full_width_half_max": 0.038
+            },
+            {
+              "name": "B03",
+              "common_name": "green",
+              "center_wavelength": 0.56,
+              "full_width_half_max": 0.045
+            },
+            {
+              "name": "B02",
+              "common_name": "blue",
+              "center_wavelength": 0.49,
+              "full_width_half_max": 0.098
+            }
+          ],
+          "file:checksum": "1220f1f49f585c5c9d162e3fde0c6524393af24d0f98bd94008bf153e0d1f0d84545",
+          "file:size": 66287,
+          "roles": [
+            "overview"
+          ]
+        },
+        "granule_metadata": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/GC/2025/1/S2B_T28UGC_20250110T120355_L2A/metadata.xml",
+          "type": "application/xml",
+          "file:checksum": "1220cd75a8a624f29c0f31c90df9f791b916a3e495ea7c087b579e2e09770559a655",
+          "file:size": 351063,
+          "roles": [
+            "metadata"
+          ]
+        },
+        "tileinfo_metadata": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/GC/2025/1/S2B_T28UGC_20250110T120355_L2A/tileInfo.json",
+          "type": "application/json",
+          "file:checksum": "1220d1c9a251b350d7c950c3be70977893a5b2c10c2e124fb0b66093ed644cab670e",
+          "file:size": 1607,
+          "roles": [
+            "metadata"
+          ]
+        },
+        "product_metadata": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/GC/2025/1/S2B_T28UGC_20250110T120355_L2A/product_metadata.xml",
+          "type": "application/xml",
+          "file:checksum": "12208208152cf7b8ff0461a8f98b958c6b601c8d7e2b0daf2a6da54fcee0188d250d",
+          "file:size": 55288,
+          "roles": [
+            "metadata"
+          ]
+        },
+        "thumbnail": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/GC/2025/1/S2B_T28UGC_20250110T120355_L2A/L2A_PVI.jpg",
+          "type": "image/jpeg",
+          "title": "Thumbnail of preview image",
+          "file:checksum": "12204514017e6fc351907beb978f8bf0d1e782b2f3f48280443825827d0e5218ff1f",
+          "file:size": 13689,
+          "roles": [
+            "thumbnail"
+          ]
+        }
+      },
+      "bbox": [-12.085467, 51.794058, -10.803474, 52.314028],
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/file/v2.1.0/schema.json",
+        "https://stac-extensions.github.io/grid/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/mgrs/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sentinel-2/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/storage/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json"
+      ],
+      "collection": "sentinel-2-c1-l2a"
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "id": "S2B_T29ULT_20250110T120355_L2A",
+      "properties": {
+        "created": "2025-01-10T16:24:35.264Z",
+        "platform": "sentinel-2b",
+        "constellation": "sentinel-2",
+        "instruments": [
+          "msi"
+        ],
+        "eo:cloud_cover": 76.681787,
+        "proj:epsg": 32629,
+        "proj:centroid": {
+          "lat": 52.11257,
+          "lon": -11.37077
+        },
+        "mgrs:utm_zone": 29,
+        "mgrs:latitude_band": "U",
+        "mgrs:grid_square": "LT",
+        "grid:code": "MGRS-29ULT",
+        "view:azimuth": 289.739549819918,
+        "view:incidence_angle": 9.25309699449269,
+        "view:sun_azimuth": 169.170970252047,
+        "view:sun_elevation": 15.6313798177967,
+        "s2:tile_id": "S2B_OPER_MSI_L2A_TL_2BPS_20250110T154043_A040990_T29ULT_N05.11",
+        "s2:degraded_msi_data_percentage": 0.0281,
+        "s2:nodata_pixel_percentage": 71.433568,
+        "s2:saturated_defective_pixel_percentage": 0,
+        "s2:cloud_shadow_percentage": 0,
+        "s2:vegetation_percentage": 0.000012,
+        "s2:not_vegetated_percentage": 0.000186,
+        "s2:water_percentage": 23.318014,
+        "s2:unclassified_percentage": 0,
+        "s2:medium_proba_clouds_percentage": 35.262308,
+        "s2:high_proba_clouds_percentage": 41.088226,
+        "s2:thin_cirrus_percentage": 0.331256,
+        "s2:snow_ice_percentage": 0,
+        "s2:product_type": "S2MSI2A",
+        "s2:processing_baseline": "05.11",
+        "s2:product_uri": "S2B_MSIL2A_20250110T120359_N0511_R066_T29ULT_20250110T154043.SAFE",
+        "s2:generation_time": "2025-01-10T15:40:43.000000Z",
+        "s2:datatake_id": "GS2B_20250110T120359_040990_N05.11",
+        "s2:datatake_type": "INS-NOBS",
+        "s2:datastrip_id": "S2B_OPER_MSI_L2A_DS_2BPS_20250110T154043_S20250110T120355_N05.11",
+        "s2:reflectance_conversion_factor": 1.03425891111326,
+        "datetime": "2025-01-10T12:06:58.560000Z",
+        "earthsearch:payload_id": "roda-sentinel-2-c1-l2a/workflow-sentinel-2-c1-l2a-to-stac/cc5f14a543c20f0fbb2d8a793a17b244",
+        "storage:platform": "AWS",
+        "storage:region": "us-west-2",
+        "storage:requester_pays": false,
+        "processing:software": {
+          "sentinel-2-c1-l2a-to-stac": "v2024.02.01"
+        },
+        "updated": "2025-01-10T16:24:35.264Z"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [-11.9341865273641, 52.3140146232143],
+            [-11.9127080253672, 51.9863614962068],
+            [-11.0571957464118, 51.7939912466001],
+            [-10.7711148716862, 52.3371889236931],
+            [-11.9341865273641, 52.3140146232143]
+          ]
+        ]
+      },
+      "links": [
+        {
+          "rel": "self",
+          "type": "application/geo+json",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a/items/S2B_T29ULT_20250110T120355_L2A"
+        },
+        {
+          "rel": "canonical",
+          "href": "s3://e84-earth-search-sentinel-data/sentinel-2-c1-l2a/29/U/LT/2025/1/S2B_T29ULT_20250110T120355_L2A/S2B_T29ULT_20250110T120355_L2A.json",
+          "type": "application/json"
+        },
+        {
+          "rel": "via",
+          "href": "s3://sentinel-s2-l2a/tiles/29/U/LT/2025/1/10/0/metadata.xml",
+          "type": "application/xml",
+          "title": "Granule Metadata in Sinergize RODA Archive"
+        },
+        {
+          "rel": "parent",
+          "type": "application/json",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a"
+        },
+        {
+          "rel": "collection",
+          "type": "application/json",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a"
+        },
+        {
+          "rel": "root",
+          "type": "application/json",
+          "href": "https://earth-search.aws.element84.com/v1"
+        },
+        {
+          "rel": "thumbnail",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a/items/S2B_T29ULT_20250110T120355_L2A/thumbnail"
+        }
+      ],
+      "assets": {
+        "red": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/LT/2025/1/S2B_T29ULT_20250110T120355_L2A/B04.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red - 10m",
+          "eo:bands": [
+            {
+              "name": "B04",
+              "common_name": "red",
+              "center_wavelength": 0.665,
+              "full_width_half_max": 0.038
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 300000, 0, -10, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12203e227546657330900c61d6557c4750c3262eb5eeb70edd161878f0db44cd933f",
+          "file:size": 56941462,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "green": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/LT/2025/1/S2B_T29ULT_20250110T120355_L2A/B03.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Green - 10m",
+          "eo:bands": [
+            {
+              "name": "B03",
+              "common_name": "green",
+              "center_wavelength": 0.56,
+              "full_width_half_max": 0.045
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 300000, 0, -10, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "122025246795e56b26d4f7d9fc31b995680db8d55ba9ad507ebc922be4509769f6c9",
+          "file:size": 56786069,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "blue": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/LT/2025/1/S2B_T29ULT_20250110T120355_L2A/B02.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Blue - 10m",
+          "eo:bands": [
+            {
+              "name": "B02",
+              "common_name": "blue",
+              "center_wavelength": 0.49,
+              "full_width_half_max": 0.098
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 300000, 0, -10, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "122039d4d6a228946d25de5f8480487f6c492398ed7d8a2c991648d04d3cd85a9935",
+          "file:size": 56623575,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "visual": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/LT/2025/1/S2B_T29ULT_20250110T120355_L2A/TCI.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "True color image",
+          "eo:bands": [
+            {
+              "name": "B04",
+              "common_name": "red",
+              "center_wavelength": 0.665,
+              "full_width_half_max": 0.038
+            },
+            {
+              "name": "B03",
+              "common_name": "green",
+              "center_wavelength": 0.56,
+              "full_width_half_max": 0.045
+            },
+            {
+              "name": "B02",
+              "common_name": "blue",
+              "center_wavelength": 0.49,
+              "full_width_half_max": 0.098
+            }
+          ],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 10
+            },
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 10
+            },
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 10
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 300000, 0, -10, 5800020],
+          "file:checksum": "122010e77d3a354175a4f00e427377412b14cb594c0ef55f2744eee10062fc94494d",
+          "file:size": 36438161,
+          "roles": [
+            "visual"
+          ]
+        },
+        "nir": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/LT/2025/1/S2B_T29ULT_20250110T120355_L2A/B08.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "NIR 1 - 10m",
+          "eo:bands": [
+            {
+              "name": "B08",
+              "common_name": "nir",
+              "center_wavelength": 0.842,
+              "full_width_half_max": 0.145
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 300000, 0, -10, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12203493df70a2489aae8e8c51256ab1b149136d0399aeff8bb521944d0a373ffb8e",
+          "file:size": 57557157,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "swir22": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/LT/2025/1/S2B_T29ULT_20250110T120355_L2A/B12.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "SWIR 2.2μm - 20m",
+          "eo:bands": [
+            {
+              "name": "B12",
+              "common_name": "swir22",
+              "center_wavelength": 2.19,
+              "full_width_half_max": 0.242
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 300000, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12207a1e16f696777c391dc53358b0a0892061539000855005f8cffb5ef1a00659c4",
+          "file:size": 15781560,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "rededge2": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/LT/2025/1/S2B_T29ULT_20250110T120355_L2A/B06.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red Edge 2 - 20m",
+          "eo:bands": [
+            {
+              "name": "B06",
+              "common_name": "rededge",
+              "center_wavelength": 0.74,
+              "full_width_half_max": 0.018
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 300000, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12203277ff67ac82a6260dd05378d0880c66af3280495382175f61b0b152cb72e671",
+          "file:size": 16820810,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "rededge3": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/LT/2025/1/S2B_T29ULT_20250110T120355_L2A/B07.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red Edge 3 - 20m",
+          "eo:bands": [
+            {
+              "name": "B07",
+              "common_name": "rededge",
+              "center_wavelength": 0.783,
+              "full_width_half_max": 0.028
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 300000, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220ce612d9136bc91eb41bc1ac94486ce6c46c6fd80f6a3c2370bb165b54e22d264",
+          "file:size": 16799086,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "rededge1": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/LT/2025/1/S2B_T29ULT_20250110T120355_L2A/B05.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red Edge 1 - 20m",
+          "eo:bands": [
+            {
+              "name": "B05",
+              "common_name": "rededge",
+              "center_wavelength": 0.704,
+              "full_width_half_max": 0.019
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 300000, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220f90ef2d43a3d5a38ccfa2dc7bbcebef1241ee73f8cd34f016f9fd1dd4195050c",
+          "file:size": 16823874,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "swir16": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/LT/2025/1/S2B_T29ULT_20250110T120355_L2A/B11.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "SWIR 1.6μm - 20m",
+          "eo:bands": [
+            {
+              "name": "B11",
+              "common_name": "swir16",
+              "center_wavelength": 1.61,
+              "full_width_half_max": 0.143
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 300000, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12206eaa8e87752b95598c4ad90eaead667c44881553ded86b19479eda4aa18b47fc",
+          "file:size": 16192304,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "wvp": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/LT/2025/1/S2B_T29ULT_20250110T120355_L2A/WVP.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Water Vapour (WVP)",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 300000, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "unit": "cm",
+              "scale": 0.001,
+              "offset": 0
+            }
+          ],
+          "file:checksum": "1220549c7f1f9556aa87f2e9e2306077af27a4871edd6f23a7b7483a945def3a3eb9",
+          "file:size": 134178,
+          "roles": [
+            "data"
+          ]
+        },
+        "nir08": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/LT/2025/1/S2B_T29ULT_20250110T120355_L2A/B8A.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "NIR 2 - 20m",
+          "eo:bands": [
+            {
+              "name": "B8A",
+              "common_name": "nir08",
+              "center_wavelength": 0.865,
+              "full_width_half_max": 0.033
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 300000, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12207d766a2efd3de74d5956711abca5765dd5734ca28672459eb4deb45421228eb7",
+          "file:size": 16836512,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "scl": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/LT/2025/1/S2B_T29ULT_20250110T120355_L2A/SCL.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Scene classification map (SCL)",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 300000, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 20
+            }
+          ],
+          "file:checksum": "1220cef0ac90be0d43aa4a3a7f4e32f86304227b58c4e1d6f12398f02ede7d0f1916",
+          "file:size": 661235,
+          "roles": [
+            "data"
+          ]
+        },
+        "aot": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/LT/2025/1/S2B_T29ULT_20250110T120355_L2A/AOT.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Aerosol optical thickness (AOT)",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 300000, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.001,
+              "offset": 0
+            }
+          ],
+          "file:checksum": "12206d45dd57516e4491befa01b0fdc88fb8b4ac6672e9b61e302b6f8f42bc5979de",
+          "file:size": 198595,
+          "roles": [
+            "data"
+          ]
+        },
+        "coastal": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/LT/2025/1/S2B_T29ULT_20250110T120355_L2A/B01.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Coastal - 60m",
+          "eo:bands": [
+            {
+              "name": "B01",
+              "common_name": "coastal",
+              "center_wavelength": 0.443,
+              "full_width_half_max": 0.027
+            }
+          ],
+          "gsd": 60,
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 300000, 0, -60, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 60,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220ddc842e5e2933d01235e0bb88ea63c867ce228316a0c5277f7cbf6f1b3221769",
+          "file:size": 1991573,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "nir09": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/LT/2025/1/S2B_T29ULT_20250110T120355_L2A/B09.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "NIR 3 - 60m",
+          "eo:bands": [
+            {
+              "name": "B09",
+              "common_name": "nir09",
+              "center_wavelength": 0.945,
+              "full_width_half_max": 0.026
+            }
+          ],
+          "gsd": 60,
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 300000, 0, -60, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 60,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220225bec7e6941aba12271c19bbe8d9c5c14ea3fc71262b2d4b75880c53ac1ee39",
+          "file:size": 2016382,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "cloud": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/LT/2025/1/S2B_T29ULT_20250110T120355_L2A/CLD_20m.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Cloud Probabilities",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 300000, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 20
+            }
+          ],
+          "file:checksum": "1220a755be67c7393e95e506909fdcfd568f6d43a6fa42cbccfc5232584d02d1eaa4",
+          "file:size": 2162795,
+          "roles": [
+            "data",
+            "cloud"
+          ]
+        },
+        "snow": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/LT/2025/1/S2B_T29ULT_20250110T120355_L2A/SNW_20m.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Snow Probabilities",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 300000, 0, -20, 5800020],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 20
+            }
+          ],
+          "file:checksum": "122099280d6b49f45f813f5c9a54c08d31cae51069d59d9558d551878d41e7dab826",
+          "file:size": 370705,
+          "roles": [
+            "data",
+            "snow-ice"
+          ]
+        },
+        "preview": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/LT/2025/1/S2B_T29ULT_20250110T120355_L2A/L2A_PVI.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "True color preview",
+          "eo:bands": [
+            {
+              "name": "B04",
+              "common_name": "red",
+              "center_wavelength": 0.665,
+              "full_width_half_max": 0.038
+            },
+            {
+              "name": "B03",
+              "common_name": "green",
+              "center_wavelength": 0.56,
+              "full_width_half_max": 0.045
+            },
+            {
+              "name": "B02",
+              "common_name": "blue",
+              "center_wavelength": 0.49,
+              "full_width_half_max": 0.098
+            }
+          ],
+          "file:checksum": "12204c088e206ddaf24ab7fcba7afb6b533fab045b82c4272f76aa21f56f3c4af391",
+          "file:size": 60549,
+          "roles": [
+            "overview"
+          ]
+        },
+        "granule_metadata": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/LT/2025/1/S2B_T29ULT_20250110T120355_L2A/metadata.xml",
+          "type": "application/xml",
+          "file:checksum": "12201c67cbc583f92626907c855af5e64967e8c9137a7c1c633f260c38900e5b8f6e",
+          "file:size": 350629,
+          "roles": [
+            "metadata"
+          ]
+        },
+        "tileinfo_metadata": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/LT/2025/1/S2B_T29ULT_20250110T120355_L2A/tileInfo.json",
+          "type": "application/json",
+          "file:checksum": "12205a7be274328fa33fbbb3aa6c6c482371a65b51770862aaafe3c67fcc4860ab32",
+          "file:size": 1568,
+          "roles": [
+            "metadata"
+          ]
+        },
+        "product_metadata": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/LT/2025/1/S2B_T29ULT_20250110T120355_L2A/product_metadata.xml",
+          "type": "application/xml",
+          "file:checksum": "1220d52627f80e6fe4575c7128c6971309760e7f6097a1c1965ffb298cc4bebefb83",
+          "file:size": 55102,
+          "roles": [
+            "metadata"
+          ]
+        },
+        "thumbnail": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/LT/2025/1/S2B_T29ULT_20250110T120355_L2A/L2A_PVI.jpg",
+          "type": "image/jpeg",
+          "title": "Thumbnail of preview image",
+          "file:checksum": "1220360fbeaa6ce13b08877966ad223cdaf36a8bae092899879eba5da47e1dcf3523",
+          "file:size": 13517,
+          "roles": [
+            "thumbnail"
+          ]
+        }
+      },
+      "bbox": [-11.934187, 51.793991, -10.771115, 52.337189],
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/file/v2.1.0/schema.json",
+        "https://stac-extensions.github.io/grid/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/mgrs/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sentinel-2/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/storage/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json"
+      ],
+      "collection": "sentinel-2-c1-l2a"
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "id": "S2B_T29UMU_20250110T120355_L2A",
+      "properties": {
+        "created": "2025-01-10T16:22:10.669Z",
+        "platform": "sentinel-2b",
+        "constellation": "sentinel-2",
+        "instruments": [
+          "msi"
+        ],
+        "eo:cloud_cover": 99.851912,
+        "proj:epsg": 32629,
+        "proj:centroid": {
+          "lat": 53.11473,
+          "lon": -10.41947
+        },
+        "mgrs:utm_zone": 29,
+        "mgrs:latitude_band": "U",
+        "mgrs:grid_square": "MU",
+        "grid:code": "MGRS-29UMU",
+        "view:azimuth": 295.133344244557,
+        "view:incidence_angle": 11.4258216022895,
+        "view:sun_azimuth": 170.514168318609,
+        "view:sun_elevation": 14.876218695379,
+        "s2:tile_id": "S2B_OPER_MSI_L2A_TL_2BPS_20250110T154043_A040990_T29UMU_N05.11",
+        "s2:degraded_msi_data_percentage": 0,
+        "s2:nodata_pixel_percentage": 97.318125,
+        "s2:saturated_defective_pixel_percentage": 0,
+        "s2:cloud_shadow_percentage": 0,
+        "s2:vegetation_percentage": 0,
+        "s2:not_vegetated_percentage": 0.001979,
+        "s2:water_percentage": 0.146106,
+        "s2:unclassified_percentage": 0,
+        "s2:medium_proba_clouds_percentage": 9.566632,
+        "s2:high_proba_clouds_percentage": 90.11963,
+        "s2:thin_cirrus_percentage": 0.165652,
+        "s2:snow_ice_percentage": 0,
+        "s2:product_type": "S2MSI2A",
+        "s2:processing_baseline": "05.11",
+        "s2:product_uri": "S2B_MSIL2A_20250110T120359_N0511_R066_T29UMU_20250110T154043.SAFE",
+        "s2:generation_time": "2025-01-10T15:40:43.000000Z",
+        "s2:datatake_id": "GS2B_20250110T120359_040990_N05.11",
+        "s2:datatake_type": "INS-NOBS",
+        "s2:datastrip_id": "S2B_OPER_MSI_L2A_DS_2BPS_20250110T154043_S20250110T120355_N05.11",
+        "s2:reflectance_conversion_factor": 1.03425891111326,
+        "datetime": "2025-01-10T12:06:38.977000Z",
+        "earthsearch:payload_id": "roda-sentinel-2-c1-l2a/workflow-sentinel-2-c1-l2a-to-stac/d7d4c025f2d4f3b3e51a14d9d98f1575",
+        "storage:platform": "AWS",
+        "storage:region": "us-west-2",
+        "storage:requester_pays": false,
+        "processing:software": {
+          "sentinel-2-c1-l2a-to-stac": "v2024.02.01"
+        },
+        "updated": "2025-01-10T16:22:10.669Z"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [-10.4990442948644, 53.2401920169908],
+            [-10.4859475114454, 52.8611868644894],
+            [-10.2734217675276, 53.242816076468],
+            [-10.4990442948644, 53.2401920169908]
+          ]
+        ]
+      },
+      "links": [
+        {
+          "rel": "self",
+          "type": "application/geo+json",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a/items/S2B_T29UMU_20250110T120355_L2A"
+        },
+        {
+          "rel": "canonical",
+          "href": "s3://e84-earth-search-sentinel-data/sentinel-2-c1-l2a/29/U/MU/2025/1/S2B_T29UMU_20250110T120355_L2A/S2B_T29UMU_20250110T120355_L2A.json",
+          "type": "application/json"
+        },
+        {
+          "rel": "via",
+          "href": "s3://sentinel-s2-l2a/tiles/29/U/MU/2025/1/10/0/metadata.xml",
+          "type": "application/xml",
+          "title": "Granule Metadata in Sinergize RODA Archive"
+        },
+        {
+          "rel": "parent",
+          "type": "application/json",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a"
+        },
+        {
+          "rel": "collection",
+          "type": "application/json",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a"
+        },
+        {
+          "rel": "root",
+          "type": "application/json",
+          "href": "https://earth-search.aws.element84.com/v1"
+        },
+        {
+          "rel": "thumbnail",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a/items/S2B_T29UMU_20250110T120355_L2A/thumbnail"
+        }
+      ],
+      "assets": {
+        "red": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/MU/2025/1/S2B_T29UMU_20250110T120355_L2A/B04.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red - 10m",
+          "eo:bands": [
+            {
+              "name": "B04",
+              "common_name": "red",
+              "center_wavelength": 0.665,
+              "full_width_half_max": 0.038
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 399960, 0, -10, 5900040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220d309c47c8b7acb6ae4c1e17ec394013535cc1013c9c9735d1f83e257272bb3aa",
+          "file:size": 5111486,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "green": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/MU/2025/1/S2B_T29UMU_20250110T120355_L2A/B03.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Green - 10m",
+          "eo:bands": [
+            {
+              "name": "B03",
+              "common_name": "green",
+              "center_wavelength": 0.56,
+              "full_width_half_max": 0.045
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 399960, 0, -10, 5900040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12207891e5d0515df9add88bbe4bd1fe100fbcaf720e34972134abc213b78c02b076",
+          "file:size": 5100143,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "blue": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/MU/2025/1/S2B_T29UMU_20250110T120355_L2A/B02.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Blue - 10m",
+          "eo:bands": [
+            {
+              "name": "B02",
+              "common_name": "blue",
+              "center_wavelength": 0.49,
+              "full_width_half_max": 0.098
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 399960, 0, -10, 5900040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12202be80f386072c1c9af35f23f2dad5abb0ea0670c275a50bee9fa47a65a97437b",
+          "file:size": 5092633,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "visual": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/MU/2025/1/S2B_T29UMU_20250110T120355_L2A/TCI.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "True color image",
+          "eo:bands": [
+            {
+              "name": "B04",
+              "common_name": "red",
+              "center_wavelength": 0.665,
+              "full_width_half_max": 0.038
+            },
+            {
+              "name": "B03",
+              "common_name": "green",
+              "center_wavelength": 0.56,
+              "full_width_half_max": 0.045
+            },
+            {
+              "name": "B02",
+              "common_name": "blue",
+              "center_wavelength": 0.49,
+              "full_width_half_max": 0.098
+            }
+          ],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 10
+            },
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 10
+            },
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 10
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 399960, 0, -10, 5900040],
+          "file:checksum": "1220101e3fd7208a1cb7deec2cb6d8d27db55beeefe9e348787feb9cf0d8ddc67da8",
+          "file:size": 562065,
+          "roles": [
+            "visual"
+          ]
+        },
+        "nir": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/MU/2025/1/S2B_T29UMU_20250110T120355_L2A/B08.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "NIR 1 - 10m",
+          "eo:bands": [
+            {
+              "name": "B08",
+              "common_name": "nir",
+              "center_wavelength": 0.842,
+              "full_width_half_max": 0.145
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 399960, 0, -10, 5900040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "122012b1bd512d34f36373af0856da95c7f8a4bd87e3608736484c5244e4159d3012",
+          "file:size": 5187449,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "swir22": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/MU/2025/1/S2B_T29UMU_20250110T120355_L2A/B12.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "SWIR 2.2μm - 20m",
+          "eo:bands": [
+            {
+              "name": "B12",
+              "common_name": "swir22",
+              "center_wavelength": 2.19,
+              "full_width_half_max": 0.242
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 399960, 0, -20, 5900040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12208f7d6fe1f69da7d1e94610dece34be45ea32a49e47577c644090eaf0bcb22611",
+          "file:size": 1596928,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "rededge2": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/MU/2025/1/S2B_T29UMU_20250110T120355_L2A/B06.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red Edge 2 - 20m",
+          "eo:bands": [
+            {
+              "name": "B06",
+              "common_name": "rededge",
+              "center_wavelength": 0.74,
+              "full_width_half_max": 0.018
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 399960, 0, -20, 5900040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220ca6df763e9ae2c033cb78bdcea27ad9d8885ff4bede1413576bb66ff28de366b",
+          "file:size": 1669812,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "rededge3": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/MU/2025/1/S2B_T29UMU_20250110T120355_L2A/B07.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red Edge 3 - 20m",
+          "eo:bands": [
+            {
+              "name": "B07",
+              "common_name": "rededge",
+              "center_wavelength": 0.783,
+              "full_width_half_max": 0.028
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 399960, 0, -20, 5900040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "122050956255cbee8d0801242c316be3c8dca2018b9be3c555a49df3919a991396c4",
+          "file:size": 1666645,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "rededge1": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/MU/2025/1/S2B_T29UMU_20250110T120355_L2A/B05.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red Edge 1 - 20m",
+          "eo:bands": [
+            {
+              "name": "B05",
+              "common_name": "rededge",
+              "center_wavelength": 0.704,
+              "full_width_half_max": 0.019
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 399960, 0, -20, 5900040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220a29376f79d03afef311addd6ae68b447fec13192e4c96dc19cb6875bf47abc43",
+          "file:size": 1670391,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "swir16": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/MU/2025/1/S2B_T29UMU_20250110T120355_L2A/B11.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "SWIR 1.6μm - 20m",
+          "eo:bands": [
+            {
+              "name": "B11",
+              "common_name": "swir16",
+              "center_wavelength": 1.61,
+              "full_width_half_max": 0.143
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 399960, 0, -20, 5900040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220792a6aa646da0a6da7185b9571185672519b6c5619d0184c2c7f33a512cf58fd",
+          "file:size": 1619071,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "wvp": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/MU/2025/1/S2B_T29UMU_20250110T120355_L2A/WVP.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Water Vapour (WVP)",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 399960, 0, -20, 5900040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "unit": "cm",
+              "scale": 0.001,
+              "offset": 0
+            }
+          ],
+          "file:checksum": "122096a7ec83f826c2d64ddfffdf0de254ab329380fe27a62a5316684905d3d2fb57",
+          "file:size": 105171,
+          "roles": [
+            "data"
+          ]
+        },
+        "nir08": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/MU/2025/1/S2B_T29UMU_20250110T120355_L2A/B8A.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "NIR 2 - 20m",
+          "eo:bands": [
+            {
+              "name": "B8A",
+              "common_name": "nir08",
+              "center_wavelength": 0.865,
+              "full_width_half_max": 0.033
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 399960, 0, -20, 5900040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12200d824dc3b6cc3b2a25a1f4418439599f9855bf56a45e0743366b5bf79fe6e430",
+          "file:size": 1673352,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "scl": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/MU/2025/1/S2B_T29UMU_20250110T120355_L2A/SCL.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Scene classification map (SCL)",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 399960, 0, -20, 5900040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 20
+            }
+          ],
+          "file:checksum": "1220b1b8d5243264af9a9a6c20e3c60bbc1cf405376b735d78cf80aa23b526237b68",
+          "file:size": 81560,
+          "roles": [
+            "data"
+          ]
+        },
+        "aot": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/MU/2025/1/S2B_T29UMU_20250110T120355_L2A/AOT.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Aerosol optical thickness (AOT)",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 399960, 0, -20, 5900040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.001,
+              "offset": 0
+            }
+          ],
+          "file:checksum": "12204f80ce4edb419f177e533dba4ac913145de59cc8e384be1455217e2fed4e25e0",
+          "file:size": 113778,
+          "roles": [
+            "data"
+          ]
+        },
+        "coastal": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/MU/2025/1/S2B_T29UMU_20250110T120355_L2A/B01.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Coastal - 60m",
+          "eo:bands": [
+            {
+              "name": "B01",
+              "common_name": "coastal",
+              "center_wavelength": 0.443,
+              "full_width_half_max": 0.027
+            }
+          ],
+          "gsd": 60,
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 399960, 0, -60, 5900040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 60,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220708a0c79160b88446637eeeee0bb16b66b7553f6472b29b65275dd5c0944ff14",
+          "file:size": 204521,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "nir09": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/MU/2025/1/S2B_T29UMU_20250110T120355_L2A/B09.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "NIR 3 - 60m",
+          "eo:bands": [
+            {
+              "name": "B09",
+              "common_name": "nir09",
+              "center_wavelength": 0.945,
+              "full_width_half_max": 0.026
+            }
+          ],
+          "gsd": 60,
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 399960, 0, -60, 5900040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 60,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12209c228a60e2ae567cfe920c25213db4ea1d78a90de769f0e8dc1f1d946db2538a",
+          "file:size": 212847,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "cloud": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/MU/2025/1/S2B_T29UMU_20250110T120355_L2A/CLD_20m.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Cloud Probabilities",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 399960, 0, -20, 5900040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 20
+            }
+          ],
+          "file:checksum": "1220a3f9f026bd5025f82f3adf0f6c2b419771977a89dd84da2726802de5492beb6f",
+          "file:size": 90369,
+          "roles": [
+            "data",
+            "cloud"
+          ]
+        },
+        "snow": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/MU/2025/1/S2B_T29UMU_20250110T120355_L2A/SNW_20m.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Snow Probabilities",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 399960, 0, -20, 5900040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 20
+            }
+          ],
+          "file:checksum": "1220a94513ceac58211fe15df962a282ba81af3b7a6c86448fdd158af7e5a72571d7",
+          "file:size": 77916,
+          "roles": [
+            "data",
+            "snow-ice"
+          ]
+        },
+        "preview": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/MU/2025/1/S2B_T29UMU_20250110T120355_L2A/L2A_PVI.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "True color preview",
+          "eo:bands": [
+            {
+              "name": "B04",
+              "common_name": "red",
+              "center_wavelength": 0.665,
+              "full_width_half_max": 0.038
+            },
+            {
+              "name": "B03",
+              "common_name": "green",
+              "center_wavelength": 0.56,
+              "full_width_half_max": 0.045
+            },
+            {
+              "name": "B02",
+              "common_name": "blue",
+              "center_wavelength": 0.49,
+              "full_width_half_max": 0.098
+            }
+          ],
+          "file:checksum": "1220a918fb0a9713c7662bea5d722e61ea704c8f72df11172c45b6faa37709bf0ba7",
+          "file:size": 5132,
+          "roles": [
+            "overview"
+          ]
+        },
+        "granule_metadata": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/MU/2025/1/S2B_T29UMU_20250110T120355_L2A/metadata.xml",
+          "type": "application/xml",
+          "file:checksum": "1220688e99c289650d08535e4526f0b30b9f827f967e201a550181d5ba95cbd06706",
+          "file:size": 101884,
+          "roles": [
+            "metadata"
+          ]
+        },
+        "tileinfo_metadata": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/MU/2025/1/S2B_T29UMU_20250110T120355_L2A/tileInfo.json",
+          "type": "application/json",
+          "file:checksum": "12209891f3af981af6621dedc4fb99d9b1e69346d48bb303bd5dd0d3c3c38798b74d",
+          "file:size": 1482,
+          "roles": [
+            "metadata"
+          ]
+        },
+        "product_metadata": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/MU/2025/1/S2B_T29UMU_20250110T120355_L2A/product_metadata.xml",
+          "type": "application/xml",
+          "file:checksum": "1220b390185e418500d3d7c46dfd44f6f490cb6771c5c2b11c8ddd909345efa0b488",
+          "file:size": 54497,
+          "roles": [
+            "metadata"
+          ]
+        },
+        "thumbnail": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/MU/2025/1/S2B_T29UMU_20250110T120355_L2A/L2A_PVI.jpg",
+          "type": "image/jpeg",
+          "title": "Thumbnail of preview image",
+          "file:checksum": "1220ad716bb6e2c9c8aeec0e64984b21d504b7fcad9c6fb68ee4c7fbd1e86a76ca48",
+          "file:size": 3202,
+          "roles": [
+            "thumbnail"
+          ]
+        }
+      },
+      "bbox": [-10.499044, 52.861187, -10.273422, 53.242816],
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/file/v2.1.0/schema.json",
+        "https://stac-extensions.github.io/grid/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/mgrs/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sentinel-2/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/storage/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json"
+      ],
+      "collection": "sentinel-2-c1-l2a"
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "id": "S2B_T28UEG_20250110T120355_L2A",
+      "properties": {
+        "created": "2025-01-10T16:24:42.505Z",
+        "platform": "sentinel-2b",
+        "constellation": "sentinel-2",
+        "instruments": [
+          "msi"
+        ],
+        "eo:cloud_cover": 100,
+        "proj:epsg": 32628,
+        "proj:centroid": {
+          "lat": 55.38441,
+          "lon": -13.58014
+        },
+        "mgrs:utm_zone": 28,
+        "mgrs:latitude_band": "U",
+        "mgrs:grid_square": "EG",
+        "grid:code": "MGRS-28UEG",
+        "view:azimuth": 107.206073425202,
+        "view:incidence_angle": 10.2725275481198,
+        "view:sun_azimuth": 166.291906822544,
+        "view:sun_elevation": 11.6956433007712,
+        "s2:tile_id": "S2B_OPER_MSI_L2A_TL_2BPS_20250110T154043_A040990_T28UEG_N05.11",
+        "s2:degraded_msi_data_percentage": 0,
+        "s2:nodata_pixel_percentage": 65.152574,
+        "s2:saturated_defective_pixel_percentage": 0,
+        "s2:cloud_shadow_percentage": 0,
+        "s2:vegetation_percentage": 0,
+        "s2:not_vegetated_percentage": 0,
+        "s2:water_percentage": 0,
+        "s2:unclassified_percentage": 0,
+        "s2:medium_proba_clouds_percentage": 1.233756,
+        "s2:high_proba_clouds_percentage": 98.766243,
+        "s2:thin_cirrus_percentage": 0,
+        "s2:snow_ice_percentage": 0,
+        "s2:product_type": "S2MSI2A",
+        "s2:processing_baseline": "05.11",
+        "s2:product_uri": "S2B_MSIL2A_20250110T120359_N0511_R066_T28UEG_20250110T154043.SAFE",
+        "s2:generation_time": "2025-01-10T15:40:43.000000Z",
+        "s2:datatake_id": "GS2B_20250110T120359_040990_N05.11",
+        "s2:datatake_type": "INS-NOBS",
+        "s2:datastrip_id": "S2B_OPER_MSI_L2A_DS_2BPS_20250110T154043_S20250110T120355_N05.11",
+        "s2:reflectance_conversion_factor": 1.03425891111326,
+        "datetime": "2025-01-10T12:06:13.388000Z",
+        "earthsearch:payload_id": "roda-sentinel-2-c1-l2a/workflow-sentinel-2-c1-l2a-to-stac/3f433637e07c4b2600b19a2e7741e644",
+        "storage:platform": "AWS",
+        "storage:region": "us-west-2",
+        "storage:requester_pays": false,
+        "processing:software": {
+          "sentinel-2-c1-l2a-to-stac": "v2024.02.01"
+        },
+        "updated": "2025-01-10T16:24:42.505Z"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [-13.6265322920318, 55.9380706206949],
+            [-14.1026482225707, 54.9557969721861],
+            [-13.2860297382675, 54.9470270219076],
+            [-13.2427407104991, 55.933193717984],
+            [-13.6265322920318, 55.9380706206949]
+          ]
+        ]
+      },
+      "links": [
+        {
+          "rel": "self",
+          "type": "application/geo+json",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a/items/S2B_T28UEG_20250110T120355_L2A"
+        },
+        {
+          "rel": "canonical",
+          "href": "s3://e84-earth-search-sentinel-data/sentinel-2-c1-l2a/28/U/EG/2025/1/S2B_T28UEG_20250110T120355_L2A/S2B_T28UEG_20250110T120355_L2A.json",
+          "type": "application/json"
+        },
+        {
+          "rel": "via",
+          "href": "s3://sentinel-s2-l2a/tiles/28/U/EG/2025/1/10/0/metadata.xml",
+          "type": "application/xml",
+          "title": "Granule Metadata in Sinergize RODA Archive"
+        },
+        {
+          "rel": "parent",
+          "type": "application/json",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a"
+        },
+        {
+          "rel": "collection",
+          "type": "application/json",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a"
+        },
+        {
+          "rel": "root",
+          "type": "application/json",
+          "href": "https://earth-search.aws.element84.com/v1"
+        },
+        {
+          "rel": "thumbnail",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a/items/S2B_T28UEG_20250110T120355_L2A/thumbnail"
+        }
+      ],
+      "assets": {
+        "red": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EG/2025/1/S2B_T28UEG_20250110T120355_L2A/B04.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red - 10m",
+          "eo:bands": [
+            {
+              "name": "B04",
+              "common_name": "red",
+              "center_wavelength": 0.665,
+              "full_width_half_max": 0.038
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 499980, 0, -10, 6200040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220b9d353ff3c5b32a6a6b9d7373a4a23e53977ca4a2a53c331a33f42db253bf1d9",
+          "file:size": 60381704,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "green": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EG/2025/1/S2B_T28UEG_20250110T120355_L2A/B03.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Green - 10m",
+          "eo:bands": [
+            {
+              "name": "B03",
+              "common_name": "green",
+              "center_wavelength": 0.56,
+              "full_width_half_max": 0.045
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 499980, 0, -10, 6200040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "122069bc8ca3f9e02a5d9cc9ccfaa346b82fbc43d49b5733ef8c0c442cd7c1029e95",
+          "file:size": 60566679,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "blue": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EG/2025/1/S2B_T28UEG_20250110T120355_L2A/B02.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Blue - 10m",
+          "eo:bands": [
+            {
+              "name": "B02",
+              "common_name": "blue",
+              "center_wavelength": 0.49,
+              "full_width_half_max": 0.098
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 499980, 0, -10, 6200040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220e79da24993985cbba76d10c1921e9e623c42efbe0dfeef64e64541abec1cabc3",
+          "file:size": 61289399,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "visual": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EG/2025/1/S2B_T28UEG_20250110T120355_L2A/TCI.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "True color image",
+          "eo:bands": [
+            {
+              "name": "B04",
+              "common_name": "red",
+              "center_wavelength": 0.665,
+              "full_width_half_max": 0.038
+            },
+            {
+              "name": "B03",
+              "common_name": "green",
+              "center_wavelength": 0.56,
+              "full_width_half_max": 0.045
+            },
+            {
+              "name": "B02",
+              "common_name": "blue",
+              "center_wavelength": 0.49,
+              "full_width_half_max": 0.098
+            }
+          ],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 10
+            },
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 10
+            },
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 10
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 499980, 0, -10, 6200040],
+          "file:checksum": "122088b33cf108ade9b4c26653c73e36729cd15ac949ded66e021c33e23c027e5c0a",
+          "file:size": 2404937,
+          "roles": [
+            "visual"
+          ]
+        },
+        "nir": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EG/2025/1/S2B_T28UEG_20250110T120355_L2A/B08.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "NIR 1 - 10m",
+          "eo:bands": [
+            {
+              "name": "B08",
+              "common_name": "nir",
+              "center_wavelength": 0.842,
+              "full_width_half_max": 0.145
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 499980, 0, -10, 6200040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220669b38f781482a19c416b172d75902376262b840cd11d4f2c0485c0483264f1a",
+          "file:size": 61404018,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "swir22": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EG/2025/1/S2B_T28UEG_20250110T120355_L2A/B12.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "SWIR 2.2μm - 20m",
+          "eo:bands": [
+            {
+              "name": "B12",
+              "common_name": "swir22",
+              "center_wavelength": 2.19,
+              "full_width_half_max": 0.242
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 6200040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "122007f0ada73a0dfc1ea5c01b7cef273f3a621e567ff8cac3d230b0f9b98dc7d377",
+          "file:size": 17601586,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "rededge2": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EG/2025/1/S2B_T28UEG_20250110T120355_L2A/B06.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red Edge 2 - 20m",
+          "eo:bands": [
+            {
+              "name": "B06",
+              "common_name": "rededge",
+              "center_wavelength": 0.74,
+              "full_width_half_max": 0.018
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 6200040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12200d4476aa9543d440f22ef65eb48baaf15d0246f02061e48ef2bf58b0802ef7ca",
+          "file:size": 19136948,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "rededge3": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EG/2025/1/S2B_T28UEG_20250110T120355_L2A/B07.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red Edge 3 - 20m",
+          "eo:bands": [
+            {
+              "name": "B07",
+              "common_name": "rededge",
+              "center_wavelength": 0.783,
+              "full_width_half_max": 0.028
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 6200040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12202f084ef5aba2af0dd40f435b33d219b893acabbc9e921d86b1a94bf112230669",
+          "file:size": 19261255,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "rededge1": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EG/2025/1/S2B_T28UEG_20250110T120355_L2A/B05.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red Edge 1 - 20m",
+          "eo:bands": [
+            {
+              "name": "B05",
+              "common_name": "rededge",
+              "center_wavelength": 0.704,
+              "full_width_half_max": 0.019
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 6200040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220969140f9d7e9cc58cf32e457f566f4c340273427ffb8dddb2f683d150835ad6c",
+          "file:size": 19065317,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "swir16": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EG/2025/1/S2B_T28UEG_20250110T120355_L2A/B11.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "SWIR 1.6μm - 20m",
+          "eo:bands": [
+            {
+              "name": "B11",
+              "common_name": "swir16",
+              "center_wavelength": 1.61,
+              "full_width_half_max": 0.143
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 6200040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220914df8e59a4a35b02a50c7a491dc3ca9a1cae1f4ae2d84a7e0255f997be7f78f",
+          "file:size": 18069457,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "wvp": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EG/2025/1/S2B_T28UEG_20250110T120355_L2A/WVP.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Water Vapour (WVP)",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 6200040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "unit": "cm",
+              "scale": 0.001,
+              "offset": 0
+            }
+          ],
+          "file:checksum": "1220737f0c96ba09ebf59029954c78d1a0a402c1053743ebff2525838d83a1511a38",
+          "file:size": 95845,
+          "roles": [
+            "data"
+          ]
+        },
+        "nir08": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EG/2025/1/S2B_T28UEG_20250110T120355_L2A/B8A.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "NIR 2 - 20m",
+          "eo:bands": [
+            {
+              "name": "B8A",
+              "common_name": "nir08",
+              "center_wavelength": 0.865,
+              "full_width_half_max": 0.033
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 6200040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "122011dd8b6bdb5f241dd736b2d504b45e34c42749a53368505a15fc6ef2affb2090",
+          "file:size": 19513705,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "scl": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EG/2025/1/S2B_T28UEG_20250110T120355_L2A/SCL.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Scene classification map (SCL)",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 6200040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 20
+            }
+          ],
+          "file:checksum": "1220a5d8882157abc3181bb1a6a46d7c64fc4c9d024b75e6d74fc16ab0e83c904c5c",
+          "file:size": 121275,
+          "roles": [
+            "data"
+          ]
+        },
+        "aot": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EG/2025/1/S2B_T28UEG_20250110T120355_L2A/AOT.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Aerosol optical thickness (AOT)",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 6200040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.001,
+              "offset": 0
+            }
+          ],
+          "file:checksum": "1220c6e200980d8d0b7d7f2e6646d494b790d40a5cbfe0cdc31df7cf1a4576456fa2",
+          "file:size": 173930,
+          "roles": [
+            "data"
+          ]
+        },
+        "coastal": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EG/2025/1/S2B_T28UEG_20250110T120355_L2A/B01.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Coastal - 60m",
+          "eo:bands": [
+            {
+              "name": "B01",
+              "common_name": "coastal",
+              "center_wavelength": 0.443,
+              "full_width_half_max": 0.027
+            }
+          ],
+          "gsd": 60,
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 499980, 0, -60, 6200040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 60,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "122086a4aeabc9e17edd3c8951f13de11c1ed3857bb33fa3cb97e68a9d0100147924",
+          "file:size": 2249862,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "nir09": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EG/2025/1/S2B_T28UEG_20250110T120355_L2A/B09.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "NIR 3 - 60m",
+          "eo:bands": [
+            {
+              "name": "B09",
+              "common_name": "nir09",
+              "center_wavelength": 0.945,
+              "full_width_half_max": 0.026
+            }
+          ],
+          "gsd": 60,
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 499980, 0, -60, 6200040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 60,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220199c59b4af3b328f6aeb6d39fc7ceb285748f594cf5c955cd0a8f4942cba3781",
+          "file:size": 1916080,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "cloud": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EG/2025/1/S2B_T28UEG_20250110T120355_L2A/CLD_20m.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Cloud Probabilities",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 6200040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 20
+            }
+          ],
+          "file:checksum": "122076cefbddfb96e123b42521059ea8dca0c458e3394688c0f886fb43c33d907402",
+          "file:size": 231288,
+          "roles": [
+            "data",
+            "cloud"
+          ]
+        },
+        "snow": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EG/2025/1/S2B_T28UEG_20250110T120355_L2A/SNW_20m.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Snow Probabilities",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 6200040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 20
+            }
+          ],
+          "file:checksum": "12209a39c5a396b02efa2a98f06213d63ee40227e1d292883e792279df61c431e8ae",
+          "file:size": 53931,
+          "roles": [
+            "data",
+            "snow-ice"
+          ]
+        },
+        "preview": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EG/2025/1/S2B_T28UEG_20250110T120355_L2A/L2A_PVI.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "True color preview",
+          "eo:bands": [
+            {
+              "name": "B04",
+              "common_name": "red",
+              "center_wavelength": 0.665,
+              "full_width_half_max": 0.038
+            },
+            {
+              "name": "B03",
+              "common_name": "green",
+              "center_wavelength": 0.56,
+              "full_width_half_max": 0.045
+            },
+            {
+              "name": "B02",
+              "common_name": "blue",
+              "center_wavelength": 0.49,
+              "full_width_half_max": 0.098
+            }
+          ],
+          "file:checksum": "122075dc35d66b6d9a941a1277a77f576ba3b7bd5c0a325d60641feefa4812bc1124",
+          "file:size": 8431,
+          "roles": [
+            "overview"
+          ]
+        },
+        "granule_metadata": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EG/2025/1/S2B_T28UEG_20250110T120355_L2A/metadata.xml",
+          "type": "application/xml",
+          "file:checksum": "1220c4312c4f5ad1f1c757186808c99ec2a552cf2874bc7740e635da2b3538bbfbfb",
+          "file:size": 276748,
+          "roles": [
+            "metadata"
+          ]
+        },
+        "tileinfo_metadata": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EG/2025/1/S2B_T28UEG_20250110T120355_L2A/tileInfo.json",
+          "type": "application/json",
+          "file:checksum": "122071fa608aa4046865213a5eac7e5d35d24204e73c393ef5ddaea518918a91e35f",
+          "file:size": 1518,
+          "roles": [
+            "metadata"
+          ]
+        },
+        "product_metadata": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EG/2025/1/S2B_T28UEG_20250110T120355_L2A/product_metadata.xml",
+          "type": "application/xml",
+          "file:checksum": "12205fd1335176b336218ed5c4e5f7930ae15d28a2944d592d89b1ca962b84f9b0ee",
+          "file:size": 54707,
+          "roles": [
+            "metadata"
+          ]
+        },
+        "thumbnail": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/U/EG/2025/1/S2B_T28UEG_20250110T120355_L2A/L2A_PVI.jpg",
+          "type": "image/jpeg",
+          "title": "Thumbnail of preview image",
+          "file:checksum": "1220659ac78ac2c72c27ef4b3d2f06306fa35ba128b539ce99a12e601e3b5dba16cd",
+          "file:size": 4633,
+          "roles": [
+            "thumbnail"
+          ]
+        }
+      },
+      "bbox": [-14.102648, 54.947027, -13.242741, 55.938071],
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/file/v2.1.0/schema.json",
+        "https://stac-extensions.github.io/grid/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/mgrs/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sentinel-2/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/storage/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json"
+      ],
+      "collection": "sentinel-2-c1-l2a"
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "id": "S2B_T28VEH_20250110T120355_L2A",
+      "properties": {
+        "created": "2025-01-10T16:23:30.675Z",
+        "platform": "sentinel-2b",
+        "constellation": "sentinel-2",
+        "instruments": [
+          "msi"
+        ],
+        "eo:cloud_cover": 99.301517,
+        "proj:epsg": 32628,
+        "proj:centroid": {
+          "lat": 56.15644,
+          "lon": -13.37486
+        },
+        "mgrs:utm_zone": 28,
+        "mgrs:latitude_band": "V",
+        "mgrs:grid_square": "EH",
+        "grid:code": "MGRS-28VEH",
+        "view:azimuth": 111.841329557221,
+        "view:incidence_angle": 11.1233547024194,
+        "view:sun_azimuth": 166.296128019016,
+        "view:sun_elevation": 10.8177386822595,
+        "s2:tile_id": "S2B_OPER_MSI_L2A_TL_2BPS_20250110T154043_A040990_T28VEH_N05.11",
+        "s2:degraded_msi_data_percentage": 0,
+        "s2:nodata_pixel_percentage": 88.483912,
+        "s2:saturated_defective_pixel_percentage": 0,
+        "s2:cloud_shadow_percentage": 0,
+        "s2:vegetation_percentage": 0,
+        "s2:not_vegetated_percentage": 0,
+        "s2:water_percentage": 0.698481,
+        "s2:unclassified_percentage": 0,
+        "s2:medium_proba_clouds_percentage": 42.502564,
+        "s2:high_proba_clouds_percentage": 44.748831,
+        "s2:thin_cirrus_percentage": 12.050124,
+        "s2:snow_ice_percentage": 0,
+        "s2:product_type": "S2MSI2A",
+        "s2:processing_baseline": "05.11",
+        "s2:product_uri": "S2B_MSIL2A_20250110T120359_N0511_R066_T28VEH_20250110T154043.SAFE",
+        "s2:generation_time": "2025-01-10T15:40:43.000000Z",
+        "s2:datatake_id": "GS2B_20250110T120359_040990_N05.11",
+        "s2:datatake_type": "INS-NOBS",
+        "s2:datastrip_id": "S2B_OPER_MSI_L2A_DS_2BPS_20250110T154043_S20250110T120355_N05.11",
+        "s2:reflectance_conversion_factor": 1.03425891111326,
+        "datetime": "2025-01-10T12:06:00.902000Z",
+        "earthsearch:payload_id": "roda-sentinel-2-c1-l2a/workflow-sentinel-2-c1-l2a-to-stac/11834873512e6300f7681a47b13878fd",
+        "storage:platform": "AWS",
+        "storage:region": "us-west-2",
+        "storage:requester_pays": false,
+        "processing:software": {
+          "sentinel-2-c1-l2a-to-stac": "v2024.02.01"
+        },
+        "updated": "2025-01-10T16:23:30.675Z"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [-13.2483259551958, 55.8448624735234],
+            [-13.206223668266, 56.7743145359432],
+            [-13.6700421061974, 55.8501437572837],
+            [-13.2483259551958, 55.8448624735234]
+          ]
+        ]
+      },
+      "links": [
+        {
+          "rel": "self",
+          "type": "application/geo+json",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a/items/S2B_T28VEH_20250110T120355_L2A"
+        },
+        {
+          "rel": "canonical",
+          "href": "s3://e84-earth-search-sentinel-data/sentinel-2-c1-l2a/28/V/EH/2025/1/S2B_T28VEH_20250110T120355_L2A/S2B_T28VEH_20250110T120355_L2A.json",
+          "type": "application/json"
+        },
+        {
+          "rel": "via",
+          "href": "s3://sentinel-s2-l2a/tiles/28/V/EH/2025/1/10/0/metadata.xml",
+          "type": "application/xml",
+          "title": "Granule Metadata in Sinergize RODA Archive"
+        },
+        {
+          "rel": "parent",
+          "type": "application/json",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a"
+        },
+        {
+          "rel": "collection",
+          "type": "application/json",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a"
+        },
+        {
+          "rel": "root",
+          "type": "application/json",
+          "href": "https://earth-search.aws.element84.com/v1"
+        },
+        {
+          "rel": "thumbnail",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a/items/S2B_T28VEH_20250110T120355_L2A/thumbnail"
+        }
+      ],
+      "assets": {
+        "red": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/V/EH/2025/1/S2B_T28VEH_20250110T120355_L2A/B04.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red - 10m",
+          "eo:bands": [
+            {
+              "name": "B04",
+              "common_name": "red",
+              "center_wavelength": 0.665,
+              "full_width_half_max": 0.038
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 499980, 0, -10, 6300000],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12209a078d936edd1a7e1bcdf766e8fcf55431b60f65328965b08f0af871af8464eb",
+          "file:size": 23470320,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "green": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/V/EH/2025/1/S2B_T28VEH_20250110T120355_L2A/B03.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Green - 10m",
+          "eo:bands": [
+            {
+              "name": "B03",
+              "common_name": "green",
+              "center_wavelength": 0.56,
+              "full_width_half_max": 0.045
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 499980, 0, -10, 6300000],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220d798375df0fc4cd2f16f037408fecb24b72f372f1658c733d3a7d522dd3eac07",
+          "file:size": 23549627,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "blue": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/V/EH/2025/1/S2B_T28VEH_20250110T120355_L2A/B02.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Blue - 10m",
+          "eo:bands": [
+            {
+              "name": "B02",
+              "common_name": "blue",
+              "center_wavelength": 0.49,
+              "full_width_half_max": 0.098
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 499980, 0, -10, 6300000],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12207470ebca173e6c56435c6e9a2da0013603294d304b7e2a12803a97029c1269b0",
+          "file:size": 23446317,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "visual": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/V/EH/2025/1/S2B_T28VEH_20250110T120355_L2A/TCI.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "True color image",
+          "eo:bands": [
+            {
+              "name": "B04",
+              "common_name": "red",
+              "center_wavelength": 0.665,
+              "full_width_half_max": 0.038
+            },
+            {
+              "name": "B03",
+              "common_name": "green",
+              "center_wavelength": 0.56,
+              "full_width_half_max": 0.045
+            },
+            {
+              "name": "B02",
+              "common_name": "blue",
+              "center_wavelength": 0.49,
+              "full_width_half_max": 0.098
+            }
+          ],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 10
+            },
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 10
+            },
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 10
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 499980, 0, -10, 6300000],
+          "file:checksum": "12207b390449b17d0cebbbd6b2de54203a94e925ac96ce54aa5b34583674c0113e89",
+          "file:size": 21770593,
+          "roles": [
+            "visual"
+          ]
+        },
+        "nir": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/V/EH/2025/1/S2B_T28VEH_20250110T120355_L2A/B08.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "NIR 1 - 10m",
+          "eo:bands": [
+            {
+              "name": "B08",
+              "common_name": "nir",
+              "center_wavelength": 0.842,
+              "full_width_half_max": 0.145
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 499980, 0, -10, 6300000],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12205b740b77c08f48ce13ee908590a25d361e72d47ade71fa055c9d268534e04223",
+          "file:size": 23641591,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "swir22": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/V/EH/2025/1/S2B_T28VEH_20250110T120355_L2A/B12.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "SWIR 2.2μm - 20m",
+          "eo:bands": [
+            {
+              "name": "B12",
+              "common_name": "swir22",
+              "center_wavelength": 2.19,
+              "full_width_half_max": 0.242
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 6300000],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "122085f33db31d5fbed707c061c7df0cc929dcc7b861df99561166b57bd6600e84ab",
+          "file:size": 6241149,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "rededge2": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/V/EH/2025/1/S2B_T28VEH_20250110T120355_L2A/B06.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red Edge 2 - 20m",
+          "eo:bands": [
+            {
+              "name": "B06",
+              "common_name": "rededge",
+              "center_wavelength": 0.74,
+              "full_width_half_max": 0.018
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 6300000],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220eb01170f6a76786fd032101911244c117c5ca2a43fb2a8162327246afaccfe09",
+          "file:size": 6636232,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "rededge3": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/V/EH/2025/1/S2B_T28VEH_20250110T120355_L2A/B07.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red Edge 3 - 20m",
+          "eo:bands": [
+            {
+              "name": "B07",
+              "common_name": "rededge",
+              "center_wavelength": 0.783,
+              "full_width_half_max": 0.028
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 6300000],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220577312552117447a506afcc312f45302506b7b184048c7da1c7e4c0dd514db9c",
+          "file:size": 6676498,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "rededge1": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/V/EH/2025/1/S2B_T28VEH_20250110T120355_L2A/B05.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red Edge 1 - 20m",
+          "eo:bands": [
+            {
+              "name": "B05",
+              "common_name": "rededge",
+              "center_wavelength": 0.704,
+              "full_width_half_max": 0.019
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 6300000],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220c33490a3ec481d86db0f85ecea1d741794cc12424dba366d2f606f8e5b23588a",
+          "file:size": 6631667,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "swir16": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/V/EH/2025/1/S2B_T28VEH_20250110T120355_L2A/B11.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "SWIR 1.6μm - 20m",
+          "eo:bands": [
+            {
+              "name": "B11",
+              "common_name": "swir16",
+              "center_wavelength": 1.61,
+              "full_width_half_max": 0.143
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 6300000],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "122072b1ed47a63d6dc0bf1ac50432268e594262a2d2b451397c0ebbdabbadd88cff",
+          "file:size": 6317373,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "wvp": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/V/EH/2025/1/S2B_T28VEH_20250110T120355_L2A/WVP.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Water Vapour (WVP)",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 6300000],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "unit": "cm",
+              "scale": 0.001,
+              "offset": 0
+            }
+          ],
+          "file:checksum": "12209a8982ff57262f14ebd82f32666904914fb550aabe6a6ddf554350fac7c2136d",
+          "file:size": 95845,
+          "roles": [
+            "data"
+          ]
+        },
+        "nir08": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/V/EH/2025/1/S2B_T28VEH_20250110T120355_L2A/B8A.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "NIR 2 - 20m",
+          "eo:bands": [
+            {
+              "name": "B8A",
+              "common_name": "nir08",
+              "center_wavelength": 0.865,
+              "full_width_half_max": 0.033
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 6300000],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220efe682a3aa1a20332f77390e4f53fbcd1b16f32f694fb3b352f8410919e5955b",
+          "file:size": 6716668,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "scl": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/V/EH/2025/1/S2B_T28VEH_20250110T120355_L2A/SCL.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Scene classification map (SCL)",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 6300000],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 20
+            }
+          ],
+          "file:checksum": "122017b19cbd43088542594dd2b1d2f70313da1a2ecfb5a4e29f20bd1bc3da1f7815",
+          "file:size": 222714,
+          "roles": [
+            "data"
+          ]
+        },
+        "aot": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/V/EH/2025/1/S2B_T28VEH_20250110T120355_L2A/AOT.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Aerosol optical thickness (AOT)",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 6300000],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.001,
+              "offset": 0
+            }
+          ],
+          "file:checksum": "1220246803d9849a422405163a49896d7106184d4e9ec6691fc49ac83816517f0509",
+          "file:size": 138722,
+          "roles": [
+            "data"
+          ]
+        },
+        "coastal": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/V/EH/2025/1/S2B_T28VEH_20250110T120355_L2A/B01.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Coastal - 60m",
+          "eo:bands": [
+            {
+              "name": "B01",
+              "common_name": "coastal",
+              "center_wavelength": 0.443,
+              "full_width_half_max": 0.027
+            }
+          ],
+          "gsd": 60,
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 499980, 0, -60, 6300000],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 60,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "122090dcd8bdb5db4777e23fbd9a863b3475caccea2632e6f082c1a40e7c0d7c615f",
+          "file:size": 801606,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "nir09": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/V/EH/2025/1/S2B_T28VEH_20250110T120355_L2A/B09.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "NIR 3 - 60m",
+          "eo:bands": [
+            {
+              "name": "B09",
+              "common_name": "nir09",
+              "center_wavelength": 0.945,
+              "full_width_half_max": 0.026
+            }
+          ],
+          "gsd": 60,
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 499980, 0, -60, 6300000],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 60,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220cb7d707d19dfdd20a6619f08f7f55e7becb8c164c73fc1ba0924ac0f50518bf6",
+          "file:size": 716309,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "cloud": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/V/EH/2025/1/S2B_T28VEH_20250110T120355_L2A/CLD_20m.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Cloud Probabilities",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 6300000],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 20
+            }
+          ],
+          "file:checksum": "12201cea1fb6f01083885b59b8c36f635d80e32062c28e214bc65e25e272e2eb73d8",
+          "file:size": 603026,
+          "roles": [
+            "data",
+            "cloud"
+          ]
+        },
+        "snow": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/V/EH/2025/1/S2B_T28VEH_20250110T120355_L2A/SNW_20m.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Snow Probabilities",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 6300000],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 20
+            }
+          ],
+          "file:checksum": "12206d5fa18554952bea897b5e8ffe90c64ae6ba98d31744de65c4e269ca0e913bbd",
+          "file:size": 53931,
+          "roles": [
+            "data",
+            "snow-ice"
+          ]
+        },
+        "preview": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/V/EH/2025/1/S2B_T28VEH_20250110T120355_L2A/L2A_PVI.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "True color preview",
+          "eo:bands": [
+            {
+              "name": "B04",
+              "common_name": "red",
+              "center_wavelength": 0.665,
+              "full_width_half_max": 0.038
+            },
+            {
+              "name": "B03",
+              "common_name": "green",
+              "center_wavelength": 0.56,
+              "full_width_half_max": 0.045
+            },
+            {
+              "name": "B02",
+              "common_name": "blue",
+              "center_wavelength": 0.49,
+              "full_width_half_max": 0.098
+            }
+          ],
+          "file:checksum": "12205adc705f4f9892cbca80a870037a9ab732ec8c93ab91639a7c9477e000d1764a",
+          "file:size": 31910,
+          "roles": [
+            "overview"
+          ]
+        },
+        "granule_metadata": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/V/EH/2025/1/S2B_T28VEH_20250110T120355_L2A/metadata.xml",
+          "type": "application/xml",
+          "file:checksum": "1220e635711170fce5974513ea062f6739b962681828dd8d1db23b026072abb6064e",
+          "file:size": 185550,
+          "roles": [
+            "metadata"
+          ]
+        },
+        "tileinfo_metadata": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/V/EH/2025/1/S2B_T28VEH_20250110T120355_L2A/tileInfo.json",
+          "type": "application/json",
+          "file:checksum": "1220d7a2e8b29cf19d297e4c685b7cd4a8a82399f0e8d6b063c1d40b9978a734f008",
+          "file:size": 1510,
+          "roles": [
+            "metadata"
+          ]
+        },
+        "product_metadata": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/V/EH/2025/1/S2B_T28VEH_20250110T120355_L2A/product_metadata.xml",
+          "type": "application/xml",
+          "file:checksum": "12200362284af62323155e23089028e143ef902c4f19f040a4341fb1ab723056e132",
+          "file:size": 54677,
+          "roles": [
+            "metadata"
+          ]
+        },
+        "thumbnail": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/28/V/EH/2025/1/S2B_T28VEH_20250110T120355_L2A/L2A_PVI.jpg",
+          "type": "image/jpeg",
+          "title": "Thumbnail of preview image",
+          "file:checksum": "1220d058912bbb7875f8b023701f44852a6a18f09d9062bb2a0476acb44e06e62ab1",
+          "file:size": 7597,
+          "roles": [
+            "thumbnail"
+          ]
+        }
+      },
+      "bbox": [-13.670042, 55.844862, -13.206224, 56.774315],
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/file/v2.1.0/schema.json",
+        "https://stac-extensions.github.io/grid/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/mgrs/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sentinel-2/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/storage/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json"
+      ],
+      "collection": "sentinel-2-c1-l2a"
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "id": "S2B_T29UNB_20250110T120355_L2A",
+      "properties": {
+        "created": "2025-01-10T16:22:47.191Z",
+        "platform": "sentinel-2b",
+        "constellation": "sentinel-2",
+        "instruments": [
+          "msi"
+        ],
+        "eo:cloud_cover": 58.027476,
+        "proj:epsg": 32629,
+        "proj:centroid": {
+          "lat": 55.76895,
+          "lon": -8.89008
+        },
+        "mgrs:utm_zone": 29,
+        "mgrs:latitude_band": "U",
+        "mgrs:grid_square": "NB",
+        "grid:code": "MGRS-29UNB",
+        "view:azimuth": 296.213391314926,
+        "view:incidence_angle": 11.2885323247034,
+        "view:sun_azimuth": 171.888242896347,
+        "view:sun_elevation": 12.3330462371241,
+        "s2:tile_id": "S2B_OPER_MSI_L2A_TL_2BPS_20250110T154043_A040990_T29UNB_N05.11",
+        "s2:degraded_msi_data_percentage": 0,
+        "s2:nodata_pixel_percentage": 94.879043,
+        "s2:saturated_defective_pixel_percentage": 0,
+        "s2:cloud_shadow_percentage": 0,
+        "s2:vegetation_percentage": 0,
+        "s2:not_vegetated_percentage": 0.000454,
+        "s2:water_percentage": 41.972074,
+        "s2:unclassified_percentage": 0,
+        "s2:medium_proba_clouds_percentage": 19.25049,
+        "s2:high_proba_clouds_percentage": 1.270002,
+        "s2:thin_cirrus_percentage": 37.50698,
+        "s2:snow_ice_percentage": 0,
+        "s2:product_type": "S2MSI2A",
+        "s2:processing_baseline": "05.11",
+        "s2:product_uri": "S2B_MSIL2A_20250110T120359_N0511_R066_T29UNB_20250110T154043.SAFE",
+        "s2:generation_time": "2025-01-10T15:40:43.000000Z",
+        "s2:datatake_id": "GS2B_20250110T120359_040990_N05.11",
+        "s2:datatake_type": "INS-NOBS",
+        "s2:datastrip_id": "S2B_OPER_MSI_L2A_DS_2BPS_20250110T154043_S20250110T120355_N05.11",
+        "s2:reflectance_conversion_factor": 1.03425891111326,
+        "datetime": "2025-01-10T12:05:52.609000Z",
+        "earthsearch:payload_id": "roda-sentinel-2-c1-l2a/workflow-sentinel-2-c1-l2a-to-stac/b708c4badc2109a13b89da40305c2ef8",
+        "storage:platform": "AWS",
+        "storage:region": "us-west-2",
+        "storage:requester_pays": false,
+        "processing:software": {
+          "sentinel-2-c1-l2a-to-stac": "v2024.02.01"
+        },
+        "updated": "2025-01-10T16:22:47.191Z"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [-9.00030421811058, 55.9457254173272],
+            [-9.00030013314029, 55.4158504628607],
+            [-8.66964406830726, 55.9452826258813],
+            [-9.00030421811058, 55.9457254173272]
+          ]
+        ]
+      },
+      "links": [
+        {
+          "rel": "self",
+          "type": "application/geo+json",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a/items/S2B_T29UNB_20250110T120355_L2A"
+        },
+        {
+          "rel": "canonical",
+          "href": "s3://e84-earth-search-sentinel-data/sentinel-2-c1-l2a/29/U/NB/2025/1/S2B_T29UNB_20250110T120355_L2A/S2B_T29UNB_20250110T120355_L2A.json",
+          "type": "application/json"
+        },
+        {
+          "rel": "via",
+          "href": "s3://sentinel-s2-l2a/tiles/29/U/NB/2025/1/10/0/metadata.xml",
+          "type": "application/xml",
+          "title": "Granule Metadata in Sinergize RODA Archive"
+        },
+        {
+          "rel": "parent",
+          "type": "application/json",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a"
+        },
+        {
+          "rel": "collection",
+          "type": "application/json",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a"
+        },
+        {
+          "rel": "root",
+          "type": "application/json",
+          "href": "https://earth-search.aws.element84.com/v1"
+        },
+        {
+          "rel": "thumbnail",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a/items/S2B_T29UNB_20250110T120355_L2A/thumbnail"
+        }
+      ],
+      "assets": {
+        "red": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/NB/2025/1/S2B_T29UNB_20250110T120355_L2A/B04.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red - 10m",
+          "eo:bands": [
+            {
+              "name": "B04",
+              "common_name": "red",
+              "center_wavelength": 0.665,
+              "full_width_half_max": 0.038
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 499980, 0, -10, 6200040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220e789936a2387f8dc7e6aabb0968bae1a6e9f84523186412e9929641effdaa361",
+          "file:size": 10027685,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "green": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/NB/2025/1/S2B_T29UNB_20250110T120355_L2A/B03.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Green - 10m",
+          "eo:bands": [
+            {
+              "name": "B03",
+              "common_name": "green",
+              "center_wavelength": 0.56,
+              "full_width_half_max": 0.045
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 499980, 0, -10, 6200040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "122063893492f1d7288fc4035b468681f4553f2887f3c74655a4c84aaf6516a37f00",
+          "file:size": 10190327,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "blue": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/NB/2025/1/S2B_T29UNB_20250110T120355_L2A/B02.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Blue - 10m",
+          "eo:bands": [
+            {
+              "name": "B02",
+              "common_name": "blue",
+              "center_wavelength": 0.49,
+              "full_width_half_max": 0.098
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 499980, 0, -10, 6200040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "122058f51b3925cec6f1e94cb2e1ba55cac8ae0b1c98fe7df627e0f0843da4b1ecd4",
+          "file:size": 10515581,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "visual": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/NB/2025/1/S2B_T29UNB_20250110T120355_L2A/TCI.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "True color image",
+          "eo:bands": [
+            {
+              "name": "B04",
+              "common_name": "red",
+              "center_wavelength": 0.665,
+              "full_width_half_max": 0.038
+            },
+            {
+              "name": "B03",
+              "common_name": "green",
+              "center_wavelength": 0.56,
+              "full_width_half_max": 0.045
+            },
+            {
+              "name": "B02",
+              "common_name": "blue",
+              "center_wavelength": 0.49,
+              "full_width_half_max": 0.098
+            }
+          ],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 10
+            },
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 10
+            },
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 10
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 499980, 0, -10, 6200040],
+          "file:checksum": "1220bad96fa28f2414eccd6c5b23831d905d7df22fd3bd24267446eaf3630d3972ea",
+          "file:size": 14154510,
+          "roles": [
+            "visual"
+          ]
+        },
+        "nir": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/NB/2025/1/S2B_T29UNB_20250110T120355_L2A/B08.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "NIR 1 - 10m",
+          "eo:bands": [
+            {
+              "name": "B08",
+              "common_name": "nir",
+              "center_wavelength": 0.842,
+              "full_width_half_max": 0.145
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 499980, 0, -10, 6200040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220e5b6a275b9c649ab2288243d5824eeebda0808e51f6a8a40a69903c690b2fbde",
+          "file:size": 10111553,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "swir22": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/NB/2025/1/S2B_T29UNB_20250110T120355_L2A/B12.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "SWIR 2.2μm - 20m",
+          "eo:bands": [
+            {
+              "name": "B12",
+              "common_name": "swir22",
+              "center_wavelength": 2.19,
+              "full_width_half_max": 0.242
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 6200040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "122026ec8ebcfa8c2d83b76bef0e7b3496ed3c1d39f87fab9e11a8ed939b4c01636c",
+          "file:size": 2437631,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "rededge2": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/NB/2025/1/S2B_T29UNB_20250110T120355_L2A/B06.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red Edge 2 - 20m",
+          "eo:bands": [
+            {
+              "name": "B06",
+              "common_name": "rededge",
+              "center_wavelength": 0.74,
+              "full_width_half_max": 0.018
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 6200040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220dd58b9912f585b50907e6526958402a7283bdf9420db9b9efb8407d6b0d36da1",
+          "file:size": 2593728,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "rededge3": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/NB/2025/1/S2B_T29UNB_20250110T120355_L2A/B07.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red Edge 3 - 20m",
+          "eo:bands": [
+            {
+              "name": "B07",
+              "common_name": "rededge",
+              "center_wavelength": 0.783,
+              "full_width_half_max": 0.028
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 6200040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "122009281ca55d8aa3bccfd8fc14d334e3fda9ed2d0083bf9e6e1c9a9799c23ab1eb",
+          "file:size": 2605950,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "rededge1": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/NB/2025/1/S2B_T29UNB_20250110T120355_L2A/B05.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red Edge 1 - 20m",
+          "eo:bands": [
+            {
+              "name": "B05",
+              "common_name": "rededge",
+              "center_wavelength": 0.704,
+              "full_width_half_max": 0.019
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 6200040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220e4b4d1744e36c8113ac5a208d79b122c4d41d6484fe43a060a306c633949d678",
+          "file:size": 2596301,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "swir16": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/NB/2025/1/S2B_T29UNB_20250110T120355_L2A/B11.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "SWIR 1.6μm - 20m",
+          "eo:bands": [
+            {
+              "name": "B11",
+              "common_name": "swir16",
+              "center_wavelength": 1.61,
+              "full_width_half_max": 0.143
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 6200040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12203738cfcacf2d49ff3ee15807d2d85fc84b3074196aa3bd7cd5ff4ec5906143b1",
+          "file:size": 2403501,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "wvp": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/NB/2025/1/S2B_T29UNB_20250110T120355_L2A/WVP.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Water Vapour (WVP)",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 6200040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "unit": "cm",
+              "scale": 0.001,
+              "offset": 0
+            }
+          ],
+          "file:checksum": "1220b4f370a63b84c6d603d295d249fcb26089f11d09a85567594f2f12507533daed",
+          "file:size": 109472,
+          "roles": [
+            "data"
+          ]
+        },
+        "nir08": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/NB/2025/1/S2B_T29UNB_20250110T120355_L2A/B8A.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "NIR 2 - 20m",
+          "eo:bands": [
+            {
+              "name": "B8A",
+              "common_name": "nir08",
+              "center_wavelength": 0.865,
+              "full_width_half_max": 0.033
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 6200040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12208c9a6417984eccfdd754b8dc7d6e5041c475412fa297ce8650d58394cace8190",
+          "file:size": 2590780,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "scl": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/NB/2025/1/S2B_T29UNB_20250110T120355_L2A/SCL.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Scene classification map (SCL)",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 6200040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 20
+            }
+          ],
+          "file:checksum": "1220c31980a5d07ba12b22daec798def163f4c63a5e2ff830a44c4ed49091da75d35",
+          "file:size": 112713,
+          "roles": [
+            "data"
+          ]
+        },
+        "aot": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/NB/2025/1/S2B_T29UNB_20250110T120355_L2A/AOT.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Aerosol optical thickness (AOT)",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 6200040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.001,
+              "offset": 0
+            }
+          ],
+          "file:checksum": "1220d0ded0020d1500a07a3ceb31efefb0b7e06474d74223f4a30d714bfdfa26faf7",
+          "file:size": 123669,
+          "roles": [
+            "data"
+          ]
+        },
+        "coastal": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/NB/2025/1/S2B_T29UNB_20250110T120355_L2A/B01.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Coastal - 60m",
+          "eo:bands": [
+            {
+              "name": "B01",
+              "common_name": "coastal",
+              "center_wavelength": 0.443,
+              "full_width_half_max": 0.027
+            }
+          ],
+          "gsd": 60,
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 499980, 0, -60, 6200040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 60,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "122002f9d96b4938ef7381d908139deffbc922903f7e59cba1c43f746f55dca19b66",
+          "file:size": 306561,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "nir09": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/NB/2025/1/S2B_T29UNB_20250110T120355_L2A/B09.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "NIR 3 - 60m",
+          "eo:bands": [
+            {
+              "name": "B09",
+              "common_name": "nir09",
+              "center_wavelength": 0.945,
+              "full_width_half_max": 0.026
+            }
+          ],
+          "gsd": 60,
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 499980, 0, -60, 6200040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 60,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220df4b77e33fe71a118c587ddde0e8b1db4a2507dc246c3c7678330e2a40b9acd9",
+          "file:size": 322261,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "cloud": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/NB/2025/1/S2B_T29UNB_20250110T120355_L2A/CLD_20m.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Cloud Probabilities",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 6200040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 20
+            }
+          ],
+          "file:checksum": "1220a3d40b111608fa4ca822a1eaf45d94e7c122e942b8378374484cdd907401f755",
+          "file:size": 116319,
+          "roles": [
+            "data",
+            "cloud"
+          ]
+        },
+        "snow": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/NB/2025/1/S2B_T29UNB_20250110T120355_L2A/SNW_20m.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Snow Probabilities",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 499980, 0, -20, 6200040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 20
+            }
+          ],
+          "file:checksum": "1220ad48781d7c7fd26e277f85a5cb6e9c786d4f4231a494a77954790b7c993e4a2a",
+          "file:size": 53931,
+          "roles": [
+            "data",
+            "snow-ice"
+          ]
+        },
+        "preview": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/NB/2025/1/S2B_T29UNB_20250110T120355_L2A/L2A_PVI.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "True color preview",
+          "eo:bands": [
+            {
+              "name": "B04",
+              "common_name": "red",
+              "center_wavelength": 0.665,
+              "full_width_half_max": 0.038
+            },
+            {
+              "name": "B03",
+              "common_name": "green",
+              "center_wavelength": 0.56,
+              "full_width_half_max": 0.045
+            },
+            {
+              "name": "B02",
+              "common_name": "blue",
+              "center_wavelength": 0.49,
+              "full_width_half_max": 0.098
+            }
+          ],
+          "file:checksum": "1220fe64e947665671aa18aaaa003c9aee5c29fe8cc23ecb611255003623f6d33aac",
+          "file:size": 19984,
+          "roles": [
+            "overview"
+          ]
+        },
+        "granule_metadata": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/NB/2025/1/S2B_T29UNB_20250110T120355_L2A/metadata.xml",
+          "type": "application/xml",
+          "file:checksum": "1220c3421f3b8734d926d99797954bdbb5043e5e2a8f985f84c3a1f8a66cbc0db831",
+          "file:size": 103367,
+          "roles": [
+            "metadata"
+          ]
+        },
+        "tileinfo_metadata": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/NB/2025/1/S2B_T29UNB_20250110T120355_L2A/tileInfo.json",
+          "type": "application/json",
+          "file:checksum": "12208512e1fe6787eaaad288dae43ad3c0c5cc17ce96eca14a5a7038c7b592215753",
+          "file:size": 1483,
+          "roles": [
+            "metadata"
+          ]
+        },
+        "product_metadata": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/NB/2025/1/S2B_T29UNB_20250110T120355_L2A/product_metadata.xml",
+          "type": "application/xml",
+          "file:checksum": "1220e04a251e328f357ce7c5c94372db4eb36ade7254870d997547795ed3087b7c3d",
+          "file:size": 54565,
+          "roles": [
+            "metadata"
+          ]
+        },
+        "thumbnail": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/U/NB/2025/1/S2B_T29UNB_20250110T120355_L2A/L2A_PVI.jpg",
+          "type": "image/jpeg",
+          "title": "Thumbnail of preview image",
+          "file:checksum": "1220df8bda6af78d169612f7fb7dff03dea50a780a19c124b033df1ed036db158db4",
+          "file:size": 4219,
+          "roles": [
+            "thumbnail"
+          ]
+        }
+      },
+      "bbox": [-9.000304, 55.41585, -8.669644, 55.945725],
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/file/v2.1.0/schema.json",
+        "https://stac-extensions.github.io/grid/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/mgrs/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sentinel-2/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/storage/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json"
+      ],
+      "collection": "sentinel-2-c1-l2a"
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "id": "S2B_T29VPE_20250110T120355_L2A",
+      "properties": {
+        "created": "2025-01-10T16:23:15.779Z",
+        "platform": "sentinel-2b",
+        "constellation": "sentinel-2",
+        "instruments": [
+          "msi"
+        ],
+        "eo:cloud_cover": 11.435952,
+        "proj:epsg": 32629,
+        "proj:centroid": {
+          "lat": 58.41245,
+          "lon": -7.14589
+        },
+        "mgrs:utm_zone": 29,
+        "mgrs:latitude_band": "V",
+        "mgrs:grid_square": "PE",
+        "grid:code": "MGRS-29VPE",
+        "view:azimuth": 297.497570529651,
+        "view:incidence_angle": 11.1788806985056,
+        "view:sun_azimuth": 173.432089910917,
+        "view:sun_elevation": 9.7935341997534,
+        "s2:tile_id": "S2B_OPER_MSI_L2A_TL_2BPS_20250110T154043_A040990_T29VPE_N05.11",
+        "s2:degraded_msi_data_percentage": 0,
+        "s2:nodata_pixel_percentage": 92.532736,
+        "s2:saturated_defective_pixel_percentage": 0,
+        "s2:cloud_shadow_percentage": 0,
+        "s2:vegetation_percentage": 0,
+        "s2:not_vegetated_percentage": 0.000044,
+        "s2:water_percentage": 88.564003,
+        "s2:unclassified_percentage": 0,
+        "s2:medium_proba_clouds_percentage": 1.015978,
+        "s2:high_proba_clouds_percentage": 0.477642,
+        "s2:thin_cirrus_percentage": 9.942332,
+        "s2:snow_ice_percentage": 0,
+        "s2:product_type": "S2MSI2A",
+        "s2:processing_baseline": "05.11",
+        "s2:product_uri": "S2B_MSIL2A_20250110T120359_N0511_R066_T29VPE_20250110T154043.SAFE",
+        "s2:generation_time": "2025-01-10T15:40:43.000000Z",
+        "s2:datatake_id": "GS2B_20250110T120359_040990_N05.11",
+        "s2:datatake_type": "INS-NOBS",
+        "s2:datastrip_id": "S2B_OPER_MSI_L2A_DS_2BPS_20250110T154043_S20250110T120355_N05.11",
+        "s2:reflectance_conversion_factor": 1.03425891111326,
+        "datetime": "2025-01-10T12:05:06.060000Z",
+        "earthsearch:payload_id": "roda-sentinel-2-c1-l2a/workflow-sentinel-2-c1-l2a-to-stac/e2bcd39fde0f241cb4b72e32d0fab57c",
+        "storage:platform": "AWS",
+        "storage:region": "us-west-2",
+        "storage:requester_pays": false,
+        "processing:software": {
+          "sentinel-2-c1-l2a-to-stac": "v2024.02.01"
+        },
+        "updated": "2025-01-10T16:23:15.779Z"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [-7.27777230636626, 58.629120925364],
+            [-7.30877351638107, 57.985540520195],
+            [-6.85111741280027, 58.6227000712756],
+            [-7.27777230636626, 58.629120925364]
+          ]
+        ]
+      },
+      "links": [
+        {
+          "rel": "self",
+          "type": "application/geo+json",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a/items/S2B_T29VPE_20250110T120355_L2A"
+        },
+        {
+          "rel": "canonical",
+          "href": "s3://e84-earth-search-sentinel-data/sentinel-2-c1-l2a/29/V/PE/2025/1/S2B_T29VPE_20250110T120355_L2A/S2B_T29VPE_20250110T120355_L2A.json",
+          "type": "application/json"
+        },
+        {
+          "rel": "via",
+          "href": "s3://sentinel-s2-l2a/tiles/29/V/PE/2025/1/10/0/metadata.xml",
+          "type": "application/xml",
+          "title": "Granule Metadata in Sinergize RODA Archive"
+        },
+        {
+          "rel": "parent",
+          "type": "application/json",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a"
+        },
+        {
+          "rel": "collection",
+          "type": "application/json",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a"
+        },
+        {
+          "rel": "root",
+          "type": "application/json",
+          "href": "https://earth-search.aws.element84.com/v1"
+        },
+        {
+          "rel": "thumbnail",
+          "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a/items/S2B_T29VPE_20250110T120355_L2A/thumbnail"
+        }
+      ],
+      "assets": {
+        "red": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/V/PE/2025/1/S2B_T29VPE_20250110T120355_L2A/B04.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red - 10m",
+          "eo:bands": [
+            {
+              "name": "B04",
+              "common_name": "red",
+              "center_wavelength": 0.665,
+              "full_width_half_max": 0.038
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 600000, 0, -10, 6500040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220afcf1c0cb6d8ba2a05279e4a67c5c3e15915f1840af95899154c282e389af636",
+          "file:size": 13978420,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "green": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/V/PE/2025/1/S2B_T29VPE_20250110T120355_L2A/B03.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Green - 10m",
+          "eo:bands": [
+            {
+              "name": "B03",
+              "common_name": "green",
+              "center_wavelength": 0.56,
+              "full_width_half_max": 0.045
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 600000, 0, -10, 6500040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "122089e64eb2d9546aff1732cd91675186f1d02cc709b24f1541e2be3c1890aca965",
+          "file:size": 14234068,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "blue": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/V/PE/2025/1/S2B_T29VPE_20250110T120355_L2A/B02.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Blue - 10m",
+          "eo:bands": [
+            {
+              "name": "B02",
+              "common_name": "blue",
+              "center_wavelength": 0.49,
+              "full_width_half_max": 0.098
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 600000, 0, -10, 6500040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220cf37736e3df661528f6bbe9ca0a835cf8d2781c2549e65057fcfaa47b6c07c8b",
+          "file:size": 13792914,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "visual": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/V/PE/2025/1/S2B_T29VPE_20250110T120355_L2A/TCI.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "True color image",
+          "eo:bands": [
+            {
+              "name": "B04",
+              "common_name": "red",
+              "center_wavelength": 0.665,
+              "full_width_half_max": 0.038
+            },
+            {
+              "name": "B03",
+              "common_name": "green",
+              "center_wavelength": 0.56,
+              "full_width_half_max": 0.045
+            },
+            {
+              "name": "B02",
+              "common_name": "blue",
+              "center_wavelength": 0.49,
+              "full_width_half_max": 0.098
+            }
+          ],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 10
+            },
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 10
+            },
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 10
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 600000, 0, -10, 6500040],
+          "file:checksum": "1220e1a8602049d4fb2d7e3682a0510a08b0b15e43f0ce758de8d594011941a7f255",
+          "file:size": 20039038,
+          "roles": [
+            "visual"
+          ]
+        },
+        "nir": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/V/PE/2025/1/S2B_T29VPE_20250110T120355_L2A/B08.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "NIR 1 - 10m",
+          "eo:bands": [
+            {
+              "name": "B08",
+              "common_name": "nir",
+              "center_wavelength": 0.842,
+              "full_width_half_max": 0.145
+            }
+          ],
+          "gsd": 10,
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 600000, 0, -10, 6500040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 10,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220e00f1a4bc6109c2c0d887962fd3f7cd4b0a83739f1ebba147e40de73ba6e541c",
+          "file:size": 14086891,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "swir22": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/V/PE/2025/1/S2B_T29VPE_20250110T120355_L2A/B12.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "SWIR 2.2μm - 20m",
+          "eo:bands": [
+            {
+              "name": "B12",
+              "common_name": "swir22",
+              "center_wavelength": 2.19,
+              "full_width_half_max": 0.242
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 600000, 0, -20, 6500040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220ad59be9557ef198922b6fb613b6ed28f469a57a2719868cd6b498cb7a9119a36",
+          "file:size": 3440114,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "rededge2": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/V/PE/2025/1/S2B_T29VPE_20250110T120355_L2A/B06.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red Edge 2 - 20m",
+          "eo:bands": [
+            {
+              "name": "B06",
+              "common_name": "rededge",
+              "center_wavelength": 0.74,
+              "full_width_half_max": 0.018
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 600000, 0, -20, 6500040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "122015fe200e3e96f760b07dd5a085148560c4822f9a9907784f397e1a8f9c7840f9",
+          "file:size": 3555878,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "rededge3": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/V/PE/2025/1/S2B_T29VPE_20250110T120355_L2A/B07.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red Edge 3 - 20m",
+          "eo:bands": [
+            {
+              "name": "B07",
+              "common_name": "rededge",
+              "center_wavelength": 0.783,
+              "full_width_half_max": 0.028
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 600000, 0, -20, 6500040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220e5beec733f2675a692cdb0a1c4029712965030cfac0afa9ef2a9cb23184210f8",
+          "file:size": 3620180,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "rededge1": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/V/PE/2025/1/S2B_T29VPE_20250110T120355_L2A/B05.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red Edge 1 - 20m",
+          "eo:bands": [
+            {
+              "name": "B05",
+              "common_name": "rededge",
+              "center_wavelength": 0.704,
+              "full_width_half_max": 0.019
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 600000, 0, -20, 6500040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12201da5a52ba45a38f0e61f58490bfa7a9e650d5afa08b7f8350850715edb74a35b",
+          "file:size": 3561439,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "swir16": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/V/PE/2025/1/S2B_T29VPE_20250110T120355_L2A/B11.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "SWIR 1.6μm - 20m",
+          "eo:bands": [
+            {
+              "name": "B11",
+              "common_name": "swir16",
+              "center_wavelength": 1.61,
+              "full_width_half_max": 0.143
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 600000, 0, -20, 6500040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12203f8f3d0c9672452094c2de1bc2d045b16216074ef10c8c50f2de4cf85fd62f20",
+          "file:size": 3339112,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "wvp": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/V/PE/2025/1/S2B_T29VPE_20250110T120355_L2A/WVP.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Water Vapour (WVP)",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 600000, 0, -20, 6500040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "unit": "cm",
+              "scale": 0.001,
+              "offset": 0
+            }
+          ],
+          "file:checksum": "1220cfc4488c1c1f04f077f62aab5a1f1aed5c8246e32e31c15bffbcdf8a575aaefe",
+          "file:size": 113489,
+          "roles": [
+            "data"
+          ]
+        },
+        "nir08": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/V/PE/2025/1/S2B_T29VPE_20250110T120355_L2A/B8A.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "NIR 2 - 20m",
+          "eo:bands": [
+            {
+              "name": "B8A",
+              "common_name": "nir08",
+              "center_wavelength": 0.865,
+              "full_width_half_max": 0.033
+            }
+          ],
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 600000, 0, -20, 6500040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12207fa89e2f2e5509cb3bb46a5798bf3d10bfc77e0db99b4099705e7ba414a673d4",
+          "file:size": 3571061,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "scl": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/V/PE/2025/1/S2B_T29VPE_20250110T120355_L2A/SCL.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Scene classification map (SCL)",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 600000, 0, -20, 6500040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 20
+            }
+          ],
+          "file:checksum": "12207e6a0165b890c165ff479833371ffd58e090f76ab592ad6eee4315671ae49481",
+          "file:size": 134774,
+          "roles": [
+            "data"
+          ]
+        },
+        "aot": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/V/PE/2025/1/S2B_T29VPE_20250110T120355_L2A/AOT.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Aerosol optical thickness (AOT)",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 600000, 0, -20, 6500040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 20,
+              "scale": 0.001,
+              "offset": 0
+            }
+          ],
+          "file:checksum": "12203c6ac06eb7a3d9d51ec7681002b16eae54e57856d7b28f14770cbf31fb882782",
+          "file:size": 118913,
+          "roles": [
+            "data"
+          ]
+        },
+        "coastal": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/V/PE/2025/1/S2B_T29VPE_20250110T120355_L2A/B01.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Coastal - 60m",
+          "eo:bands": [
+            {
+              "name": "B01",
+              "common_name": "coastal",
+              "center_wavelength": 0.443,
+              "full_width_half_max": 0.027
+            }
+          ],
+          "gsd": 60,
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 600000, 0, -60, 6500040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 60,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "12204dcef553ab0c337169780220b31ec9b1a24d778438cc90c9eae23a08dc7a1fb3",
+          "file:size": 371951,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "nir09": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/V/PE/2025/1/S2B_T29VPE_20250110T120355_L2A/B09.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "NIR 3 - 60m",
+          "eo:bands": [
+            {
+              "name": "B09",
+              "common_name": "nir09",
+              "center_wavelength": 0.945,
+              "full_width_half_max": 0.026
+            }
+          ],
+          "gsd": 60,
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 600000, 0, -60, 6500040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint16",
+              "spatial_resolution": 60,
+              "scale": 0.0001,
+              "offset": -0.1
+            }
+          ],
+          "file:checksum": "1220fd8f1fb2de99745bc4fbda52099ee12f21cc147f02b6ff946c6422a88bf0fedd",
+          "file:size": 360501,
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "cloud": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/V/PE/2025/1/S2B_T29VPE_20250110T120355_L2A/CLD_20m.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Cloud Probabilities",
+          "gsd": 20,
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 600000, 0, -20, 6500040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 20
+            }
+          ],
+          "file:checksum": "122054a47012552753b4e55a873394377da8c2e1264c613cdb9fcf92e8a4dfc7fbc7",
+          "file:size": 89971,
+          "roles": [
+            "data",
+            "cloud"
+          ]
+        },
+        "snow": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/V/PE/2025/1/S2B_T29VPE_20250110T120355_L2A/SNW_20m.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Snow Probabilities",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 600000, 0, -20, 6500040],
+          "raster:bands": [
+            {
+              "nodata": 0,
+              "data_type": "uint8",
+              "spatial_resolution": 20
+            }
+          ],
+          "file:checksum": "1220bd2dd2207c60d18109116b1a1725ac526fd6101b1ce16e8c352b0c58b0d89b22",
+          "file:size": 53931,
+          "roles": [
+            "data",
+            "snow-ice"
+          ]
+        },
+        "preview": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/V/PE/2025/1/S2B_T29VPE_20250110T120355_L2A/L2A_PVI.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "True color preview",
+          "eo:bands": [
+            {
+              "name": "B04",
+              "common_name": "red",
+              "center_wavelength": 0.665,
+              "full_width_half_max": 0.038
+            },
+            {
+              "name": "B03",
+              "common_name": "green",
+              "center_wavelength": 0.56,
+              "full_width_half_max": 0.045
+            },
+            {
+              "name": "B02",
+              "common_name": "blue",
+              "center_wavelength": 0.49,
+              "full_width_half_max": 0.098
+            }
+          ],
+          "file:checksum": "122065d3085676567c18174d812abb82f2823a98b2442d3013b3a2ab05af3ae5d892",
+          "file:size": 23139,
+          "roles": [
+            "overview"
+          ]
+        },
+        "granule_metadata": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/V/PE/2025/1/S2B_T29VPE_20250110T120355_L2A/metadata.xml",
+          "type": "application/xml",
+          "file:checksum": "1220c057f7cfd0855e31ead555fe7f3adc705757a2ed7ba69b6ec90f392c6d9afb77",
+          "file:size": 104646,
+          "roles": [
+            "metadata"
+          ]
+        },
+        "tileinfo_metadata": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/V/PE/2025/1/S2B_T29VPE_20250110T120355_L2A/tileInfo.json",
+          "type": "application/json",
+          "file:checksum": "122085c2343946f211d76226554f92b456be62783d29a427f4e9f81fd47d9baa492e",
+          "file:size": 1481,
+          "roles": [
+            "metadata"
+          ]
+        },
+        "product_metadata": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/V/PE/2025/1/S2B_T29VPE_20250110T120355_L2A/product_metadata.xml",
+          "type": "application/xml",
+          "file:checksum": "1220ec3afeb78300267b27f5a3707163883d208fc20b23bb0feacc85f1ad69b9a5d3",
+          "file:size": 54561,
+          "roles": [
+            "metadata"
+          ]
+        },
+        "thumbnail": {
+          "href": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-c1-l2a/29/V/PE/2025/1/S2B_T29VPE_20250110T120355_L2A/L2A_PVI.jpg",
+          "type": "image/jpeg",
+          "title": "Thumbnail of preview image",
+          "file:checksum": "1220e2bff46670175ca4680698e6f65659767c331ed35c51865fdc46267bd4096960",
+          "file:size": 3710,
+          "roles": [
+            "thumbnail"
+          ]
+        }
+      },
+      "bbox": [-7.308774, 57.985541, -6.851117, 58.629121],
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/file/v2.1.0/schema.json",
+        "https://stac-extensions.github.io/grid/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/mgrs/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sentinel-2/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/storage/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json"
+      ],
+      "collection": "sentinel-2-c1-l2a"
+    }
+  ],
+  "links": [
+    {
+      "rel": "next",
+      "title": "Next page of Items",
+      "method": "GET",
+      "type": "application/geo+json",
+      "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a/items?collections=sentinel-2-c1-l2a&next=2025-01-10T12%3A05%3A06.060000Z%2CS2B_T29VPE_20250110T120355_L2A%2Csentinel-2-c1-l2a"
+    },
+    {
+      "rel": "root",
+      "type": "application/json",
+      "href": "https://earth-search.aws.element84.com/v1"
+    },
+    {
+      "rel": "self",
+      "type": "application/geo+json",
+      "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a/items"
+    },
+    {
+      "rel": "collection",
+      "type": "application/json",
+      "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a"
+    }
+  ]
+}

--- a/spark/common/src/test/resources/datasource_stac/collection.json
+++ b/spark/common/src/test/resources/datasource_stac/collection.json
@@ -1,0 +1,142 @@
+{
+  "id": "simple-collection",
+  "type": "Collection",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json"
+  ],
+  "stac_version": "1.1.0",
+  "description": "A simple collection demonstrating core catalog fields with links to a couple of items",
+  "title": "Simple Example Collection",
+  "keywords": [
+    "simple",
+    "example",
+    "collection"
+  ],
+  "providers": [
+    {
+      "name": "Remote Data, Inc",
+      "description": "Producers of awesome spatiotemporal assets",
+      "roles": [
+        "producer",
+        "processor"
+      ],
+      "url": "http://remotedata.io"
+    }
+  ],
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [
+          172.91173669923782,
+          1.3438851951615003,
+          172.95469614953714,
+          1.3690476620161975
+        ]
+      ]
+    },
+    "temporal": {
+      "interval": [
+        [
+          "2020-12-11T22:38:32.125Z",
+          "2020-12-14T18:02:31.437Z"
+        ]
+      ]
+    }
+  },
+  "license": "CC-BY-4.0",
+  "summaries": {
+    "platform": [
+      "cool_sat1",
+      "cool_sat2"
+    ],
+    "constellation": [
+      "ion"
+    ],
+    "instruments": [
+      "cool_sensor_v1",
+      "cool_sensor_v2"
+    ],
+    "gsd": {
+      "minimum": 0.512,
+      "maximum": 0.66
+    },
+    "eo:cloud_cover": {
+      "minimum": 1.2,
+      "maximum": 1.2
+    },
+    "proj:cpde": [
+      "EPSG:32659"
+    ],
+    "view:sun_elevation": {
+      "minimum": 54.9,
+      "maximum": 54.9
+    },
+    "view:off_nadir": {
+      "minimum": 3.8,
+      "maximum": 3.8
+    },
+    "view:sun_azimuth": {
+      "minimum": 135.7,
+      "maximum": 135.7
+    },
+    "statistics": {
+      "type": "object",
+      "properties": {
+        "vegetation": {
+          "description": "Percentage of pixels that are detected as vegetation, e.g. forests, grasslands, etc.",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "water": {
+          "description": "Percentage of pixels that are detected as water, e.g. rivers, oceans and ponds.",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "urban": {
+          "description": "Percentage of pixels that detected as urban, e.g. roads and buildings.",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
+    }
+  },
+  "links": [
+    {
+      "rel": "root",
+      "href": "./collection.json",
+      "type": "application/json",
+      "title": "Simple Example Collection"
+    },
+    {
+      "rel": "item",
+      "href": "./simple-item.json",
+      "type": "application/geo+json",
+      "title": "Simple Item"
+    },
+    {
+      "rel": "item",
+      "href": "./core-item.json",
+      "type": "application/geo+json",
+      "title": "Core Item"
+    },
+    {
+      "rel": "item",
+      "href": "./extended-item.json",
+      "type": "application/geo+json",
+      "title": "Extended Item"
+    },
+    {
+      "rel": "self",
+      "href": "https://raw.githubusercontent.com/radiantearth/stac-spec/v1.1.0/examples/collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "child",
+      "href": "./nested/nested-collection.json",
+      "type": "application/json",
+      "title": "Nested Collection"
+    }
+  ]
+}

--- a/spark/common/src/test/resources/datasource_stac/core-item.json
+++ b/spark/common/src/test/resources/datasource_stac/core-item.json
@@ -1,0 +1,125 @@
+{
+  "stac_version": "1.1.0",
+  "stac_extensions": [],
+  "type": "Feature",
+  "id": "20201211_223832_CS2",
+  "bbox": [
+    172.91173669923782,
+    1.3438851951615003,
+    172.95469614953714,
+    1.3690476620161975
+  ],
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          172.91173669923782,
+          1.3438851951615003
+        ],
+        [
+          172.95469614953714,
+          1.3438851951615003
+        ],
+        [
+          172.95469614953714,
+          1.3690476620161975
+        ],
+        [
+          172.91173669923782,
+          1.3690476620161975
+        ],
+        [
+          172.91173669923782,
+          1.3438851951615003
+        ]
+      ]
+    ]
+  },
+  "properties": {
+    "title": "Core Item",
+    "description": "A sample STAC Item that includes examples of all common metadata",
+    "datetime": null,
+    "start_datetime": "2020-12-11T22:38:32.125Z",
+    "end_datetime": "2020-12-11T22:38:32.327Z",
+    "created": "2020-12-12T01:48:13.725Z",
+    "updated": "2020-12-12T01:48:13.725Z",
+    "platform": "cool_sat1",
+    "instruments": [
+      "cool_sensor_v1"
+    ],
+    "constellation": "ion",
+    "mission": "collection 5624",
+    "gsd": 0.512
+  },
+  "collection": "simple-collection",
+  "links": [
+    {
+      "rel": "collection",
+      "href": "./collection.json",
+      "type": "application/json",
+      "title": "Simple Example Collection"
+    },
+    {
+      "rel": "root",
+      "href": "./collection.json",
+      "type": "application/json",
+      "title": "Simple Example Collection"
+    },
+    {
+      "rel": "parent",
+      "href": "./collection.json",
+      "type": "application/json",
+      "title": "Simple Example Collection"
+    },
+    {
+      "rel": "alternate",
+      "type": "text/html",
+      "href": "http://remotedata.io/catalog/20201211_223832_CS2/index.html",
+      "title": "HTML version of this STAC Item"
+    }
+  ],
+  "assets": {
+    "analytic": {
+      "href": "https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2_analytic.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "4-Band Analytic",
+      "roles": [
+        "data"
+      ]
+    },
+    "thumbnail": {
+      "href": "https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2.jpg",
+      "title": "Thumbnail",
+      "type": "image/png",
+      "roles": [
+        "thumbnail"
+      ]
+    },
+    "visual": {
+      "href": "https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "3-Band Visual",
+      "roles": [
+        "visual"
+      ]
+    },
+    "udm": {
+      "href": "https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2_analytic_udm.tif",
+      "title": "Unusable Data Mask",
+      "type": "image/tiff; application=geotiff"
+    },
+    "json-metadata": {
+      "href": "http://remotedata.io/catalog/20201211_223832_CS2/extended-metadata.json",
+      "title": "Extended Metadata",
+      "type": "application/json",
+      "roles": [
+        "metadata"
+      ]
+    },
+    "ephemeris": {
+      "href": "http://cool-sat.com/catalog/20201211_223832_CS2/20201211_223832_CS2.EPH",
+      "title": "Satellite Ephemeris Metadata"
+    }
+  }
+}

--- a/spark/common/src/test/resources/datasource_stac/extended-item.json
+++ b/spark/common/src/test/resources/datasource_stac/extended-item.json
@@ -1,0 +1,210 @@
+{
+  "stac_version": "1.1.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/remote-data/v1.0.0/schema.json"
+  ],
+  "type": "Feature",
+  "id": "20201211_223832_CS2",
+  "bbox": [
+    172.91173669923782,
+    1.3438851951615003,
+    172.95469614953714,
+    1.3690476620161975
+  ],
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          172.91173669923782,
+          1.3438851951615003
+        ],
+        [
+          172.95469614953714,
+          1.3438851951615003
+        ],
+        [
+          172.95469614953714,
+          1.3690476620161975
+        ],
+        [
+          172.91173669923782,
+          1.3690476620161975
+        ],
+        [
+          172.91173669923782,
+          1.3438851951615003
+        ]
+      ]
+    ]
+  },
+  "properties": {
+    "title": "Extended Item",
+    "description": "A sample STAC Item that includes a variety of examples from the stable extensions",
+    "keywords": [
+      "extended",
+      "example",
+      "item"
+    ],
+    "datetime": "2020-12-14T18:02:31.437000Z",
+    "created": "2020-12-15T01:48:13.725Z",
+    "updated": "2020-12-15T01:48:13.725Z",
+    "platform": "cool_sat2",
+    "instruments": [
+      "cool_sensor_v2"
+    ],
+    "gsd": 0.66,
+    "eo:cloud_cover": 1.2,
+    "eo:snow_cover": 0,
+    "statistics": {
+      "vegetation": 12.57,
+      "water": 1.23,
+      "urban": 26.2
+    },
+    "proj:code": "EPSG:32659",
+    "proj:shape": [
+      5558,
+      9559
+    ],
+    "proj:transform": [
+      0.5,
+      0,
+      712710,
+      0,
+      -0.5,
+      151406,
+      0,
+      0,
+      1
+    ],
+    "view:sun_elevation": 54.9,
+    "view:off_nadir": 3.8,
+    "view:sun_azimuth": 135.7,
+    "rd:type": "scene",
+    "rd:anomalous_pixels": 0.14,
+    "rd:earth_sun_distance": 1.014156,
+    "rd:sat_id": "cool_sat2",
+    "rd:product_level": "LV3A",
+    "sci:doi": "10.5061/dryad.s2v81.2/27.2"
+  },
+  "collection": "simple-collection",
+  "links": [
+    {
+      "rel": "collection",
+      "href": "./collection.json",
+      "type": "application/json",
+      "title": "Simple Example Collection"
+    },
+    {
+      "rel": "root",
+      "href": "./collection.json",
+      "type": "application/json",
+      "title": "Simple Example Collection"
+    },
+    {
+      "rel": "parent",
+      "href": "./collection.json",
+      "type": "application/json",
+      "title": "Simple Example Collection"
+    },
+    {
+      "rel": "alternate",
+      "type": "text/html",
+      "href": "http://remotedata.io/catalog/20201211_223832_CS2/index.html",
+      "title": "HTML version of this STAC Item"
+    }
+  ],
+  "assets": {
+    "analytic": {
+      "href": "https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2_analytic.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "4-Band Analytic",
+      "roles": [
+        "data"
+      ],
+      "bands": [
+        {
+          "name": "band1",
+          "eo:common_name": "blue",
+          "eo:center_wavelength": 0.47,
+          "eo:full_width_half_max": 70
+        },
+        {
+          "name": "band2",
+          "eo:common_name": "green",
+          "eo:center_wavelength": 0.56,
+          "eo:full_width_half_max": 80
+        },
+        {
+          "name": "band3",
+          "eo:common_name": "red",
+          "eo:center_wavelength": 0.645,
+          "eo:full_width_half_max": 90
+        },
+        {
+          "name": "band4",
+          "eo:common_name": "nir",
+          "eo:center_wavelength": 0.8,
+          "eo:full_width_half_max": 152
+        }
+      ]
+    },
+    "thumbnail": {
+      "href": "https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2.jpg",
+      "title": "Thumbnail",
+      "type": "image/png",
+      "roles": [
+        "thumbnail"
+      ]
+    },
+    "visual": {
+      "href": "https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "3-Band Visual",
+      "roles": [
+        "visual"
+      ],
+      "bands": [
+        {
+          "name": "band3",
+          "eo:common_name": "red",
+          "eo:center_wavelength": 0.645,
+          "eo:full_width_half_max": 90
+        },
+        {
+          "name": "band2",
+          "eo:common_name": "green",
+          "eo:center_wavelength": 0.56,
+          "eo:full_width_half_max": 80
+        },
+        {
+          "name": "band1",
+          "eo:common_name": "blue",
+          "eo:center_wavelength": 0.47,
+          "eo:full_width_half_max": 70
+        }
+      ]
+    },
+    "udm": {
+      "href": "https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2_analytic_udm.tif",
+      "title": "Unusable Data Mask",
+      "type": "image/tiff; application=geotiff"
+    },
+    "json-metadata": {
+      "href": "http://remotedata.io/catalog/20201211_223832_CS2/extended-metadata.json",
+      "title": "Extended Metadata",
+      "type": "application/json",
+      "roles": [
+        "metadata"
+      ]
+    },
+    "ephemeris": {
+      "href": "http://cool-sat.com/catalog/20201211_223832_CS2/20201211_223832_CS2.EPH",
+      "title": "Satellite Ephemeris Metadata"
+    }
+  }
+}

--- a/spark/common/src/test/resources/datasource_stac/nested/nested-collection.json
+++ b/spark/common/src/test/resources/datasource_stac/nested/nested-collection.json
@@ -1,0 +1,130 @@
+{
+  "id": "nested-collection",
+  "type": "Collection",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json"
+  ],
+  "stac_version": "1.1.0",
+  "description": "A nested collection demonstrating core catalog fields with links to an item and items",
+  "title": "Nested Example Collection",
+  "keywords": [
+    "nested",
+    "example",
+    "collection"
+  ],
+  "providers": [
+    {
+      "name": "Remote Data, Inc",
+      "description": "Producers of awesome spatiotemporal assets",
+      "roles": [
+        "producer",
+        "processor"
+      ],
+      "url": "http://remotedata.io"
+    }
+  ],
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [
+          17.91173669923782,
+          10.3438851951615003,
+          17.95469614953714,
+          10.3690476620161975
+        ]
+      ]
+    },
+    "temporal": {
+      "interval": [
+        [
+          "2020-12-11T22:38:32.125Z",
+          "2020-12-14T18:02:31.437Z"
+        ]
+      ]
+    }
+  },
+  "license": "CC-BY-4.0",
+  "summaries": {
+    "platform": [
+      "cool_sat1",
+      "cool_sat2"
+    ],
+    "constellation": [
+      "ion"
+    ],
+    "instruments": [
+      "cool_sensor_v1",
+      "cool_sensor_v2"
+    ],
+    "gsd": {
+      "minimum": 0.512,
+      "maximum": 0.66
+    },
+    "eo:cloud_cover": {
+      "minimum": 1.2,
+      "maximum": 1.2
+    },
+    "proj:cpde": [
+      "EPSG:32659"
+    ],
+    "view:sun_elevation": {
+      "minimum": 54.9,
+      "maximum": 54.9
+    },
+    "view:off_nadir": {
+      "minimum": 3.8,
+      "maximum": 3.8
+    },
+    "view:sun_azimuth": {
+      "minimum": 135.7,
+      "maximum": 135.7
+    },
+    "statistics": {
+      "type": "object",
+      "properties": {
+        "vegetation": {
+          "description": "Percentage of pixels that are detected as vegetation, e.g. forests, grasslands, etc.",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "water": {
+          "description": "Percentage of pixels that are detected as water, e.g. rivers, oceans and ponds.",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "urban": {
+          "description": "Percentage of pixels that detected as urban, e.g. roads and buildings.",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
+    }
+  },
+  "links": [
+    {
+      "rel": "root",
+      "href": "./nested-collection.json",
+      "type": "application/json",
+      "title": "Nested Example Collection"
+    },
+    {
+      "rel": "item",
+      "href": "./nested-item.json",
+      "type": "application/geo+json",
+      "title": "Nested Item"
+    },
+    {
+      "rel": "items",
+      "href": "./nested-items.json",
+      "type": "application/geo+json",
+      "title": "Nested Items"
+    },
+    {
+      "rel": "self",
+      "href": "https://raw.githubusercontent.com/radiantearth/stac-spec/v1.1.0/examples/nested-collection.json",
+      "type": "application/json"
+    }
+  ]
+}

--- a/spark/common/src/test/resources/datasource_stac/nested/nested-item.json
+++ b/spark/common/src/test/resources/datasource_stac/nested/nested-item.json
@@ -1,0 +1,55 @@
+{
+  "id": "nested-item",
+  "type": "Feature",
+  "stac_version": "1.1.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json"
+  ],
+  "bbox": [
+    17.91173669923782,
+    10.3438851951615003,
+    17.95469614953714,
+    10.3690476620161975
+  ],
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [17.91173669923782, 10.3438851951615003],
+        [17.95469614953714, 10.3438851951615003],
+        [17.95469614953714, 10.3690476620161975],
+        [17.91173669923782, 10.3690476620161975],
+        [17.91173669923782, 10.3438851951615003]
+      ]
+    ]
+  },
+  "properties": {
+    "title": "Nested Item",
+    "description": "A sample STAC nested Item that includes examples of all common metadata",
+    "datetime": "2020-12-12T00:00:00Z",
+    "eo:cloud_cover": 1.2,
+    "proj:epsg": 32659,
+    "view:sun_elevation": 54.9,
+    "view:off_nadir": 3.8,
+    "view:sun_azimuth": 135.7
+  },
+  "assets": {
+    "visual": {
+      "href": "https://e84-earth-search-sentinel-data.s3/example/visual.tif",
+      "title": "Visual asset",
+      "type": "image/tiff; application=geotiff",
+      "roles": ["visual"]
+    }
+  },
+  "links": [
+    {
+      "rel": "collection",
+      "href": "./nested-collection.json",
+      "type": "application/json",
+      "title": "Nested Example Collection"
+    }
+  ]
+}
+

--- a/spark/common/src/test/resources/datasource_stac/nested/nested-items.json
+++ b/spark/common/src/test/resources/datasource_stac/nested/nested-items.json
@@ -1,0 +1,110 @@
+{
+  "type": "FeatureCollection",
+  "stac_version": "1.1.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json"
+  ],
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "stac_version": "1.1.0",
+      "id": "nested-item-1",
+      "type": "Feature",
+      "bbox": [
+        17.91173669923782,
+        10.3438851951615003,
+        17.95469614953714,
+        10.3690476620161975
+      ],
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [17.91173669923782, 10.3438851951615003],
+            [17.95469614953714, 10.3438851951615003],
+            [17.95469614953714, 10.3690476620161975],
+            [17.91173669923782, 10.3690476620161975],
+            [17.91173669923782, 10.3438851951615003]
+          ]
+        ]
+      },
+      "properties": {
+        "title": "Nested Item 1",
+        "description": "A sample STAC nested Item that includes examples of all common metadata",
+        "datetime": "2020-12-12T00:00:00Z",
+        "eo:cloud_cover": 1.2,
+        "proj:epsg": 32659,
+        "view:sun_elevation": 54.9,
+        "view:off_nadir": 3.8,
+        "view:sun_azimuth": 135.7
+      },
+      "assets": {
+        "visual": {
+          "href": "http://e84-earth-search-sentinel-data.s3/example/visual1.tif",
+          "title": "Visual asset 1",
+          "type": "image/tiff; application=geotiff",
+          "roles": ["visual"]
+        }
+      },
+      "links": [
+        {
+          "rel": "collection",
+          "href": "./nested-collection.json",
+          "type": "application/json",
+          "title": "Nested Example Collection"
+        }
+      ]
+    },
+    {
+      "stac_version": "1.1.0",
+      "id": "nested-item-2",
+      "type": "Feature",
+      "bbox": [
+        17.91173669923782,
+        10.3438851951615003,
+        17.95469614953714,
+        10.3690476620161975
+      ],
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [17.91173669923782, 10.3438851951615003],
+            [17.95469614953714, 10.3438851951615003],
+            [17.95469614953714, 10.3690476620161975],
+            [17.91173669923782, 10.3690476620161975],
+            [17.91173669923782, 10.3438851951615003]
+          ]
+        ]
+      },
+      "properties": {
+        "title": "Nested Item 2",
+        "description": "A sample STAC nested Item that includes examples of all common metadata",
+        "datetime": "2020-12-13T00:00:00Z",
+        "eo:cloud_cover": 1.2,
+        "proj:epsg": 32659,
+        "view:sun_elevation": 54.9,
+        "view:off_nadir": 3.8,
+        "view:sun_azimuth": 135.7
+      },
+      "assets": {
+        "visual": {
+          "href": "http://e84-earth-search-sentinel-data.s3/example/visual2.tif",
+          "title": "Visual asset 2",
+          "type": "image/tiff; application=geotiff",
+          "roles": ["visual"]
+        }
+      },
+      "links": [
+        {
+          "rel": "collection",
+          "href": "./nested-collection.json",
+          "type": "application/json",
+          "title": "Nested Example Collection"
+        }
+      ]
+    }
+  ]
+}

--- a/spark/common/src/test/resources/datasource_stac/simple-item.json
+++ b/spark/common/src/test/resources/datasource_stac/simple-item.json
@@ -1,0 +1,83 @@
+{
+  "stac_version": "1.1.0",
+  "stac_extensions": [],
+  "type": "Feature",
+  "id": "20201211_223832_CS2",
+  "bbox": [
+    172.91173669923782,
+    1.3438851951615003,
+    172.95469614953714,
+    1.3690476620161975
+  ],
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          172.91173669923782,
+          1.3438851951615003
+        ],
+        [
+          172.95469614953714,
+          1.3438851951615003
+        ],
+        [
+          172.95469614953714,
+          1.3690476620161975
+        ],
+        [
+          172.91173669923782,
+          1.3690476620161975
+        ],
+        [
+          172.91173669923782,
+          1.3438851951615003
+        ]
+      ]
+    ]
+  },
+  "properties": {
+    "title": "Simple Item ",
+    "description": "A sample STAC nested Item that includes examples of some metadata",
+    "datetime": "2020-12-11T22:38:32.125000Z"
+  },
+  "collection": "simple-collection",
+  "links": [
+    {
+      "rel": "collection",
+      "href": "./collection.json",
+      "type": "application/json",
+      "title": "Simple Example Collection"
+    },
+    {
+      "rel": "root",
+      "href": "./collection.json",
+      "type": "application/json",
+      "title": "Simple Example Collection"
+    },
+    {
+      "rel": "parent",
+      "href": "./collection.json",
+      "type": "application/json",
+      "title": "Simple Example Collection"
+    }
+  ],
+  "assets": {
+    "visual": {
+      "href": "https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "3-Band Visual",
+      "roles": [
+        "visual"
+      ]
+    },
+    "thumbnail": {
+      "href": "https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2.jpg",
+      "title": "Thumbnail",
+      "type": "image/jpeg",
+      "roles": [
+        "thumbnail"
+      ]
+    }
+  }
+}

--- a/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacBatchTest.scala
+++ b/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacBatchTest.scala
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.spark.sql.sedona_sql.io.stac
+
+import org.apache.sedona.sql.TestBaseScala
+import org.apache.spark.sql.connector.read.InputPartition
+import org.apache.spark.sql.types.StructType
+
+import scala.io.Source
+import scala.collection.mutable
+
+class StacBatchTest extends TestBaseScala {
+
+  def loadJsonFromResource(resourceFilePath: String): String = {
+    Source.fromResource(resourceFilePath).getLines().mkString("\n")
+  }
+
+  def getAbsolutePathOfResource(resourceFilePath: String): String = {
+    val resourceUrl = getClass.getClassLoader.getResource(resourceFilePath)
+    if (resourceUrl != null) {
+      resourceUrl.getPath
+    } else {
+      throw new IllegalArgumentException(s"Resource not found: $resourceFilePath")
+    }
+  }
+
+  it("planInputPartitions should create correct number of partitions") {
+    val stacCollectionJson =
+      """
+        |{
+        |  "stac_version": "1.0.0",
+        |  "id": "sample-collection",
+        |  "description": "A sample STAC collection",
+        |  "links": [
+        |    {"rel": "item", "href": "https://path/to/item1.json"},
+        |    {"rel": "item", "href": "https://path/to/item2.json"},
+        |    {"rel": "item", "href": "https://path/to/item3.json"}
+        |  ]
+        |}
+      """.stripMargin
+
+    val opts = mutable.Map("numPartitions" -> "2").toMap
+    val collectionUrl = "https://path/to/collection.json"
+
+    val stacBatch =
+      StacBatch(collectionUrl, stacCollectionJson, StructType(Seq()), opts, None, None)
+    val partitions: Array[InputPartition] = stacBatch.planInputPartitions()
+
+    assert(partitions.length == 2)
+    assert(partitions(0).asInstanceOf[StacPartition].items.length == 2)
+    assert(partitions(1).asInstanceOf[StacPartition].items.length == 1)
+  }
+
+  it("planInputPartitions should handle empty links array") {
+    val stacCollectionJson =
+      """
+        |{
+        |  "links": []
+        |}
+      """.stripMargin
+
+    val opts = mutable.Map("numPartitions" -> "2").toMap
+    val collectionUrl = "https://path/to/collection.json"
+
+    val stacBatch =
+      StacBatch(collectionUrl, stacCollectionJson, StructType(Seq()), opts, None, None)
+    val partitions: Array[InputPartition] = stacBatch.planInputPartitions()
+
+    assert(partitions.isEmpty)
+  }
+
+  it("planInputPartitions should create correct number of partitions with real collection.json") {
+    val rootJsonFile = "datasource_stac/collection.json"
+    val stacCollectionJson = loadJsonFromResource(rootJsonFile)
+    val opts = mutable.Map("numPartitions" -> "3").toMap
+    val collectionUrl = getAbsolutePathOfResource(rootJsonFile)
+
+    val stacBatch =
+      StacBatch(collectionUrl, stacCollectionJson, StructType(Seq()), opts, None, None)
+    val partitions: Array[InputPartition] = stacBatch.planInputPartitions()
+
+    assert(partitions.length == 3)
+    assert(partitions(0).asInstanceOf[StacPartition].items.length == 2)
+    assert(partitions(1).asInstanceOf[StacPartition].items.length == 2)
+    assert(partitions(2).asInstanceOf[StacPartition].items.length == 1)
+  }
+}

--- a/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacDataSourceTest.scala
+++ b/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacDataSourceTest.scala
@@ -39,7 +39,8 @@ class StacDataSourceTest extends TestBaseScala {
 
   it("basic df load from local file should work") {
     val dfStac = sparkSession.read.format("stac").load(STAC_COLLECTION_LOCAL)
-    dfStac.show(false)
+    val rowCount = dfStac.count()
+    assert(rowCount > 0)
   }
 
   it("basic df load from remote service endpoints should work") {
@@ -73,8 +74,6 @@ class StacDataSourceTest extends TestBaseScala {
       "SELECT id, datetime as dt, geometry, bbox " +
         "FROM STACTBL " +
         "WHERE datetime BETWEEN '2020-01-01T00:00:00Z' AND '2020-12-13T00:00:00Z'")
-
-    dfSelect.explain(true)
 
     val physicalPlan = dfSelect.queryExecution.executedPlan.toString()
     assert(physicalPlan.contains(

--- a/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacDataSourceTest.scala
+++ b/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacDataSourceTest.scala
@@ -39,7 +39,6 @@ class StacDataSourceTest extends TestBaseScala {
 
   it("basic df load from local file should work") {
     val dfStac = sparkSession.read.format("stac").load(STAC_COLLECTION_LOCAL)
-    dfStac.printSchema()
     dfStac.show(false)
   }
 
@@ -47,8 +46,6 @@ class StacDataSourceTest extends TestBaseScala {
     STAC_COLLECTION_REMOTE.foreach { endpoint =>
       val dfStac = sparkSession.read.format("stac").load(endpoint)
       assertSchema(dfStac.schema)
-      dfStac.printSchema()
-      dfStac.show(true)
     }
   }
 
@@ -59,7 +56,6 @@ class StacDataSourceTest extends TestBaseScala {
     val dfSelect =
       sparkSession.sql("SELECT id, datetime as dt, geometry, bbox FROM STACTBL")
 
-    dfSelect.printSchema()
     assert(dfSelect.schema.fieldNames.contains("id"))
     assert(dfSelect.schema.fieldNames.contains("dt"))
     assert(dfSelect.schema.fieldNames.contains("geometry"))
@@ -97,8 +93,6 @@ class StacDataSourceTest extends TestBaseScala {
         "FROM STACTBL " +
         "WHERE st_contains(ST_GeomFromText('POLYGON((17 10, 18 10, 18 11, 17 11, 17 10))'), geometry)")
 
-    dfSelect.explain(true)
-
     val physicalPlan = dfSelect.queryExecution.executedPlan.toString()
     assert(physicalPlan.contains(
       "PushedSpatialFilters -> LeafFilter(geometry,INTERSECTS,POLYGON ((17 10, 18 10, 18 11, 17 11, 17 10)))"))
@@ -115,8 +109,6 @@ class StacDataSourceTest extends TestBaseScala {
       "FROM STACTBL " +
       "WHERE datetime BETWEEN '2020-01-01T00:00:00Z' AND '2020-12-13T00:00:00Z' " +
       "AND st_contains(ST_GeomFromText('POLYGON((17 10, 18 10, 18 11, 17 11, 17 10))'), geometry)")
-
-    dfSelect.explain(true)
 
     val physicalPlan = dfSelect.queryExecution.executedPlan.toString()
     assert(physicalPlan.contains(
@@ -137,8 +129,6 @@ class StacDataSourceTest extends TestBaseScala {
         "FROM STACTBL " +
         "WHERE id = 'some-id'")
 
-    dfSelect.explain(true)
-
     val physicalPlan = dfSelect.queryExecution.executedPlan.toString()
     assert(physicalPlan.contains("PushedSpatialFilters -> None, PushedTemporalFilters -> None"))
 
@@ -155,8 +145,6 @@ class StacDataSourceTest extends TestBaseScala {
       "WHERE id = 'some-id' " +
       "AND datetime BETWEEN '2020-01-01T00:00:00Z' AND '2020-12-13T00:00:00Z' " +
       "AND st_contains(ST_GeomFromText('POLYGON((17 10, 18 10, 18 11, 17 11, 17 10))'), geometry)")
-
-    dfSelect.explain(true)
 
     val physicalPlan = dfSelect.queryExecution.executedPlan.toString()
     assert(physicalPlan.contains(

--- a/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacDataSourceTest.scala
+++ b/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacDataSourceTest.scala
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.spark.sql.sedona_sql.io.stac
+
+import org.apache.sedona.sql.TestBaseScala
+import org.apache.spark.sql.sedona_sql.UDT.{GeometryUDT, RasterUDT}
+import org.apache.spark.sql.types.{ArrayType, DoubleType, MapType, StringType, StructField, StructType, TimestampType}
+import org.scalatest.BeforeAndAfterAll
+
+import java.util.TimeZone
+
+class StacDataSourceTest extends TestBaseScala with BeforeAndAfterAll {
+
+  val STAC_COLLECTION_LOCAL: String = resourceFolder + "datasource_stac/collection.json"
+  val STAC_ITEM_LOCAL: String = resourceFolder + "geojson/core-item.json"
+
+  val STAC_COLLECTION_REMOTE: List[String] = List(
+    "https://earth-search.aws.element84.com/v1/collections/sentinel-2-pre-c1-l2a",
+    "https://storage.googleapis.com/cfo-public/vegetation/collection.json",
+    "https://storage.googleapis.com/cfo-public/wildfire/collection.json",
+    "https://earthdatahub.destine.eu/api/stac/v1/collections/copernicus-dem",
+    "https://planetarycomputer.microsoft.com/api/stac/v1/collections/naip")
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+  }
+
+  override def afterAll(): Unit = {
+    TimeZone.setDefault(null) // Reset to the system default time zone
+    super.afterAll()
+  }
+
+  it("basic df load from local file should work") {
+    val dfStac = sparkSession.read.format("stac").load(STAC_COLLECTION_LOCAL)
+    dfStac.printSchema()
+    dfStac.show(false)
+  }
+
+  it("basic df load from remote service endpoints should work") {
+    STAC_COLLECTION_REMOTE.foreach { endpoint =>
+      val dfStac = sparkSession.read.format("stac").load(endpoint)
+      assertSchema(dfStac.schema)
+      dfStac.printSchema()
+      dfStac.show(true)
+    }
+  }
+
+  it("normal select SQL without any filter") {
+    val dfStac = sparkSession.read.format("stac").load(STAC_COLLECTION_LOCAL)
+    dfStac.createOrReplaceTempView("STACTBL")
+
+    val dfSelect =
+      sparkSession.sql("SELECT id, datetime as dt, geometry, bbox FROM STACTBL")
+
+    dfSelect.printSchema()
+    assert(dfSelect.schema.fieldNames.contains("id"))
+    assert(dfSelect.schema.fieldNames.contains("dt"))
+    assert(dfSelect.schema.fieldNames.contains("geometry"))
+    assert(dfSelect.schema.fieldNames.contains("bbox"))
+
+    val rowCount = dfSelect.count()
+    assert(rowCount == 6)
+  }
+
+  it("select SQL with filter on datetime") {
+    val dfStac = sparkSession.read.format("stac").load(STAC_COLLECTION_LOCAL)
+    dfStac.createOrReplaceTempView("STACTBL")
+
+    val dfSelect = sparkSession.sql(
+      "SELECT id, datetime as dt, geometry, bbox " +
+        "FROM STACTBL " +
+        "WHERE datetime BETWEEN '2020-01-01' AND '2020-12-13'")
+
+    dfSelect.explain(true)
+
+    val physicalPlan = dfSelect.queryExecution.executedPlan.toString()
+    assert(physicalPlan.contains(
+      "PushedTemporalFilters -> AndFilter(GreaterThanFilter(datetime,2020-01-01T00:00),LessThanFilter(datetime,2020-12-13T00:00))"))
+
+    val rowCount = dfSelect.count()
+    assert(rowCount == 4)
+  }
+
+  it("select SQL with spatial filter") {
+    val dfStac = sparkSession.read.format("stac").load(STAC_COLLECTION_LOCAL)
+    dfStac.createOrReplaceTempView("STACTBL")
+
+    val dfSelect = sparkSession.sql(
+      "SELECT id, geometry " +
+        "FROM STACTBL " +
+        "WHERE st_contains(ST_GeomFromText('POLYGON((17 10, 18 10, 18 11, 17 11, 17 10))'), geometry)")
+
+    dfSelect.explain(true)
+
+    val physicalPlan = dfSelect.queryExecution.executedPlan.toString()
+    assert(physicalPlan.contains(
+      "PushedSpatialFilters -> LeafFilter(geometry,INTERSECTS,POLYGON ((17 10, 18 10, 18 11, 17 11, 17 10)))"))
+
+    val rowCount = dfSelect.count()
+    assert(rowCount == 3)
+  }
+
+  it("select SQL with both spatial and temporal filters") {
+    val dfStac = sparkSession.read.format("stac").load(STAC_COLLECTION_LOCAL)
+    dfStac.createOrReplaceTempView("STACTBL")
+
+    val dfSelect = sparkSession.sql("SELECT id, datetime as dt, geometry, bbox " +
+      "FROM STACTBL " +
+      "WHERE datetime BETWEEN '2020-01-01' AND '2020-12-13' " +
+      "AND st_contains(ST_GeomFromText('POLYGON((17 10, 18 10, 18 11, 17 11, 17 10))'), geometry)")
+
+    dfSelect.explain(true)
+
+    val physicalPlan = dfSelect.queryExecution.executedPlan.toString()
+    assert(physicalPlan.contains(
+      "PushedSpatialFilters -> LeafFilter(geometry,INTERSECTS,POLYGON ((17 10, 18 10, 18 11, 17 11, 17 10)))"))
+    assert(physicalPlan.contains(
+      "PushedTemporalFilters -> AndFilter(GreaterThanFilter(datetime,2020-01-01T00:00),LessThanFilter(datetime,2020-12-13T00:00))"))
+
+    val rowCount = dfSelect.count()
+    assert(rowCount == 3)
+  }
+
+  it("select SQL with regular filter on id") {
+    val dfStac = sparkSession.read.format("stac").load(STAC_COLLECTION_LOCAL)
+    dfStac.createOrReplaceTempView("STACTBL")
+
+    val dfSelect = sparkSession.sql(
+      "SELECT id, datetime as dt, geometry, bbox " +
+        "FROM STACTBL " +
+        "WHERE id = 'some-id'")
+
+    dfSelect.explain(true)
+
+    val physicalPlan = dfSelect.queryExecution.executedPlan.toString()
+    assert(physicalPlan.contains("PushedSpatialFilters -> None, PushedTemporalFilters -> None"))
+
+    val rowCount = dfSelect.count()
+    assert(rowCount == 0)
+  }
+
+  it("select SQL with regular, spatial, and temporal filters") {
+    val dfStac = sparkSession.read.format("stac").load(STAC_COLLECTION_LOCAL)
+    dfStac.createOrReplaceTempView("STACTBL")
+
+    val dfSelect = sparkSession.sql("SELECT id, datetime as dt, geometry, bbox " +
+      "FROM STACTBL " +
+      "WHERE id = 'some-id' " +
+      "AND datetime BETWEEN '2020-01-01' AND '2020-12-13' " +
+      "AND st_contains(ST_GeomFromText('POLYGON((17 10, 18 10, 18 11, 17 11, 17 10))'), geometry)")
+
+    dfSelect.explain(true)
+
+    val physicalPlan = dfSelect.queryExecution.executedPlan.toString()
+    assert(physicalPlan.contains(
+      "PushedSpatialFilters -> LeafFilter(geometry,INTERSECTS,POLYGON ((17 10, 18 10, 18 11, 17 11, 17 10)))"))
+    assert(physicalPlan.contains(
+      "PushedTemporalFilters -> AndFilter(GreaterThanFilter(datetime,2020-01-01T00:00),LessThanFilter(datetime,2020-12-13T00:00))"))
+
+    val rowCount = dfSelect.count()
+    assert(rowCount == 0)
+  }
+
+  def assertSchema(actualSchema: StructType): Unit = {
+    val expectedSchema = StructType(
+      Seq(
+        StructField("stac_version", StringType, nullable = false),
+        StructField(
+          "stac_extensions",
+          ArrayType(StringType, containsNull = true),
+          nullable = true),
+        StructField("type", StringType, nullable = false),
+        StructField("id", StringType, nullable = false),
+        StructField("bbox", ArrayType(DoubleType, containsNull = true), nullable = true),
+        StructField("geometry", new GeometryUDT(), nullable = true),
+        StructField("title", StringType, nullable = true),
+        StructField("description", StringType, nullable = true),
+        StructField("datetime", TimestampType, nullable = true),
+        StructField("start_datetime", TimestampType, nullable = true),
+        StructField("end_datetime", TimestampType, nullable = true),
+        StructField("created", TimestampType, nullable = true),
+        StructField("updated", TimestampType, nullable = true),
+        StructField("platform", StringType, nullable = true),
+        StructField("instruments", ArrayType(StringType, containsNull = true), nullable = true),
+        StructField("constellation", StringType, nullable = true),
+        StructField("mission", StringType, nullable = true),
+        StructField("gsd", DoubleType, nullable = true),
+        StructField("collection", StringType, nullable = true),
+        StructField(
+          "links",
+          ArrayType(
+            StructType(Seq(
+              StructField("rel", StringType, nullable = true),
+              StructField("href", StringType, nullable = true),
+              StructField("type", StringType, nullable = true),
+              StructField("title", StringType, nullable = true))),
+            containsNull = true),
+          nullable = true),
+        StructField(
+          "assets",
+          MapType(
+            StringType,
+            StructType(Seq(
+              StructField("href", StringType, nullable = true),
+              StructField("type", StringType, nullable = true),
+              StructField("title", StringType, nullable = true),
+              StructField("roles", ArrayType(StringType, containsNull = true), nullable = true))),
+            valueContainsNull = true),
+          nullable = true)))
+
+    assert(
+      actualSchema == expectedSchema,
+      s"Schema does not match. Expected: $expectedSchema, Actual: $actualSchema")
+  }
+}

--- a/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacDataSourceTest.scala
+++ b/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacDataSourceTest.scala
@@ -25,7 +25,7 @@ import org.scalatest.BeforeAndAfterAll
 
 import java.util.TimeZone
 
-class StacDataSourceTest extends TestBaseScala with BeforeAndAfterAll {
+class StacDataSourceTest extends TestBaseScala {
 
   val STAC_COLLECTION_LOCAL: String = resourceFolder + "datasource_stac/collection.json"
   val STAC_ITEM_LOCAL: String = resourceFolder + "geojson/core-item.json"
@@ -36,16 +36,6 @@ class StacDataSourceTest extends TestBaseScala with BeforeAndAfterAll {
     "https://storage.googleapis.com/cfo-public/wildfire/collection.json",
     "https://earthdatahub.destine.eu/api/stac/v1/collections/copernicus-dem",
     "https://planetarycomputer.microsoft.com/api/stac/v1/collections/naip")
-
-  override def beforeAll(): Unit = {
-    super.beforeAll()
-    TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
-  }
-
-  override def afterAll(): Unit = {
-    TimeZone.setDefault(null) // Reset to the system default time zone
-    super.afterAll()
-  }
 
   it("basic df load from local file should work") {
     val dfStac = sparkSession.read.format("stac").load(STAC_COLLECTION_LOCAL)
@@ -86,7 +76,7 @@ class StacDataSourceTest extends TestBaseScala with BeforeAndAfterAll {
     val dfSelect = sparkSession.sql(
       "SELECT id, datetime as dt, geometry, bbox " +
         "FROM STACTBL " +
-        "WHERE datetime BETWEEN '2020-01-01' AND '2020-12-13'")
+        "WHERE datetime BETWEEN '2020-01-01T00:00:00Z' AND '2020-12-13T00:00:00Z'")
 
     dfSelect.explain(true)
 
@@ -123,7 +113,7 @@ class StacDataSourceTest extends TestBaseScala with BeforeAndAfterAll {
 
     val dfSelect = sparkSession.sql("SELECT id, datetime as dt, geometry, bbox " +
       "FROM STACTBL " +
-      "WHERE datetime BETWEEN '2020-01-01' AND '2020-12-13' " +
+      "WHERE datetime BETWEEN '2020-01-01T00:00:00Z' AND '2020-12-13T00:00:00Z' " +
       "AND st_contains(ST_GeomFromText('POLYGON((17 10, 18 10, 18 11, 17 11, 17 10))'), geometry)")
 
     dfSelect.explain(true)
@@ -163,7 +153,7 @@ class StacDataSourceTest extends TestBaseScala with BeforeAndAfterAll {
     val dfSelect = sparkSession.sql("SELECT id, datetime as dt, geometry, bbox " +
       "FROM STACTBL " +
       "WHERE id = 'some-id' " +
-      "AND datetime BETWEEN '2020-01-01' AND '2020-12-13' " +
+      "AND datetime BETWEEN '2020-01-01T00:00:00Z' AND '2020-12-13T00:00:00Z' " +
       "AND st_contains(ST_GeomFromText('POLYGON((17 10, 18 10, 18 11, 17 11, 17 10))'), geometry)")
 
     dfSelect.explain(true)

--- a/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacPartitionReaderTest.scala
+++ b/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacPartitionReaderTest.scala
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.spark.sql.sedona_sql.io.stac
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.InternalRow
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
+
+import scala.jdk.CollectionConverters.mapAsJavaMapConverter
+
+class StacPartitionReaderTest extends AnyFunSuite with BeforeAndAfterAll {
+
+  val TEST_DATA_FOLDER: String =
+    System.getProperty("user.dir") + "/src/test/resources/datasource_stac"
+  val JSON_STAC_ITEM_SIMPLE: String = s"file://$TEST_DATA_FOLDER/simple-item.json"
+  val JSON_STAC_ITEM_CORE: String = s"file://$TEST_DATA_FOLDER/core-item.json"
+  val JSON_STAC_ITEM_EXTENDED: String = s"file://$TEST_DATA_FOLDER/extended-item.json"
+  val JSON_STAC_ITEM_FEATURES: String = s"file://$TEST_DATA_FOLDER/collection-items.json"
+  val HTTPS_STAC_ITEM_FEATURES: String =
+    "https://earth-search.aws.element84.com/v1/collections/sentinel-2-pre-c1-l2a/items"
+
+  private var spark: SparkSession = _
+
+  override def beforeAll(): Unit = {
+    spark = SparkSession
+      .builder()
+      .appName("StacPartitionReaderTest")
+      .master("local[*]")
+      .getOrCreate()
+  }
+
+  override def afterAll(): Unit = {
+    if (spark != null) {
+      spark.stop()
+    }
+  }
+
+  test("StacPartitionReader should read feature files from local files") {
+    val jsonFiles =
+      Seq(JSON_STAC_ITEM_SIMPLE, JSON_STAC_ITEM_CORE, JSON_STAC_ITEM_EXTENDED).toArray
+    val partition = StacPartition(0, jsonFiles, Map.empty[String, String].asJava)
+    val reader =
+      new StacPartitionReader(
+        partition,
+        StacTable.SCHEMA_V1_1_0,
+        Map.empty[String, String],
+        None,
+        None)
+
+    assert(reader.next())
+    (1 to 3).foreach { i =>
+      val row: InternalRow = reader.get()
+      assert(row != null)
+      assert(reader.next() == (i < 3))
+    }
+
+    reader.close()
+  }
+
+  test("StacPartitionReader should read features collection file from local files") {
+    val jsonFiles = Seq(JSON_STAC_ITEM_FEATURES).toArray
+    val partition = StacPartition(0, jsonFiles, Map.empty[String, String].asJava)
+    val reader =
+      new StacPartitionReader(
+        partition,
+        StacTable.SCHEMA_V1_1_0,
+        Map.empty[String, String],
+        None,
+        None)
+
+    assert(reader.next())
+    (1 to 10).foreach { i =>
+      val row: InternalRow = reader.get()
+      assert(row != null)
+      assert(reader.next() == (i < 10))
+    }
+
+    reader.close()
+  }
+
+  test("StacPartitionReader should read features collection file from https endpoint") {
+    val jsonFiles = Seq(HTTPS_STAC_ITEM_FEATURES).toArray
+    val partition = StacPartition(0, jsonFiles, Map.empty[String, String].asJava)
+    val reader =
+      new StacPartitionReader(
+        partition,
+        StacTable.SCHEMA_V1_1_0,
+        Map.empty[String, String],
+        None,
+        None)
+
+    assert(reader.next())
+    (1 to 10).foreach { i =>
+      val row: InternalRow = reader.get()
+      assert(row != null)
+      assert(reader.next() == (i < 10))
+    }
+
+    reader.close()
+  }
+}

--- a/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacPartitionReaderTest.scala
+++ b/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacPartitionReaderTest.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
 
-import scala.jdk.CollectionConverters.mapAsJavaMapConverter
+import scala.jdk.CollectionConverters._
 
 class StacPartitionReaderTest extends AnyFunSuite with BeforeAndAfterAll {
 

--- a/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacPartitionReaderTest.scala
+++ b/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacPartitionReaderTest.scala
@@ -18,14 +18,12 @@
  */
 package org.apache.spark.sql.sedona_sql.io.stac
 
-import org.apache.spark.sql.SparkSession
+import org.apache.sedona.sql.TestBaseScala
 import org.apache.spark.sql.catalyst.InternalRow
-import org.scalatest.BeforeAndAfterAll
-import org.scalatest.funsuite.AnyFunSuite
 
 import scala.jdk.CollectionConverters._
 
-class StacPartitionReaderTest extends AnyFunSuite with BeforeAndAfterAll {
+class StacPartitionReaderTest extends TestBaseScala {
 
   val TEST_DATA_FOLDER: String =
     System.getProperty("user.dir") + "/src/test/resources/datasource_stac"
@@ -36,23 +34,7 @@ class StacPartitionReaderTest extends AnyFunSuite with BeforeAndAfterAll {
   val HTTPS_STAC_ITEM_FEATURES: String =
     "https://earth-search.aws.element84.com/v1/collections/sentinel-2-pre-c1-l2a/items"
 
-  private var spark: SparkSession = _
-
-  override def beforeAll(): Unit = {
-    spark = SparkSession
-      .builder()
-      .appName("StacPartitionReaderTest")
-      .master("local[*]")
-      .getOrCreate()
-  }
-
-  override def afterAll(): Unit = {
-    if (spark != null) {
-      spark.stop()
-    }
-  }
-
-  test("StacPartitionReader should read feature files from local files") {
+  it("StacPartitionReader should read feature files from local files") {
     val jsonFiles =
       Seq(JSON_STAC_ITEM_SIMPLE, JSON_STAC_ITEM_CORE, JSON_STAC_ITEM_EXTENDED).toArray
     val partition = StacPartition(0, jsonFiles, Map.empty[String, String].asJava)
@@ -74,7 +56,7 @@ class StacPartitionReaderTest extends AnyFunSuite with BeforeAndAfterAll {
     reader.close()
   }
 
-  test("StacPartitionReader should read features collection file from local files") {
+  it("StacPartitionReader should read features collection file from local files") {
     val jsonFiles = Seq(JSON_STAC_ITEM_FEATURES).toArray
     val partition = StacPartition(0, jsonFiles, Map.empty[String, String].asJava)
     val reader =
@@ -95,7 +77,7 @@ class StacPartitionReaderTest extends AnyFunSuite with BeforeAndAfterAll {
     reader.close()
   }
 
-  test("StacPartitionReader should read features collection file from https endpoint") {
+  it("StacPartitionReader should read features collection file from https endpoint") {
     val jsonFiles = Seq(HTTPS_STAC_ITEM_FEATURES).toArray
     val partition = StacPartition(0, jsonFiles, Map.empty[String, String].asJava)
     val reader =

--- a/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacTableTest.scala
+++ b/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacTableTest.scala
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.spark.sql.sedona_sql.io.stac
+
+import org.apache.spark.sql.sedona_sql.io.stac.StacTable.{SCHEMA_GEOPARQUET, addAssetStruct, addAssetsStruct}
+import org.apache.spark.sql.types.{ArrayType, MapType, StringType, StructField, StructType}
+import org.scalatest.funsuite.AnyFunSuite
+
+class StacTableTest extends AnyFunSuite {
+
+  def printSchema(schema: StructType): Unit = {
+    def printFields(fields: Array[StructField], indent: String): Unit = {
+      fields.foreach { field =>
+        println(
+          s"$indent- ${field.name}: ${field.dataType.simpleString} (nullable = ${field.nullable})")
+        field.dataType match {
+          case structType: StructType => printFields(structType.fields, indent + "  ")
+          case arrayType: ArrayType =>
+            println(s"$indent  - elementType: ${arrayType.elementType.simpleString}")
+            arrayType.elementType match {
+              case structType: StructType => printFields(structType.fields, indent + "    ")
+              case _ => // Do nothing
+            }
+          case mapType: MapType =>
+            println(s"$indent  - keyType: ${mapType.keyType.simpleString}")
+            println(s"$indent  - valueType: ${mapType.valueType.simpleString}")
+            mapType.valueType match {
+              case structType: StructType => printFields(structType.fields, indent + "    ")
+              case _ => // Do nothing
+            }
+          case _ => // Do nothing
+        }
+      }
+    }
+    printFields(schema.fields, "")
+  }
+
+  test("addAssetStruct should add a new asset to an existing assets struct") {
+    val initialSchema = StructType(
+      Seq(
+        StructField("id", StringType, nullable = false),
+        StructField(
+          "assets",
+          StructType(Seq(StructField(
+            "image",
+            StructType(Seq(
+              StructField("href", StringType, nullable = true),
+              StructField("roles", ArrayType(StringType), nullable = true),
+              StructField("title", StringType, nullable = true),
+              StructField("type", StringType, nullable = true))),
+            nullable = true))),
+          nullable = true)))
+
+    val updatedSchema = addAssetStruct(initialSchema, "thumbnail")
+
+    assert(updatedSchema.fieldNames.contains("assets"))
+    val assetsField = updatedSchema("assets").dataType.asInstanceOf[StructType]
+    assert(assetsField.fieldNames.contains("thumbnail"))
+  }
+
+  test("addAssetStruct should create assets struct if it doesn't exist") {
+    val initialSchema = StructType(Seq(StructField("id", StringType, nullable = false)))
+
+    val updatedSchema1 = addAssetStruct(initialSchema, "image")
+    val updatedSchema2 = addAssetStruct(updatedSchema1, "rast")
+
+    assert(updatedSchema2.fieldNames.contains("assets"))
+    val assetsField = updatedSchema2("assets").dataType.asInstanceOf[StructType]
+    assert(assetsField.fieldNames.contains("image"))
+    assert(assetsField.fieldNames.contains("rast"))
+  }
+
+  test("addAssetStruct should not modify other fields") {
+    val initialSchema = SCHEMA_GEOPARQUET
+
+    val updatedSchema = addAssetsStruct(initialSchema, Array("thumbnail", "preview"))
+    printSchema(updatedSchema)
+
+    assert(updatedSchema.fieldNames.contains("id"))
+    assert(updatedSchema.fieldNames.contains("stac_version"))
+    assert(updatedSchema.fieldNames.contains("stac_extensions"))
+    assert(updatedSchema.fieldNames.contains("bbox"))
+    assert(updatedSchema.fieldNames.contains("geometry"))
+    assert(updatedSchema.fieldNames.contains("assets"))
+  }
+}

--- a/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacTableTest.scala
+++ b/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacTableTest.scala
@@ -24,33 +24,6 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class StacTableTest extends AnyFunSuite {
 
-  def printSchema(schema: StructType): Unit = {
-    def printFields(fields: Array[StructField], indent: String): Unit = {
-      fields.foreach { field =>
-        println(
-          s"$indent- ${field.name}: ${field.dataType.simpleString} (nullable = ${field.nullable})")
-        field.dataType match {
-          case structType: StructType => printFields(structType.fields, indent + "  ")
-          case arrayType: ArrayType =>
-            println(s"$indent  - elementType: ${arrayType.elementType.simpleString}")
-            arrayType.elementType match {
-              case structType: StructType => printFields(structType.fields, indent + "    ")
-              case _ => // Do nothing
-            }
-          case mapType: MapType =>
-            println(s"$indent  - keyType: ${mapType.keyType.simpleString}")
-            println(s"$indent  - valueType: ${mapType.valueType.simpleString}")
-            mapType.valueType match {
-              case structType: StructType => printFields(structType.fields, indent + "    ")
-              case _ => // Do nothing
-            }
-          case _ => // Do nothing
-        }
-      }
-    }
-    printFields(schema.fields, "")
-  }
-
   test("addAssetStruct should add a new asset to an existing assets struct") {
     val initialSchema = StructType(
       Seq(
@@ -88,9 +61,7 @@ class StacTableTest extends AnyFunSuite {
 
   test("addAssetStruct should not modify other fields") {
     val initialSchema = SCHEMA_GEOPARQUET
-
     val updatedSchema = addAssetsStruct(initialSchema, Array("thumbnail", "preview"))
-    printSchema(updatedSchema)
 
     assert(updatedSchema.fieldNames.contains("id"))
     assert(updatedSchema.fieldNames.contains("stac_version"))

--- a/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacUtilsTest.scala
+++ b/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacUtilsTest.scala
@@ -27,7 +27,7 @@ import org.scalatest.funsuite.AnyFunSuite
 
 import java.io.{File, PrintWriter}
 import scala.io.Source
-import scala.jdk.CollectionConverters.asScalaIteratorConverter
+import scala.jdk.CollectionConverters._
 
 class StacUtilsTest extends AnyFunSuite {
 

--- a/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacUtilsTest.scala
+++ b/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacUtilsTest.scala
@@ -1,0 +1,594 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.spark.sql.sedona_sql.io.stac
+
+import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.sedona_sql.io.stac.StacUtils.getNumPartitions
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.io.{File, PrintWriter}
+import scala.io.Source
+import scala.jdk.CollectionConverters.asScalaIteratorConverter
+
+class StacUtilsTest extends AnyFunSuite {
+
+  test("getStacCollectionBasePath should return base URL for HTTP URL") {
+    val opts = Map("path" -> "https://service_url/collections/collection.json")
+    val result = StacUtils.getStacCollectionBasePath(opts)
+    assert(result == "https://service_url/")
+  }
+
+  test("getStacCollectionBasePath should return base URL for HTTPS URL") {
+    val opts = Map("path" -> "https://service_url/collections/collection.json")
+    val result = StacUtils.getStacCollectionBasePath(opts)
+    assert(result == "https://service_url/")
+  }
+
+  test("getStacCollectionBasePath should return base path for file URL") {
+    val opts = Map("path" -> "file:///usr/opt/collection.json")
+    val result = StacUtils.getStacCollectionBasePath(opts)
+    assert(result == "file:///usr/opt/")
+  }
+
+  test("getStacCollectionBasePath should return base path for local file path") {
+    val opts = Map("path" -> "/usr/opt/collection.json")
+    val result = StacUtils.getStacCollectionBasePath(opts)
+    assert(result == "file:///usr/opt/")
+  }
+
+  test(
+    "getStacCollectionBasePath should throw IllegalArgumentException if neither url nor service is provided") {
+    val opts = Map.empty[String, String]
+    assertThrows[IllegalArgumentException] {
+      StacUtils.getStacCollectionBasePath(opts)
+    }
+  }
+
+  test(
+    "getStacCollectionBasePath should throw IllegalArgumentException for invalid URL or file path") {
+    val opts = Map("path" -> "invalid_path")
+    assertThrows[IllegalArgumentException] {
+      StacUtils.getStacCollectionBasePath(opts)
+    }
+  }
+
+  test("getNumPartitions should return numPartitions if it is greater than 0") {
+    assert(
+      getNumPartitions(
+        itemCount = 100,
+        numPartitions = 5,
+        maxPartitionItemFiles = 10,
+        defaultParallelism = 4) == 5)
+  }
+
+  test(
+    "getNumPartitions should calculate partitions based on maxPartitionItemFiles and defaultParallelism") {
+    assert(
+      getNumPartitions(
+        itemCount = 100,
+        numPartitions = 0,
+        maxPartitionItemFiles = 10,
+        defaultParallelism = 4) == 10)
+  }
+
+  test(
+    "getNumPartitions should handle case when maxPartitionItemFiles is less than sum of files / defaultParallelism") {
+    assert(
+      getNumPartitions(
+        itemCount = 100,
+        numPartitions = 0,
+        maxPartitionItemFiles = 5,
+        defaultParallelism = 4) == 20)
+  }
+
+  test("getNumPartitions should handle case when maxPartitionItemFiles is 0") {
+    assert(
+      getNumPartitions(
+        itemCount = 100,
+        numPartitions = 0,
+        maxPartitionItemFiles = 0,
+        defaultParallelism = 4) == 4)
+  }
+
+  test("getNumPartitions should handle case when defaultParallelism is 1") {
+    assert(
+      getNumPartitions(
+        itemCount = 100,
+        numPartitions = 0,
+        maxPartitionItemFiles = 10,
+        defaultParallelism = 1) == 10)
+  }
+
+  test("getNumPartitions should return at least 1 partition") {
+    assert(
+      getNumPartitions(
+        itemCount = 0,
+        numPartitions = 0,
+        maxPartitionItemFiles = 10,
+        defaultParallelism = 4) == 1)
+  }
+
+  test(
+    "processStacCollection should process STAC collection from JSON string and save features to output file") {
+    val spark = SparkSession.builder().master("local").appName("StacUtilsTest").getOrCreate()
+    val hadoopConf = spark.sparkContext.hadoopConfiguration
+    val fs = FileSystem.get(hadoopConf)
+
+    // Create a temporary STAC collection JSON file
+    val stacCollectionJson =
+      """
+        |{
+        |  "stac_version": "1.0.0",
+        |  "id": "sample-collection",
+        |  "description": "A sample STAC collection",
+        |  "links": [
+        |    {"rel": "item", "href": "file:///tmp/item1.json"},
+        |    {"rel": "item", "href": "file:///tmp/item2.json"}
+        |  ]
+        |}
+      """.stripMargin
+    val stacCollectionPath = new Path("/tmp/collection.json")
+    val stacCollectionWriter = new PrintWriter(new File(stacCollectionPath.toString))
+    stacCollectionWriter.write(stacCollectionJson)
+    stacCollectionWriter.close()
+
+    // Create temporary item JSON files
+    val item1Json =
+      """
+        |{
+        |  "stac_version": "1.1.0",
+        |  "stac_extensions": [],
+        |  "type": "Feature",
+        |  "id": "20201211_223832_CS2_item1",
+        |  "bbox": [
+        |    172.91173669923782,
+        |    1.3438851951615003,
+        |    172.95469614953714,
+        |    1.3690476620161975
+        |  ],
+        |  "geometry": {
+        |    "type": "Polygon",
+        |    "coordinates": [
+        |      [
+        |        [
+        |          172.91173669923782,
+        |          1.3438851951615003
+        |        ],
+        |        [
+        |          172.95469614953714,
+        |          1.3438851951615003
+        |        ],
+        |        [
+        |          172.95469614953714,
+        |          1.3690476620161975
+        |        ],
+        |        [
+        |          172.91173669923782,
+        |          1.3690476620161975
+        |        ],
+        |        [
+        |          172.91173669923782,
+        |          1.3438851951615003
+        |        ]
+        |      ]
+        |    ]
+        |  },
+        |  "properties": {
+        |    "title": "Item 1",
+        |    "description": "A sample STAC Item 1 that includes examples of all common metadata",
+        |    "datetime": null,
+        |    "start_datetime": "2020-12-11T22:38:32.125Z",
+        |    "end_datetime": "2020-12-11T22:38:32.327Z",
+        |    "created": "2020-12-12T01:48:13.725Z",
+        |    "updated": "2020-12-12T01:48:13.725Z",
+        |    "platform": "cool_sat1",
+        |    "instruments": [
+        |      "cool_sensor_v1"
+        |    ],
+        |    "constellation": "ion",
+        |    "mission": "collection 5624",
+        |    "gsd": 0.512
+        |  },
+        |  "collection": "simple-collection",
+        |  "links": [
+        |    {
+        |      "rel": "collection",
+        |      "href": "./collection.json",
+        |      "type": "application/json",
+        |      "title": "Simple Example Collection"
+        |    },
+        |    {
+        |      "rel": "root",
+        |      "href": "./collection.json",
+        |      "type": "application/json",
+        |      "title": "Simple Example Collection"
+        |    },
+        |    {
+        |      "rel": "parent",
+        |      "href": "./collection.json",
+        |      "type": "application/json",
+        |      "title": "Simple Example Collection"
+        |    },
+        |    {
+        |      "rel": "alternate",
+        |      "type": "text/html",
+        |      "href": "https://remotedata.io/catalog/20201211_223832_CS2_item1/index.html",
+        |      "title": "HTML version of this STAC Item"
+        |    }
+        |  ],
+        |  "assets": {
+        |    "analytic": {
+        |      "href": "https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2_item1_analytic.tif",
+        |      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        |      "title": "4-Band Analytic",
+        |      "roles": [
+        |        "data"
+        |      ]
+        |    },
+        |    "thumbnail": {
+        |      "href": "https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2_item1.jpg",
+        |      "title": "Thumbnail",
+        |      "type": "image/png",
+        |      "roles": [
+        |        "thumbnail"
+        |      ]
+        |    },
+        |    "visual": {
+        |      "href": "https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2_item1.tif",
+        |      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        |      "title": "3-Band Visual",
+        |      "roles": [
+        |        "visual"
+        |      ]
+        |    },
+        |    "udm": {
+        |      "href": "https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2_item1_analytic_udm.tif",
+        |      "title": "Unusable Data Mask",
+        |      "type": "image/tiff; application=geotiff"
+        |    },
+        |    "json-metadata": {
+        |      "href": "https://remotedata.io/catalog/20201211_223832_CS2_item1/extended-metadata.json",
+        |      "title": "Extended Metadata",
+        |      "type": "application/json",
+        |      "roles": [
+        |        "metadata"
+        |      ]
+        |    },
+        |    "ephemeris": {
+        |      "href": "https://cool-sat.com/catalog/20201211_223832_CS2_item1/20201211_223832_CS2_item1.EPH",
+        |      "title": "Satellite Ephemeris Metadata"
+        |    }
+        |  }
+        |}
+      """.stripMargin
+    val item1Path = new Path("/tmp/item1.json")
+    val item1Writer = new PrintWriter(new File(item1Path.toString))
+    item1Writer.write(item1Json)
+    item1Writer.close()
+
+    val item2Json =
+      """
+        |{
+        |  "stac_version": "1.1.0",
+        |  "stac_extensions": [],
+        |  "type": "Feature",
+        |  "id": "20201211_223832_CS2_item2",
+        |  "bbox": [
+        |    173.91173669923782,
+        |    2.3438851951615003,
+        |    173.95469614953714,
+        |    2.3690476620161975
+        |  ],
+        |  "geometry": {
+        |    "type": "Polygon",
+        |    "coordinates": [
+        |      [
+        |        [
+        |          173.91173669923782,
+        |          2.3438851951615003
+        |        ],
+        |        [
+        |          173.95469614953714,
+        |          2.3438851951615003
+        |        ],
+        |        [
+        |          173.95469614953714,
+        |          2.3690476620161975
+        |        ],
+        |        [
+        |          173.91173669923782,
+        |          2.3690476620161975
+        |        ],
+        |        [
+        |          173.91173669923782,
+        |          2.3438851951615003
+        |        ]
+        |      ]
+        |    ]
+        |  },
+        |  "properties": {
+        |    "title": "Item 2",
+        |    "description": "A different sample STAC Item 2 that includes examples of all common metadata",
+        |    "datetime": null,
+        |    "start_datetime": "2020-12-12T22:38:32.125Z",
+        |    "end_datetime": "2020-12-12T22:38:32.327Z",
+        |    "created": "2020-12-13T01:48:13.725Z",
+        |    "updated": "2020-12-13T01:48:13.725Z",
+        |    "platform": "cool_sat2",
+        |    "instruments": [
+        |      "cool_sensor_v2"
+        |    ],
+        |    "constellation": "ion",
+        |    "mission": "collection 5625",
+        |    "gsd": 0.512
+        |  },
+        |  "collection": "simple-collection",
+        |  "links": [
+        |    {
+        |      "rel": "collection",
+        |      "href": "./collection.json",
+        |      "type": "application/json",
+        |      "title": "Simple Example Collection"
+        |    },
+        |    {
+        |      "rel": "root",
+        |      "href": "./collection.json",
+        |      "type": "application/json",
+        |      "title": "Simple Example Collection"
+        |    },
+        |    {
+        |      "rel": "parent",
+        |      "href": "./collection.json",
+        |      "type": "application/json",
+        |      "title": "Simple Example Collection"
+        |    },
+        |    {
+        |      "rel": "alternate",
+        |      "type": "text/html",
+        |      "href": "https://remotedata.io/catalog/20201211_223832_CS2_item2/index.html",
+        |      "title": "HTML version of this STAC Item"
+        |    }
+        |  ],
+        |  "assets": {
+        |    "analytic": {
+        |      "href": "https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2_item2_analytic.tif",
+        |      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        |      "title": "4-Band Analytic",
+        |      "roles": [
+        |        "data"
+        |      ]
+        |    },
+        |    "thumbnail": {
+        |      "href": "https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2_item2.jpg",
+        |      "title": "Thumbnail",
+        |      "type": "image/png",
+        |      "roles": [
+        |        "thumbnail"
+        |      ]
+        |    },
+        |    "visual": {
+        |      "href": "https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2_item2.tif",
+        |      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        |      "title": "3-Band Visual",
+        |      "roles": [
+        |        "visual"
+        |      ]
+        |    },
+        |    "udm": {
+        |      "href": "https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2_item2_analytic_udm.tif",
+        |      "title": "Unusable Data Mask",
+        |      "type": "image/tiff; application=geotiff"
+        |    },
+        |    "json-metadata": {
+        |      "href": "https://remotedata.io/catalog/20201211_223832_CS2_item2/extended-metadata.json",
+        |      "title": "Extended Metadata",
+        |      "type": "application/json",
+        |      "roles": [
+        |        "metadata"
+        |      ]
+        |    },
+        |    "ephemeris": {
+        |      "href": "https://cool-sat.com/catalog/20201211_223832_CS2_item2/20201211_223832_CS2_item2.EPH",
+        |      "title": "Satellite Ephemeris Metadata"
+        |    }
+        |  }
+        |}
+  """.stripMargin
+    val item2Path = new Path("/tmp/item2.json")
+    val item2Writer = new PrintWriter(new File(item2Path.toString))
+    item2Writer.write(item2Json)
+    item2Writer.close()
+
+    // Load the STAC collection JSON
+    val opts = Map("path" -> "file:///tmp/collection.json")
+    val stacCollectionJsonString = StacUtils.loadStacCollectionToJson(opts)
+    val outputPath = "/tmp/output.json"
+
+    // Call the function to process the STAC collection
+    saveStacCollection(stacCollectionJsonString, outputPath)
+
+    // Verify the output file
+    val outputFile = new File(outputPath)
+    assert(outputFile.exists())
+
+    val outputContent = Source.fromFile(outputFile).getLines().mkString("\n")
+    assert(outputContent.contains("item1"))
+    assert(outputContent.contains("item2"))
+
+    // Clean up temporary files
+    fs.delete(stacCollectionPath, false)
+    fs.delete(item1Path, false)
+    fs.delete(item2Path, false)
+    outputFile.delete()
+  }
+
+  test(
+    "processStacCollection should process STAC collection with mixed 'item' and 'items' rels and save features to output file") {
+    val spark = SparkSession.builder().master("local").appName("StacUtilsTest").getOrCreate()
+    val hadoopConf = spark.sparkContext.hadoopConfiguration
+    val fs = FileSystem.get(hadoopConf)
+
+    // Create a temporary STAC collection JSON file
+    val stacCollectionJson =
+      """
+        |{
+        |  "stac_version": "1.0.0",
+        |  "id": "sample-collection",
+        |  "description": "A sample STAC collection",
+        |  "links": [
+        |    {"rel": "item", "href": "file:///tmp/item1.json"},
+        |    {"rel": "items", "href": "file:///tmp/items.json"}
+        |  ]
+        |}
+      """.stripMargin
+    val stacCollectionPath = new Path("/tmp/collection.json")
+    val stacCollectionWriter = new PrintWriter(new File(stacCollectionPath.toString))
+    stacCollectionWriter.write(stacCollectionJson)
+    stacCollectionWriter.close()
+
+    // Create temporary item JSON files
+    val item1Json =
+      """
+        |{
+        |  "type": "Feature",
+        |  "id": "item1",
+        |  "geometry": {
+        |    "type": "Point",
+        |    "coordinates": [100.0, 0.0]
+        |  },
+        |  "properties": {
+        |    "title": "Item 1"
+        |  }
+        |}
+      """.stripMargin
+    val item1Path = new Path("/tmp/item1.json")
+    val item1Writer = new PrintWriter(new File(item1Path.toString))
+    item1Writer.write(item1Json)
+    item1Writer.close()
+
+    val itemsJson =
+      """
+        |{
+        |  "type": "FeatureCollection",
+        |  "features": [
+        |    {
+        |      "type": "Feature",
+        |      "id": "item2",
+        |      "geometry": {
+        |        "type": "Point",
+        |        "coordinates": [101.0, 1.0]
+        |      },
+        |      "properties": {
+        |        "title": "Item 2"
+        |      }
+        |    },
+        |    {
+        |      "type": "Feature",
+        |      "id": "item3",
+        |      "geometry": {
+        |        "type": "Point",
+        |        "coordinates": [102.0, 2.0]
+        |      },
+        |      "properties": {
+        |        "title": "Item 3"
+        |      }
+        |    }
+        |  ]
+        |}
+      """.stripMargin
+    val itemsPath = new Path("/tmp/items.json")
+    val itemsWriter = new PrintWriter(new File(itemsPath.toString))
+    itemsWriter.write(itemsJson)
+    itemsWriter.close()
+
+    // Load the STAC collection JSON
+    val opts = Map("path" -> "file:///tmp/collection.json")
+    val stacCollectionJsonString = StacUtils.loadStacCollectionToJson(opts)
+    val outputPath = "/tmp/output.json"
+
+    // Call the function to process the STAC collection
+    saveStacCollection(stacCollectionJsonString, outputPath)
+
+    // Verify the output file
+    val outputFile = new File(outputPath)
+    assert(outputFile.exists())
+
+    val outputContent = Source.fromFile(outputFile).getLines().mkString("\n")
+    assert(outputContent.contains("item1"))
+    assert(outputContent.contains("item2"))
+    assert(outputContent.contains("item3"))
+
+    // Clean up temporary files
+    fs.delete(stacCollectionPath, false)
+    fs.delete(item1Path, false)
+    fs.delete(itemsPath, false)
+    outputFile.delete()
+  }
+
+  // Function to process STAC collection
+  def saveStacCollection(stacCollectionJson: String, outputPath: String): Unit = {
+    // Create the ObjectMapper
+    val mapper = new ObjectMapper()
+    mapper.registerModule(DefaultScalaModule)
+
+    // Parse the STAC collection JSON
+    val collection: JsonNode = mapper.readTree(stacCollectionJson)
+
+    // Extract item and items links
+    val itemLinks = collection.get("links").elements().asScala.filter { link =>
+      val rel = link.get("rel").asText()
+      rel == "item" || rel == "items"
+    }
+
+    // Open a writer for the output multiline JSON file
+    val writer = new PrintWriter(new File(outputPath))
+
+    try {
+      // Iterate over each item link
+      itemLinks.foreach { link =>
+        val itemUrl = link.get("href").asText()
+
+        // Fetch the item JSON
+        val itemJson = Source.fromURL(itemUrl).mkString
+
+        // Parse the item JSON
+        val itemCollection: JsonNode = mapper.readTree(itemJson)
+
+        // Check if the link is of type "items"
+        if (link.get("rel").asText() == "items") {
+          // Iterate over each feature in the item collection
+          val features = itemCollection.get("features").elements().asScala
+          features.foreach { feature =>
+            // Write each feature JSON as a single line in the output file
+            writer.println(mapper.writeValueAsString(feature))
+          }
+        } else {
+          // Write the item JSON as a single line in the output file
+          writer.println(mapper.writeValueAsString(itemCollection))
+        }
+      }
+    } finally {
+      // Close the writer
+      writer.close()
+    }
+  }
+}


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-XXX. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?
This PR adds an STAC (SpatioTemporal Asset Catalog) collection reader to Sedona. The reader will fetch STAC items and load them into a Sedona DataFrame. The data can be sourced from static JSON files, GeoParquet, or external services, such as Earth Search by Element84.

## How was this patch tested?
Unit tests under: org.apache.spark.sql.sedona_sql.io.stac

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.
