### PR TITLE
[SEDONA-706] Fix Python dataframe api for multi-threaded environment

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -163,13 +163,9 @@ jobs:
       - name: Run Spark Connect tests
         env:
           PYTHON_VERSION: ${{ matrix.python }}
+          SPARK_VERSION: ${{ matrix.spark }}
+        if: ${{ matrix.spark >= '3.4.0' }}
         run: |
-          if [ ! -f "${VENV_PATH}/lib/python${PYTHON_VERSION}/site-packages/pyspark/sbin/start-connect-server.sh" ]
-          then
-            echo "Skipping connect tests for Spark $SPARK_VERSION"
-            exit
-          fi
-
           export SPARK_HOME=${VENV_PATH}/lib/python${PYTHON_VERSION}/site-packages/pyspark
           export SPARK_REMOTE=local
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-706. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

* Fixes https://github.com/apache/sedona/issues/1771
* Make Spark Connect tests run on GitHub Actions. They were skipped for all Spark versions before, this patch enables the tests for Spark 3.4 and 3.5.

## How was this patch tested?

* Add a new multi threaded test that would fail without this patch
* Passing CI

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
