### PR TITLE
chore: standardize spelling in Java code

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/utils/FormatUtils.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/FormatUtils.java
@@ -141,14 +141,15 @@ public class FormatUtils<T extends Geometry> implements Serializable {
     geoJSONReader = new GeoJSONReader();
   }
 
-  private void handleNonSpatialDataToGeometry(Geometry geometry, List<String> splitedGeometryData) {
-    LinkedList<String> splitedGeometryDataList = new LinkedList<String>(splitedGeometryData);
+  private void handleNonSpatialDataToGeometry(
+      Geometry geometry, List<String> splittedGeometryData) {
+    LinkedList<String> splittedGeometryDataList = new LinkedList<String>(splittedGeometryData);
     if (carryInputData) {
       if (this.splitter != FileDataSplitter.GEOJSON) {
         // remove spatial data position
-        splitedGeometryDataList.remove(this.startOffset);
+        splittedGeometryDataList.remove(this.startOffset);
       }
-      geometry.setUserData(String.join("\t", splitedGeometryDataList));
+      geometry.setUserData(String.join("\t", splittedGeometryDataList));
     }
   }
 


### PR DESCRIPTION
We use "splitted" a lot more than "splited".

So this PR just makes the usage consistent.

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No

## What changes were proposed in this PR?

Making spelling of terms consistent.

## How was this patch tested?

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
