### PR TITLE
[CI] pre-commit: auto add license headers to `.c` and `.h` files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,15 @@ repos:
     rev: v1.5.5
     hooks:
       - id: insert-license
+        name: add license for all .c and .h files
+        files: \.(c|h)$
+        args:
+          - --comment-style
+          - "/*|*|*/"
+          - --license-filepath
+          - .github/workflows/license-templates/LICENSE.txt
+          - --fuzzy-match-generates-todo
+      - id: insert-license
         name: add license for all Markdown files
         files: \.md$
         args:


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- No this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

Adds another hook that will auto add license headers to files on git commit for `.c` and `.h` files.

We already had the correct license headers in all `.c` and `.h` files so this is just adding a check/test.

This should enforce standards and stop regressions.

## How was this patch tested?

Ran pre-commit.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
