### PR TITLE
[CI] pre-commit(insert-license): fix bug in comment markers for .c an…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,11 +33,20 @@ repos:
     rev: v1.5.5
     hooks:
       - id: insert-license
-        name: add license for all .c and .h files
-        files: \.(c|h)$
+        name: add license for all .c files
+        files: \.c$
         args:
           - --comment-style
-          - "/*|*|*/"
+          - "/*| *| */"
+          - --license-filepath
+          - .github/workflows/license-templates/LICENSE.txt
+          - --fuzzy-match-generates-todo
+      - id: insert-license
+        name: add license for all .h files
+        files: \.h$
+        args:
+          - --comment-style
+          - "/*| *| */"
           - --license-filepath
           - .github/workflows/license-templates/LICENSE.txt
           - --fuzzy-match-generates-todo


### PR DESCRIPTION
…d .h

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

When working on PR #1880 I found a syntax bug with the license hook for Scala files when not using the extras spaces in the `--comment-style` argument.

So just now I have retested the `.c` and `.h` license hook and found that the license was added but then Clang Format ran after and then reformatted these licenses to be compliant.

So I have now updated the `--comment-style` to be the same for `.c` and `.h` and the licenses are added correctly and then Clang does not reformat.

A minor issue but was a bit tricky to figure out.

For this PR I have also separated the `.c` and `.h` license hook into two separate hooks. I think it is easier to debug going forwards and we have done it this way for the other file types. 

## How was this patch tested?

Edited and deleted licenses, played around with `--comment-style` arguments and ran pre-commit a number of times.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
