### PR TITLE
[GH-1761] error when invalid ST_Subdivide maxVertices argument

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/Functions.java
+++ b/common/src/main/java/org/apache/sedona/common/Functions.java
@@ -1866,6 +1866,9 @@ public class Functions {
   }
 
   public static Geometry[] subDivide(Geometry geometry, int maxVertices) {
+    if (maxVertices < 5) {
+      throw new IllegalArgumentException("ST_Subdivide needs 5 or more max vertices");
+    }
     return GeometrySubDivider.subDivide(geometry, maxVertices);
   }
 

--- a/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
@@ -4420,4 +4420,12 @@ public class FunctionsTest extends TestBase {
     assertFalse(Functions.hasM(emptyPoint));
     assertFalse(Functions.hasZ(emptyPoint));
   }
+
+  @Test
+  public void subdivideInvalidMaxVertices() {
+    LineString lineString = GEOMETRY_FACTORY.createLineString(coordArray(0, 0, 99, 99));
+    IllegalArgumentException e =
+        assertThrows(IllegalArgumentException.class, () -> Functions.subDivide(lineString, 4));
+    assertEquals("ST_Subdivide needs 5 or more max vertices", e.getMessage());
+  }
 }

--- a/docs/api/flink/Function.md
+++ b/docs/api/flink/Function.md
@@ -4041,6 +4041,8 @@ POINT(100 150)
 
 Introduction: Returns list of geometries divided based of given maximum number of vertices.
 
+A minimum of 5 vertices is required for maxVertices parameter to form a closed box.
+
 Format: `ST_SubDivide(geom: Geometry, maxVertices: Integer)`
 
 Since: `v1.5.0`

--- a/docs/api/snowflake/vector-data/Function.md
+++ b/docs/api/snowflake/vector-data/Function.md
@@ -3169,6 +3169,8 @@ Output: `POINT(100 150)`
 
 Introduction: Returns a multi-geometry divided based of given maximum number of vertices.
 
+A minimum of 5 vertices is required for maxVertices parameter to form a closed box.
+
 Format: `ST_SubDivide(geom: geometry, maxVertices: int)`
 
 SQL example:
@@ -3187,6 +3189,8 @@ MULTILINESTRING ((0 0, 5 5), (5 5, 10 10), (10 10, 21 21), (21 21, 60 60), (60 6
 ## ST_SubDivideExplode
 
 Introduction: It works the same as ST_SubDivide but returns new rows with geometries instead of a multi-geometry.
+
+A minimum of 5 vertices is required for maxVertices parameter to form a closed box.
 
 Format: `
 SELECT SEDONA.ST_AsText(GEOM)

--- a/docs/api/sql/Function.md
+++ b/docs/api/sql/Function.md
@@ -4253,6 +4253,8 @@ POINT(100 150)
 
 Introduction: Returns list of geometries divided based of given maximum number of vertices.
 
+A minimum of 5 vertices is required for maxVertices parameter to form a closed box.
+
 Format: `ST_SubDivide(geom: Geometry, maxVertices: Integer)`
 
 Since: `v1.1.0`
@@ -4308,6 +4310,8 @@ Output:
 ## ST_SubDivideExplode
 
 Introduction: It works the same as ST_SubDivide but returns new rows with geometries instead of list.
+
+A minimum of 5 vertices is required for maxVertices parameter to form a closed box.
 
 Format: `ST_SubDivideExplode(geom: Geometry, maxVertices: Integer)`
 

--- a/spark/common/src/test/scala/org/apache/sedona/sql/PreserveSRIDSuite.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/PreserveSRIDSuite.scala
@@ -75,7 +75,7 @@ class PreserveSRIDSuite extends TestBaseScala with TableDrivenPropertyChecks {
       ("ST_SetPoint(geom3, 1, ST_Point(0.5, 0.5))", 1000),
       ("ST_ClosestPoint(geom1, geom2)", 1000),
       ("ST_FlipCoordinates(geom1)", 1000),
-      ("ST_SubDivide(geom4, 4)", 1000),
+      ("ST_SubDivide(geom4, 5)", 1000),
       ("ST_MakeEnvelope(0, 1, 2, 3, 1000)", 1000),
       ("ST_MakeLine(geom3, geom3)", 1000),
       ("ST_Points(geom1)", 1000),

--- a/spark/common/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
@@ -3770,4 +3770,14 @@ class functionTestScala
       "The Line has SRID 4326 and Point has SRID 3857. The Line and Point should be in the same SRID.")
   }
 
+  it("should raise an error when using ST_SubDivide with not enough vertices") {
+    val invalidDf = sparkSession.sql("""
+        |SELECT ST_Subdivide(ST_GeomFromWKT('LINESTRING(0 0, 99 99)'), 4) as result
+    """.stripMargin)
+
+    val exception = intercept[Exception] {
+      invalidDf.collect()
+    }
+    exception.getMessage should include("ST_Subdivide needs 5 or more max vertices")
+  }
 }


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?
- Yes, and the PR name follows the format `[GH-XXX] my subject`.
- https://github.com/apache/sedona/issues/1761

## What changes were proposed in this PR?
Throws InvalidArgumentException when maxVertices is lower that 5.

## How was this patch tested?
- Created 'subdivideInvalidMaxVertices' test in common/src/test/java/org/apache/sedona/common/FunctionsTest.java
- Created test in in spark/common/src/test/scala/org/apache/sedona/sql/functionTestScala.scala

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation (ST_Subdivide/ST_SubdivideExplode) in both docs/api/sql/Function.md and docs/api/flink/Function.md