### PR TITLE
[DOCS] Format Python Markdown codeblocks with black

### DIFF
--- a/docs/tutorial/concepts/spatial-joins.md
+++ b/docs/tutorial/concepts/spatial-joins.md
@@ -164,13 +164,15 @@ Here is the content of the lines table:
 Here’s a join that matches any touching values:
 
 ```python
-sedona.sql("""
+sedona.sql(
+    """
 SELECT
     lines.id as line_id,
     polygons.id as polygon_id
 FROM lines
 LEFT JOIN polygons ON ST_Touches(lines.geometry, polygons.geometry);  
-""").show()
+"""
+).show()
 ```
 
 Here’s the result of the join:

--- a/docs/tutorial/files/geojson-sedona-spark.md
+++ b/docs/tutorial/files/geojson-sedona-spark.md
@@ -40,10 +40,14 @@ Here’s how to read a multiline GeoJSON file with Sedona:
 
 ```python
 df = (
-    sedona.read.format("geojson").option("multiLine", "true").load("data/multiline_geojson.json")
+    sedona.read.format("geojson")
+    .option("multiLine", "true")
+    .load("data/multiline_geojson.json")
     .selectExpr("explode(features) as features")
     .select("features.*")
-    .withColumn("prop0", expr("properties['prop0']")).drop("properties").drop("type")
+    .withColumn("prop0", expr("properties['prop0']"))
+    .drop("properties")
+    .drop("type")
 )
 df.show(truncate=False)
 ```
@@ -112,9 +116,7 @@ Here's how you can read many GeoJSON files:
 
 ```python
 df = (
-    sedona.read.format("geojson")
-    .option("multiLine", "true")
-    .load("data/many_geojsons")
+    sedona.read.format("geojson").option("multiLine", "true").load("data/many_geojsons")
 )
 ```
 
@@ -132,7 +134,7 @@ df = (
     .load("data/singleline_geojson.json")
     .withColumn("prop0", expr("properties['prop0']"))
     .drop("properties")
-    .drop("type")  
+    .drop("type")
 )
 df.show(truncate=False)
 ```

--- a/docs/tutorial/files/geopackage-sedona-spark.md
+++ b/docs/tutorial/files/geopackage-sedona-spark.md
@@ -113,11 +113,7 @@ gpkgs/
 Here’s how you can read all the files:
 
 ```python
-df = (
-    sedona.read.format("geopackage")
-    .option("tableName", "my_layer")
-    .load("/tmp/gpkgs")
-)
+df = sedona.read.format("geopackage").option("tableName", "my_layer").load("/tmp/gpkgs")
 df.show()
 ```
 
@@ -143,7 +139,11 @@ Sedona is an excellent option for analyzing many GeoPackage files because it can
 You can also load data from raster tables in the GeoPackage file. To load raster data, you can use the following code.
 
 ```python
-df = sedona.read.format("geopackage").option("tableName", "raster_table").load("/path/to/geopackage")
+df = (
+    sedona.read.format("geopackage")
+    .option("tableName", "raster_table")
+    .load("/path/to/geopackage")
+)
 ```
 
 Here are the contents of the DataFrame:

--- a/docs/tutorial/files/geoparquet-sedona-spark.md
+++ b/docs/tutorial/files/geoparquet-sedona-spark.md
@@ -37,11 +37,14 @@ Let's see how to write a Sedona DataFrame to GeoParquet files.
 Start by creating a Sedona DataFrame:
 
 ```python
-df = sedona.createDataFrame([
-    ("a", 'LINESTRING(2.0 5.0,6.0 1.0)'),
-    ("b", 'LINESTRING(7.0 4.0,9.0 2.0)'),
-    ("c", 'LINESTRING(1.0 3.0,3.0 1.0)'),
-], ["id", "geometry"])
+df = sedona.createDataFrame(
+    [
+        ("a", "LINESTRING(2.0 5.0,6.0 1.0)"),
+        ("b", "LINESTRING(7.0 4.0,9.0 2.0)"),
+        ("c", "LINESTRING(1.0 3.0,3.0 1.0)"),
+    ],
+    ["id", "geometry"],
+)
 df = df.withColumn("geometry", ST_GeomFromText(col("geometry")))
 ```
 
@@ -258,13 +261,15 @@ Now, let’s apply a spatial filter to read points within a particular area:
 Here is the query:
 
 ```python
-my_shape = 'POLYGON((4.0 3.5, 4.0 6.0, 8.0 6.0, 8.0 4.5, 4.0 3.5))'
+my_shape = "POLYGON((4.0 3.5, 4.0 6.0, 8.0 6.0, 8.0 4.5, 4.0 3.5))"
 
-res = sedona.sql(f'''
+res = sedona.sql(
+    f"""
 select *
 from points
 where st_intersects(geometry, ST_GeomFromWKT('{my_shape}'))
-''')
+"""
+)
 res.show(truncate=False)
 ```
 

--- a/docs/tutorial/files/shapefiles-sedona-spark.md
+++ b/docs/tutorial/files/shapefiles-sedona-spark.md
@@ -38,13 +38,9 @@ from shapely.geometry import Point
 point1 = Point(0, 0)
 point2 = Point(1, 1)
 
-data = {
-    'name': ['Point A', 'Point B'],
-    'value': [10, 20],
-    'geometry': [point1, point2]
-}
+data = {"name": ["Point A", "Point B"], "value": [10, 20], "geometry": [point1, point2]}
 
-gdf = gpd.GeoDataFrame(data, geometry='geometry')
+gdf = gpd.GeoDataFrame(data, geometry="geometry")
 gdf.to_file("/tmp/my_geodata.shp")
 ```
 
@@ -98,7 +94,11 @@ df = (
 The name of the geometry column is geometry by default. You can change the name of the geometry column using the `geometry.name` option. Suppose one of the non-spatial attributes is named "geometry", `geometry.name` must be configured to avoid conflict.
 
 ```python
-df = sedona.read.format("shapefile").option("geometry.name", "geom").load("/path/to/shapefile")
+df = (
+    sedona.read.format("shapefile")
+    .option("geometry.name", "geom")
+    .load("/path/to/shapefile")
+)
 ```
 
 The character encoding of string attributes are inferred from the `.cpg` file. If you see garbled values in string fields, you can manually specify the correct charset using the `charset` option. For example:
@@ -118,7 +118,11 @@ The character encoding of string attributes are inferred from the `.cpg` file. I
 === "Python"
 
     ```python
-    df = sedona.read.format("shapefile").option("charset", "UTF-8").load("/path/to/shapefile")
+    df = (
+        sedona.read.format("shapefile")
+        .option("charset", "UTF-8")
+        .load("/path/to/shapefile")
+    )
     ```
 
 Let’s see how to load many Shapefiles into a Sedona DataFrame.


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No this is a documentation update. The PR name follows the format `[DOCS] my subject`

## What changes were proposed in this PR?

Formatted some code blocks with black

refs #1797 

## How was this patch tested?

Markdown edits only so with visual inspection.

Ran `pre-commit run --all-files`

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
