### PR TITLE
[GH-1922] ST_X/Y/Z ON null geometries

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/Functions.java
+++ b/common/src/main/java/org/apache/sedona/common/Functions.java
@@ -603,28 +603,28 @@ public class Functions {
   }
 
   public static Double x(Geometry geometry) {
-    if (geometry instanceof Point) {
+    if (geometry instanceof Point && geometry.getCoordinate() != null) {
       return geometry.getCoordinate().x;
     }
     return null;
   }
 
   public static Double y(Geometry geometry) {
-    if (geometry instanceof Point) {
+    if (geometry instanceof Point && geometry.getCoordinate() != null) {
       return geometry.getCoordinate().y;
     }
     return null;
   }
 
   public static Double z(Geometry geometry) {
-    if (geometry instanceof Point) {
+    if (geometry instanceof Point && geometry.getCoordinate() != null) {
       return geometry.getCoordinate().z;
     }
     return null;
   }
 
   public static Double m(Geometry geom) {
-    if (geom instanceof Point) {
+    if (geom instanceof Point && geom.getCoordinate() != null) {
       return geom.getCoordinate().getM();
     }
     return null;
@@ -708,12 +708,12 @@ public class Functions {
 
   public static boolean hasM(Geometry geom) {
     Coordinate coord = geom.getCoordinate();
-    return !Double.isNaN(coord.getM());
+    return coord != null && !Double.isNaN(coord.getM());
   }
 
   public static boolean hasZ(Geometry geom) {
     Coordinate coord = geom.getCoordinate();
-    return !Double.isNaN(coord.getZ());
+    return coord != null && !Double.isNaN(coord.getZ());
   }
 
   public static Geometry flipCoordinates(Geometry geometry) {

--- a/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
@@ -4402,4 +4402,22 @@ public class FunctionsTest extends TestBase {
     expected = 2.75;
     assertEquals(expected, actual, 1e-6);
   }
+
+  @Test
+  public void emptyPoint() throws ParseException {
+    Geometry point = Constructors.geomFromEWKT("POINT(1 1)");
+    Geometry emptyPoint = Constructors.geomFromEWKT("POINT EMPTY");
+
+    double actualX = Functions.x(point);
+    double expectedX = 1.0;
+    assertEquals(expectedX, actualX, 1e-6);
+
+    assertNull(Functions.x(emptyPoint));
+    assertNull(Functions.y(emptyPoint));
+    assertNull(Functions.z(emptyPoint));
+    assertNull(Functions.m(emptyPoint));
+
+    assertFalse(Functions.hasM(emptyPoint));
+    assertFalse(Functions.hasZ(emptyPoint));
+  }
 }


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`.
- https://github.com/apache/sedona/issues/1922

## What changes were proposed in this PR?
- Check for nullity of geometry in the x/y/z/m functions (common/srcmain/java/org/apache/sedona/common/Functions.java), so that their invocation on empty geometries returns null.

## How was this patch tested?
- Created emptyPoint() test on common/src/test/java/org/apache/sedona/common/FunctionsTest.java

## Did this PR include necessary documentation updates?
- No, this PR does not affect any public API so no need to change the documentation.
