### PR TITLE
[SEDONA-704] Fix STC reader option issues and add retry logic

### DIFF
--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacBatch.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacBatch.scala
@@ -48,7 +48,11 @@ case class StacBatch(
     temporalFilter: Option[TemporalFilter])
     extends Batch {
 
-  private val defaultItemsLimitPerRequest = opts.getOrElse("itemsLimitPerRequest", "10").toInt
+  private val defaultItemsLimitPerRequest: Int = {
+    val itemsLimitMax = opts.getOrElse("itemsLimitMax", "-1").toInt
+    val limitPerRequest = opts.getOrElse("itemsLimitPerRequest", "10").toInt
+    if (itemsLimitMax > 0 && limitPerRequest > itemsLimitMax) itemsLimitMax else limitPerRequest
+  }
   private val itemsLoadProcessReportThreshold =
     opts.getOrElse("itemsLoadProcessReportThreshold", "1000000").toInt
   private var itemMaxLeft: Int = -1


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-XXX. The PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?
- Fix STAC reader option issues when itemsLimitMax is less than the itemsLimitPerRequest
- Add retry logic to the partition reader

## How was this patch tested?
unt tests under stac package

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
