### PR TITLE
[SEDONA-690] Set default metric to use Haversine for KNN join and code refactoring

### DIFF
--- a/spark/common/src/main/java/org/apache/sedona/core/joinJudgement/InMemoryKNNJoinIterator.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/joinJudgement/InMemoryKNNJoinIterator.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.core.joinJudgement;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.NoSuchElementException;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.sedona.core.enums.DistanceMetric;
+import org.apache.sedona.core.wrapper.UniqueGeometry;
+import org.apache.spark.util.LongAccumulator;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.index.strtree.ItemDistance;
+import org.locationtech.jts.index.strtree.STRtree;
+
+public class InMemoryKNNJoinIterator<T extends Geometry, U extends Geometry>
+    implements Iterator<Pair<T, U>> {
+  private final Iterator<T> querySideIterator;
+  private final STRtree strTree;
+
+  private final int k;
+  private final Double searchRadius;
+  private final DistanceMetric distanceMetric;
+  private final boolean includeTies;
+  private final ItemDistance itemDistance;
+
+  private final LongAccumulator streamCount;
+  private final LongAccumulator resultCount;
+
+  private final List<Pair<T, U>> currentResults = new ArrayList<>();
+  private int currentResultIndex = 0;
+
+  public InMemoryKNNJoinIterator(
+      Iterator<T> querySideIterator,
+      STRtree strTree,
+      int k,
+      Double searchRadius,
+      DistanceMetric distanceMetric,
+      boolean includeTies,
+      LongAccumulator streamCount,
+      LongAccumulator resultCount) {
+    this.querySideIterator = querySideIterator;
+    this.strTree = strTree;
+
+    this.k = k;
+    this.searchRadius = searchRadius;
+    this.distanceMetric = distanceMetric;
+    this.includeTies = includeTies;
+    this.itemDistance = KnnJoinIndexJudgement.getItemDistance(distanceMetric);
+
+    this.streamCount = streamCount;
+    this.resultCount = resultCount;
+  }
+
+  @Override
+  public boolean hasNext() {
+    if (currentResultIndex < currentResults.size()) {
+      return true;
+    }
+
+    currentResultIndex = 0;
+    currentResults.clear();
+    while (querySideIterator.hasNext()) {
+      populateNextBatch();
+      if (!currentResults.isEmpty()) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  @Override
+  public Pair<T, U> next() {
+    if (!hasNext()) {
+      throw new NoSuchElementException();
+    }
+
+    return currentResults.get(currentResultIndex++);
+  }
+
+  private void populateNextBatch() {
+    T queryItem = querySideIterator.next();
+    Geometry queryGeom;
+    if (queryItem instanceof UniqueGeometry) {
+      queryGeom = (Geometry) ((UniqueGeometry<?>) queryItem).getOriginalGeometry();
+    } else {
+      queryGeom = queryItem;
+    }
+    streamCount.add(1);
+
+    Object[] localK =
+        strTree.nearestNeighbour(queryGeom.getEnvelopeInternal(), queryGeom, itemDistance, k);
+    if (includeTies) {
+      localK = getUpdatedLocalKWithTies(queryGeom, localK, strTree);
+    }
+    if (searchRadius != null) {
+      localK =
+          KnnJoinIndexJudgement.getInSearchRadius(localK, queryGeom, distanceMetric, searchRadius);
+    }
+
+    for (Object obj : localK) {
+      U candidate = (U) obj;
+      Pair<T, U> pair = Pair.of(queryItem, candidate);
+      currentResults.add(pair);
+      resultCount.add(1);
+    }
+  }
+
+  private Object[] getUpdatedLocalKWithTies(
+      Geometry streamShape, Object[] localK, STRtree strTree) {
+    Envelope searchEnvelope = streamShape.getEnvelopeInternal();
+    // get the maximum distance from the k nearest neighbors
+    double maxDistance = 0.0;
+    LinkedHashSet<U> uniqueCandidates = new LinkedHashSet<>();
+    for (Object obj : localK) {
+      U candidate = (U) obj;
+      uniqueCandidates.add(candidate);
+      double distance = streamShape.distance(candidate);
+      if (distance > maxDistance) {
+        maxDistance = distance;
+      }
+    }
+    searchEnvelope.expandBy(maxDistance);
+    List<U> candidates = strTree.query(searchEnvelope);
+    if (!candidates.isEmpty()) {
+      // update localK with all candidates that are within the maxDistance
+      List<Object> tiedResults = new ArrayList<>();
+      // add all localK
+      Collections.addAll(tiedResults, localK);
+
+      for (U candidate : candidates) {
+        double distance = streamShape.distance(candidate);
+        if (distance == maxDistance && !uniqueCandidates.contains(candidate)) {
+          tiedResults.add(candidate);
+        }
+      }
+      localK = tiedResults.toArray();
+    }
+    return localK;
+  }
+}

--- a/spark/common/src/main/java/org/apache/sedona/core/joinJudgement/InMemoryKNNJoinIterator.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/joinJudgement/InMemoryKNNJoinIterator.java
@@ -39,7 +39,6 @@ public class InMemoryKNNJoinIterator<T extends Geometry, U extends Geometry>
   private final STRtree strTree;
 
   private final int k;
-  private final Double searchRadius;
   private final DistanceMetric distanceMetric;
   private final boolean includeTies;
   private final ItemDistance itemDistance;
@@ -54,7 +53,6 @@ public class InMemoryKNNJoinIterator<T extends Geometry, U extends Geometry>
       Iterator<T> querySideIterator,
       STRtree strTree,
       int k,
-      Double searchRadius,
       DistanceMetric distanceMetric,
       boolean includeTies,
       LongAccumulator streamCount,
@@ -63,7 +61,6 @@ public class InMemoryKNNJoinIterator<T extends Geometry, U extends Geometry>
     this.strTree = strTree;
 
     this.k = k;
-    this.searchRadius = searchRadius;
     this.distanceMetric = distanceMetric;
     this.includeTies = includeTies;
     this.itemDistance = KnnJoinIndexJudgement.getItemDistance(distanceMetric);
@@ -113,10 +110,6 @@ public class InMemoryKNNJoinIterator<T extends Geometry, U extends Geometry>
         strTree.nearestNeighbour(queryGeom.getEnvelopeInternal(), queryGeom, itemDistance, k);
     if (includeTies) {
       localK = getUpdatedLocalKWithTies(queryGeom, localK, strTree);
-    }
-    if (searchRadius != null) {
-      localK =
-          KnnJoinIndexJudgement.getInSearchRadius(localK, queryGeom, distanceMetric, searchRadius);
     }
 
     for (Object obj : localK) {

--- a/spark/common/src/main/java/org/apache/sedona/core/joinJudgement/KnnJoinIndexJudgement.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/joinJudgement/KnnJoinIndexJudgement.java
@@ -19,19 +19,19 @@
 package org.apache.sedona.core.joinJudgement;
 
 import java.io.Serializable;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.sedona.core.enums.DistanceMetric;
 import org.apache.sedona.core.knnJudgement.EuclideanItemDistance;
 import org.apache.sedona.core.knnJudgement.HaversineItemDistance;
 import org.apache.sedona.core.knnJudgement.SpheroidDistance;
-import org.apache.sedona.core.wrapper.UniqueGeometry;
 import org.apache.spark.api.java.function.FlatMapFunction2;
 import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.util.LongAccumulator;
-import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.index.SpatialIndex;
 import org.locationtech.jts.index.strtree.GeometryItemDistance;
 import org.locationtech.jts.index.strtree.ItemDistance;
 import org.locationtech.jts.index.strtree.STRtree;
@@ -45,19 +45,19 @@ import org.locationtech.jts.index.strtree.STRtree;
  */
 public class KnnJoinIndexJudgement<T extends Geometry, U extends Geometry>
     extends JudgementBase<T, U>
-    implements FlatMapFunction2<Iterator<T>, Iterator<SpatialIndex>, Pair<U, T>>, Serializable {
+    implements FlatMapFunction2<Iterator<T>, Iterator<U>, Pair<T, U>>, Serializable {
   private final int k;
   private final Double searchRadius;
   private final DistanceMetric distanceMetric;
   private final boolean includeTies;
-  private final Broadcast<List> broadcastQueryObjects;
+  private final Broadcast<List<T>> broadcastQueryObjects;
   private final Broadcast<STRtree> broadcastObjectsTreeIndex;
 
   /**
    * Constructor for the KnnJoinIndexJudgement class.
    *
    * @param k the number of nearest neighbors to find
-   * @param searchRadius
+   * @param searchRadius only search for nearest neighbors within this radius
    * @param distanceMetric the distance metric to use
    * @param broadcastQueryObjects the broadcast geometries on queries
    * @param broadcastObjectsTreeIndex the broadcast spatial index on objects
@@ -71,7 +71,7 @@ public class KnnJoinIndexJudgement<T extends Geometry, U extends Geometry>
       Double searchRadius,
       DistanceMetric distanceMetric,
       boolean includeTies,
-      Broadcast<List> broadcastQueryObjects,
+      Broadcast<List<T>> broadcastQueryObjects,
       Broadcast<STRtree> broadcastObjectsTreeIndex,
       LongAccumulator buildCount,
       LongAccumulator streamCount,
@@ -91,15 +91,15 @@ public class KnnJoinIndexJudgement<T extends Geometry, U extends Geometry>
    * and uses the spatial index to find the k nearest neighbors for each geometry. The method
    * returns an iterator over the join results.
    *
-   * @param streamShapes iterator over the geometries in the stream side
-   * @param treeIndexes iterator over the spatial indexes
+   * @param queryShapes iterator over the geometries in the query side
+   * @param objectShapes iterator over the geometries in the object side
    * @return an iterator over the join results
    * @throws Exception if the spatial index is not of type STRtree
    */
   @Override
-  public Iterator<Pair<U, T>> call(Iterator<T> streamShapes, Iterator<SpatialIndex> treeIndexes)
+  public Iterator<Pair<T, U>> call(Iterator<T> queryShapes, Iterator<U> objectShapes)
       throws Exception {
-    if (!treeIndexes.hasNext() || (streamShapes != null && !streamShapes.hasNext())) {
+    if (!objectShapes.hasNext() || (queryShapes != null && !queryShapes.hasNext())) {
       buildCount.add(0);
       streamCount.add(0);
       resultCount.add(0);
@@ -107,91 +107,85 @@ public class KnnJoinIndexJudgement<T extends Geometry, U extends Geometry>
       return Collections.emptyIterator();
     }
 
-    STRtree strTree;
-    if (broadcastObjectsTreeIndex != null) {
-      // get the broadcast spatial index on objects side if available
-      strTree = broadcastObjectsTreeIndex.getValue();
-    } else {
-      // get the spatial index from the iterator
-      SpatialIndex treeIndex = treeIndexes.next();
-      if (!(treeIndex instanceof STRtree)) {
-        throw new Exception(
-            "[KnnJoinIndexJudgement][Call] Only STRtree index supports KNN search.");
-      }
-      strTree = (STRtree) treeIndex;
-    }
-
-    // TODO: For future improvement, instead of using a list to store the results,
-    // we can use lazy evaluation to avoid storing all the results in memory.
-    List<Pair<U, T>> result = new ArrayList<>();
-
-    List queryItems;
-    if (broadcastQueryObjects != null) {
-      // get the broadcast spatial index on queries side if available
-      queryItems = broadcastQueryObjects.getValue();
-      for (Object item : queryItems) {
-        T queryGeom;
-        if (item instanceof UniqueGeometry) {
-          queryGeom = (T) ((UniqueGeometry) item).getOriginalGeometry();
-        } else {
-          queryGeom = (T) item;
-        }
-        streamCount.add(1);
-
-        Object[] localK =
-            strTree.nearestNeighbour(
-                queryGeom.getEnvelopeInternal(), queryGeom, getItemDistance(), k);
-        if (includeTies) {
-          localK = getUpdatedLocalKWithTies(queryGeom, localK, strTree);
-        }
-        if (searchRadius != null) {
-          localK = getInSearchRadius(localK, queryGeom);
-        }
-
-        for (Object obj : localK) {
-          T candidate = (T) obj;
-          Pair<U, T> pair = Pair.of((U) item, candidate);
-          result.add(pair);
-          resultCount.add(1);
-        }
-      }
-      return result.iterator();
-    } else {
-      while (streamShapes.hasNext()) {
-        T streamShape = streamShapes.next();
-        streamCount.add(1);
-
-        Object[] localK =
-            strTree.nearestNeighbour(
-                streamShape.getEnvelopeInternal(), streamShape, getItemDistance(), k);
-        if (includeTies) {
-          localK = getUpdatedLocalKWithTies(streamShape, localK, strTree);
-        }
-        if (searchRadius != null) {
-          localK = getInSearchRadius(localK, streamShape);
-        }
-
-        for (Object obj : localK) {
-          T candidate = (T) obj;
-          Pair<U, T> pair = Pair.of((U) streamShape, candidate);
-          result.add(pair);
-          resultCount.add(1);
-        }
-      }
-      return result.iterator();
-    }
+    STRtree strTree = buildSTRtree(objectShapes);
+    return new InMemoryKNNJoinIterator<>(
+        queryShapes,
+        strTree,
+        k,
+        searchRadius,
+        distanceMetric,
+        includeTies,
+        streamCount,
+        resultCount);
   }
 
-  private Object[] getInSearchRadius(Object[] localK, T queryGeom) {
-    localK =
-        Arrays.stream(localK)
-            .filter(
-                candidate -> {
-                  Geometry candidateGeom = (Geometry) candidate;
-                  return distanceByMetric(queryGeom, candidateGeom, distanceMetric) <= searchRadius;
-                })
-            .toArray();
-    return localK;
+  /**
+   * This method performs the KNN join operation using the broadcast spatial index built using all
+   * geometries in the object side.
+   *
+   * @param queryShapes iterator over the geometries in the query side
+   * @return an iterator over the join results
+   */
+  public Iterator<Pair<T, U>> callUsingBroadcastObjectIndex(Iterator<T> queryShapes) {
+    if (!queryShapes.hasNext()) {
+      buildCount.add(0);
+      streamCount.add(0);
+      resultCount.add(0);
+      candidateCount.add(0);
+      return Collections.emptyIterator();
+    }
+
+    // There's no need to use external spatial index, since the object side is small enough to be
+    // broadcasted, the STRtree built from the broadcasted object should be able to fit into memory.
+    STRtree strTree = broadcastObjectsTreeIndex.getValue();
+    return new InMemoryKNNJoinIterator<>(
+        queryShapes,
+        strTree,
+        k,
+        searchRadius,
+        distanceMetric,
+        includeTies,
+        streamCount,
+        resultCount);
+  }
+
+  /**
+   * This method performs the KNN join operation using the broadcast query geometries.
+   *
+   * @param objectShapes iterator over the geometries in the object side
+   * @return an iterator over the join results
+   */
+  public Iterator<Pair<T, U>> callUsingBroadcastQueryList(Iterator<U> objectShapes) {
+    if (!objectShapes.hasNext()) {
+      buildCount.add(0);
+      streamCount.add(0);
+      resultCount.add(0);
+      candidateCount.add(0);
+      return Collections.emptyIterator();
+    }
+
+    List<T> queryItems = broadcastQueryObjects.getValue();
+    STRtree strTree = buildSTRtree(objectShapes);
+    return new InMemoryKNNJoinIterator<>(
+        queryItems.iterator(),
+        strTree,
+        k,
+        searchRadius,
+        distanceMetric,
+        includeTies,
+        streamCount,
+        resultCount);
+  }
+
+  private STRtree buildSTRtree(Iterator<U> objectShapes) {
+    STRtree strTree = new STRtree();
+    while (objectShapes.hasNext()) {
+      U spatialObject = objectShapes.next();
+      strTree.insert(spatialObject.getEnvelopeInternal(), spatialObject);
+      buildCount.add(1);
+    }
+    strTree.build();
+    return strTree;
   }
 
   /**
@@ -219,12 +213,6 @@ public class KnnJoinIndexJudgement<T extends Geometry, U extends Geometry>
     }
   }
 
-  private ItemDistance getItemDistance() {
-    ItemDistance itemDistance;
-    itemDistance = getItemDistanceByMetric(distanceMetric);
-    return itemDistance;
-  }
-
   /**
    * This method returns the ItemDistance object based on the specified distance metric.
    *
@@ -250,38 +238,6 @@ public class KnnJoinIndexJudgement<T extends Geometry, U extends Geometry>
     return itemDistance;
   }
 
-  private Object[] getUpdatedLocalKWithTies(T streamShape, Object[] localK, STRtree strTree) {
-    Envelope searchEnvelope = streamShape.getEnvelopeInternal();
-    // get the maximum distance from the k nearest neighbors
-    double maxDistance = 0.0;
-    LinkedHashSet<T> uniqueCandidates = new LinkedHashSet<>();
-    for (Object obj : localK) {
-      T candidate = (T) obj;
-      uniqueCandidates.add(candidate);
-      double distance = streamShape.distance(candidate);
-      if (distance > maxDistance) {
-        maxDistance = distance;
-      }
-    }
-    searchEnvelope.expandBy(maxDistance);
-    List<T> candidates = strTree.query(searchEnvelope);
-    if (!candidates.isEmpty()) {
-      // update localK with all candidates that are within the maxDistance
-      List<Object> tiedResults = new ArrayList<>();
-      // add all localK
-      Collections.addAll(tiedResults, localK);
-
-      for (T candidate : candidates) {
-        double distance = streamShape.distance(candidate);
-        if (distance == maxDistance && !uniqueCandidates.contains(candidate)) {
-          tiedResults.add(candidate);
-        }
-      }
-      localK = tiedResults.toArray();
-    }
-    return localK;
-  }
-
   public static <U extends Geometry, T extends Geometry> double distance(
       U key, T value, DistanceMetric distanceMetric) {
     switch (distanceMetric) {
@@ -294,5 +250,24 @@ public class KnnJoinIndexJudgement<T extends Geometry, U extends Geometry>
       default:
         return new EuclideanItemDistance().distance(key, value);
     }
+  }
+
+  public static Object[] getInSearchRadius(
+      Object[] localK, Geometry queryGeom, DistanceMetric distanceMetric, double searchRadius) {
+    localK =
+        Arrays.stream(localK)
+            .filter(
+                candidate -> {
+                  Geometry candidateGeom = (Geometry) candidate;
+                  return distanceByMetric(queryGeom, candidateGeom, distanceMetric) <= searchRadius;
+                })
+            .toArray();
+    return localK;
+  }
+
+  public static ItemDistance getItemDistance(DistanceMetric distanceMetric) {
+    ItemDistance itemDistance;
+    itemDistance = getItemDistanceByMetric(distanceMetric);
+    return itemDistance;
   }
 }

--- a/spark/common/src/main/java/org/apache/sedona/core/spatialOperator/JoinQuery.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/spatialOperator/JoinQuery.java
@@ -37,13 +37,11 @@ import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
-import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.api.java.function.Function2;
 import org.apache.spark.api.java.function.PairFunction;
 import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.util.LongAccumulator;
 import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.index.SpatialIndex;
 import org.locationtech.jts.index.strtree.STRtree;
 import scala.Tuple2;
 
@@ -890,22 +888,11 @@ public class JoinQuery {
       JavaRDD<Pair<U, T>> querySideBroadcastKNNJoin(
           SpatialRDD<T> objectRDD,
           JoinParams joinParams,
-          KnnJoinIndexJudgement judgement,
+          KnnJoinIndexJudgement<UniqueGeometry<U>, T> judgement,
           boolean includeTies) {
     final JavaRDD<Pair<U, T>> joinResult;
-    JavaRDD<Pair<U, T>> joinResultMapped =
-        objectRDD.indexedRawRDD.mapPartitions(
-            iterator -> {
-              List<Pair<U, T>> results = new ArrayList<>();
-              if (iterator.hasNext()) {
-                SpatialIndex spatialIndex = iterator.next();
-                // the broadcast join won't need inputs from the query's shape stream
-                Iterator<Pair<U, T>> callResult =
-                    judgement.call(null, Collections.singletonList(spatialIndex).iterator());
-                callResult.forEachRemaining(results::add);
-              }
-              return results.iterator();
-            });
+    JavaRDD<Pair<UniqueGeometry<U>, T>> joinResultMapped =
+        objectRDD.rawSpatialRDD.mapPartitions(judgement::callUsingBroadcastQueryList);
     // this is to avoid serializable issues with the broadcast variable
     int k = joinParams.k;
     DistanceMetric distanceMetric = joinParams.distanceMetric;
@@ -914,72 +901,67 @@ public class JoinQuery {
     // (based on a grouping key and distance)
     joinResult =
         joinResultMapped
-            .groupBy(pair -> pair.getKey()) // Group by the first geometry
+            .groupBy(pair -> pair.getKey().getUniqueId())
             .flatMap(
-                (FlatMapFunction<Tuple2<U, Iterable<Pair<U, T>>>, Pair<U, T>>)
-                    pair -> {
-                      Iterable<Pair<U, T>> values = pair._2;
+                pair -> {
+                  Iterable<Pair<UniqueGeometry<U>, T>> values = pair._2;
 
-                      // Extract and sort values by distance
-                      List<Pair<U, T>> sortedPairs = new ArrayList<>();
-                      for (Pair<U, T> p : values) {
-                        Pair<U, T> newPair =
-                            Pair.of(
-                                (U) ((UniqueGeometry<?>) p.getKey()).getOriginalGeometry(),
-                                p.getValue());
-                        sortedPairs.add(newPair);
-                      }
+                  // Extract and sort values by distance
+                  List<Pair<U, T>> sortedPairs = new ArrayList<>();
+                  for (Pair<UniqueGeometry<U>, T> p : values) {
+                    Pair<U, T> newPair = Pair.of(p.getKey().getOriginalGeometry(), p.getValue());
+                    sortedPairs.add(newPair);
+                  }
 
-                      // Sort pairs based on the distance function between the two geometries
-                      sortedPairs.sort(
-                          (p1, p2) -> {
-                            double distance1 =
-                                KnnJoinIndexJudgement.distance(
-                                    p1.getKey(), p1.getValue(), distanceMetric);
-                            double distance2 =
-                                KnnJoinIndexJudgement.distance(
-                                    p2.getKey(), p2.getValue(), distanceMetric);
-                            return Double.compare(
-                                distance1, distance2); // Sort ascending by distance
-                          });
+                  // Sort pairs based on the distance function between the two geometries
+                  sortedPairs.sort(
+                      (p1, p2) -> {
+                        double distance1 =
+                            KnnJoinIndexJudgement.distance(
+                                p1.getKey(), p1.getValue(), distanceMetric);
+                        double distance2 =
+                            KnnJoinIndexJudgement.distance(
+                                p2.getKey(), p2.getValue(), distanceMetric);
+                        return Double.compare(distance1, distance2); // Sort ascending by distance
+                      });
 
-                      if (includeTies) {
-                        // Keep the top k pairs, including ties
-                        List<Pair<U, T>> topPairs = new ArrayList<>();
-                        double kthDistance = -1;
-                        for (int i = 0; i < sortedPairs.size(); i++) {
-                          if (i < k) {
-                            topPairs.add(sortedPairs.get(i));
-                            if (i == k - 1) {
-                              kthDistance =
-                                  KnnJoinIndexJudgement.distance(
-                                      sortedPairs.get(i).getKey(),
-                                      sortedPairs.get(i).getValue(),
-                                      distanceMetric);
-                            }
-                          } else {
-                            double currentDistance =
-                                KnnJoinIndexJudgement.distance(
-                                    sortedPairs.get(i).getKey(),
-                                    sortedPairs.get(i).getValue(),
-                                    distanceMetric);
-                            if (currentDistance == kthDistance) {
-                              topPairs.add(sortedPairs.get(i));
-                            } else {
-                              break;
-                            }
-                          }
+                  if (includeTies) {
+                    // Keep the top k pairs, including ties
+                    List<Pair<U, T>> topPairs = new ArrayList<>();
+                    double kthDistance = -1;
+                    for (int i = 0; i < sortedPairs.size(); i++) {
+                      if (i < k) {
+                        topPairs.add(sortedPairs.get(i));
+                        if (i == k - 1) {
+                          kthDistance =
+                              KnnJoinIndexJudgement.distance(
+                                  sortedPairs.get(i).getKey(),
+                                  sortedPairs.get(i).getValue(),
+                                  distanceMetric);
                         }
-                        return topPairs.iterator();
                       } else {
-                        // Keep the top k pairs without ties
-                        List<Pair<U, T>> topPairs = new ArrayList<>();
-                        for (int i = 0; i < Math.min(k, sortedPairs.size()); i++) {
+                        double currentDistance =
+                            KnnJoinIndexJudgement.distance(
+                                sortedPairs.get(i).getKey(),
+                                sortedPairs.get(i).getValue(),
+                                distanceMetric);
+                        if (currentDistance == kthDistance) {
                           topPairs.add(sortedPairs.get(i));
+                        } else {
+                          break;
                         }
-                        return topPairs.iterator();
                       }
-                    });
+                    }
+                    return topPairs.iterator();
+                  } else {
+                    // Keep the top k pairs without ties
+                    List<Pair<U, T>> topPairs = new ArrayList<>();
+                    for (int i = 0; i < Math.min(k, sortedPairs.size()); i++) {
+                      topPairs.add(sortedPairs.get(i));
+                    }
+                    return topPairs.iterator();
+                  }
+                });
 
     return joinResult;
   }

--- a/spark/common/src/main/java/org/apache/sedona/core/spatialOperator/JoinQuery.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/spatialOperator/JoinQuery.java
@@ -399,7 +399,7 @@ public class JoinQuery {
       DistanceMetric distanceMetric)
       throws Exception {
     final JoinParams joinParams =
-        new JoinParams(true, null, IndexType.RTREE, null, k, distanceMetric, null);
+        new JoinParams(true, null, IndexType.RTREE, null, k, distanceMetric);
 
     final JavaPairRDD<U, T> joinResults = knnJoin(queryRDD, objectRDD, joinParams, false, false);
     return collectGeometriesByKey(joinResults);
@@ -817,7 +817,6 @@ public class JoinQuery {
       final KnnJoinIndexJudgement<U, T> judgement =
           new KnnJoinIndexJudgement<>(
               joinParams.k,
-              joinParams.searchRadius,
               joinParams.distanceMetric,
               includeTies,
               null,
@@ -833,7 +832,6 @@ public class JoinQuery {
       final KnnJoinIndexJudgement<U, T> judgement =
           new KnnJoinIndexJudgement<>(
               joinParams.k,
-              joinParams.searchRadius,
               joinParams.distanceMetric,
               includeTies,
               null,
@@ -849,7 +847,6 @@ public class JoinQuery {
       final KnnJoinIndexJudgement<UniqueGeometry<U>, T> judgement =
           new KnnJoinIndexJudgement<>(
               joinParams.k,
-              joinParams.searchRadius,
               joinParams.distanceMetric,
               includeTies,
               broadcastQueryObjects,
@@ -975,14 +972,13 @@ public class JoinQuery {
     // KNN specific parameters
     public final int k;
     public final DistanceMetric distanceMetric;
-    public final Double searchRadius;
 
     public JoinParams(
         boolean useIndex,
         SpatialPredicate spatialPredicate,
         IndexType polygonIndexType,
         JoinBuildSide joinBuildSide) {
-      this(useIndex, spatialPredicate, polygonIndexType, joinBuildSide, -1, null, null);
+      this(useIndex, spatialPredicate, polygonIndexType, joinBuildSide, -1, null);
     }
 
     public JoinParams(
@@ -991,15 +987,13 @@ public class JoinQuery {
         IndexType polygonIndexType,
         JoinBuildSide joinBuildSide,
         int k,
-        DistanceMetric distanceMetric,
-        Double searchRadius) {
+        DistanceMetric distanceMetric) {
       this.useIndex = useIndex;
       this.spatialPredicate = spatialPredicate;
       this.indexType = polygonIndexType;
       this.joinBuildSide = joinBuildSide;
       this.k = k;
       this.distanceMetric = distanceMetric;
-      this.searchRadius = searchRadius;
     }
 
     public JoinParams(boolean useIndex, SpatialPredicate spatialPredicate) {

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/BroadcastObjectSideKNNJoinExec.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/BroadcastObjectSideKNNJoinExec.scala
@@ -138,7 +138,7 @@ case class BroadcastObjectSideKNNJoinExec(
     // Number of neighbors to find
     val kValue: Int = this.k.eval().asInstanceOf[Int]
     // Metric to use in the join to calculate the distance, only Euclidean and Spheroid are supported
-    val distanceMetric = if (isGeography) DistanceMetric.SPHEROID else DistanceMetric.EUCLIDEAN
+    val distanceMetric = if (isGeography) DistanceMetric.HAVERSINE else DistanceMetric.EUCLIDEAN
     val joinParams =
       new JoinParams(true, null, IndexType.RTREE, null, kValue, distanceMetric, null)
     joinParams

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/BroadcastObjectSideKNNJoinExec.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/BroadcastObjectSideKNNJoinExec.scala
@@ -140,7 +140,7 @@ case class BroadcastObjectSideKNNJoinExec(
     // Metric to use in the join to calculate the distance, only Euclidean and Spheroid are supported
     val distanceMetric = if (isGeography) DistanceMetric.HAVERSINE else DistanceMetric.EUCLIDEAN
     val joinParams =
-      new JoinParams(true, null, IndexType.RTREE, null, kValue, distanceMetric, null)
+      new JoinParams(true, null, IndexType.RTREE, null, kValue, distanceMetric)
     joinParams
   }
 

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/BroadcastQuerySideKNNJoinExec.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/BroadcastQuerySideKNNJoinExec.scala
@@ -151,7 +151,7 @@ case class BroadcastQuerySideKNNJoinExec(
     // Metric to use in the join to calculate the distance, only Euclidean and Spheroid are supported
     val distanceMetric = if (isGeography) DistanceMetric.HAVERSINE else DistanceMetric.EUCLIDEAN
     val joinParams =
-      new JoinParams(true, null, IndexType.RTREE, null, kValue, distanceMetric, null)
+      new JoinParams(true, null, IndexType.RTREE, null, kValue, distanceMetric)
     joinParams
   }
 

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/BroadcastQuerySideKNNJoinExec.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/BroadcastQuerySideKNNJoinExec.scala
@@ -149,7 +149,7 @@ case class BroadcastQuerySideKNNJoinExec(
     // Number of neighbors to find
     val kValue: Int = this.k.eval().asInstanceOf[Int]
     // Metric to use in the join to calculate the distance, only Euclidean and Spheroid are supported
-    val distanceMetric = if (isGeography) DistanceMetric.SPHEROID else DistanceMetric.EUCLIDEAN
+    val distanceMetric = if (isGeography) DistanceMetric.HAVERSINE else DistanceMetric.EUCLIDEAN
     val joinParams =
       new JoinParams(true, null, IndexType.RTREE, null, kValue, distanceMetric, null)
     joinParams

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/KNNJoinExec.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/KNNJoinExec.scala
@@ -209,7 +209,7 @@ case class KNNJoinExec(
     // Number of neighbors to find
     val kValue: Int = this.k.eval().asInstanceOf[Int]
     // Metric to use in the join to calculate the distance, only Euclidean and Spheroid are supported
-    val distanceMetric = if (isGeography) DistanceMetric.SPHEROID else DistanceMetric.EUCLIDEAN
+    val distanceMetric = if (isGeography) DistanceMetric.HAVERSINE else DistanceMetric.EUCLIDEAN
     val joinParams =
       new JoinParams(true, null, IndexType.RTREE, null, kValue, distanceMetric, null)
     joinParams

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/KNNJoinExec.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/KNNJoinExec.scala
@@ -211,7 +211,7 @@ case class KNNJoinExec(
     // Metric to use in the join to calculate the distance, only Euclidean and Spheroid are supported
     val distanceMetric = if (isGeography) DistanceMetric.HAVERSINE else DistanceMetric.EUCLIDEAN
     val joinParams =
-      new JoinParams(true, null, IndexType.RTREE, null, kValue, distanceMetric, null)
+      new JoinParams(true, null, IndexType.RTREE, null, kValue, distanceMetric)
     joinParams
   }
 }


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

This PR change the default distance metric to use Haversine distance when use_spheroid = true. It also refactors the join index judgement code to be more readable.

## How was this patch tested?
KNNTestSuit

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
