### PR TITLE
[DOCS] Fix Referer of matomo tracking pixel

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -201,7 +201,7 @@ extra:
     current_rc: 1.7.1-rc1
     current_snapshot: 1.8.0-SNAPSHOT
     next_version: 1.8.0
-copyright: Copyright © 2025 The Apache Software Foundation. Apache Sedona, Sedona, Apache, the Apache feather logo, and the Apache Sedona project logo are either registered trademarks or trademarks of The Apache Software Foundation in the United States and other countries. All other marks mentioned may be trademarks or registered trademarks of their respective owners. Please visit <a href="https://www.apache.org/">Apache Software Foundation</a> for more details.<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=f3e121f6-c909-4592-8be6-5bd345768cba" /><img src="https://analytics.apache.org/matomo.php?idsite=74&rec=1" />
+copyright: Copyright © 2025 The Apache Software Foundation. Apache Sedona, Sedona, Apache, the Apache feather logo, and the Apache Sedona project logo are either registered trademarks or trademarks of The Apache Software Foundation in the United States and other countries. All other marks mentioned may be trademarks or registered trademarks of their respective owners. Please visit <a href="https://www.apache.org/">Apache Software Foundation</a> for more details.<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=f3e121f6-c909-4592-8be6-5bd345768cba" /><img referrerpolicy="no-referrer-when-downgrade" src="https://analytics.apache.org/matomo.php?idsite=74&rec=1" />
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a documentation update. The PR name follows the format `[DOCS] my subject`

## What changes were proposed in this PR?

This PR adds `referrerpolicy="no-referrer-when-downgrade"` attribute to the tracking pixel. The HTTP request sent by browser will have full URL with path in the Referer header.

## How was this patch tested?

`mkdocs serve` locally and observe that the HTTP request has Referer header containing the full URL.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
