### PR TITLE
[SEDONA-722] Fix precision loss problems caused by casting world coordinates from double to float

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/utils/RasterUtils.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/RasterUtils.java
@@ -45,7 +45,6 @@ import org.geotools.coverage.Category;
 import org.geotools.coverage.CoverageFactoryFinder;
 import org.geotools.coverage.GridSampleDimension;
 import org.geotools.coverage.TypeMap;
-import org.geotools.coverage.grid.GridCoordinates2D;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.coverage.grid.GridCoverageFactory;
 import org.geotools.coverage.grid.GridEnvelope2D;
@@ -467,10 +466,11 @@ public class RasterUtils {
 
   public static Point2D getWorldCornerCoordinates(GridCoverage2D raster, int colX, int rowY)
       throws TransformException {
+    Point2D.Double gridCoord = new DirectPosition2D(colX - 1, rowY - 1);
     return raster
         .getGridGeometry()
         .getGridToCRS2D(PixelOrientation.UPPER_LEFT)
-        .transform(new GridCoordinates2D(colX - 1, rowY - 1), null);
+        .transform(gridCoord, null);
   }
 
   /**
@@ -488,7 +488,7 @@ public class RasterUtils {
   public static Point2D getWorldCornerCoordinatesWithRangeCheck(
       GridCoverage2D raster, int colX, int rowY)
       throws IndexOutOfBoundsException, TransformException {
-    GridCoordinates2D gridCoordinates2D = new GridCoordinates2D(colX - 1, rowY - 1);
+    Point2D.Double gridCoordinates2D = new DirectPosition2D(colX - 1, rowY - 1);
     if (!(raster.getGridGeometry().getGridRange2D().contains(gridCoordinates2D)))
       throw new IndexOutOfBoundsException(
           String.format(

--- a/common/src/test/java/org/apache/sedona/common/raster/FunctionsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/FunctionsTest.java
@@ -149,7 +149,7 @@ public class FunctionsTest extends RasterTestBase {
     List<PixelRecord> points = PixelFunctions.getPixelAsPolygons(emptyRaster, 1);
 
     PixelRecord point = points.get(11);
-    Geometry geom = (Geometry) point.geom;
+    Geometry geom = point.geom;
     String expected = "POLYGON ((131 -246, 139 -246, 139 -254, 131 -254, 131 -246))";
     assertEquals(expected, geom.toString());
 
@@ -157,7 +157,7 @@ public class FunctionsTest extends RasterTestBase {
     emptyRaster = RasterConstructors.makeEmptyRaster(1, 5, 10, 234, -43, 3, 4, 2, 3, 0);
     points = PixelFunctions.getPixelAsPolygons(emptyRaster, 1);
     point = points.get(11);
-    geom = (Geometry) point.geom;
+    geom = point.geom;
     expected = "POLYGON ((241 -32, 244 -29, 246 -25, 243 -28, 241 -32))";
     assertEquals(expected, geom.toString());
   }
@@ -284,13 +284,13 @@ public class FunctionsTest extends RasterTestBase {
     List<PixelRecord> points = PixelFunctions.getPixelAsPoints(emptyRaster, 1);
 
     PixelRecord point1 = points.get(0);
-    Geometry geom1 = (Geometry) point1.geom;
+    Geometry geom1 = point1.geom;
     assertEquals(123, geom1.getCoordinate().x, FP_TOLERANCE);
     assertEquals(-230, geom1.getCoordinate().y, FP_TOLERANCE);
     assertEquals(0.0, point1.value, FP_TOLERANCE);
 
     PixelRecord point2 = points.get(22);
-    Geometry geom2 = (Geometry) point2.geom;
+    Geometry geom2 = point2.geom;
     assertEquals(139, geom2.getCoordinate().x, FP_TOLERANCE);
     assertEquals(-262, geom2.getCoordinate().y, FP_TOLERANCE);
     assertEquals(0.0, point2.value, FP_TOLERANCE);
@@ -303,7 +303,7 @@ public class FunctionsTest extends RasterTestBase {
         RasterConstructors.makeEmptyRaster(1, 5, 5, -123, 54, 5, 5, 0, 0, srid);
     List<PixelRecord> points = PixelFunctions.getPixelAsPoints(emptyRaster, 1);
     PixelRecord point1 = points.get(0);
-    Geometry geom1 = (Geometry) point1.geom;
+    Geometry geom1 = point1.geom;
     assertEquals(-123, geom1.getCoordinate().x, FP_TOLERANCE);
     assertEquals(54, geom1.getCoordinate().y, FP_TOLERANCE);
     assertEquals(srid, geom1.getSRID());
@@ -317,7 +317,7 @@ public class FunctionsTest extends RasterTestBase {
     List<PixelRecord> points = PixelFunctions.getPixelAsPoints(emptyRaster, 1);
 
     PixelRecord point1 = points.get(11);
-    Geometry geom1 = (Geometry) point1.geom;
+    Geometry geom1 = point1.geom;
     assertEquals(-118, geom1.getCoordinate().x, FP_TOLERANCE);
     assertEquals(34, geom1.getCoordinate().y, FP_TOLERANCE);
     assertEquals(srid, geom1.getSRID());
@@ -329,10 +329,10 @@ public class FunctionsTest extends RasterTestBase {
     GridCoverage2D raster = rasterFromGeoTiff(resourceFolder + "raster/test1.tiff");
     List<PixelRecord> points = PixelFunctions.getPixelAsPoints(raster, 1);
     PixelRecord firstPoint = points.get(0);
-    Geometry firstGeom = (Geometry) firstPoint.geom;
+    Geometry firstGeom = firstPoint.geom;
 
-    double expectedX = -1.3095818E7;
-    double expectedY = 4021262.75;
+    double expectedX = -1.3095817809482181E7;
+    double expectedY = 4021262.7487925636;
     double val = 0.0;
 
     assertEquals(expectedX, firstGeom.getCoordinate().x, FP_TOLERANCE);
@@ -348,7 +348,7 @@ public class FunctionsTest extends RasterTestBase {
     List<PixelRecord> points = PixelFunctions.getPixelAsPoints(emptyRaster, 1);
 
     PixelRecord point1 = points.get(26);
-    Geometry geom1 = (Geometry) point1.geom;
+    Geometry geom1 = point1.geom;
     String expected = "POINT (250 -186)";
     assertEquals(expected, geom1.toString());
   }

--- a/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
@@ -1831,7 +1831,7 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
           s"SELECT RS_PixelAsPoints(RS_MakeEmptyRaster($numBands, $widthInPixel, $heightInPixel, $upperLeftX, $upperLeftY, $cellSize), 1)")
         .first()
         .getList(0)
-      val expected = "[POINT (127.19000244140625 -12),0.0,2,1]"
+      val expected = "[POINT (127.19 -12),0.0,2,1]"
       assertEquals(expected, result.get(1).toString)
     }
 
@@ -1863,7 +1863,7 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
         .first()
         .getString(0)
       val expected =
-        "POLYGON ((127.19000244140625 -20, 131.19000244140625 -20, 131.19000244140625 -24, 127.19000244140625 -24, 127.19000244140625 -20))"
+        "POLYGON ((127.19 -20, 131.19 -20, 131.19 -24, 127.19 -24, 127.19 -20))"
       assertEquals(expected, result)
     }
 
@@ -1880,7 +1880,7 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
         .first()
         .getList(0)
       val expected =
-        "[POLYGON ((127.19000244140625 -20, 131.19000244140625 -20, 131.19000244140625 -24, 127.19000244140625 -24, 127.19000244140625 -20)),0.0,2,3]"
+        "[POLYGON ((127.19 -20, 131.19 -20, 131.19 -24, 127.19 -24, 127.19 -20)),0.0,2,3]"
       assertEquals(expected, result.get(11).toString)
     }
 
@@ -1963,9 +1963,11 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
     it("Passed RS_RasterToWorldCoord with raster") {
       var df = sparkSession.read.format("binaryFile").load(resourceFolder + "raster/test1.tiff")
       df = df.selectExpr("RS_FromGeoTiff(content) as raster")
-      val result = df.selectExpr("RS_RasterToWorldCoord(raster, 1, 1)").first().get(0).toString
-      val expected = "POINT (-13095818 4021262.75)"
-      assertEquals(expected, result)
+      val result =
+        df.selectExpr("RS_RasterToWorldCoord(raster, 1, 1)").first().get(0).asInstanceOf[Geometry]
+      val actualCoordinate = result.getCoordinate
+      assertEquals(-13095817.809482181, actualCoordinate.x, 0.5d)
+      assertEquals(4021262.7487925636, actualCoordinate.y, 0.5d)
     }
 
     it("Passed RS_WorldToRasterCoord with raster") {


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

The world coordinates were silently casted from double to float when getting world coordinates from grid coordinates. This affects the precision of `RS_RasterToWorldCoord*`, `RS_PixelAsPolygon`, etc.

## How was this patch tested?

Updated the expected results of tests to more precise coordinates.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
