### PR TITLE
.asf.yaml: remove committer jbampton from collaborators

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -27,7 +27,6 @@ github:
     homepage: https://sedona.apache.org/
     collaborators:
         - MrPowers
-        - jbampton
     autolink_jira:
         - SEDONA
     labels:


### PR DESCRIPTION
https://github.com/apache/infrastructure-asfyaml?tab=readme-ov-file#assigning-the-github-triage-role-to-external-collaborators

"Projects may assign external (non-committer) collaborators the triage role for their repository."

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- No

## What changes were proposed in this PR?

Cleans up the outside collaborators list.

refs #1803 

## How was this patch tested?

Committers already have write access and can triage issues and PRs.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
