### PR TITLE
[GH-1931] Move packaging module import to geopandas try-except block

### DIFF
--- a/python/sedona/maps/SedonaMapUtils.py
+++ b/python/sedona/maps/SedonaMapUtils.py
@@ -19,7 +19,6 @@ import json
 
 from sedona.sql.types import GeometryType
 from sedona.utils.geoarrow import dataframe_to_arrow
-from packaging.version import parse
 
 
 class SedonaMapUtils:
@@ -46,6 +45,9 @@ class SedonaMapUtils:
             return data_pyarrow.to_pandas()
         try:
             import geopandas as gpd
+
+            # packaging is a dependency of geopandas
+            from packaging.version import parse
         except ImportError:
             msg = "GeoPandas is missing. You can install it manually or via apache-sedona[kepler-map] or apache-sedona[pydeck-map]."
             raise ImportError(msg) from None


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`.

## What changes were proposed in this PR?

Fixes #1931 

I have moved the import of `packaging.version.parse` to the try-except block that `geopandas` is imported in, as `packaging` is already a dependency of `geopandas`

## How was this patch tested?

Local test by successfully running


```py
from sedona.spark import SedonaContext
import pyspark.sql.functions as sf


SedonaContext.create(spark)
spark.range(10).withColumn("geom", sf.expr("ST_POINT(id, id)")).show()
```

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
