### PR TITLE
[SEDONA-718] Auto Detect geometry column in GeoJSON writer

### DIFF
--- a/docs/tutorial/files/geojson-sedona-spark.md
+++ b/docs/tutorial/files/geojson-sedona-spark.md
@@ -190,7 +190,16 @@ a_thing/
 
 Sedona writes multiple GeoJSON files in parallel, which is faster than writing a single file.
 
-Note that the DataFrame must contain a column named geometry for the write operation to work.
+Note that the DataFrame must contain at least one column with geometry type for the write operation to work. Sedona will use the following rules to determine which column to use as the geometry:
+
+1. If there's a column named "geometry" with geometry type, Sedona will use this column
+2. Otherwise, Sedona will use the first geometry column found in the root schema
+
+You can also manually specify which geometry column to use with the "geometry.column" option:
+
+```python
+df.write.format("geojson").option("geometry.column", "geometry").save("/tmp/a_thing")
+```
 
 Now let’s read these GeoJSON files into a DataFrame:
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-718. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Currently, the GeoJSON writer will only use the column named "geometry" as the geometry field of the GeoJSON, users have to use `.option("geometry.column", "geom")` to specify other geometry columns. This is very common where a DataFrame contains only `geom` field but not `geometry` field, and we want to support writing such DataFrames as GeoJSON out of box.

We want to make the GeoJSON writer a bit smarter by automatically detecting columns with geometry types when the column named "geometry" does not present, or does not have geometry type:

1. If there's a column named "geometry" with geometry type, Sedona will use this column
2. Otherwise, Sedona will use the first geometry column found in the root schema

## How was this patch tested?

Added new tests for the geometry column selection behavior.

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.
