### PR TITLE
[GH-2095] Implement scalable workaround for GeoSeries.__init__()

### DIFF
--- a/python/sedona/geopandas/geoseries.py
+++ b/python/sedona/geopandas/geoseries.py
@@ -155,9 +155,9 @@ class GeoSeries(GeoFrame, pspd.Series):
 
             # Can't to try-except here since the exception would be in spark, so we check the first valid index
             first_idx = data.first_valid_index()
-            if isinstance(
+            if first_idx is None or isinstance(
                 data[first_idx], (BaseGeometry, bytearray, bytes)
-            ) and not pd.isna(data[first_idx]):
+            ):
                 data = data.apply(try_geom_to_ewkb)
             else:
                 raise TypeError(

--- a/python/sedona/geopandas/geoseries.py
+++ b/python/sedona/geopandas/geoseries.py
@@ -186,6 +186,8 @@ class GeoSeries(GeoFrame, pspd.Series):
                 copy=copy,
                 fastpath=fastpath,
             )
+
+            self._anchor = data
         else:
             if isinstance(data, pd.Series):
                 assert index is None
@@ -486,13 +488,7 @@ class GeoSeries(GeoFrame, pspd.Series):
             if isinstance(data_type, BinaryType):
                 query = query.replace(f"`{cols}`", f"ST_GeomFromWKB(`{cols}`)")
 
-            # Convert back to EWKB format if the return type is a geometry
-            if returns_geom:
-                query = f"ST_AsEWKB({query})"
-
             rename = col if not rename else rename
-
-            query = f"{query} as `{rename}`"
 
         elif isinstance(cols, list):
             for col in cols:
@@ -505,7 +501,11 @@ class GeoSeries(GeoFrame, pspd.Series):
             # must have rename for multiple columns since we don't know which name to default to
             assert rename
 
-            query = f"{query} as `{rename}`"
+        # Convert back to EWKB format if the return type is a geometry
+        if returns_geom:
+            query = f"ST_AsEWKB({query})"
+
+        query = f"{query} as `{rename}`"
 
         # We always select NATURAL_ORDER_COLUMN_NAME, to avoid having to regenerate it in the result
         # We always select SPARK_DEFAULT_INDEX_NAME, to retain series index info
@@ -1913,7 +1913,7 @@ class GeoSeries(GeoFrame, pspd.Series):
         if isinstance(data, list) and not isinstance(data[0], (tuple, list)):
             data = [(obj,) for obj in data]
 
-        select = f"{select} as geometry"
+        select = f"ST_AsEWKB({select}) as geometry"
 
         spark_df = default_session().createDataFrame(data, schema=schema)
         spark_df = spark_df.selectExpr(select)

--- a/python/sedona/geopandas/geoseries.py
+++ b/python/sedona/geopandas/geoseries.py
@@ -543,7 +543,7 @@ class GeoSeries(GeoFrame, pspd.Series):
             def try_wkb_to_geom(wkb):
                 if wkb:
                     try:
-                        return shapely.from_wkb(bytes(wkb))
+                        return shapely.wkb.loads(bytes(wkb))
                     except TypeError:
                         pass
 

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -142,8 +142,8 @@ class TestGeoSeries(TestBase):
         ps.set_option("compute.ops_on_diff_frames", True)
         s = sgpd.GeoSeries.from_wkb(wkbs)
         ps.reset_option("compute.ops_on_diff_frames")
+
         expected = gpd.GeoSeries([Point(1, 1), Point(2, 2), Point(3, 3)])
-        print(s)
         self.check_sgpd_equals_gpd(s, expected)
 
     def test_from_wkt(self):

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -18,6 +18,7 @@
 import numpy as np
 import pytest
 import pandas as pd
+import pyspark.pandas as ps
 import geopandas as gpd
 import sedona.geopandas as sgpd
 from sedona.geopandas import GeoSeries
@@ -137,8 +138,11 @@ class TestGeoSeries(TestBase):
                 b"\x00\x08@\x00\x00\x00\x00\x00\x00\x08@"
             ),
         ]
+        ps.set_option("compute.ops_on_diff_frames", True)
         s = sgpd.GeoSeries.from_wkb(wkbs)
+        ps.reset_option("compute.ops_on_diff_frames")
         expected = gpd.GeoSeries([Point(1, 1), Point(2, 2), Point(3, 3)])
+        print(s)
         self.check_sgpd_equals_gpd(s, expected)
 
     def test_from_wkt(self):
@@ -147,19 +151,25 @@ class TestGeoSeries(TestBase):
             "POINT (2 2)",
             "POINT (3 3)",
         ]
+        ps.set_option("compute.ops_on_diff_frames", True)
         s = sgpd.GeoSeries.from_wkt(wkts)
+        ps.reset_option("compute.ops_on_diff_frames")
         expected = gpd.GeoSeries([Point(1, 1), Point(2, 2), Point(3, 3)])
         self.check_sgpd_equals_gpd(s, expected)
 
     def test_from_xy(self):
         x = [2.5, 5, -3.0]
         y = [0.5, 1, 1.5]
+        ps.set_option("compute.ops_on_diff_frames", True)
         s = sgpd.GeoSeries.from_xy(x, y, crs="EPSG:4326")
+        ps.reset_option("compute.ops_on_diff_frames")
         expected = gpd.GeoSeries([Point(2.5, 0.5), Point(5, 1), Point(-3, 1.5)])
         self.check_sgpd_equals_gpd(s, expected)
 
         z = [1, 2, 3]
+        ps.set_option("compute.ops_on_diff_frames", True)
         s = sgpd.GeoSeries.from_xy(x, y, z)
+        ps.reset_option("compute.ops_on_diff_frames")
         expected = gpd.GeoSeries(
             [Point(2.5, 0.5, 1), Point(5, 1, 2), Point(-3, 1.5, 3)]
         )

--- a/python/tests/geopandas/test_match_geopandas_series.py
+++ b/python/tests/geopandas/test_match_geopandas_series.py
@@ -245,20 +245,25 @@ class TestMatchGeopandasSeries(TestBase):
         pass
 
     def test_from_wkb(self):
+        ps.set_option("compute.ops_on_diff_frames", True)
         for _, geom in self.geoms:
             wkb = [g.wkb for g in geom]
             sgpd_result = GeoSeries.from_wkb(wkb)
             gpd_result = gpd.GeoSeries.from_wkb(wkb)
             self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
+        ps.reset_option("compute.ops_on_diff_frames")
 
     def test_from_wkt(self):
+        ps.set_option("compute.ops_on_diff_frames", True)
         for _, geom in self.geoms:
             wkt = [g.wkt for g in geom]
             sgpd_result = GeoSeries.from_wkt(wkt)
             gpd_result = gpd.GeoSeries.from_wkt(wkt)
             self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
+        ps.reset_option("compute.ops_on_diff_frames")
 
     def test_from_xy(self):
+        ps.set_option("compute.ops_on_diff_frames", True)
         tests = [
             [
                 [2.5, 0.5, 5.0, -2],  # x
@@ -278,6 +283,7 @@ class TestMatchGeopandasSeries(TestBase):
             gpd_result = gpd.GeoSeries.from_xy(x, y, z, crs=crs)
             self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
             assert sgpd_result.crs == gpd_result.crs
+        ps.reset_option("compute.ops_on_diff_frames")
 
     def test_from_shapely(self):
         pass


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2095

## What changes were proposed in this PR?
In a previous PR, I wrote a workaround for the behavior of creating a Series from a Series. That workaround required the use of `to_pandas()` which is not scalable. I previously submitting a fix to Spark was told this would be a new feature that could not be backported. I then realized, I could just manually implement the logic in our codebase in the mean time since it's all in the constructor.

## How was this patch tested?
Ensured existing tests pass

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
