### PR TITLE
[GH-2066] Fix the Geopandas sindex query method predicate logic

### DIFF
--- a/python/tests/geopandas/test_sindex.py
+++ b/python/tests/geopandas/test_sindex.py
@@ -114,7 +114,7 @@ class TestSpatialIndex(TestBase):
         query_point = Point(2.2, 2.2)
 
         # Execute query
-        result_indices = sindex.query(query_point, "contains")
+        result_indices = sindex.query(query_point, "intersects")
 
         # Verify results - should find at least one result (polygon containing the point)
         assert len(result_indices) > 0
@@ -128,7 +128,7 @@ class TestSpatialIndex(TestBase):
         box_results = sindex.query(query_box, predicate="contains")
 
         # Verify results - should find multiple polygons
-        assert len(box_results) > 1
+        assert len(box_results) == 1
 
         # Test with contains predicate
         # The query box fully contains polygon at index 2 (POLYGON((2 2, 3 2, 3 3, 2 3, 2 2)))


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #<issue_number>

## What changes were proposed in this PR?
- contains and intersects gets reversed
- add checkes to indicate only support these two types of predicates

## How was this patch tested?
sindex test in python

## Did this PR include necessary documentation updates?
- No, this PR does not affect any public API so no need to change the documentation.
