### PR TITLE
[SEDONA-716] Change the spark parser order to use delegate parser first

### DIFF
--- a/spark/spark-3.3/src/main/scala/org/apache/sedona/sql/parser/SedonaSqlParser.scala
+++ b/spark/spark-3.3/src/main/scala/org/apache/sedona/sql/parser/SedonaSqlParser.scala
@@ -28,17 +28,22 @@ class SedonaSqlParser(delegate: ParserInterface) extends SparkSqlParser {
   val parserBuilder = new SedonaSqlAstBuilder
 
   /**
-   * Parse the SQL text and return the logical plan.
+   * Parse the SQL text and return the logical plan. This method first attempts to use the
+   * delegate parser to parse the SQL text. If the delegate parser fails (throws an exception), it
+   * falls back to using the Sedona SQL parser.
+   *
    * @param sqlText
+   *   The SQL text to be parsed.
    * @return
+   *   The parsed logical plan.
    */
   override def parsePlan(sqlText: String): LogicalPlan =
     try {
-      parse(sqlText) { parser =>
-        parserBuilder.visit(parser.singleStatement())
-      }.asInstanceOf[LogicalPlan]
+      delegate.parsePlan(sqlText)
     } catch {
       case _: Exception =>
-        delegate.parsePlan(sqlText)
+        parse(sqlText) { parser =>
+          parserBuilder.visit(parser.singleStatement())
+        }.asInstanceOf[LogicalPlan]
     }
 }

--- a/spark/spark-3.4/src/main/scala/org/apache/sedona/sql/parser/SedonaSqlParser.scala
+++ b/spark/spark-3.4/src/main/scala/org/apache/sedona/sql/parser/SedonaSqlParser.scala
@@ -28,17 +28,22 @@ class SedonaSqlParser(delegate: ParserInterface) extends SparkSqlParser {
   val parserBuilder = new SedonaSqlAstBuilder
 
   /**
-   * Parse the SQL text and return the logical plan.
+   * Parse the SQL text and return the logical plan. This method first attempts to use the
+   * delegate parser to parse the SQL text. If the delegate parser fails (throws an exception), it
+   * falls back to using the Sedona SQL parser.
+   *
    * @param sqlText
+   *   The SQL text to be parsed.
    * @return
+   *   The parsed logical plan.
    */
   override def parsePlan(sqlText: String): LogicalPlan =
     try {
-      parse(sqlText) { parser =>
-        parserBuilder.visit(parser.singleStatement())
-      }.asInstanceOf[LogicalPlan]
+      delegate.parsePlan(sqlText)
     } catch {
       case _: Exception =>
-        delegate.parsePlan(sqlText)
+        parse(sqlText) { parser =>
+          parserBuilder.visit(parser.singleStatement())
+        }.asInstanceOf[LogicalPlan]
     }
 }

--- a/spark/spark-3.5/src/main/scala/org/apache/sedona/sql/parser/SedonaSqlParser.scala
+++ b/spark/spark-3.5/src/main/scala/org/apache/sedona/sql/parser/SedonaSqlParser.scala
@@ -28,17 +28,22 @@ class SedonaSqlParser(delegate: ParserInterface) extends SparkSqlParser {
   val parserBuilder = new SedonaSqlAstBuilder
 
   /**
-   * Parse the SQL text and return the logical plan.
+   * Parse the SQL text and return the logical plan. This method first attempts to use the
+   * delegate parser to parse the SQL text. If the delegate parser fails (throws an exception), it
+   * falls back to using the Sedona SQL parser.
+   *
    * @param sqlText
+   *   The SQL text to be parsed.
    * @return
+   *   The parsed logical plan.
    */
   override def parsePlan(sqlText: String): LogicalPlan =
     try {
-      parse(sqlText) { parser =>
-        parserBuilder.visit(parser.singleStatement())
-      }.asInstanceOf[LogicalPlan]
+      delegate.parsePlan(sqlText)
     } catch {
       case _: Exception =>
-        delegate.parsePlan(sqlText)
+        parse(sqlText) { parser =>
+          parserBuilder.visit(parser.singleStatement())
+        }.asInstanceOf[LogicalPlan]
     }
 }


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-XXX. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?
This PR change the spark parser order to use delegate parser first. 

## How was this patch tested?
unit tests all pass

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
