### PR TITLE
[SEDONA-705] Add unique partitioner wrapper to enable partitioned writes with Sedona

### DIFF
--- a/docs/tutorial/sql.md
+++ b/docs/tutorial/sql.md
@@ -1651,7 +1651,9 @@ You can use `StructuredAdapter` and the `spatialRDD.spatialPartitioningWithoutDu
 === "Scala"
 
 	```scala
-	spatialRDD.spatialPartitioning(GridType.KDBTREE)
+	spatialRDD.spatialParitioningWithoutDuplicates(GridType.KDBTREE)
+	// Specify the desired number of partitions as 10, though the actual number may vary
+	// spatialRDD.spatialParitioningWithoutDuplicates(GridType.KDBTREE, 10)
 	var spatialDf = StructuredAdapter.toSpatialPartitionedDf(spatialRDD, sedona)
 	```
 

--- a/docs/tutorial/sql.md
+++ b/docs/tutorial/sql.md
@@ -1638,6 +1638,37 @@ Use SedonaSQL DataFrame-RDD Adapter to convert a DataFrame to an SpatialRDD. Ple
 	spatialDf = StructuredAdapter.toDf(spatialRDD, sedona)
 	```
 
+### SpatialRDD to DataFrame with spatial partitioning
+
+By default, `StructuredAdapter.toDf()` does not preserve spatial partitions because doing so
+may introduce duplicate features for most types of spatial data. These duplicates
+are introduced on purpose to ensure correctness when performing a spatial join;
+however, when using Sedona to prepare a dataset for distribution this is not typically
+desired.
+
+=== "Scala"
+
+	```scala
+	spatialRDD.spatialPartitioning(GridType.KDBTREE)
+	var spatialDf = StructuredAdapter.toSpatialPartitionedDf(spatialRDD, sedona)
+	```
+
+=== "Java"
+
+	```java
+	spatialRDD.spatialPartitioning(GridType.KDBTREE)
+	Dataset<Row> spatialDf = StructuredAdapter.toSpatialPartitionedDf(spatialRDD, sedona)
+	```
+
+=== "Python"
+
+	```python
+	from sedona.utils.structured_adapter import StructuredAdapter
+
+	spatialRDD.spatialPartitioning(GridType.KDBTREE)
+	spatialDf = StructuredAdapter.toSpatialPartitionedDf(spatialRDD, sedona)
+	```
+
 ### SpatialPairRDD to DataFrame
 
 PairRDD is the result of a spatial join query or distance join query. SedonaSQL DataFrame-RDD Adapter can convert the result to a DataFrame. But you need to provide the schema of the left and right RDDs.

--- a/docs/tutorial/sql.md
+++ b/docs/tutorial/sql.md
@@ -1662,7 +1662,7 @@ You can use `StructuredAdapter` and the `spatialRDD.spatialPartitioningWithoutDu
 	```java
 	spatialRDD.spatialParitioningWithoutDuplicates(GridType.KDBTREE)
 	// Specify the desired number of partitions as 10, though the actual number may vary
-	// spatialRDD.spatialParitioningWithoutDuplicates(GridType.KDBTREE, 10)	
+	// spatialRDD.spatialParitioningWithoutDuplicates(GridType.KDBTREE, 10)
 	Dataset<Row> spatialDf = StructuredAdapter.toSpatialPartitionedDf(spatialRDD, sedona)
 	```
 

--- a/docs/tutorial/sql.md
+++ b/docs/tutorial/sql.md
@@ -1667,7 +1667,9 @@ You can use `StructuredAdapter` and the `spatialRDD.spatialPartitioningWithoutDu
 	```python
 	from sedona.utils.structured_adapter import StructuredAdapter
 
-	spatialRDD.spatialPartitioning(GridType.KDBTREE)
+	spatialRDD.spatialPartitioningWithoutDuplicates(GridType.KDBTREE)
+	# Specify the desired number of partitions as 10, though the actual number may vary
+	# spatialRDD.spatialParitioningWithoutDuplicates(GridType.KDBTREE, 10)
 	spatialDf = StructuredAdapter.toSpatialPartitionedDf(spatialRDD, sedona)
 	```
 

--- a/docs/tutorial/sql.md
+++ b/docs/tutorial/sql.md
@@ -1646,6 +1646,8 @@ are introduced on purpose to ensure correctness when performing a spatial join;
 however, when using Sedona to prepare a dataset for distribution this is not typically
 desired.
 
+You can use `StructuredAdapter` and the `spatialRDD.spatialPartitioningWithoutDuplicates` function to obtain a Sedona DataFrame that is spatially partitioned without duplicates. This is especially useful for generating balanced GeoParquet files while preserving spatial proximity within files, which is crucial for optimizing filter pushdown performance in GeoParquet files.
+
 === "Scala"
 
 	```scala

--- a/docs/tutorial/sql.md
+++ b/docs/tutorial/sql.md
@@ -1660,7 +1660,9 @@ You can use `StructuredAdapter` and the `spatialRDD.spatialPartitioningWithoutDu
 === "Java"
 
 	```java
-	spatialRDD.spatialPartitioning(GridType.KDBTREE)
+	spatialRDD.spatialParitioningWithoutDuplicates(GridType.KDBTREE)
+	// Specify the desired number of partitions as 10, though the actual number may vary
+	// spatialRDD.spatialParitioningWithoutDuplicates(GridType.KDBTREE, 10)	
 	Dataset<Row> spatialDf = StructuredAdapter.toSpatialPartitionedDf(spatialRDD, sedona)
 	```
 

--- a/python/sedona/core/SpatialRDD/spatial_rdd.py
+++ b/python/sedona/core/SpatialRDD/spatial_rdd.py
@@ -19,7 +19,7 @@ import pickle
 from typing import List, Optional, Union
 
 import attr
-from py4j.java_gateway import get_field
+from py4j.java_gateway import get_field, get_method
 from pyspark import RDD, SparkContext, StorageLevel
 from pyspark.sql import SparkSession
 
@@ -50,6 +50,15 @@ class SpatialPartitioner:
             partitioner = None
 
         return cls(partitioner, jvm_partitioner)
+
+    def getGrids(self) -> List[Envelope]:
+        jvm_grids = get_method(self.jvm_partitioner, "getGrids")()
+        number_of_grids = jvm_grids.size()
+        envelopes = [
+            Envelope.from_jvm_instance(jvm_grids[index])
+            for index in range(number_of_grids)
+        ]
+        return envelopes
 
 
 @attr.s

--- a/python/sedona/core/SpatialRDD/spatial_rdd.py
+++ b/python/sedona/core/SpatialRDD/spatial_rdd.py
@@ -420,6 +420,7 @@ class SpatialRDD:
         self,
         partitioning: Union[str, GridType, SpatialPartitioner, List[Envelope]],
         num_partitions: Optional[int] = None,
+        introduce_duplicates: bool = True,
     ) -> bool:
         """
 
@@ -445,10 +446,15 @@ class SpatialRDD:
 
         self._spatial_partitioned = True
 
-        if num_partitions:
-            return self._srdd.spatialPartitioning(grid, num_partitions)
+        if introduce_duplicates:
+            method = self._srdd.spatialPartitioning
         else:
-            return self._srdd.spatialPartitioning(grid)
+            method = self._srdd.spatialPartitioningWithoutDuplicates
+
+        if num_partitions:
+            return method(grid, num_partitions)
+        else:
+            return method(grid)
 
     def set_srdd(self, srdd):
         self._srdd = srdd

--- a/python/tests/spatial_rdd/test_spatial_rdd.py
+++ b/python/tests/spatial_rdd/test_spatial_rdd.py
@@ -174,7 +174,7 @@ class TestSpatialRDD(TestBase):
         spatial_rdd = Adapter.toSpatialRdd(df, "geometry")
 
         spatial_rdd.spatialPartitioning(grids)
-        assert spatial_rdd.spatialPartitionedRDD.count() == 5
+        assert spatial_rdd.spatialPartitionedRDD.count() in (4, 5)
         assert spatial_rdd.getPartitioner().getGrids() == grids
 
         spatial_rdd.spatialPartitioning(grids, introduce_duplicates=False)

--- a/python/tests/spatial_rdd/test_spatial_rdd.py
+++ b/python/tests/spatial_rdd/test_spatial_rdd.py
@@ -177,6 +177,6 @@ class TestSpatialRDD(TestBase):
         assert spatial_rdd.spatialPartitionedRDD.count() == 5
         assert spatial_rdd.getPartitioner().getGrids() == grids
 
-        spatial_rdd.spatialPartitioning(grids, introduce_duplicates=False)
+        spatial_rdd.spatialPartitioningWithoutDuplicates(grids)
         assert spatial_rdd.spatialPartitionedRDD.count() == 1
         spatial_rdd.getPartitioner().getGrids() == grids

--- a/python/tests/spatial_rdd/test_spatial_rdd.py
+++ b/python/tests/spatial_rdd/test_spatial_rdd.py
@@ -174,7 +174,7 @@ class TestSpatialRDD(TestBase):
         spatial_rdd = Adapter.toSpatialRdd(df, "geometry")
 
         spatial_rdd.spatialPartitioning(grids)
-        assert spatial_rdd.spatialPartitionedRDD.count() in (4, 5)
+        assert spatial_rdd.spatialPartitionedRDD.count() == 5
         assert spatial_rdd.getPartitioner().getGrids() == grids
 
         spatial_rdd.spatialPartitioning(grids, introduce_duplicates=False)

--- a/python/tests/spatial_rdd/test_spatial_rdd.py
+++ b/python/tests/spatial_rdd/test_spatial_rdd.py
@@ -162,10 +162,10 @@ class TestSpatialRDD(TestBase):
 
     def test_partition_unique(self):
         grids = [
-            Envelope(0, 10, 0, 10),
-            Envelope(10, 20, 0, 10),
-            Envelope(0, 10, 10, 20),
-            Envelope(10, 20, 10, 20),
+            Envelope(0.0, 10.0, 0.0, 10.0),
+            Envelope(10.0, 20.0, 0.0, 10.0),
+            Envelope(0.0, 10.0, 10.0, 20.0),
+            Envelope(10.0, 20.0, 10.0, 20.0),
         ]
 
         df = self.spark.createDataFrame(

--- a/python/tests/sql/test_structured_adapter.py
+++ b/python/tests/sql/test_structured_adapter.py
@@ -70,7 +70,7 @@ class TestStructuredAdapter(TestBase):
 
         rdd = StructuredAdapter.toSpatialRdd(df, "geom")
         rdd.analyze()
-        rdd.spatialPartitioning(GridType.KDBTREE, num_partitions=16)
+        rdd.spatialPartitioningWithoutDuplicates(GridType.KDBTREE, num_partitions=16)
         n_spatial_partitions = rdd.spatialPartitionedRDD.getNumPartitions()
         assert n_spatial_partitions >= 16
 

--- a/python/tests/sql/test_structured_adapter.py
+++ b/python/tests/sql/test_structured_adapter.py
@@ -14,6 +14,9 @@
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
+import glob
+import tempfile
+
 from pyspark.sql import DataFrame
 
 from sedona.core.SpatialRDD import CircleRDD
@@ -58,3 +61,22 @@ class TestStructuredAdapter(TestBase):
             join_result_pair_rdd, schema, schema, self.spark
         )
         assert join_result_df.count() == 1
+
+    def test_spatial_partitioned_write(self):
+        xys = [(i, i // 100, i % 100) for i in range(1_000)]
+        df = self.spark.createDataFrame(xys, ["id", "x", "y"]).selectExpr(
+            "id", "ST_Point(x, y) AS geom"
+        )
+
+        rdd = StructuredAdapter.toSpatialRdd(df, "geom")
+        rdd.analyze()
+        rdd.spatialPartitioning(GridType.KDBTREE, num_partitions=16)
+        n_spatial_partitions = rdd.spatialPartitionedRDD.getNumPartitions()
+        assert n_spatial_partitions >= 16
+
+        partitioned_df = StructuredAdapter.toSpatialPartitionedDf(rdd, self.spark)
+
+        with tempfile.TemporaryDirectory() as td:
+            out = td + "/out"
+            partitioned_df.write.format("geoparquet").save(out)
+            assert len(glob.glob(out + "/*.parquet")) == n_spatial_partitions

--- a/spark/common/src/main/java/org/apache/sedona/core/spatialPartitioning/GenericUniquePartitioner.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/spatialPartitioning/GenericUniquePartitioner.java
@@ -20,8 +20,11 @@ package org.apache.sedona.core.spatialPartitioning;
 
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import javax.annotation.Nullable;
+import org.apache.sedona.core.enums.GridType;
 import org.apache.sedona.core.joinJudgement.DedupParams;
+import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import scala.Tuple2;
 
@@ -29,8 +32,15 @@ public class GenericUniquePartitioner extends SpatialPartitioner {
   private SpatialPartitioner parent;
 
   public GenericUniquePartitioner(SpatialPartitioner parent) {
-    super(parent.getGridType(), parent.getGrids());
     this.parent = parent;
+  }
+
+  public GridType getGridType() {
+    return parent.gridType;
+  }
+
+  public List<Envelope> getGrids() {
+    return parent.grids;
   }
 
   @Override

--- a/spark/common/src/main/java/org/apache/sedona/core/spatialPartitioning/GenericUniquePartitioner.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/spatialPartitioning/GenericUniquePartitioner.java
@@ -1,0 +1,53 @@
+package org.apache.sedona.core.spatialPartitioning;
+
+import java.util.HashSet;
+import java.util.Iterator;
+
+import javax.annotation.Nullable;
+
+import org.apache.sedona.core.joinJudgement.DedupParams;
+import org.locationtech.jts.geom.Geometry;
+
+import scala.Tuple2;
+
+class GenericUniquePartitioner extends SpatialPartitioner {
+    private SpatialPartitioner parent;
+
+    protected GenericUniquePartitioner(SpatialPartitioner parent) {
+        super(parent.getGridType(), parent.getGrids());
+        this.parent = parent;
+    }
+
+    @Override
+    public Iterator<Tuple2<Integer, Geometry>> placeObject(Geometry spatialObject) throws Exception {
+        Iterator<Tuple2<Integer, Geometry>> it = parent.placeObject(spatialObject);
+        int minParitionId = Integer.MAX_VALUE;
+        Geometry minGeometry = null;
+        while (it.hasNext()) {
+            Tuple2<Integer, Geometry> value = it.next();
+            if (value._1() < minParitionId) {
+                minParitionId = value._1();
+                minGeometry = value._2();
+            }
+        }
+
+        HashSet<Tuple2<Integer, Geometry>> out = new HashSet<Tuple2<Integer, Geometry>>();
+        if (minGeometry != null) {
+            out.add(new Tuple2<Integer, Geometry>(minParitionId, minGeometry));
+        }
+
+        return out.iterator();
+    }
+
+    @Override
+    @Nullable
+    public DedupParams getDedupParams() {
+        throw new UnsupportedOperationException("Unique partitioner cannot deduplicate join results");
+    }
+
+    @Override
+    public int numPartitions() {
+        return parent.numPartitions();
+    }
+
+}

--- a/spark/common/src/main/java/org/apache/sedona/core/spatialPartitioning/GenericUniquePartitioner.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/spatialPartitioning/GenericUniquePartitioner.java
@@ -10,10 +10,10 @@ import org.locationtech.jts.geom.Geometry;
 
 import scala.Tuple2;
 
-class GenericUniquePartitioner extends SpatialPartitioner {
+public class GenericUniquePartitioner extends SpatialPartitioner {
     private SpatialPartitioner parent;
 
-    protected GenericUniquePartitioner(SpatialPartitioner parent) {
+    public GenericUniquePartitioner(SpatialPartitioner parent) {
         super(parent.getGridType(), parent.getGrids());
         this.parent = parent;
     }

--- a/spark/common/src/main/java/org/apache/sedona/core/spatialPartitioning/GenericUniquePartitioner.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/spatialPartitioning/GenericUniquePartitioner.java
@@ -1,53 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.sedona.core.spatialPartitioning;
 
 import java.util.HashSet;
 import java.util.Iterator;
-
 import javax.annotation.Nullable;
-
 import org.apache.sedona.core.joinJudgement.DedupParams;
 import org.locationtech.jts.geom.Geometry;
-
 import scala.Tuple2;
 
 public class GenericUniquePartitioner extends SpatialPartitioner {
-    private SpatialPartitioner parent;
+  private SpatialPartitioner parent;
 
-    public GenericUniquePartitioner(SpatialPartitioner parent) {
-        super(parent.getGridType(), parent.getGrids());
-        this.parent = parent;
+  public GenericUniquePartitioner(SpatialPartitioner parent) {
+    super(parent.getGridType(), parent.getGrids());
+    this.parent = parent;
+  }
+
+  @Override
+  public Iterator<Tuple2<Integer, Geometry>> placeObject(Geometry spatialObject) throws Exception {
+    Iterator<Tuple2<Integer, Geometry>> it = parent.placeObject(spatialObject);
+    int minParitionId = Integer.MAX_VALUE;
+    Geometry minGeometry = null;
+    while (it.hasNext()) {
+      Tuple2<Integer, Geometry> value = it.next();
+      if (value._1() < minParitionId) {
+        minParitionId = value._1();
+        minGeometry = value._2();
+      }
     }
 
-    @Override
-    public Iterator<Tuple2<Integer, Geometry>> placeObject(Geometry spatialObject) throws Exception {
-        Iterator<Tuple2<Integer, Geometry>> it = parent.placeObject(spatialObject);
-        int minParitionId = Integer.MAX_VALUE;
-        Geometry minGeometry = null;
-        while (it.hasNext()) {
-            Tuple2<Integer, Geometry> value = it.next();
-            if (value._1() < minParitionId) {
-                minParitionId = value._1();
-                minGeometry = value._2();
-            }
-        }
-
-        HashSet<Tuple2<Integer, Geometry>> out = new HashSet<Tuple2<Integer, Geometry>>();
-        if (minGeometry != null) {
-            out.add(new Tuple2<Integer, Geometry>(minParitionId, minGeometry));
-        }
-
-        return out.iterator();
+    HashSet<Tuple2<Integer, Geometry>> out = new HashSet<Tuple2<Integer, Geometry>>();
+    if (minGeometry != null) {
+      out.add(new Tuple2<Integer, Geometry>(minParitionId, minGeometry));
     }
 
-    @Override
-    @Nullable
-    public DedupParams getDedupParams() {
-        throw new UnsupportedOperationException("Unique partitioner cannot deduplicate join results");
-    }
+    return out.iterator();
+  }
 
-    @Override
-    public int numPartitions() {
-        return parent.numPartitions();
-    }
+  @Override
+  @Nullable
+  public DedupParams getDedupParams() {
+    throw new UnsupportedOperationException("Unique partitioner cannot deduplicate join results");
+  }
 
+  @Override
+  public int numPartitions() {
+    return parent.numPartitions();
+  }
 }

--- a/spark/common/src/main/java/org/apache/sedona/core/spatialPartitioning/GenericUniquePartitioner.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/spatialPartitioning/GenericUniquePartitioner.java
@@ -45,6 +45,9 @@ public class GenericUniquePartitioner extends SpatialPartitioner {
 
   @Override
   public Iterator<Tuple2<Integer, Geometry>> placeObject(Geometry spatialObject) throws Exception {
+    // Rather than take the first result from the parent, consume the entire iterator
+    // and return the partition with the minimum ID. This ensures that given the same
+    // (parent) partitioner, the output partitions from this method will be consistent.
     Iterator<Tuple2<Integer, Geometry>> it = parent.placeObject(spatialObject);
     int minParitionId = Integer.MAX_VALUE;
     Geometry minGeometry = null;

--- a/spark/common/src/main/java/org/apache/sedona/core/spatialPartitioning/IndexedGridPartitioner.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/spatialPartitioning/IndexedGridPartitioner.java
@@ -48,7 +48,7 @@ public class IndexedGridPartitioner extends FlatGridPartitioner {
   }
 
   public IndexedGridPartitioner(GridType gridType, List<Envelope> grids) {
-    this(gridType, grids, false);
+    this(gridType, grids, true);
   }
 
   public IndexedGridPartitioner(List<Envelope> grids, Boolean preserveUncontainedGeometries) {

--- a/spark/common/src/main/java/org/apache/sedona/core/spatialPartitioning/SpatialPartitioner.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/spatialPartitioning/SpatialPartitioner.java
@@ -35,6 +35,11 @@ public abstract class SpatialPartitioner extends Partitioner implements Serializ
   protected final GridType gridType;
   protected final List<Envelope> grids;
 
+  protected SpatialPartitioner() {
+    gridType = null;
+    grids = null;
+  }
+
   protected SpatialPartitioner(GridType gridType, List<Envelope> grids) {
     this.gridType = gridType;
     this.grids = Objects.requireNonNull(grids, "grids");

--- a/spark/common/src/main/java/org/apache/sedona/core/spatialRDD/SpatialRDD.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/spatialRDD/SpatialRDD.java
@@ -168,6 +168,16 @@ public class SpatialRDD<T extends Geometry> implements Serializable {
     return true;
   }
 
+  /**
+   * Calculate non-duplicate inducing partitioning
+   *
+   * Note that non-duplicating partitioners are intended for use by distributed
+   * partitioned writers and not able to be used for spatial joins.
+   *
+   * @param gridType The target GridType
+   * @param numPartitions The target number of partitions
+   * @throws Exception
+   */
   public void spatialPartitioningWithoutDuplicates(GridType gridType, int numPartitions)
       throws Exception {
     calc_partitioner(gridType, numPartitions);
@@ -175,12 +185,36 @@ public class SpatialRDD<T extends Geometry> implements Serializable {
     this.spatialPartitionedRDD = partition(partitioner);
   }
 
+  /**
+   * Calculate non-duplicate inducing partitioning from an existing SpatialPartitioner
+   *
+   * Note that non-duplicating partitioners are intended for use by distributed
+   * partitioned writers and not able to be used for spatial joins.
+   *
+   * @param partitioner An existing partitioner obtained from the partitioning
+   *   of another SpatialRDD.
+   * @throws Exception
+   */
   public void spatialPartitioningWithoutDuplicates(SpatialPartitioner partitioner) {
     partitioner = new GenericUniquePartitioner(partitioner);
     this.spatialPartitionedRDD = partition(partitioner);
   }
 
-  /** @deprecated Use spatialPartitioningWithoutDuplicates(SpatialPartitioner partitioner) */
+  /**
+   * Calculate non-duplicate inducing partitioning based on a list of existing envelopes
+   *
+   * This is shorthand for spatialPartitioningWithoutDuplicates(new IndexedGridPartitioner()).
+   * Using spatialPartitioningWithoutDuplicates(gridType, numPartitions) is typically more
+   * appropriate because it is able to adapt to the content of the partition and is able
+   * to produce more consistently balanced partitions.
+   *
+   * Note that non-duplicating partitioners are intended for use by distributed
+   * partitioned writers and not able to be used for spatial joins.
+   *
+   * @param otherGrids A list of existing envelopes
+   * @return true on success
+   * @throws Exception
+   */
   public boolean spatialPartitioningWithoutDuplicates(final List<Envelope> otherGrids)
       throws Exception {
     this.partitioner = new GenericUniquePartitioner(new IndexedGridPartitioner(otherGrids));
@@ -192,7 +226,7 @@ public class SpatialRDD<T extends Geometry> implements Serializable {
    * Spatial partitioning.
    *
    * @param gridType the grid type
-   * @return true, if successful
+   * @param numPartitions the target number of partitions
    * @throws Exception the exception
    */
   public void calc_partitioner(GridType gridType, int numPartitions) throws Exception {

--- a/spark/common/src/main/java/org/apache/sedona/core/spatialRDD/SpatialRDD.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/spatialRDD/SpatialRDD.java
@@ -168,7 +168,8 @@ public class SpatialRDD<T extends Geometry> implements Serializable {
     return true;
   }
 
-  public void spatialPartitioningWithoutDuplicates(GridType gridType, int numPartitions) throws Exception {
+  public void spatialPartitioningWithoutDuplicates(GridType gridType, int numPartitions)
+      throws Exception {
     calc_partitioner(gridType, numPartitions);
     partitioner = new GenericUniquePartitioner(partitioner);
     this.spatialPartitionedRDD = partition(partitioner);

--- a/spark/common/src/main/java/org/apache/sedona/core/spatialRDD/SpatialRDD.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/spatialRDD/SpatialRDD.java
@@ -171,8 +171,8 @@ public class SpatialRDD<T extends Geometry> implements Serializable {
   /**
    * Calculate non-duplicate inducing partitioning
    *
-   * Note that non-duplicating partitioners are intended for use by distributed
-   * partitioned writers and not able to be used for spatial joins.
+   * <p>Note that non-duplicating partitioners are intended for use by distributed partitioned
+   * writers and not able to be used for spatial joins.
    *
    * @param gridType The target GridType
    * @param numPartitions The target number of partitions
@@ -188,11 +188,11 @@ public class SpatialRDD<T extends Geometry> implements Serializable {
   /**
    * Calculate non-duplicate inducing partitioning from an existing SpatialPartitioner
    *
-   * Note that non-duplicating partitioners are intended for use by distributed
-   * partitioned writers and not able to be used for spatial joins.
+   * <p>Note that non-duplicating partitioners are intended for use by distributed partitioned
+   * writers and not able to be used for spatial joins.
    *
-   * @param partitioner An existing partitioner obtained from the partitioning
-   *   of another SpatialRDD.
+   * @param partitioner An existing partitioner obtained from the partitioning of another
+   *     SpatialRDD.
    * @throws Exception
    */
   public void spatialPartitioningWithoutDuplicates(SpatialPartitioner partitioner) {
@@ -203,13 +203,13 @@ public class SpatialRDD<T extends Geometry> implements Serializable {
   /**
    * Calculate non-duplicate inducing partitioning based on a list of existing envelopes
    *
-   * This is shorthand for spatialPartitioningWithoutDuplicates(new IndexedGridPartitioner()).
+   * <p>This is shorthand for spatialPartitioningWithoutDuplicates(new IndexedGridPartitioner()).
    * Using spatialPartitioningWithoutDuplicates(gridType, numPartitions) is typically more
-   * appropriate because it is able to adapt to the content of the partition and is able
-   * to produce more consistently balanced partitions.
+   * appropriate because it is able to adapt to the content of the partition and is able to produce
+   * more consistently balanced partitions.
    *
-   * Note that non-duplicating partitioners are intended for use by distributed
-   * partitioned writers and not able to be used for spatial joins.
+   * <p>Note that non-duplicating partitioners are intended for use by distributed partitioned
+   * writers and not able to be used for spatial joins.
    *
    * @param otherGrids A list of existing envelopes
    * @return true on success

--- a/spark/common/src/main/java/org/apache/sedona/core/spatialRDD/SpatialRDD.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/spatialRDD/SpatialRDD.java
@@ -162,6 +162,23 @@ public class SpatialRDD<T extends Geometry> implements Serializable {
     return true;
   }
 
+  public boolean spatialParitioningWithoutDuplicates(GridType gridType) throws Exception {
+    int numPartitions = this.rawSpatialRDD.rdd().partitions().length;
+    spatialPartitioningWithoutDuplicates(gridType, numPartitions);
+    return true;
+  }
+
+  public void spatialPartitioningWithoutDuplicates(GridType gridType, int numPartitions) throws Exception {
+    calc_partitioner(gridType, numPartitions);
+    partitioner = new GenericUniquePartitioner(partitioner);
+    this.spatialPartitionedRDD = partition(partitioner);
+  }
+
+  public void spatialPartitioningWithoutDuplicates(SpatialPartitioner partitioner) {
+    partitioner = new GenericUniquePartitioner(partitioner);
+    this.spatialPartitionedRDD = partition(partitioner);
+  }
+
   /**
    * Spatial partitioning.
    *

--- a/spark/common/src/main/java/org/apache/sedona/core/spatialRDD/SpatialRDD.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/spatialRDD/SpatialRDD.java
@@ -180,6 +180,14 @@ public class SpatialRDD<T extends Geometry> implements Serializable {
     this.spatialPartitionedRDD = partition(partitioner);
   }
 
+  /** @deprecated Use spatialPartitioningWithoutDuplicates(SpatialPartitioner partitioner) */
+  public boolean spatialPartitioningWithoutDuplicates(final List<Envelope> otherGrids)
+      throws Exception {
+    this.partitioner = new GenericUniquePartitioner(new IndexedGridPartitioner(otherGrids));
+    this.spatialPartitionedRDD = partition(partitioner);
+    return true;
+  }
+
   /**
    * Spatial partitioning.
    *
@@ -299,7 +307,7 @@ public class SpatialRDD<T extends Geometry> implements Serializable {
 
   /** @deprecated Use spatialPartitioning(SpatialPartitioner partitioner) */
   public boolean spatialPartitioning(final List<Envelope> otherGrids) throws Exception {
-    this.partitioner = new FlatGridPartitioner(otherGrids);
+    this.partitioner = new IndexedGridPartitioner(otherGrids);
     this.spatialPartitionedRDD = partition(partitioner);
     return true;
   }

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/adapters/StructuredAdapter.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/adapters/StructuredAdapter.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.types.{DataType, StructType}
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import org.locationtech.jts.geom.Geometry
 import org.slf4j.{Logger, LoggerFactory}
+import org.apache.sedona.core.spatialPartitioning.GenericUniquePartitioner
 
 /**
  * Adapter for converting between DataFrame and SpatialRDD. It provides methods to convert
@@ -143,8 +144,11 @@ object StructuredAdapter {
     if (spatialRDD.spatialPartitionedRDD == null)
       throw new RuntimeException(
         "SpatialRDD is not spatially partitioned. Please call spatialPartitioning method before calling this method.")
-    logger.warn(
-      "SpatialPartitionedRDD might have duplicate geometries. Please make sure you are aware of it.")
+
+    if (!spatialRDD.getPartitioner().isInstanceOf[GenericUniquePartitioner]) {
+      logger.warn(
+        "SpatialPartitionedRDD might have duplicate geometries. Please make sure you are aware of it.")
+    }
     val rowRdd = spatialRDD.spatialPartitionedRDD.map(geometry => {
       val row = geometry.getUserData.asInstanceOf[InternalRow]
       row

--- a/spark/common/src/test/java/org/apache/sedona/core/spatialPartitioning/GenericUniquePartitionerTest.java
+++ b/spark/common/src/test/java/org/apache/sedona/core/spatialPartitioning/GenericUniquePartitionerTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.core.spatialPartitioning;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import org.apache.commons.collections.IteratorUtils;
+import org.junit.Test;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import scala.Tuple2;
+
+public class GenericUniquePartitionerTest {
+  private final GeometryFactory factory = new GeometryFactory();
+
+  @Test
+  public void testUniquePartition() throws Exception {
+    ArrayList<Envelope> grids = new ArrayList<Envelope>();
+    grids.add(new Envelope(0, 10, 0, 10));
+    grids.add(new Envelope(10, 20, 0, 10));
+    grids.add(new Envelope(0, 10, 10, 20));
+    grids.add(new Envelope(10, 20, 10, 20));
+
+    FlatGridPartitioner partitioner = new FlatGridPartitioner(grids);
+    GenericUniquePartitioner uniquePartitioner = new GenericUniquePartitioner(partitioner);
+
+    assertEquals(partitioner.getGridType(), uniquePartitioner.getGridType());
+    assertEquals(partitioner.getGrids(), uniquePartitioner.getGrids());
+
+    Envelope definitelyHasMultiplePartitions = new Envelope(5, 15, 5, 15);
+
+    Iterator<Tuple2<Integer, Geometry>> placedWithDuplicates =
+        partitioner.placeObject(factory.toGeometry(definitelyHasMultiplePartitions));
+    // Because the geometry is not completely contained by any of the partitions,
+    // it also gets placed in the overflow partition (hence 5, not 4)
+    assertEquals(5, IteratorUtils.toList(placedWithDuplicates).size());
+
+    Iterator<Tuple2<Integer, Geometry>> placedWithoutDuplicates =
+        uniquePartitioner.placeObject(factory.toGeometry(definitelyHasMultiplePartitions));
+    assertEquals(1, IteratorUtils.toList(placedWithoutDuplicates).size());
+  }
+}

--- a/spark/common/src/test/resources/.gitignore
+++ b/spark/common/src/test/resources/.gitignore
@@ -1,2 +1,3 @@
 *.DS_Store
 real-*
+wkb/testSaveAs*


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-705. The PR name follows the format `[SEDONA-705] my subject`.


## What changes were proposed in this PR?

After SEDONA-695 (https://github.com/apache/sedona/pull/1751), we will have the ability to do partitioned writes! To be useful in most contexts, we also need the ability to create those partitions assigning a unique partition to each feature (i.e., don't introduce duplicates).

- Added a set of `spatialPartitioningWithoutDuplicates()` functions to match `spatialPartitioning()`
- Added a `GenericUniqueSpatialPartitioner` that wraps an existing partitioner producing a (deterministic) single result on `placeObject()`.
- Wired up the functions to Python

## How was this patch tested?

Tests were added in Java and Python.

## Did this PR include necessary documentation updates?

- New API, will add once the approach is validated in principle!
