### PR TITLE
[WIP] Stream GeoArrow by batch from the driver

### DIFF
--- a/python/sedona/utils/geoarrow.py
+++ b/python/sedona/utils/geoarrow.py
@@ -161,7 +161,7 @@ def project_dataframe_geoarrow(df, col_is_geometry):
     return df.select(*df_columns)
 
 
-def raw_schema_to_geoarrow_schema(raw_schema, col_is_geometry, crs):
+def raw_schema_to_geoarrow_schema(raw_schema, col_is_geometry, crs, columns=None):
     import pyarrow as pa
 
     try:
@@ -171,9 +171,12 @@ def raw_schema_to_geoarrow_schema(raw_schema, col_is_geometry, crs):
     except ImportError:
         spec = None
 
+    if columns is None:
+        columns = [None] * len(col_is_geometry)
+
     new_fields = [
         (
-            wrap_geoarrow_field(raw_schema.field(i), None, crs, spec)
+            wrap_geoarrow_field(raw_schema.field(i), columns[i], crs, spec)
             if is_geom
             else raw_schema.field(i)
         )
@@ -206,7 +209,7 @@ def wrap_table_or_batch(table_or_batch, col_is_geometry, crs):
         # of operations (e.g., writing this table to a file or passing it to
         # DuckDB as long as no intermediate transformations were applied).
         schema = raw_schema_to_geoarrow_schema(
-            table_or_batch.schema, col_is_geometry, crs
+            table_or_batch.schema, col_is_geometry, crs, table_or_batch.columns
         )
         return table_or_batch.from_arrays(table_or_batch.columns, schema=schema)
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

(Not yet!)

- Yes, and the PR name follows the format `[SEDONA-XXX] my subject`.
- Yes, and the PR name follows the format `[GH-XXX] my subject`.

- No:
  - this is a documentation update. The PR name follows the format `[DOCS] my subject`
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

This PR implements a batch-by-batch reader (as opposed to a complete whole-table reader. For large results this might help increase the size of result that can be handled, although I think that no matter how it happens the whole result has to be collected in the JVM.

Still working on the details!

## How was this patch tested?

Tests forthcoming!

## Did this PR include necessary documentation updates?

- Yes, I am adding a new API. I am using the [current SNAPSHOT version number](https://github.com/apache/sedona/blob/99239524f17389fc4ae9548ea88756f8ea538bb9/pom.xml#L29) in `vX.Y.Z` format.
- Yes, I have updated the documentation.
- No, this PR does not affect any public API so no need to change the documentation.

Reprex:

```python
from sedona.spark import SedonaContext

config = (
    SedonaContext.builder()
    .config(
        "spark.jars",
        "spark-shaded/target/sedona-spark-shaded-3.5_2.12-1.7.1-SNAPSHOT.jar",
    )
    .config("spark.executor.memory", "6G")
    .config("spark.driver.memory", "6G")
    .getOrCreate()
)

sedona = SedonaContext.create(config)

from sedona.utils.geoarrow import GeoArrowDataFrameReader, dataframe_to_arrow

df = sedona.read.format("geoparquet").load(
    "/Users/dewey/gh/geoarrow-data/microsoft-buildings/files/microsoft-buildings_point_geo.parquet"
).limit(100_000)

reader = GeoArrowDataFrameReader(df)
print(reader.schema)
#> geometry: extension<geoarrow.wkb<WkbType>>
for batch in reader:
    print(".", end="")
print()
print(batch)
#> pyarrow.RecordBatch
#> geometry: extension<geoarrow.wkb<WkbType>>
#> ----
#> geometry: [01...
print(reader.batch_order)
#> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
```




