### PR TITLE
[CI] Update CODEOWNERS add reviewers for linters

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,8 @@
 *                           @jiayuasu
+.editorconfig               @jbampton @jiayuasu
 .pre-commit-config.yaml     @jbampton @jiayuasu
+.prettierignore             @jbampton @jiayuasu
+.prettierrc                 @jbampton @jiayuasu
+.shellcheckrc               @jbampton @jiayuasu
+Makefile                    @jbampton @jiayuasu
+/.github/linters/           @jbampton @jiayuasu


### PR DESCRIPTION
The linter config files work with the pre-commit config.

So adding @jbampton as one of the default reviewers.

Added reviewers for the Makefile as well.

An example of how a CODEOWNERS file works:

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

## How was this patch tested?

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
