### PR TITLE
[CI] Update CODEOWNERS add @jbampton for pre-commit config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-*   @jiayuasu
+*                           @jiayuasu
+.pre-commit-config.yaml     @jbampton @jiayuasu


### PR DESCRIPTION
People with write permissions for the repository can create or edit the CODEOWNERS file and be listed as code owners.

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

See the link below for an example of how a CODEOWNERS file works:

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

I am a committer with write access and I work on the pre-commit config all the time so I should be one of the default people that get called for a review when others work on our pre-commit framework.

## How was this patch tested?

When you visit the CODEOWNERS file on the GitHub website it will tell you if it is valid or not.

For example go here:

https://github.com/apache/sedona/blob/master/.github/CODEOWNERS

And you will see this:

![Screenshot from 2025-03-29 14-37-10](https://github.com/user-attachments/assets/9ddb1b2c-1ea1-4bb2-9aad-5faa03f0342f)

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
