### PR TITLE
[CI] pre-commit: auto add license check for Java files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,15 @@ repos:
           - .github/workflows/license-templates/LICENSE.txt
           - --fuzzy-match-generates-todo
       - id: insert-license
+        name: add license for all Java files
+        files: \.java$
+        args:
+          - --comment-style
+          - "/*|*|*/"
+          - --license-filepath
+          - .github/workflows/license-templates/LICENSE.txt
+          - --fuzzy-match-generates-todo
+      - id: insert-license
         name: add license for all Markdown files
         files: \.md$
         args:


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- No this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

Added another check/hook/test to our pre-commit framework.  This hook will auto add a license header to Java files on git commit if they are missing the license.  So far all Java files seem to have the correct license so this is just a check to stop regressions and keep the code base standardized.  Small piece of automation to auto add missing license headers.

## How was this patch tested?

Added the license hook and then ran pre-commit for all files.  No Java files were modified.  I did test by changing / modifying a Java license and it did fail the hook test locally for that file. 

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
