### PR TITLE
[GH-1996] Shade S2 and Guava into runtime JARs

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -89,11 +89,6 @@
             <artifactId>s2-geometry-library</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${googles2-guava.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.uber</groupId>
             <artifactId>h3</artifactId>
         </dependency>
@@ -176,16 +171,6 @@
                                     <include>it.geosolutions.jaiext.jiffle:*</include>
                                     <include>org.antlr:*</include>
                                     <include>org.codehaus.janino:*</include>
-
-                                    <!--
-                                      We shade our own released version of s2-geometry-library to avoid conflicts with
-                                      any other official com.google.geometry:s2-geometry in the runtime environment.
-
-                                      Our new s2-geometry-library requires a version of guava higher than what Spark
-                                      ships with, so we shade it as well to make s2-geometry-library work.
-                                    -->
-                                    <include>org.datasyslab:s2-geometry-library</include>
-                                    <include>com.google.guava:guava</include>
                                 </includes>
                             </artifactSet>
                             <relocations>
@@ -203,14 +188,6 @@
                                 <relocation>
                                     <pattern>org.codehaus</pattern>
                                     <shadedPattern>org.apache.sedona.shaded.codehaus</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>com.google.common.geometry</pattern>
-                                    <shadedPattern>org.apache.sedona.shaded.s2</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>com.google.common</pattern>
-                                    <shadedPattern>org.apache.sedona.shaded.guava</shadedPattern>
                                 </relocation>
                             </relocations>
                             <filters>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -87,7 +87,6 @@
         <dependency>
             <groupId>org.datasyslab</groupId>
             <artifactId>s2-geometry-library</artifactId>
-            <version>20250620-rc1</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -118,6 +118,12 @@
             <groupId>edu.ucar</groupId>
             <artifactId>cdm-core</artifactId>
         </dependency>
+        <!-- For shading a janino package that works with Spark for jiffle -->
+        <dependency>
+            <groupId>org.codehaus.janino</groupId>
+            <artifactId>janino</artifactId>
+            <version>${janino-version}</version>
+        </dependency>
     </dependencies>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
@@ -145,15 +151,8 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Shade some dependencies into sedona-common to resolve various package conflict issues -->
             <plugin>
-                <!--
-                  We need to shade jiffle and its antlr and janino dependencies for the following reasons:
-
-                  1. Databricks runtime uses an older version of janino (3.0.16) that does not work
-                     with jiffle in Spark repl. See https://github.com/apache/sedona/discussions/1945
-
-                  2. Spark 4 uses an incompatible version of antlr at runtime.
-                -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <executions>
@@ -165,9 +164,25 @@
                         <configuration>
                             <artifactSet>
                                 <includes>
+                                    <!--
+                                      We need to shade jiffle and its antlr and janino dependencies for the following reasons:
+
+                                      1. Databricks runtime uses an older version of janino (3.0.16) that does not work
+                                         with jiffle in Spark repl. See https://github.com/apache/sedona/discussions/1945
+
+                                      2. Spark 4 uses an incompatible version of antlr at runtime.
+                                    -->
                                     <include>it.geosolutions.jaiext.jiffle:*</include>
                                     <include>org.antlr:*</include>
                                     <include>org.codehaus.janino:*</include>
+
+                                    <!--
+                                      We shade our own released version of s2-geometry-library to avoid conflicts with
+                                      any other official com.google.geometry:s2-geometry in the runtime environment.
+
+                                      Our new s2-geometry-library requires a version of guava higher than what Spark
+                                      ships with, so we shade it as well to make s2-geometry-library work.
+                                    -->
                                     <include>org.datasyslab:s2-geometry-library</include>
                                     <include>com.google.guava:guava</include>
                                 </includes>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -147,8 +147,15 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- Shade some dependencies into sedona-common to resolve various package conflict issues -->
             <plugin>
+                <!--
+                  We need to shade jiffle and its antlr and janino dependencies for the following reasons:
+
+                  1. Databricks runtime uses an older version of janino (3.0.16) that does not work
+                     with jiffle in Spark repl. See https://github.com/apache/sedona/discussions/1945
+
+                  2. Spark 4 uses an incompatible version of antlr at runtime.
+                -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <executions>
@@ -160,14 +167,6 @@
                         <configuration>
                             <artifactSet>
                                 <includes>
-                                    <!--
-                                      We need to shade jiffle and its antlr and janino dependencies for the following reasons:
-
-                                      1. Databricks runtime uses an older version of janino (3.0.16) that does not work
-                                         with jiffle in Spark repl. See https://github.com/apache/sedona/discussions/1945
-
-                                      2. Spark 4 uses an incompatible version of antlr at runtime.
-                                    -->
                                     <include>it.geosolutions.jaiext.jiffle:*</include>
                                     <include>org.antlr:*</include>
                                     <include>org.codehaus.janino:*</include>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>33.4.7-jre</version>
+            <version>${googles2-guava.version}</version>
         </dependency>
         <dependency>
             <groupId>com.uber</groupId>
@@ -117,7 +117,9 @@
             <groupId>edu.ucar</groupId>
             <artifactId>cdm-core</artifactId>
         </dependency>
-        <!-- For shading a janino package that works with Spark for jiffle -->
+        <!-- For shading a janino package that works with Spark for jiffle. We don't add this to
+             dependencyManagement in parent pom.xml because we don't want to mess up with the
+             janino versions required by Spark. -->
         <dependency>
             <groupId>org.codehaus.janino</groupId>
             <artifactId>janino</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -90,6 +90,11 @@
             <version>20250620-rc1</version>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>33.4.7-jre</version>
+        </dependency>
+        <dependency>
             <groupId>com.uber</groupId>
             <artifactId>h3</artifactId>
         </dependency>
@@ -164,6 +169,7 @@
                                     <include>org.antlr:*</include>
                                     <include>org.codehaus.janino:*</include>
                                     <include>org.datasyslab:s2-geometry-library</include>
+                                    <include>com.google.guava:guava</include>
                                 </includes>
                             </artifactSet>
                             <relocations>
@@ -185,6 +191,10 @@
                                 <relocation>
                                     <pattern>com.google.common.geometry</pattern>
                                     <shadedPattern>org.apache.sedona.shaded.s2</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.common</pattern>
+                                    <shadedPattern>org.apache.sedona.shaded.guava</shadedPattern>
                                 </relocation>
                             </relocations>
                             <filters>

--- a/flink-shaded/pom.xml
+++ b/flink-shaded/pom.xml
@@ -88,6 +88,23 @@
                                     <exclude>org.scala-lang:scala-library</exclude>
                                 </excludes>
                             </artifactSet>
+                            <relocations>
+                                <!--
+                                  We relocate our own released version of s2-geometry-library to avoid conflicts with
+                                  any other official com.google.geometry:s2-geometry in the runtime environment.
+
+                                  Our new s2-geometry-library requires a version of guava higher than what Spark
+                                  ships with, so we relocate it as well to make s2-geometry-library work.
+                                -->
+                                <relocation>
+                                    <pattern>com.google.common.geometry</pattern>
+                                    <shadedPattern>org.apache.sedona.shaded.s2</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.common</pattern>
+                                    <shadedPattern>org.apache.sedona.shaded.guava</shadedPattern>
+                                </relocation>
+                            </relocations>
                             <filters>
                                 <!--  filter to address "Invalid signature file" issue - see http://stackoverflow.com/a/6743609/589215 -->
                                 <filter>

--- a/flink-shaded/pom.xml
+++ b/flink-shaded/pom.xml
@@ -104,6 +104,10 @@
                                     <pattern>com.google.common</pattern>
                                     <shadedPattern>org.apache.sedona.shaded.guava</shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <pattern>it.unimi.dsi.fastutil</pattern>
+                                    <shadedPattern>org.apache.sedona.shaded.fastutil</shadedPattern>
+                                </relocation>
                             </relocations>
                             <filters>
                                 <!--  filter to address "Invalid signature file" issue - see http://stackoverflow.com/a/6743609/589215 -->

--- a/flink/pom.xml
+++ b/flink/pom.xml
@@ -44,6 +44,14 @@
             <version>${project.version}</version>
             <exclusions>
                 <exclusion>
+                    <groupId>it.geosolutions.jaiext.jiffle</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.janino</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.datasyslab</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>

--- a/flink/pom.xml
+++ b/flink/pom.xml
@@ -51,14 +51,6 @@
                     <groupId>org.codehaus.janino</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>org.datasyslab</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/flink/pom.xml
+++ b/flink/pom.xml
@@ -42,6 +42,16 @@
             <groupId>org.apache.sedona</groupId>
             <artifactId>sedona-common</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.datasyslab</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>

--- a/flink/src/test/java/org/apache/sedona/flink/TestBase.java
+++ b/flink/src/test/java/org/apache/sedona/flink/TestBase.java
@@ -21,11 +21,11 @@ package org.apache.sedona.flink;
 import static org.apache.flink.table.api.Expressions.*;
 import static org.junit.Assert.fail;
 
+import com.google.common.math.DoubleMath;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.apache.commons.math3.util.Precision;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -72,7 +72,7 @@ public class TestBase {
           for (int d = 0; d < dimension; d++) {
             double ord1 = s1.getOrdinate(i, d);
             double ord2 = s2.getOrdinate(i, d);
-            int comp = Precision.compareTo(ord1, ord2, FP_TOLERANCE);
+            int comp = DoubleMath.fuzzyCompare(ord1, ord2, FP_TOLERANCE);
             if (comp != 0) return comp;
           }
           return 0;

--- a/flink/src/test/java/org/apache/sedona/flink/TestBase.java
+++ b/flink/src/test/java/org/apache/sedona/flink/TestBase.java
@@ -21,11 +21,11 @@ package org.apache.sedona.flink;
 import static org.apache.flink.table.api.Expressions.*;
 import static org.junit.Assert.fail;
 
-import com.google.common.math.DoubleMath;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.apache.commons.math3.util.Precision;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -72,7 +72,7 @@ public class TestBase {
           for (int d = 0; d < dimension; d++) {
             double ord1 = s1.getOrdinate(i, d);
             double ord2 = s2.getOrdinate(i, d);
-            int comp = DoubleMath.fuzzyCompare(ord1, ord2, FP_TOLERANCE);
+            int comp = Precision.compareTo(ord1, ord2, FP_TOLERANCE);
             if (comp != 0) return comp;
           }
           return 0;

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
 
         <flink.version>1.19.0</flink.version>
         <slf4j.version>1.7.36</slf4j.version>
-        <googles2.version>2.0.0</googles2.version>
+        <googles2.version>20250620-rc1</googles2.version>
         <uberh3.version>4.1.1</uberh3.version>
         <scalatest.version>3.1.1</scalatest.version>
         <scala-collection-compat.version>2.5.0</scala-collection-compat.version>
@@ -351,8 +351,8 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>com.google.geometry</groupId>
-                <artifactId>s2-geometry</artifactId>
+                <groupId>org.datasyslab</groupId>
+                <artifactId>s2-geometry-library</artifactId>
                 <version>${googles2.version}</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <flink.version>1.19.0</flink.version>
         <slf4j.version>1.7.36</slf4j.version>
         <googles2.version>20250620-rc1</googles2.version>
-        <googles2-guava.version>33.4.7-jre</googles2-guava.version>
+        <guava.version>33.4.7-jre</guava.version>
         <uberh3.version>4.1.1</uberh3.version>
         <scalatest.version>3.1.1</scalatest.version>
         <scala-collection-compat.version>2.5.0</scala-collection-compat.version>
@@ -355,6 +355,11 @@
                 <groupId>org.datasyslab</groupId>
                 <artifactId>s2-geometry-library</artifactId>
                 <version>${googles2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.uber</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -345,11 +345,6 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.codehaus.janino</groupId>
-                <artifactId>janino</artifactId>
-                <version>${janino-version}</version>
-            </dependency>
-            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.13.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,7 @@
         <flink.version>1.19.0</flink.version>
         <slf4j.version>1.7.36</slf4j.version>
         <googles2.version>20250620-rc1</googles2.version>
+        <googles2-guava.version>33.4.7-jre</googles2-guava.version>
         <uberh3.version>4.1.1</uberh3.version>
         <scalatest.version>3.1.1</scalatest.version>
         <scala-collection-compat.version>2.5.0</scala-collection-compat.version>

--- a/snowflake/pom.xml
+++ b/snowflake/pom.xml
@@ -55,14 +55,6 @@
                     <groupId>org.codehaus.janino</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>org.datasyslab</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -139,6 +131,23 @@
                                     <exclude>org.scala-lang:scala-library</exclude>
                                 </excludes>
                             </artifactSet>
+                            <relocations>
+                                <!--
+                                  We relocate our own released version of s2-geometry-library to avoid conflicts with
+                                  any other official com.google.geometry:s2-geometry in the runtime environment.
+
+                                  Our new s2-geometry-library requires a version of guava higher than what Spark
+                                  ships with, so we relocate it as well to make s2-geometry-library work.
+                                -->
+                                <relocation>
+                                    <pattern>com.google.common.geometry</pattern>
+                                    <shadedPattern>org.apache.sedona.shaded.s2</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.common</pattern>
+                                    <shadedPattern>org.apache.sedona.shaded.guava</shadedPattern>
+                                </relocation>
+                            </relocations>
                             <filters>
                                 <!--  filter to address "Invalid signature file" issue - see http://stackoverflow.com/a/6743609/589215 -->
                                 <filter>

--- a/snowflake/pom.xml
+++ b/snowflake/pom.xml
@@ -47,6 +47,14 @@
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.datasyslab</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/snowflake/pom.xml
+++ b/snowflake/pom.xml
@@ -147,6 +147,10 @@
                                     <pattern>com.google.common</pattern>
                                     <shadedPattern>org.apache.sedona.shaded.guava</shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <pattern>it.unimi.dsi.fastutil</pattern>
+                                    <shadedPattern>org.apache.sedona.shaded.fastutil</shadedPattern>
+                                </relocation>
                             </relocations>
                             <filters>
                                 <!--  filter to address "Invalid signature file" issue - see http://stackoverflow.com/a/6743609/589215 -->

--- a/snowflake/pom.xml
+++ b/snowflake/pom.xml
@@ -48,6 +48,14 @@
                     <artifactId>*</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>it.geosolutions.jaiext.jiffle</groupId>
+                    <artifactId>jt-jiffle-language</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.janino</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.datasyslab</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>

--- a/spark-shaded/pom.xml
+++ b/spark-shaded/pom.xml
@@ -56,14 +56,6 @@
                     <groupId>org.codehaus.janino</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>org.datasyslab</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -249,6 +241,23 @@
                                     <exclude>commons-logging:commons-logging</exclude>
                                 </excludes>
                             </artifactSet>
+                            <relocations>
+                                <!--
+                                  We relocate our own released version of s2-geometry-library to avoid conflicts with
+                                  any other official com.google.geometry:s2-geometry in the runtime environment.
+
+                                  Our new s2-geometry-library requires a version of guava higher than what Spark
+                                  ships with, so we relocate it as well to make s2-geometry-library work.
+                                -->
+                                <relocation>
+                                    <pattern>com.google.common.geometry</pattern>
+                                    <shadedPattern>org.apache.sedona.shaded.s2</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.common</pattern>
+                                    <shadedPattern>org.apache.sedona.shaded.guava</shadedPattern>
+                                </relocation>
+                            </relocations>
                             <filters>
                                 <!--  filter to address "Invalid signature file" issue - see http://stackoverflow.com/a/6743609/589215 -->
                                 <filter>

--- a/spark-shaded/pom.xml
+++ b/spark-shaded/pom.xml
@@ -257,6 +257,10 @@
                                     <pattern>com.google.common</pattern>
                                     <shadedPattern>org.apache.sedona.shaded.guava</shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <pattern>it.unimi.dsi.fastutil</pattern>
+                                    <shadedPattern>org.apache.sedona.shaded.fastutil</shadedPattern>
+                                </relocation>
                             </relocations>
                             <filters>
                                 <!--  filter to address "Invalid signature file" issue - see http://stackoverflow.com/a/6743609/589215 -->

--- a/spark-shaded/pom.xml
+++ b/spark-shaded/pom.xml
@@ -53,6 +53,10 @@
                     <artifactId>jt-jiffle-language</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.codehaus.janino</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.datasyslab</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>

--- a/spark-shaded/pom.xml
+++ b/spark-shaded/pom.xml
@@ -52,6 +52,14 @@
                     <groupId>it.geosolutions.jaiext.jiffle</groupId>
                     <artifactId>jt-jiffle-language</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.datasyslab</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/spark/common/pom.xml
+++ b/spark/common/pom.xml
@@ -46,6 +46,14 @@
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.datasyslab</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/spark/common/pom.xml
+++ b/spark/common/pom.xml
@@ -54,14 +54,6 @@
                     <groupId>org.codehaus.janino</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>org.datasyslab</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/spark/common/pom.xml
+++ b/spark/common/pom.xml
@@ -47,6 +47,14 @@
                     <artifactId>*</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>it.geosolutions.jaiext.jiffle</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.janino</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.datasyslab</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>

--- a/spark/spark-3.4/pom.xml
+++ b/spark/spark-3.4/pom.xml
@@ -46,6 +46,14 @@
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.datasyslab</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/spark/spark-3.4/pom.xml
+++ b/spark/spark-3.4/pom.xml
@@ -54,14 +54,6 @@
                     <groupId>org.codehaus.janino</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>org.datasyslab</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/spark/spark-3.4/pom.xml
+++ b/spark/spark-3.4/pom.xml
@@ -47,6 +47,14 @@
                     <artifactId>*</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>it.geosolutions.jaiext.jiffle</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.janino</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.datasyslab</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>

--- a/spark/spark-3.5/pom.xml
+++ b/spark/spark-3.5/pom.xml
@@ -46,6 +46,14 @@
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.datasyslab</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/spark/spark-3.5/pom.xml
+++ b/spark/spark-3.5/pom.xml
@@ -54,14 +54,6 @@
                     <groupId>org.codehaus.janino</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>org.datasyslab</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/spark/spark-3.5/pom.xml
+++ b/spark/spark-3.5/pom.xml
@@ -47,6 +47,14 @@
                     <artifactId>*</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>it.geosolutions.jaiext.jiffle</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.janino</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.datasyslab</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>

--- a/spark/spark-4.0/pom.xml
+++ b/spark/spark-4.0/pom.xml
@@ -46,6 +46,14 @@
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.datasyslab</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/spark/spark-4.0/pom.xml
+++ b/spark/spark-4.0/pom.xml
@@ -54,14 +54,6 @@
                     <groupId>org.codehaus.janino</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>org.datasyslab</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/spark/spark-4.0/pom.xml
+++ b/spark/spark-4.0/pom.xml
@@ -47,6 +47,14 @@
                     <artifactId>*</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>it.geosolutions.jaiext.jiffle</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.janino</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.datasyslab</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`.

## What changes were proposed in this PR?

As discussed in https://github.com/apache/sedona/issues/1996#issuecomment-2995332894, we have switched s2 dependency to our own `org.datasyslab:s2-geometry-library`. This may cause conflicts if there's `com.google.geometry:s2-geometry` packages in the runtime environment. We decided to shade it into runtime jars to get rid of possible conflicts.

`org.datasyslab:s2-geometry-library` depends on a recent version of Guava, which is incompatible with the Guava jar shipped with Apache Spark, so we have to shade guava into runtime jars as well.

We have also cherry-picked https://github.com/apache/sedona/commit/e005f23c3d7438d55dcfa199f497064d8178924f#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8 into this PR, this is for fixing problems with shading janino found when releasing 1.7.2.

## How was this patch tested?

* Passing existing tests
* Manually tested the spark-shaded jar in local environment

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
