### PR TITLE
[DOCS] Re-enable GitHub discussion due to ASF Infra change

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -49,4 +49,6 @@ github:
         issues: true
         # Enable projects for project management boards
         projects: false
+        # Enable github discussion
+        discussions: true
     ghp_branch:


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a documentation update. The PR name follows the format `[DOCS] my subject`

## What changes were proposed in this PR?

Recently ASF Infra automated the process of GitHub discussion and hence accidentally disabled all GitHub discussion. This is to re-enable it via .asf.yml
