### PR TITLE
[GH-1998] Fix typo in install-scala page (#1998)

### DIFF
--- a/docs/setup/install-scala.md
+++ b/docs/setup/install-scala.md
@@ -19,7 +19,7 @@
 
 Before starting the Sedona journey, you need to make sure your Apache Spark cluster is ready.
 
-There are two ways to use a Scala or Java library with Apache Spark. You can user either one to run Sedona.
+There are two ways to use a Scala or Java library with Apache Spark. You can use either one to run Sedona.
 
 * Spark interactive Scala or SQL shell: easy to start, good for new learners to try simple functions
 * Self-contained Scala / Java project: a steep learning curve of package management, but good for large projects


### PR DESCRIPTION
## Did you read the Contributor Guide?

- [x] Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)
- [ ] No, I haven't read it.

## Is this PR related to a ticket?

- [ ] Yes, and the PR name follows the format `[SEDONA-XXX] my subject`.
- [x] Yes, and the PR name follows the format `[GH-XXX] my subject`.  
  (This addresses [GH-1998](https://github.com/apache/sedona/issues/1998))
- [ ] No:
  - [x] this is a documentation update. The PR name follows the format `[DOCS] my subject`
  - [ ] this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

This PR fixes a typo in the documentation page [`install-scala`](https://sedona.apache.org/1.5.0/setup/install-scala/), where the word **"user"** was mistakenly used instead of **"use"**.

As discussed in issue #1998, I’ve limited this PR only to the typo fix and did not proceed with mass `http` to `https` replacements, since it would affect too many files.

## How was this patch tested?

Since this is a markdown documentation fix, I manually verified the change in the file and ensured the typo is corrected.

## Did this PR include necessary documentation updates?

- [ ] Yes, I am adding a new API. I am using the [current SNAPSHOT version number](https://github.com/apache/sedona/blob/99239524f17389fc4ae9548ea88756f8ea538bb9/pom.xml#L29) in `vX.Y.Z` format.
- [ ] Yes, I have updated the documentation.
- [x] No, this PR does not affect any public API so no need to change the documentation.
