### PR TITLE
[CI] Fix failed Python build extension CI

### DIFF
--- a/.github/workflows/python-extension.yml
+++ b/.github/workflows/python-extension.yml
@@ -62,8 +62,13 @@ jobs:
       - name: Install dependencies
         run: |
           cd python
-          pipenv --python ${{ matrix.python }}
-          pipenv install --dev
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+              PYTHON_EXE_PATH="$pythonLocation/python.exe"
+          else
+              PYTHON_EXE_PATH="$pythonLocation/python"
+          fi
+          echo "Using Python executable at: $PYTHON_EXE_PATH"
+          pipenv install --dev --python "$PYTHON_EXE_PATH"
       - name: Build extension
         run: |
           cd python


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

Reported by @Kontinuation

> Sometimes pipenv goes crazy and creates a virtual environment containing a 32-bit python interpreter. We explicitly specify the python executable to get rid of this issue. I have not found similar issues being reported yet and don't know why pipenv's behavior changed.

## How was this patch tested?


## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
