### PR TITLE
[GH-2012] Add 'Closes #<issue_number>' to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@
 ## Is this PR related to a ticket?
 
 - Yes, and the PR name follows the format `[SEDONA-XXX] my subject`.
-- Yes, and the PR name follows the format `[GH-XXX] my subject`.
+- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #<issue_number>
 
 - No:
   - this is a documentation update. The PR name follows the format `[DOCS] my subject`


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

- No, I haven't read it.

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[SEDONA-XXX] my subject`.
- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2012

- No:
  - this is a documentation update. The PR name follows the format `[DOCS] my subject`
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?
Adds `Closes #<issue_number>` to the PR template. Should be fairly quick to copy and paste over the <issue_number> part, while still being descriptive enough to explain what goes there.

## How was this patch tested?


## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
