### PR TITLE
[GH-1945] Shade Jiffle and its dependencies

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -139,10 +139,10 @@
             <plugin>
                 <!--
                   We need to shade jiffle and its antlr and janino dependencies for the following reasons:
-                  
+
                   1. Databricks runtime uses an older version of janino (3.0.16) that does not work
                      with jiffle in Spark repl. See https://github.com/apache/sedona/discussions/1945
-                  
+
                   2. Spark 4 uses an incompatible version of antlr at runtime.
                 -->
                 <groupId>org.apache.maven.plugins</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -105,19 +105,6 @@
             <groupId>it.geosolutions.jaiext.jiffle</groupId>
             <artifactId>jt-jiffle-language</artifactId>
         </dependency>
-        <!-- These test dependencies are for running map algebra tests -->
-        <dependency>
-            <groupId>org.antlr</groupId>
-            <artifactId>antlr4-runtime</artifactId>
-            <version>${antlr-runtime.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.janino</groupId>
-            <artifactId>janino</artifactId>
-            <version>${janino-version}</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>edu.ucar</groupId>
             <artifactId>cdm-core</artifactId>
@@ -133,6 +120,78 @@
                     <source>11</source>
                     <target>11</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <!-- Skip running resolved-pom-maven-plugin since shade will
+                     generate dependency reduced pom which substitutes property
+                     values. resolved-pom-maven-plugin will break pom
+                     installation when working with maven-shade-plugin.  -->
+                <groupId>io.paradoxical</groupId>
+                <artifactId>resolved-pom-maven-plugin</artifactId>
+                <version>1.0</version>
+                <executions>
+                    <execution>
+                        <id>resolve-my-pom</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <!--
+                  We need to shade jiffle and its antlr and janino dependencies for the following reasons:
+                  
+                  1. Databricks runtime uses an older version of janino (3.0.16) that does not work
+                     with jiffle in Spark repl. See https://github.com/apache/sedona/discussions/1945
+                  
+                  2. Spark 4 uses an incompatible version of antlr at runtime.
+                -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>it.geosolutions.jaiext.jiffle:*</include>
+                                    <include>org.antlr:*</include>
+                                    <include>org.codehaus.janino:*</include>
+                                </includes>
+                            </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>it.geosolutions.jaiext.jiffle</pattern>
+                                    <shadedPattern>org.apache.sedona.shaded.jiffle</shadedPattern>
+                                    <excludes>
+                                        <exclude>it.geosolutions.jaiext.jiffle.runtime.*</exclude>
+                                    </excludes>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.antlr.v4.runtime</pattern>
+                                    <shadedPattern>org.apache.sedona.shaded.antlr</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.codehaus</pattern>
+                                    <shadedPattern>org.apache.sedona.shaded.codehaus</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <filters>
+                                <!--  filter to address "Invalid signature file" issue - see http://stackoverflow.com/a/6743609/589215 -->
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <scala.compat.version>2.12</scala.compat.version>
         <spark.version>3.4.0</spark.version>
         <spark.compat.version>3.4</spark.compat.version>
-        <log4j.version>2.17.2</log4j.version>
+        <log4j.version>2.19.0</log4j.version>
         <graphframe.version>0.8.3-spark3.4</graphframe.version>
 
         <flink.version>1.19.0</flink.version>
@@ -272,11 +272,14 @@
                 <groupId>it.geosolutions.jaiext.jiffle</groupId>
                 <artifactId>jt-jiffle-language</artifactId>
                 <version>${jt-jiffle.version}</version>
-                <scope>${geotools.scope}</scope>
                 <exclusions>
                     <exclusion>
-                        <groupId>*</groupId>
+                        <groupId>javax.media</groupId>
                         <artifactId>*</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>it.geosolutions.jaiext.utilities</groupId>
+                        <artifactId>jt-utilities</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -340,6 +343,11 @@
                 <artifactId>kryo</artifactId>
                 <version>4.0.2</version>
                 <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.janino</groupId>
+                <artifactId>janino</artifactId>
+                <version>${janino-version}</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>

--- a/spark-shaded/pom.xml
+++ b/spark-shaded/pom.xml
@@ -47,6 +47,11 @@
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
+                <!-- Even those these are shaded, the shaded POM isn't used when building projects in a single Maven run -->
+                <exclusion>
+                    <groupId>it.geosolutions.jaiext.jiffle</groupId>
+                    <artifactId>jt-jiffle-language</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/spark/common/pom.xml
+++ b/spark/common/pom.xml
@@ -163,10 +163,6 @@
             <artifactId>gt-arcgrid</artifactId>
         </dependency>
         <dependency>
-            <groupId>it.geosolutions.jaiext.jiffle</groupId>
-            <artifactId>jt-jiffle-language</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.locationtech.jts</groupId>
             <artifactId>jts-core</artifactId>
         </dependency>


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`.

## What changes were proposed in this PR?

This PR shades jiffle into sedona-common to workaround problems encountered on runtimes with low janino version. Please refer to https://github.com/apache/sedona/discussions/1945 for details.

This PR is mostly taken from https://github.com/apache/sedona/pull/1919, which shades jiffle and antlr. This PR shades janino additionally.

Jiffle should be removed from geotools-wrapper (see https://github.com/jiayuasu/geotools-wrapper/pull/12), since now it is shaded into sedona-common and shipped with sedona-spark-shaded jar.

## How was this patch tested?

Tested manually on DBR 15.4 LTS.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
