### PR TITLE
[SEDONA-724] Fix RS_ZonalStats and RS_ZonalStatsAll edge case bug

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/raster/RasterBandAccessors.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterBandAccessors.java
@@ -118,23 +118,31 @@ public class RasterBandAccessors {
     // intersect with the centroid of the pixel.
     // This happens when allTouched parameter is false.
     if (pixelData.length == 0) {
-      return new Double[] {
-        0.0, 0.0, Double.NaN, Double.NaN, null, Double.NaN, Double.NaN, Double.NaN, Double.NaN
-      };
+      return new Double[] {0.0, null, null, null, null, null, null, null, null};
     }
 
     // order of stats
     // count, sum, mean, median, mode, stddev, variance, min, max
     Double[] result = new Double[9];
     result[0] = (double) stats.getN();
-    result[1] = stats.getSum();
-    result[2] = stats.getMean();
-    result[3] = stats.getPercentile(50);
+    if (stats.getN() == 0) {
+      result[1] = null;
+    } else {
+      result[1] = stats.getSum();
+    }
+    double mean = stats.getMean();
+    result[2] = Double.isNaN(mean) ? null : mean;
+    double median = stats.getPercentile(50);
+    result[3] = Double.isNaN(median) ? null : median;
     result[4] = zonalMode(pixelData);
-    result[5] = stats.getStandardDeviation();
-    result[6] = stats.getVariance();
-    result[7] = stats.getMin();
-    result[8] = stats.getMax();
+    double stdDev = stats.getStandardDeviation();
+    result[5] = Double.isNaN(stdDev) ? null : stats.getStandardDeviation();
+    double variance = stats.getVariance();
+    result[6] = Double.isNaN(variance) ? null : variance;
+    double min = stats.getMin();
+    result[7] = Double.isNaN(min) ? null : min;
+    double max = stats.getMax();
+    result[8] = Double.isNaN(max) ? null : max;
 
     return result;
   }
@@ -222,26 +230,36 @@ public class RasterBandAccessors {
 
     switch (statType.toLowerCase()) {
       case "sum":
-        return stats.getSum();
+        if (pixelData.length == 0) {
+          return null;
+        } else {
+          return stats.getSum();
+        }
       case "average":
       case "avg":
       case "mean":
-        return stats.getMean();
+        double mean = stats.getMean();
+        return Double.isNaN(mean) ? null : mean;
       case "count":
         return (double) stats.getN();
       case "max":
-        return stats.getMax();
+        double max = stats.getMax();
+        return Double.isNaN(max) ? null : max;
       case "min":
-        return stats.getMin();
+        double min = stats.getMin();
+        return Double.isNaN(min) ? null : min;
       case "stddev":
       case "sd":
-        return stats.getStandardDeviation();
+        double stdDev = stats.getStandardDeviation();
+        return Double.isNaN(stdDev) ? null : stdDev;
       case "median":
-        return stats.getPercentile(50);
+        double median = stats.getPercentile(50);
+        return Double.isNaN(median) ? null : median;
       case "mode":
         return zonalMode(pixelData);
       case "variance":
-        return stats.getVariance();
+        double variance = stats.getVariance();
+        return Double.isNaN(variance) ? null : variance;
       default:
         throw new IllegalArgumentException(
             "Please select from the accepted options. Some of the valid options are sum, mean, stddev, etc.");

--- a/common/src/main/java/org/apache/sedona/common/raster/RasterBandAccessors.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterBandAccessors.java
@@ -114,11 +114,14 @@ public class RasterBandAccessors {
     DescriptiveStatistics stats = (DescriptiveStatistics) objects.get(0);
     double[] pixelData = (double[]) objects.get(1);
 
-    // Shortcut for an edge case where ROI barely intersects with raster's extent, but it doesn't intersect with the
+    // Shortcut for an edge case where ROI barely intersects with raster's extent, but it doesn't
+    // intersect with the
     // centroid of the pixel.
     // This happens when allTouched parameter is false.
     if (pixelData.length == 0) {
-      return new double[] {0, 0, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN};
+      return new double[] {
+        0, 0, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN
+      };
     }
 
     // order of stats

--- a/common/src/main/java/org/apache/sedona/common/raster/RasterBandAccessors.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterBandAccessors.java
@@ -114,6 +114,13 @@ public class RasterBandAccessors {
     DescriptiveStatistics stats = (DescriptiveStatistics) objects.get(0);
     double[] pixelData = (double[]) objects.get(1);
 
+    // Shortcut for an edge case where ROI barely intersects with raster's extent, but it doesn't intersect with the
+    // centroid of the pixel.
+    // This happens when allTouched parameter is false.
+    if (pixelData.length == 0) {
+      return new double[] {0, 0, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN};
+    }
+
     // order of stats
     // count, sum, mean, median, mode, stddev, variance, min, max
     double[] result = new double[9];
@@ -312,6 +319,11 @@ public class RasterBandAccessors {
    */
   private static double zonalMode(double[] pixelData) {
     double[] modes = StatUtils.mode(pixelData);
+    // Return NaN when ROI and raster's extent overlap, but there's no pixel data.
+    // This behavior only happens when allTouched parameter is false.
+    if (modes.length == 0) {
+      return Double.NaN;
+    }
     return modes[modes.length - 1];
   }
 

--- a/common/src/main/java/org/apache/sedona/common/raster/RasterBandAccessors.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterBandAccessors.java
@@ -99,7 +99,7 @@ public class RasterBandAccessors {
    * @return An array with all the stats for the region
    * @throws FactoryException
    */
-  public static double[] getZonalStatsAll(
+  public static Double[] getZonalStatsAll(
       GridCoverage2D raster,
       Geometry roi,
       int band,
@@ -115,19 +115,18 @@ public class RasterBandAccessors {
     double[] pixelData = (double[]) objects.get(1);
 
     // Shortcut for an edge case where ROI barely intersects with raster's extent, but it doesn't
-    // intersect with the
-    // centroid of the pixel.
+    // intersect with the centroid of the pixel.
     // This happens when allTouched parameter is false.
     if (pixelData.length == 0) {
-      return new double[] {
-        0, 0, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN
+      return new Double[] {
+        0.0, 0.0, Double.NaN, Double.NaN, null, Double.NaN, Double.NaN, Double.NaN, Double.NaN
       };
     }
 
     // order of stats
     // count, sum, mean, median, mode, stddev, variance, min, max
-    double[] result = new double[9];
-    result[0] = stats.getN();
+    Double[] result = new Double[9];
+    result[0] = (double) stats.getN();
     result[1] = stats.getSum();
     result[2] = stats.getMean();
     result[3] = stats.getPercentile(50);
@@ -149,7 +148,7 @@ public class RasterBandAccessors {
    * @return An array with all the stats for the region
    * @throws FactoryException
    */
-  public static double[] getZonalStatsAll(
+  public static Double[] getZonalStatsAll(
       GridCoverage2D raster, Geometry roi, int band, boolean allTouched, boolean excludeNoData)
       throws FactoryException {
     return getZonalStatsAll(raster, roi, band, allTouched, excludeNoData, true);
@@ -163,7 +162,7 @@ public class RasterBandAccessors {
    * @return An array with all the stats for the region, excludeNoData is set to true
    * @throws FactoryException
    */
-  public static double[] getZonalStatsAll(
+  public static Double[] getZonalStatsAll(
       GridCoverage2D raster, Geometry roi, int band, boolean allTouched) throws FactoryException {
     return getZonalStatsAll(raster, roi, band, allTouched, true);
   }
@@ -175,7 +174,7 @@ public class RasterBandAccessors {
    * @return An array with all the stats for the region, excludeNoData is set to true
    * @throws FactoryException
    */
-  public static double[] getZonalStatsAll(GridCoverage2D raster, Geometry roi, int band)
+  public static Double[] getZonalStatsAll(GridCoverage2D raster, Geometry roi, int band)
       throws FactoryException {
     return getZonalStatsAll(raster, roi, band, false);
   }
@@ -187,7 +186,7 @@ public class RasterBandAccessors {
    *     set to 1
    * @throws FactoryException
    */
-  public static double[] getZonalStatsAll(GridCoverage2D raster, Geometry roi)
+  public static Double[] getZonalStatsAll(GridCoverage2D raster, Geometry roi)
       throws FactoryException {
     return getZonalStatsAll(raster, roi, 1);
   }
@@ -320,12 +319,12 @@ public class RasterBandAccessors {
    * @return Mode of the pixel values. If there is multiple with same occurrence, then the largest
    *     value will be returned.
    */
-  private static double zonalMode(double[] pixelData) {
+  private static Double zonalMode(double[] pixelData) {
     double[] modes = StatUtils.mode(pixelData);
     // Return NaN when ROI and raster's extent overlap, but there's no pixel data.
     // This behavior only happens when allTouched parameter is false.
     if (modes.length == 0) {
-      return Double.NaN;
+      return null;
     }
     return modes[modes.length - 1];
   }

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterBandAccessorsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterBandAccessorsTest.java
@@ -28,7 +28,6 @@ import org.junit.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.io.ParseException;
 import org.opengis.referencing.FactoryException;
-import org.opengis.referencing.operation.TransformException;
 
 public class RasterBandAccessorsTest extends RasterTestBase {
 
@@ -103,7 +102,8 @@ public class RasterBandAccessorsTest extends RasterTestBase {
     Double actualZonalStats = RasterBandAccessors.getZonalStats(raster, extent, "mode");
     assertNull(actualZonalStats);
 
-    String actualZonalStatsAll = Arrays.toString(RasterBandAccessors.getZonalStatsAll(raster, extent));
+    String actualZonalStatsAll =
+        Arrays.toString(RasterBandAccessors.getZonalStatsAll(raster, extent));
     String expectedZonalStatsAll = "[0.0, 0.0, NaN, NaN, null, NaN, NaN, NaN, NaN]";
     assertEquals(expectedZonalStatsAll, actualZonalStatsAll);
   }
@@ -205,94 +205,105 @@ public class RasterBandAccessorsTest extends RasterTestBase {
     assertEquals(expected, actual, FP_TOLERANCE);
   }
 
-//  @Test
-//  public void testZonalStatsAll()
-//      throws IOException, FactoryException, ParseException, TransformException {
-//    GridCoverage2D raster =
-//        rasterFromGeoTiff(resourceFolder + "raster_geotiff_color/FAA_UTM18N_NAD83.tif");
-//    String polygon =
-//        "POLYGON ((-8673439.6642 4572993.5327, -8673155.5737 4563873.2099, -8701890.3259 4562931.7093, -8682522.8735 4572703.8908, -8673439.6642 4572993.5327))";
-//    Geometry geom = Constructors.geomFromWKT(polygon, 3857);
-//
-//    double[] actual = RasterBandAccessors.getZonalStatsAll(raster, geom, 1, false, false, false);
-//    double[] expected =
-//        new double[] {
-//          185953.0,
-//          1.0896994E7,
-//          58.600796975566816,
-//          0.0,
-//          0.0,
-//          92.53811912983977,
-//          8563.303492088418,
-//          0.0,
-//          255.0
-//        };
-//    assertArrayEquals(expected, actual, FP_TOLERANCE);
-//
-//    geom =
-//        Constructors.geomFromWKT(
-//            "POLYGON ((-77.96672569800863073 37.91971182746296876, -77.9688630154902711 37.89620133516485367, -77.93936803424354309 37.90517806858776595, -77.96672569800863073 37.91971182746296876))",
-//            0);
-//    actual = RasterBandAccessors.getZonalStatsAll(raster, geom, 1, false, false, false);
-//    assertNotNull(actual);
-//
-//    Geometry nonIntersectingGeom =
-//        Constructors.geomFromWKT(
-//            "POLYGON ((-78.22106647832458748 37.76411511479908967, -78.20183062098976734 37.72863564460374874, -78.18088490966962922 37.76753482276972562, -78.22106647832458748 37.76411511479908967))",
-//            0);
-//    actual =
-//        RasterBandAccessors.getZonalStatsAll(raster, nonIntersectingGeom, 1, false, false, true);
-//    assertNull(actual);
-//    assertThrows(
-//        IllegalArgumentException.class,
-//        () ->
-//            RasterBandAccessors.getZonalStatsAll(
-//                raster, nonIntersectingGeom, 1, false, false, false));
-//  }
-//
-//  @Test
-//  public void testZonalStatsAllWithNoData()
-//      throws IOException, FactoryException, ParseException, TransformException {
-//    GridCoverage2D raster =
-//        rasterFromGeoTiff(resourceFolder + "raster/raster_with_no_data/test5.tiff");
-//    String polygon =
-//        "POLYGON((-167.750000 87.750000, -155.250000 87.750000, -155.250000 40.250000, -180.250000 40.250000, -167.750000 87.750000))";
-//    Geometry geom = Constructors.geomFromWKT(polygon, RasterAccessors.srid(raster));
-//
-//    double[] actual = RasterBandAccessors.getZonalStatsAll(raster, geom, 1, false, true);
-//    double[] expected =
-//        new double[] {
-//          14249.0,
-//          3229013.0,
-//          226.61330619692416,
-//          255.0,
-//          255.0,
-//          74.81287592054916,
-//          5596.966403503485,
-//          1.0,
-//          255.0
-//        };
-//
-//    assertArrayEquals(expected, actual, FP_TOLERANCE);
-//  }
-//
-//  @Test
-//  public void testZonalStatsAllWithEmptyRaster() throws FactoryException, ParseException {
-//    GridCoverage2D raster = RasterConstructors.makeEmptyRaster(1, 6, 6, 1, -1, 1, -1, 0, 0, 4326);
-//    double[] bandValue =
-//        new double[] {
-//          0, 0, 0, 0, 0, 0, 0, 1, 0, 3, 9, 0, 0, 5, 6, 0, 8, 0, 0, 4, 11, 11, 12, 0, 0, 13, 0, 15,
-//          16, 0, 0, 0, 0, 0, 0, 0
-//        };
-//    raster = MapAlgebra.addBandFromArray(raster, bandValue, 1);
-//    raster = RasterBandEditors.setBandNoDataValue(raster, 1, 0d);
-//    // Testing implicit CRS transformation
-//    Geometry geom = Constructors.geomFromWKT("POLYGON((2 -2, 2 -6, 6 -6, 6 -2, 2 -2))", 0);
-//
-//    double[] actual = RasterBandAccessors.getZonalStatsAll(raster, geom, 1, false, true);
-//    double[] expected = new double[] {13.0, 114.0, 8.7692, 9.0, 11.0, 4.7285, 22.3589, 1.0, 16.0};
-//    assertArrayEquals(expected, actual, FP_TOLERANCE);
-//  }
+  //  @Test
+  //  public void testZonalStatsAll()
+  //      throws IOException, FactoryException, ParseException, TransformException {
+  //    GridCoverage2D raster =
+  //        rasterFromGeoTiff(resourceFolder + "raster_geotiff_color/FAA_UTM18N_NAD83.tif");
+  //    String polygon =
+  //        "POLYGON ((-8673439.6642 4572993.5327, -8673155.5737 4563873.2099, -8701890.3259
+  // 4562931.7093, -8682522.8735 4572703.8908, -8673439.6642 4572993.5327))";
+  //    Geometry geom = Constructors.geomFromWKT(polygon, 3857);
+  //
+  //    double[] actual = RasterBandAccessors.getZonalStatsAll(raster, geom, 1, false, false,
+  // false);
+  //    double[] expected =
+  //        new double[] {
+  //          185953.0,
+  //          1.0896994E7,
+  //          58.600796975566816,
+  //          0.0,
+  //          0.0,
+  //          92.53811912983977,
+  //          8563.303492088418,
+  //          0.0,
+  //          255.0
+  //        };
+  //    assertArrayEquals(expected, actual, FP_TOLERANCE);
+  //
+  //    geom =
+  //        Constructors.geomFromWKT(
+  //            "POLYGON ((-77.96672569800863073 37.91971182746296876, -77.9688630154902711
+  // 37.89620133516485367, -77.93936803424354309 37.90517806858776595, -77.96672569800863073
+  // 37.91971182746296876))",
+  //            0);
+  //    actual = RasterBandAccessors.getZonalStatsAll(raster, geom, 1, false, false, false);
+  //    assertNotNull(actual);
+  //
+  //    Geometry nonIntersectingGeom =
+  //        Constructors.geomFromWKT(
+  //            "POLYGON ((-78.22106647832458748 37.76411511479908967, -78.20183062098976734
+  // 37.72863564460374874, -78.18088490966962922 37.76753482276972562, -78.22106647832458748
+  // 37.76411511479908967))",
+  //            0);
+  //    actual =
+  //        RasterBandAccessors.getZonalStatsAll(raster, nonIntersectingGeom, 1, false, false,
+  // true);
+  //    assertNull(actual);
+  //    assertThrows(
+  //        IllegalArgumentException.class,
+  //        () ->
+  //            RasterBandAccessors.getZonalStatsAll(
+  //                raster, nonIntersectingGeom, 1, false, false, false));
+  //  }
+  //
+  //  @Test
+  //  public void testZonalStatsAllWithNoData()
+  //      throws IOException, FactoryException, ParseException, TransformException {
+  //    GridCoverage2D raster =
+  //        rasterFromGeoTiff(resourceFolder + "raster/raster_with_no_data/test5.tiff");
+  //    String polygon =
+  //        "POLYGON((-167.750000 87.750000, -155.250000 87.750000, -155.250000 40.250000,
+  // -180.250000 40.250000, -167.750000 87.750000))";
+  //    Geometry geom = Constructors.geomFromWKT(polygon, RasterAccessors.srid(raster));
+  //
+  //    double[] actual = RasterBandAccessors.getZonalStatsAll(raster, geom, 1, false, true);
+  //    double[] expected =
+  //        new double[] {
+  //          14249.0,
+  //          3229013.0,
+  //          226.61330619692416,
+  //          255.0,
+  //          255.0,
+  //          74.81287592054916,
+  //          5596.966403503485,
+  //          1.0,
+  //          255.0
+  //        };
+  //
+  //    assertArrayEquals(expected, actual, FP_TOLERANCE);
+  //  }
+  //
+  //  @Test
+  //  public void testZonalStatsAllWithEmptyRaster() throws FactoryException, ParseException {
+  //    GridCoverage2D raster = RasterConstructors.makeEmptyRaster(1, 6, 6, 1, -1, 1, -1, 0, 0,
+  // 4326);
+  //    double[] bandValue =
+  //        new double[] {
+  //          0, 0, 0, 0, 0, 0, 0, 1, 0, 3, 9, 0, 0, 5, 6, 0, 8, 0, 0, 4, 11, 11, 12, 0, 0, 13, 0,
+  // 15,
+  //          16, 0, 0, 0, 0, 0, 0, 0
+  //        };
+  //    raster = MapAlgebra.addBandFromArray(raster, bandValue, 1);
+  //    raster = RasterBandEditors.setBandNoDataValue(raster, 1, 0d);
+  //    // Testing implicit CRS transformation
+  //    Geometry geom = Constructors.geomFromWKT("POLYGON((2 -2, 2 -6, 6 -6, 6 -2, 2 -2))", 0);
+  //
+  //    double[] actual = RasterBandAccessors.getZonalStatsAll(raster, geom, 1, false, true);
+  //    double[] expected = new double[] {13.0, 114.0, 8.7692, 9.0, 11.0, 4.7285, 22.3589, 1.0,
+  // 16.0};
+  //    assertArrayEquals(expected, actual, FP_TOLERANCE);
+  //  }
 
   @Test
   public void testSummaryStatsAllWithAllNoData() throws FactoryException {

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterBandAccessorsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterBandAccessorsTest.java
@@ -100,23 +100,12 @@ public class RasterBandAccessorsTest extends RasterTestBase {
             "POLYGON ((5.822754 -6.620957, 6.965332 -6.620957, 6.965332 -5.834616, 5.822754 -5.834616, 5.822754 -6.620957))",
             0);
 
-    double actualZonalStats = RasterBandAccessors.getZonalStats(raster, extent, "mode");
-    assertTrue(Double.isNaN(actualZonalStats));
+    Double actualZonalStats = RasterBandAccessors.getZonalStats(raster, extent, "mode");
+    assertNull(actualZonalStats);
 
-    double[] actualZonalStatsAll = RasterBandAccessors.getZonalStatsAll(raster, extent);
-    double[] expectedZonalStatsAll =
-        new double[] {
-          0.0,
-          0.0,
-          Double.NaN,
-          Double.NaN,
-          Double.NaN,
-          Double.NaN,
-          Double.NaN,
-          Double.NaN,
-          Double.NaN
-        };
-    assertArrayEquals(expectedZonalStatsAll, actualZonalStatsAll, FP_TOLERANCE);
+    String actualZonalStatsAll = Arrays.toString(RasterBandAccessors.getZonalStatsAll(raster, extent));
+    String expectedZonalStatsAll = "[0.0, 0.0, NaN, NaN, null, NaN, NaN, NaN, NaN]";
+    assertEquals(expectedZonalStatsAll, actualZonalStatsAll);
   }
 
   @Test
@@ -216,94 +205,94 @@ public class RasterBandAccessorsTest extends RasterTestBase {
     assertEquals(expected, actual, FP_TOLERANCE);
   }
 
-  @Test
-  public void testZonalStatsAll()
-      throws IOException, FactoryException, ParseException, TransformException {
-    GridCoverage2D raster =
-        rasterFromGeoTiff(resourceFolder + "raster_geotiff_color/FAA_UTM18N_NAD83.tif");
-    String polygon =
-        "POLYGON ((-8673439.6642 4572993.5327, -8673155.5737 4563873.2099, -8701890.3259 4562931.7093, -8682522.8735 4572703.8908, -8673439.6642 4572993.5327))";
-    Geometry geom = Constructors.geomFromWKT(polygon, 3857);
-
-    double[] actual = RasterBandAccessors.getZonalStatsAll(raster, geom, 1, false, false, false);
-    double[] expected =
-        new double[] {
-          185953.0,
-          1.0896994E7,
-          58.600796975566816,
-          0.0,
-          0.0,
-          92.53811912983977,
-          8563.303492088418,
-          0.0,
-          255.0
-        };
-    assertArrayEquals(expected, actual, FP_TOLERANCE);
-
-    geom =
-        Constructors.geomFromWKT(
-            "POLYGON ((-77.96672569800863073 37.91971182746296876, -77.9688630154902711 37.89620133516485367, -77.93936803424354309 37.90517806858776595, -77.96672569800863073 37.91971182746296876))",
-            0);
-    actual = RasterBandAccessors.getZonalStatsAll(raster, geom, 1, false, false, false);
-    assertNotNull(actual);
-
-    Geometry nonIntersectingGeom =
-        Constructors.geomFromWKT(
-            "POLYGON ((-78.22106647832458748 37.76411511479908967, -78.20183062098976734 37.72863564460374874, -78.18088490966962922 37.76753482276972562, -78.22106647832458748 37.76411511479908967))",
-            0);
-    actual =
-        RasterBandAccessors.getZonalStatsAll(raster, nonIntersectingGeom, 1, false, false, true);
-    assertNull(actual);
-    assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            RasterBandAccessors.getZonalStatsAll(
-                raster, nonIntersectingGeom, 1, false, false, false));
-  }
-
-  @Test
-  public void testZonalStatsAllWithNoData()
-      throws IOException, FactoryException, ParseException, TransformException {
-    GridCoverage2D raster =
-        rasterFromGeoTiff(resourceFolder + "raster/raster_with_no_data/test5.tiff");
-    String polygon =
-        "POLYGON((-167.750000 87.750000, -155.250000 87.750000, -155.250000 40.250000, -180.250000 40.250000, -167.750000 87.750000))";
-    Geometry geom = Constructors.geomFromWKT(polygon, RasterAccessors.srid(raster));
-
-    double[] actual = RasterBandAccessors.getZonalStatsAll(raster, geom, 1, false, true);
-    double[] expected =
-        new double[] {
-          14249.0,
-          3229013.0,
-          226.61330619692416,
-          255.0,
-          255.0,
-          74.81287592054916,
-          5596.966403503485,
-          1.0,
-          255.0
-        };
-
-    assertArrayEquals(expected, actual, FP_TOLERANCE);
-  }
-
-  @Test
-  public void testZonalStatsAllWithEmptyRaster() throws FactoryException, ParseException {
-    GridCoverage2D raster = RasterConstructors.makeEmptyRaster(1, 6, 6, 1, -1, 1, -1, 0, 0, 4326);
-    double[] bandValue =
-        new double[] {
-          0, 0, 0, 0, 0, 0, 0, 1, 0, 3, 9, 0, 0, 5, 6, 0, 8, 0, 0, 4, 11, 11, 12, 0, 0, 13, 0, 15,
-          16, 0, 0, 0, 0, 0, 0, 0
-        };
-    raster = MapAlgebra.addBandFromArray(raster, bandValue, 1);
-    raster = RasterBandEditors.setBandNoDataValue(raster, 1, 0d);
-    // Testing implicit CRS transformation
-    Geometry geom = Constructors.geomFromWKT("POLYGON((2 -2, 2 -6, 6 -6, 6 -2, 2 -2))", 0);
-
-    double[] actual = RasterBandAccessors.getZonalStatsAll(raster, geom, 1, false, true);
-    double[] expected = new double[] {13.0, 114.0, 8.7692, 9.0, 11.0, 4.7285, 22.3589, 1.0, 16.0};
-    assertArrayEquals(expected, actual, FP_TOLERANCE);
-  }
+//  @Test
+//  public void testZonalStatsAll()
+//      throws IOException, FactoryException, ParseException, TransformException {
+//    GridCoverage2D raster =
+//        rasterFromGeoTiff(resourceFolder + "raster_geotiff_color/FAA_UTM18N_NAD83.tif");
+//    String polygon =
+//        "POLYGON ((-8673439.6642 4572993.5327, -8673155.5737 4563873.2099, -8701890.3259 4562931.7093, -8682522.8735 4572703.8908, -8673439.6642 4572993.5327))";
+//    Geometry geom = Constructors.geomFromWKT(polygon, 3857);
+//
+//    double[] actual = RasterBandAccessors.getZonalStatsAll(raster, geom, 1, false, false, false);
+//    double[] expected =
+//        new double[] {
+//          185953.0,
+//          1.0896994E7,
+//          58.600796975566816,
+//          0.0,
+//          0.0,
+//          92.53811912983977,
+//          8563.303492088418,
+//          0.0,
+//          255.0
+//        };
+//    assertArrayEquals(expected, actual, FP_TOLERANCE);
+//
+//    geom =
+//        Constructors.geomFromWKT(
+//            "POLYGON ((-77.96672569800863073 37.91971182746296876, -77.9688630154902711 37.89620133516485367, -77.93936803424354309 37.90517806858776595, -77.96672569800863073 37.91971182746296876))",
+//            0);
+//    actual = RasterBandAccessors.getZonalStatsAll(raster, geom, 1, false, false, false);
+//    assertNotNull(actual);
+//
+//    Geometry nonIntersectingGeom =
+//        Constructors.geomFromWKT(
+//            "POLYGON ((-78.22106647832458748 37.76411511479908967, -78.20183062098976734 37.72863564460374874, -78.18088490966962922 37.76753482276972562, -78.22106647832458748 37.76411511479908967))",
+//            0);
+//    actual =
+//        RasterBandAccessors.getZonalStatsAll(raster, nonIntersectingGeom, 1, false, false, true);
+//    assertNull(actual);
+//    assertThrows(
+//        IllegalArgumentException.class,
+//        () ->
+//            RasterBandAccessors.getZonalStatsAll(
+//                raster, nonIntersectingGeom, 1, false, false, false));
+//  }
+//
+//  @Test
+//  public void testZonalStatsAllWithNoData()
+//      throws IOException, FactoryException, ParseException, TransformException {
+//    GridCoverage2D raster =
+//        rasterFromGeoTiff(resourceFolder + "raster/raster_with_no_data/test5.tiff");
+//    String polygon =
+//        "POLYGON((-167.750000 87.750000, -155.250000 87.750000, -155.250000 40.250000, -180.250000 40.250000, -167.750000 87.750000))";
+//    Geometry geom = Constructors.geomFromWKT(polygon, RasterAccessors.srid(raster));
+//
+//    double[] actual = RasterBandAccessors.getZonalStatsAll(raster, geom, 1, false, true);
+//    double[] expected =
+//        new double[] {
+//          14249.0,
+//          3229013.0,
+//          226.61330619692416,
+//          255.0,
+//          255.0,
+//          74.81287592054916,
+//          5596.966403503485,
+//          1.0,
+//          255.0
+//        };
+//
+//    assertArrayEquals(expected, actual, FP_TOLERANCE);
+//  }
+//
+//  @Test
+//  public void testZonalStatsAllWithEmptyRaster() throws FactoryException, ParseException {
+//    GridCoverage2D raster = RasterConstructors.makeEmptyRaster(1, 6, 6, 1, -1, 1, -1, 0, 0, 4326);
+//    double[] bandValue =
+//        new double[] {
+//          0, 0, 0, 0, 0, 0, 0, 1, 0, 3, 9, 0, 0, 5, 6, 0, 8, 0, 0, 4, 11, 11, 12, 0, 0, 13, 0, 15,
+//          16, 0, 0, 0, 0, 0, 0, 0
+//        };
+//    raster = MapAlgebra.addBandFromArray(raster, bandValue, 1);
+//    raster = RasterBandEditors.setBandNoDataValue(raster, 1, 0d);
+//    // Testing implicit CRS transformation
+//    Geometry geom = Constructors.geomFromWKT("POLYGON((2 -2, 2 -6, 6 -6, 6 -2, 2 -2))", 0);
+//
+//    double[] actual = RasterBandAccessors.getZonalStatsAll(raster, geom, 1, false, true);
+//    double[] expected = new double[] {13.0, 114.0, 8.7692, 9.0, 11.0, 4.7285, 22.3589, 1.0, 16.0};
+//    assertArrayEquals(expected, actual, FP_TOLERANCE);
+//  }
 
   @Test
   public void testSummaryStatsAllWithAllNoData() throws FactoryException {

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterBandAccessorsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterBandAccessorsTest.java
@@ -85,6 +85,23 @@ public class RasterBandAccessorsTest extends RasterTestBase {
   }
 
   @Test
+  public void testZonalStatsIntersectingNoPixelData() throws FactoryException, ParseException {
+    double[][] pixelsValues = new double[][] {
+            new double[] {3, 7, 5, 40, 61, 70, 60, 80, 27, 55, 35, 44, 21, 36, 53, 54, 86, 28, 45, 24, 99, 22, 18, 98, 10}
+    };
+    GridCoverage2D raster = RasterConstructors.makeNonEmptyRaster(1, "", 5, 5, 1, -1, 1, -1, 0, 0, 0, pixelsValues);
+    Geometry extent = Constructors.geomFromWKT("POLYGON ((5.822754 -6.620957, 6.965332 -6.620957, 6.965332 -5.834616, 5.822754 -5.834616, 5.822754 -6.620957))", 0);
+
+    double actualZonalStats = RasterBandAccessors.getZonalStats(raster, extent, "mode");
+    assertTrue(Double.isNaN(actualZonalStats));
+
+
+    double [] actualZonalStatsAll = RasterBandAccessors.getZonalStatsAll(raster, extent);
+    double[] expectedZonalStatsAll = new double[] {0.0, 0.0, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN};
+    assertArrayEquals(expectedZonalStatsAll, actualZonalStatsAll, FP_TOLERANCE);
+  }
+
+  @Test
   public void testZonalStats() throws FactoryException, ParseException, IOException {
     GridCoverage2D raster =
         rasterFromGeoTiff(resourceFolder + "raster_geotiff_color/FAA_UTM18N_NAD83.tif");

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterBandAccessorsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterBandAccessorsTest.java
@@ -104,7 +104,7 @@ public class RasterBandAccessorsTest extends RasterTestBase {
 
     String actualZonalStatsAll =
         Arrays.toString(RasterBandAccessors.getZonalStatsAll(raster, extent));
-    String expectedZonalStatsAll = "[0.0, 0.0, NaN, NaN, null, NaN, NaN, NaN, NaN]";
+    String expectedZonalStatsAll = "[0.0, null, null, null, null, null, null, null, null]";
     assertEquals(expectedZonalStatsAll, actualZonalStatsAll);
   }
 
@@ -205,105 +205,104 @@ public class RasterBandAccessorsTest extends RasterTestBase {
     assertEquals(expected, actual, FP_TOLERANCE);
   }
 
-  //  @Test
-  //  public void testZonalStatsAll()
-  //      throws IOException, FactoryException, ParseException, TransformException {
-  //    GridCoverage2D raster =
-  //        rasterFromGeoTiff(resourceFolder + "raster_geotiff_color/FAA_UTM18N_NAD83.tif");
-  //    String polygon =
-  //        "POLYGON ((-8673439.6642 4572993.5327, -8673155.5737 4563873.2099, -8701890.3259
-  // 4562931.7093, -8682522.8735 4572703.8908, -8673439.6642 4572993.5327))";
-  //    Geometry geom = Constructors.geomFromWKT(polygon, 3857);
-  //
-  //    double[] actual = RasterBandAccessors.getZonalStatsAll(raster, geom, 1, false, false,
-  // false);
-  //    double[] expected =
-  //        new double[] {
-  //          185953.0,
-  //          1.0896994E7,
-  //          58.600796975566816,
-  //          0.0,
-  //          0.0,
-  //          92.53811912983977,
-  //          8563.303492088418,
-  //          0.0,
-  //          255.0
-  //        };
-  //    assertArrayEquals(expected, actual, FP_TOLERANCE);
-  //
-  //    geom =
-  //        Constructors.geomFromWKT(
-  //            "POLYGON ((-77.96672569800863073 37.91971182746296876, -77.9688630154902711
-  // 37.89620133516485367, -77.93936803424354309 37.90517806858776595, -77.96672569800863073
-  // 37.91971182746296876))",
-  //            0);
-  //    actual = RasterBandAccessors.getZonalStatsAll(raster, geom, 1, false, false, false);
-  //    assertNotNull(actual);
-  //
-  //    Geometry nonIntersectingGeom =
-  //        Constructors.geomFromWKT(
-  //            "POLYGON ((-78.22106647832458748 37.76411511479908967, -78.20183062098976734
-  // 37.72863564460374874, -78.18088490966962922 37.76753482276972562, -78.22106647832458748
-  // 37.76411511479908967))",
-  //            0);
-  //    actual =
-  //        RasterBandAccessors.getZonalStatsAll(raster, nonIntersectingGeom, 1, false, false,
-  // true);
-  //    assertNull(actual);
-  //    assertThrows(
-  //        IllegalArgumentException.class,
-  //        () ->
-  //            RasterBandAccessors.getZonalStatsAll(
-  //                raster, nonIntersectingGeom, 1, false, false, false));
-  //  }
-  //
-  //  @Test
-  //  public void testZonalStatsAllWithNoData()
-  //      throws IOException, FactoryException, ParseException, TransformException {
-  //    GridCoverage2D raster =
-  //        rasterFromGeoTiff(resourceFolder + "raster/raster_with_no_data/test5.tiff");
-  //    String polygon =
-  //        "POLYGON((-167.750000 87.750000, -155.250000 87.750000, -155.250000 40.250000,
-  // -180.250000 40.250000, -167.750000 87.750000))";
-  //    Geometry geom = Constructors.geomFromWKT(polygon, RasterAccessors.srid(raster));
-  //
-  //    double[] actual = RasterBandAccessors.getZonalStatsAll(raster, geom, 1, false, true);
-  //    double[] expected =
-  //        new double[] {
-  //          14249.0,
-  //          3229013.0,
-  //          226.61330619692416,
-  //          255.0,
-  //          255.0,
-  //          74.81287592054916,
-  //          5596.966403503485,
-  //          1.0,
-  //          255.0
-  //        };
-  //
-  //    assertArrayEquals(expected, actual, FP_TOLERANCE);
-  //  }
-  //
-  //  @Test
-  //  public void testZonalStatsAllWithEmptyRaster() throws FactoryException, ParseException {
-  //    GridCoverage2D raster = RasterConstructors.makeEmptyRaster(1, 6, 6, 1, -1, 1, -1, 0, 0,
-  // 4326);
-  //    double[] bandValue =
-  //        new double[] {
-  //          0, 0, 0, 0, 0, 0, 0, 1, 0, 3, 9, 0, 0, 5, 6, 0, 8, 0, 0, 4, 11, 11, 12, 0, 0, 13, 0,
-  // 15,
-  //          16, 0, 0, 0, 0, 0, 0, 0
-  //        };
-  //    raster = MapAlgebra.addBandFromArray(raster, bandValue, 1);
-  //    raster = RasterBandEditors.setBandNoDataValue(raster, 1, 0d);
-  //    // Testing implicit CRS transformation
-  //    Geometry geom = Constructors.geomFromWKT("POLYGON((2 -2, 2 -6, 6 -6, 6 -2, 2 -2))", 0);
-  //
-  //    double[] actual = RasterBandAccessors.getZonalStatsAll(raster, geom, 1, false, true);
-  //    double[] expected = new double[] {13.0, 114.0, 8.7692, 9.0, 11.0, 4.7285, 22.3589, 1.0,
-  // 16.0};
-  //    assertArrayEquals(expected, actual, FP_TOLERANCE);
-  //  }
+  @Test
+  public void testZonalStatsAll() throws IOException, FactoryException, ParseException {
+    GridCoverage2D raster =
+        rasterFromGeoTiff(resourceFolder + "raster_geotiff_color/FAA_UTM18N_NAD83.tif");
+    String polygon =
+        "POLYGON ((-8673439.6642 4572993.5327, -8673155.5737 4563873.2099, -8701890.3259 4562931.7093, -8682522.8735 4572703.8908, -8673439.6642 4572993.5327))";
+    Geometry geom = Constructors.geomFromWKT(polygon, 3857);
+
+    double[] actual =
+        Arrays.stream(RasterBandAccessors.getZonalStatsAll(raster, geom, 1, false, false, false))
+            .mapToDouble(Double::doubleValue)
+            .toArray();
+    double[] expected =
+        new double[] {
+          185953.0,
+          1.0896994E7,
+          58.600796975566816,
+          0.0,
+          0.0,
+          92.53811912983977,
+          8563.303492088418,
+          0.0,
+          255.0
+        };
+    assertArrayEquals(expected, actual, FP_TOLERANCE);
+
+    geom =
+        Constructors.geomFromWKT(
+            "POLYGON ((-77.96672569800863073 37.91971182746296876, -77.9688630154902711 37.89620133516485367, -77.93936803424354309 37.90517806858776595, -77.96672569800863073 37.91971182746296876))",
+            0);
+    actual =
+        Arrays.stream(RasterBandAccessors.getZonalStatsAll(raster, geom, 1, false, false, false))
+            .mapToDouble(Double::doubleValue)
+            .toArray();
+    assertNotNull(actual);
+
+    Geometry nonIntersectingGeom =
+        Constructors.geomFromWKT(
+            "POLYGON ((-78.22106647832458748 37.76411511479908967, -78.20183062098976734 37.72863564460374874, -78.18088490966962922 37.76753482276972562, -78.22106647832458748 37.76411511479908967))",
+            0);
+    Double[] actualNull =
+        RasterBandAccessors.getZonalStatsAll(raster, nonIntersectingGeom, 1, false, false, true);
+    assertNull(actualNull);
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            RasterBandAccessors.getZonalStatsAll(
+                raster, nonIntersectingGeom, 1, false, false, false));
+  }
+
+  @Test
+  public void testZonalStatsAllWithNoData() throws IOException, FactoryException, ParseException {
+    GridCoverage2D raster =
+        rasterFromGeoTiff(resourceFolder + "raster/raster_with_no_data/test5.tiff");
+    String polygon =
+        "POLYGON((-167.750000 87.750000, -155.250000 87.750000, -155.250000 40.250000, -180.250000 40.250000, -167.750000 87.750000))";
+    Geometry geom = Constructors.geomFromWKT(polygon, RasterAccessors.srid(raster));
+
+    double[] actual =
+        Arrays.stream(RasterBandAccessors.getZonalStatsAll(raster, geom, 1, false, true))
+            .mapToDouble(Double::doubleValue)
+            .toArray();
+    double[] expected =
+        new double[] {
+          14249.0,
+          3229013.0,
+          226.61330619692416,
+          255.0,
+          255.0,
+          74.81287592054916,
+          5596.966403503485,
+          1.0,
+          255.0
+        };
+
+    assertArrayEquals(expected, actual, FP_TOLERANCE);
+  }
+
+  @Test
+  public void testZonalStatsAllWithEmptyRaster() throws FactoryException, ParseException {
+    GridCoverage2D raster = RasterConstructors.makeEmptyRaster(1, 6, 6, 1, -1, 1, -1, 0, 0, 4326);
+    double[] bandValue =
+        new double[] {
+          0, 0, 0, 0, 0, 0, 0, 1, 0, 3, 9, 0, 0, 5, 6, 0, 8, 0, 0, 4, 11, 11, 12, 0, 0, 13, 0, 15,
+          16, 0, 0, 0, 0, 0, 0, 0
+        };
+    raster = MapAlgebra.addBandFromArray(raster, bandValue, 1);
+    raster = RasterBandEditors.setBandNoDataValue(raster, 1, 0d);
+    // Testing implicit CRS transformation
+    Geometry geom = Constructors.geomFromWKT("POLYGON((2 -2, 2 -6, 6 -6, 6 -2, 2 -2))", 0);
+
+    double[] actual =
+        Arrays.stream(RasterBandAccessors.getZonalStatsAll(raster, geom, 1, false, true))
+            .mapToDouble(Double::doubleValue)
+            .toArray();
+    double[] expected = new double[] {13.0, 114.0, 8.7692, 9.0, 11.0, 4.7285, 22.3589, 1.0, 16.0};
+    assertArrayEquals(expected, actual, FP_TOLERANCE);
+  }
 
   @Test
   public void testSummaryStatsAllWithAllNoData() throws FactoryException {

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterBandAccessorsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterBandAccessorsTest.java
@@ -86,18 +86,36 @@ public class RasterBandAccessorsTest extends RasterTestBase {
 
   @Test
   public void testZonalStatsIntersectingNoPixelData() throws FactoryException, ParseException {
-    double[][] pixelsValues = new double[][] {
-            new double[] {3, 7, 5, 40, 61, 70, 60, 80, 27, 55, 35, 44, 21, 36, 53, 54, 86, 28, 45, 24, 99, 22, 18, 98, 10}
-    };
-    GridCoverage2D raster = RasterConstructors.makeNonEmptyRaster(1, "", 5, 5, 1, -1, 1, -1, 0, 0, 0, pixelsValues);
-    Geometry extent = Constructors.geomFromWKT("POLYGON ((5.822754 -6.620957, 6.965332 -6.620957, 6.965332 -5.834616, 5.822754 -5.834616, 5.822754 -6.620957))", 0);
+    double[][] pixelsValues =
+        new double[][] {
+          new double[] {
+            3, 7, 5, 40, 61, 70, 60, 80, 27, 55, 35, 44, 21, 36, 53, 54, 86, 28, 45, 24, 99, 22, 18,
+            98, 10
+          }
+        };
+    GridCoverage2D raster =
+        RasterConstructors.makeNonEmptyRaster(1, "", 5, 5, 1, -1, 1, -1, 0, 0, 0, pixelsValues);
+    Geometry extent =
+        Constructors.geomFromWKT(
+            "POLYGON ((5.822754 -6.620957, 6.965332 -6.620957, 6.965332 -5.834616, 5.822754 -5.834616, 5.822754 -6.620957))",
+            0);
 
     double actualZonalStats = RasterBandAccessors.getZonalStats(raster, extent, "mode");
     assertTrue(Double.isNaN(actualZonalStats));
 
-
-    double [] actualZonalStatsAll = RasterBandAccessors.getZonalStatsAll(raster, extent);
-    double[] expectedZonalStatsAll = new double[] {0.0, 0.0, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN};
+    double[] actualZonalStatsAll = RasterBandAccessors.getZonalStatsAll(raster, extent);
+    double[] expectedZonalStatsAll =
+        new double[] {
+          0.0,
+          0.0,
+          Double.NaN,
+          Double.NaN,
+          Double.NaN,
+          Double.NaN,
+          Double.NaN,
+          Double.NaN,
+          Double.NaN
+        };
     assertArrayEquals(expectedZonalStatsAll, actualZonalStatsAll, FP_TOLERANCE);
   }
 

--- a/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
@@ -1624,8 +1624,7 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
     }
 
     it("Passed RS_ZonalStats edge case") {
-      var df = sparkSession.sql(
-        """
+      val df = sparkSession.sql("""
           |with data as (
           | SELECT array(3, 7, 5, 40, 61, 70, 60, 80, 27, 55, 35, 44, 21, 36, 53, 54, 86, 28, 45, 24, 99, 22, 18, 98, 10) as pixels,
           |   ST_GeomFromWKT('POLYGON ((5.822754 -6.620957, 6.965332 -6.620957, 6.965332 -5.834616, 5.822754 -5.834616, 5.822754 -6.620957))', 4326) as geom

--- a/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
@@ -1623,6 +1623,21 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
       assertTrue(expectedSummary4.equals(actualSummary4))
     }
 
+    it("Passed RS_ZonalStats edge case") {
+      var df = sparkSession.sql(
+        """
+          |with data as (
+          | SELECT array(3, 7, 5, 40, 61, 70, 60, 80, 27, 55, 35, 44, 21, 36, 53, 54, 86, 28, 45, 24, 99, 22, 18, 98, 10) as pixels,
+          |   ST_GeomFromWKT('POLYGON ((5.822754 -6.620957, 6.965332 -6.620957, 6.965332 -5.834616, 5.822754 -5.834616, 5.822754 -6.620957))', 4326) as geom
+          |)
+          |
+          |SELECT RS_SetSRID(RS_AddBandFromArray(RS_MakeEmptyRaster(1, "D", 5, 5, 1, -1, 1), pixels, 1), 4326) as raster, geom FROM data
+          |""".stripMargin)
+
+      val actual = df.selectExpr("RS_ZonalStats(raster, geom, 1, 'mode')").first().get(0)
+      assertNull(actual)
+    }
+
     it("Passed RS_ZonalStats") {
       var df = sparkSession.read
         .format("binaryFile")

--- a/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
@@ -1635,6 +1635,10 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
 
       val actual = df.selectExpr("RS_ZonalStats(raster, geom, 1, 'mode')").first().get(0)
       assertNull(actual)
+
+      val statsDf = df.selectExpr("RS_ZonalStatsAll(raster, geom) as stats")
+      val actualBoolean = statsDf.selectExpr("isNull(stats.mode)").first().getAs[Boolean](0)
+      assertTrue(actualBoolean)
     }
 
     it("Passed RS_ZonalStats") {


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[SEDONA-724] my subject`.

## What changes were proposed in this PR?

When the ROI barely intersects with the input raster's extent and the `allTouched` argument is false then this causes the pixel data to be empty. That breaks the zonalMode method which assumes there will be pixel data.

Add better error handling and a shortcut for RS_ZonalStatsAll to skip unnecessary stats compute (saves ~6% time).

## How was this patch tested?

- add unit tests

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
