### PR TITLE
[DOCS] Add notification target for GitHub Discussions

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -49,4 +49,6 @@ github:
         issues: true
         # Enable projects for project management boards
         projects: false
+        # Enable github discussion
+        discussions: true
     ghp_branch:

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -19,6 +19,7 @@ notifications:
     commits:    commits@sedona.apache.org
     issues_status:    issues@sedona.apache.org
     issues_comment:    issues@sedona.apache.org
+    discussions: issues@sedona.apache.org
     pullrequests_status:    issues@sedona.apache.org
     pullrequests_comment:    issues@sedona.apache.org
     jira_options: link label worklog


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a documentation update. The PR name follows the format `[DOCS] my subject`

## What changes were proposed in this PR?

Add a notification target for GitHub Discussion otherwise it won't take effect
