### PR TITLE
[GH-2039] Geopandas.GeoSeries: Implement from_wkb, from_wkt, from_xy + temp __init__ fix

### DIFF
--- a/python/sedona/geopandas/geoseries.py
+++ b/python/sedona/geopandas/geoseries.py
@@ -1266,8 +1266,6 @@ class GeoSeries(GeoFrame, pspd.Series):
 
         select = f"{select} as geometry"
 
-        print(data)
-        print(select)
         spark_df = default_session().createDataFrame(data, schema=schema)
         spark_df = spark_df.selectExpr(select)
 

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -108,7 +108,23 @@ class TestGeoSeries(TestBase):
         pass
 
     def test_from_wkb(self):
-        pass
+        wkbs = [
+            (
+                b"\x01\x01\x00\x00\x00\x00\x00\x00\x00"
+                b"\x00\x00\xf0?\x00\x00\x00\x00\x00\x00\xf0?"
+            ),
+            (
+                b"\x01\x01\x00\x00\x00\x00\x00\x00\x00"
+                b"\x00\x00\x00@\x00\x00\x00\x00\x00\x00\x00@"
+            ),
+            (
+                b"\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00"
+                b"\x00\x08@\x00\x00\x00\x00\x00\x00\x08@"
+            ),
+        ]
+        s = sgpd.GeoSeries.from_wkb(wkbs)
+        expected = gpd.GeoSeries([Point(1, 1), Point(2, 2), Point(3, 3)])
+        self.check_sgpd_equals_gpd(s, expected)
 
     def test_from_wkt(self):
         wkts = [

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -111,7 +111,14 @@ class TestGeoSeries(TestBase):
         pass
 
     def test_from_wkt(self):
-        pass
+        wkts = [
+            "POINT (1 1)",
+            "POINT (2 2)",
+            "POINT (3 3)",
+        ]
+        s = sgpd.GeoSeries.from_wkt(wkts)
+        expected = gpd.GeoSeries([Point(1, 1), Point(2, 2), Point(3, 3)])
+        self.check_sgpd_equals_gpd(s, expected)
 
     def test_from_xy(self):
         pass

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -137,7 +137,18 @@ class TestGeoSeries(TestBase):
         self.check_sgpd_equals_gpd(s, expected)
 
     def test_from_xy(self):
-        pass
+        x = [2.5, 5, -3.0]
+        y = [0.5, 1, 1.5]
+        s = sgpd.GeoSeries.from_xy(x, y, crs="EPSG:4326")
+        expected = gpd.GeoSeries([Point(2.5, 0.5), Point(5, 1), Point(-3, 1.5)])
+        self.check_sgpd_equals_gpd(s, expected)
+
+        z = [1, 2, 3]
+        s = sgpd.GeoSeries.from_xy(x, y, z)
+        expected = gpd.GeoSeries(
+            [Point(2.5, 0.5, 1), Point(5, 1, 2), Point(-3, 1.5, 3)]
+        )
+        self.check_sgpd_equals_gpd(s, expected)
 
     def test_from_shapely(self):
         pass

--- a/python/tests/geopandas/test_match_geopandas_series.py
+++ b/python/tests/geopandas/test_match_geopandas_series.py
@@ -247,10 +247,8 @@ class TestMatchGeopandasSeries(TestBase):
             self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
 
     def test_from_wkt(self):
-        from shapely import to_wkt
-
         for _, geom in self.geoms:
-            wkt = [to_wkt(g) for g in geom]
+            wkt = [g.wkt for g in geom]
             sgpd_result = GeoSeries.from_wkt(wkt)
             gpd_result = gpd.GeoSeries.from_wkt(wkt)
             self.check_sgpd_equals_gpd(sgpd_result, gpd_result)

--- a/python/tests/geopandas/test_match_geopandas_series.py
+++ b/python/tests/geopandas/test_match_geopandas_series.py
@@ -256,7 +256,25 @@ class TestMatchGeopandasSeries(TestBase):
             self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
 
     def test_from_xy(self):
-        pass
+        tests = [
+            [
+                [2.5, 0.5, 5.0, -2],  # x
+                [5, 10, 0, 1],  # y
+                [-3, 1.5, -1000, 25],  # z
+                "EPSG:4326",
+            ],
+            [
+                [2.5, -0.5, 1, 500],  # x
+                [5, 1, -100, 1000],  # y
+                None,
+                None,
+            ],
+        ]
+        for x, y, z, crs in tests:
+            sgpd_result = GeoSeries.from_xy(x, y, z, crs=crs)
+            gpd_result = gpd.GeoSeries.from_xy(x, y, z, crs=crs)
+            self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
+            assert sgpd_result.crs == gpd_result.crs
 
     def test_from_shapely(self):
         pass

--- a/python/tests/geopandas/test_match_geopandas_series.py
+++ b/python/tests/geopandas/test_match_geopandas_series.py
@@ -243,7 +243,13 @@ class TestMatchGeopandasSeries(TestBase):
         pass
 
     def test_from_wkt(self):
-        pass
+        from shapely import to_wkt
+
+        for _, geom in self.geoms:
+            wkt = [to_wkt(g) for g in geom]
+            sgpd_result = GeoSeries.from_wkt(wkt)
+            gpd_result = gpd.GeoSeries.from_wkt(wkt)
+            self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
 
     def test_from_xy(self):
         pass

--- a/python/tests/geopandas/test_match_geopandas_series.py
+++ b/python/tests/geopandas/test_match_geopandas_series.py
@@ -240,7 +240,11 @@ class TestMatchGeopandasSeries(TestBase):
         pass
 
     def test_from_wkb(self):
-        pass
+        for _, geom in self.geoms:
+            wkb = [g.wkb for g in geom]
+            sgpd_result = GeoSeries.from_wkb(wkb)
+            gpd_result = gpd.GeoSeries.from_wkb(wkb)
+            self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
 
     def test_from_wkt(self):
         from shapely import to_wkt


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2039

## What changes were proposed in this PR?
- Implement from_wkb, from_wkt, from_xy
- Implement a hacky fix for the` __init__` constructor so it now correctly calls `super().__init__` without failing on the ps.Series or sgpd.Series cases.

## How was this patch tested?
Added tests

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.
