### PR TITLE
[SEDONA-717] Fix `dataframe_to_arrow()` for zero-row results

### DIFF
--- a/python/sedona/utils/geoarrow.py
+++ b/python/sedona/utils/geoarrow.py
@@ -71,9 +71,9 @@ def dataframe_to_arrow(df, crs=None):
         # Using the extension type ensures that the type and its metadata will
         # propagate through all pyarrow transformations.
         import geoarrow.types as gat
-        from geoarrow.types.type_pyarrow import register_extension_types
 
-        register_extension_types()
+        try_register_extension_types()
+
         spec = gat.wkb()
 
         new_cols = [
@@ -117,7 +117,16 @@ def dataframe_to_arrow_raw(df):
 
     self_destruct = jconf.arrowPySparkSelfDestructEnabled()
     batches = df._collect_as_arrow(split_batches=self_destruct)
+
+    # The zero row case can use from_batches() with schema (nothing to cast)
+    if not batches:
+        return pa.Table.from_batches([], schema)
+
+    # When batches were returned, use cast(schema). This was backported from
+    # Spark, where presumably there is a good reason that the schemas of batches
+    # may not necessarily align with that of schema (thus a cast is required)
     table = pa.Table.from_batches(batches).cast(schema)
+
     # Ensure only the table has a reference to the batches, so that
     # self_destruct (if enabled) is effective
     del batches
@@ -159,6 +168,21 @@ def crs_to_json(crs):
         import pyproj
 
         return pyproj.CRS(crs).to_json()
+
+
+def try_register_extension_types():
+    """Try to register extension types using geoarrow-types
+
+    Do this defensively, because it can fail if the extension type was
+    registered in some other way (notably: old versions of geoarrow-pyarrow,
+    which is apparently a recursive dependency of Kepler).
+    """
+    from geoarrow.types.type_pyarrow import register_extension_types
+
+    try:
+        register_extension_types()
+    except:
+        pass
 
 
 def unique_srid_from_ewkb(obj):

--- a/python/sedona/utils/geoarrow.py
+++ b/python/sedona/utils/geoarrow.py
@@ -175,7 +175,7 @@ def try_register_extension_types():
 
     Do this defensively, because it can fail if the extension type was
     registered in some other way (notably: old versions of geoarrow-pyarrow,
-    which is apparently a recursive dependency of Kepler).
+    which is a dependency of Kepler).
     """
     from geoarrow.types.type_pyarrow import register_extension_types
 

--- a/python/sedona/utils/geoarrow.py
+++ b/python/sedona/utils/geoarrow.py
@@ -181,7 +181,7 @@ def try_register_extension_types():
 
     try:
         register_extension_types()
-    except:
+    except RuntimeError:
         pass
 
 

--- a/python/tests/utils/test_geoarrow.py
+++ b/python/tests/utils/test_geoarrow.py
@@ -37,6 +37,12 @@ class TestGeoArrow(TestBase):
         wkt_table = dataframe_to_arrow(wkt_df)
         assert wkt_table == pa.table({"wkt": TEST_WKT})
 
+    def test_to_geoarrow_zero_rows(self):
+        schema = StructType().add("wkt", StringType())
+        wkt_df = TestGeoArrow.spark.createDataFrame(zip(TEST_WKT), schema).limit(0)
+        wkt_table = dataframe_to_arrow(wkt_df)
+        assert wkt_table == pa.table({"wkt": pa.array([], pa.utf8())})
+
     def test_to_geoarrow_with_geometry(self):
         schema = StructType().add("wkt", StringType())
         wkt_df = TestGeoArrow.spark.createDataFrame(zip(TEST_WKT), schema)


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-717. The PR name follows the format `[SEDONA-717] my subject`.

Closes #1815

## What changes were proposed in this PR?

This PR makes some minor updates to ensure that Arrow collection does not fail for empty results (which can be confusing when, for example, maps are created).

I investigated two other things I have noticed recently involving failed Kepler map renders, but I don't think they are specifically related to Arrow conversion.

- I have noticed a failure `Can't clean for JSON: Decimal('123')`, which I think started to occur because we return decimals from the new shapefile reader (which is where I first discovered the error)
- When rendering the Overature buildings layer, we get an error when the widgets layer tries to serialize the `names` column (`MapType(StringType(), ArrayType(MapType(StringType(), StringType())))`). I think this error started to appear because these names were perhaps more common or more available in one of the last two overature releases.

## How was this patch tested?

A test was added to test_geoarrow.py

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
