### PR TITLE
[GH-2095] Geopandas: Implement Scalable workaround and store as geometries instead of EWKB

### DIFF
--- a/python/sedona/geopandas/geodataframe.py
+++ b/python/sedona/geopandas/geodataframe.py
@@ -92,14 +92,17 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
 
             try:
                 result = sgpd.GeoSeries(ps_series)
-                srid = shapely.get_srid(ps_series[0])
+                first_idx = ps_series.first_valid_index()
+                if first_idx is not None:
+                    geom = ps_series.iloc[int(first_idx)]
+                    srid = shapely.get_srid(geom)
 
-                # Shapely objects stored in the ps.Series retain their srid
-                # but the GeoSeries does not, so we manually re-set it here
-                if srid > 0:
-                    result.set_crs(srid, inplace=True)
+                    # Shapely objects stored in the ps.Series retain their srid
+                    # but the GeoSeries does not, so we manually re-set it here
+                    if srid > 0:
+                        result.set_crs(srid, inplace=True)
                 return result
-            except:
+            except TypeError:
                 return ps_series
 
         # Handle list of column names

--- a/python/sedona/geopandas/geodataframe.py
+++ b/python/sedona/geopandas/geodataframe.py
@@ -92,6 +92,12 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
 
             try:
                 result = sgpd.GeoSeries(ps_series)
+                srid = shapely.get_srid(ps_series[0])
+
+                # Shapely objects stored in the ps.Series retain their srid
+                # but the GeoSeries does not, so we manually re-set it here
+                if srid > 0:
+                    result.set_crs(srid, inplace=True)
                 return result
             except:
                 return ps_series
@@ -139,36 +145,6 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
         from sedona.geopandas import GeoSeries
         from pyspark.sql import DataFrame as SparkDataFrame
 
-        # Simplified version of the function from GeoSeries.__init__()
-        def try_geom_to_ewkb(x) -> bytes:
-            if isinstance(x, BaseGeometry):
-                kwargs = {}
-                if crs:
-                    from pyproj import CRS
-
-                    srid = CRS.from_user_input(crs)
-                    kwargs["srid"] = srid.to_epsg()
-
-                return shapely.wkb.dumps(x, **kwargs)
-            elif isinstance(x, bytearray):
-                return bytes(x)
-            elif x is None or isinstance(x, bytes):
-                return x
-            else:
-                raise TypeError(f"expected geometry or bytes, got {type(x)}: {x}")
-
-        def safe_apply_to_each_column(
-            df: pd.DataFrame | pspd.DataFrame, func: Callable
-        ):
-            # try except won't work here for ps.DataFrame case, so we use first_valid_index() instead
-            for col in df.columns:
-                first_idx = df[col].first_valid_index()
-                if first_idx is not None and isinstance(
-                    df[col][first_idx], BaseGeometry
-                ):
-                    df[col] = df[col].apply(try_geom_to_ewkb)
-            return df
-
         if isinstance(data, GeoDataFrame):
             if data._safe_get_crs() is None:
                 data.crs = crs
@@ -181,8 +157,6 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
             # This way, if Spark adds support later, than we inherit those changes naturally
             super().__init__(data, index=index, columns=columns, dtype=dtype, copy=copy)
         elif isinstance(data, PandasOnSparkDataFrame):
-
-            data = safe_apply_to_each_column(data, try_geom_to_ewkb)
 
             super().__init__(data, index=index, columns=columns, dtype=dtype, copy=copy)
         elif isinstance(data, PandasOnSparkSeries):
@@ -215,17 +189,13 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
                     dtype=dtype,
                     copy=copy,
                 )
-            gdf = gpd.GeoDataFrame(df)
-            # convert each geometry column to wkb type
 
-            # It's possible we get a list, dict, pd.Series, gpd.GeoSeries, etc of shapely.Geometry objects.
-            gdf = safe_apply_to_each_column(gdf, try_geom_to_ewkb)
+            # Spark complains if it's left as a geometry type
+            pd_df = df.astype(object)
 
-            pdf = pd.DataFrame(gdf)
-
-            # initialize the parent class pyspark Dataframe with the pandas Series
+            # initialize the parent class pyspark Dataframe with the pandas Dataframe
             super().__init__(
-                data=pdf,
+                data=pd_df,
                 index=index,
                 dtype=dtype,
                 copy=copy,
@@ -666,7 +636,7 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
         0           1.0      1
         1           4.0      2
         """
-        return self._process_geometry_columns("ST_Area", rename_suffix="_area")
+        return self.geometry.area
 
     def _safe_get_crs(self):
         """

--- a/python/tests/geopandas/test_geodataframe.py
+++ b/python/tests/geopandas/test_geodataframe.py
@@ -20,6 +20,7 @@ import tempfile
 from shapely.geometry import (
     Point,
 )
+import shapely
 
 from sedona.geopandas import GeoDataFrame, GeoSeries
 from tests.geopandas.test_geopandas_base import TestGeopandasBase
@@ -32,6 +33,10 @@ from pandas.testing import assert_frame_equal, assert_series_equal
 from packaging.version import parse as parse_version
 
 
+@pytest.mark.skipif(
+    parse_version(shapely.__version__) < parse_version("2.0.0"),
+    reason=f"Tests require shapely>=2.0.0, but found v{shapely.__version__}",
+)
 class TestDataframe(TestGeopandasBase):
     @pytest.mark.parametrize(
         "obj",

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -40,6 +40,10 @@ import pytest
 from packaging.version import parse as parse_version
 
 
+@pytest.mark.skipif(
+    parse_version(shapely.__version__) < parse_version("2.0.0"),
+    reason=f"Tests require shapely>=2.0.0, but found v{shapely.__version__}",
+)
 class TestGeoSeries(TestGeopandasBase):
     def setup_method(self):
         self.geoseries = sgpd.GeoSeries(

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -57,6 +57,10 @@ class TestGeoSeries(TestGeopandasBase):
             ]
         )
 
+    def test_empty_list(self):
+        s = sgpd.GeoSeries([])
+        assert s.count() == 0
+
     def test_area(self):
         result = self.geoseries.area.to_pandas()
         expected = pd.Series([0.0, 0.0, 5.23, 5.23])

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -222,22 +222,20 @@ class TestGeoSeries(TestGeopandasBase):
         )
         self.check_sgpd_equals_gpd(result, expected)
 
-        data = [None, Point(0, 0), None]
+        data = [Point(0, 0), None]
         # Ensure filling with np.nan or pd.NA returns None
         import numpy as np
 
         for fill_val in [np.nan, pd.NA]:
             result = GeoSeries(data).fillna(fill_val)
-            expected = gpd.GeoSeries([None, Point(0, 0), None])
+            expected = gpd.GeoSeries([Point(0, 0), None])
             self.check_sgpd_equals_gpd(result, expected)
 
         # Ensure filling with None is empty GeometryColleciton and not None
         # Also check that inplace works
         result = GeoSeries(data)
         result.fillna(None, inplace=True)
-        expected = gpd.GeoSeries(
-            [GeometryCollection(), Point(0, 0), GeometryCollection()]
-        )
+        expected = gpd.GeoSeries([Point(0, 0), GeometryCollection()])
         self.check_sgpd_equals_gpd(result, expected)
 
     def test_explode(self):
@@ -424,7 +422,8 @@ class TestGeoSeries(TestGeopandasBase):
                     ]
                 ),
                 GeometryCollection([Point(0, 0), LineString([(0, 0), (1, 1)])]),
-                LinearRing([(0, 0), (1, 1), (1, 0), (0, 1), (0, 0)]),
+                # Errors for LinearRing: issue #2120
+                # LinearRing([(0, 0), (1, 1), (1, 0), (0, 1), (0, 0)]),
             ]
         )
         result = geoseries.geom_type
@@ -437,7 +436,7 @@ class TestGeoSeries(TestGeopandasBase):
                 "Polygon",
                 "MultiPolygon",
                 "GeometryCollection",
-                "LineString",  # Note: Sedona returns LineString instead of LinearRing
+                # "LineString",  # Note: Sedona returns LineString instead of LinearRing
             ]
         )
         assert_series_equal(result.to_pandas(), expected)
@@ -524,12 +523,14 @@ class TestGeoSeries(TestGeopandasBase):
             [
                 LineString([(0, 0), (1, 1), (1, -1), (0, 1)]),
                 LineString([(0, 0), (1, 1), (1, -1)]),
-                LinearRing([(0, 0), (1, 1), (1, -1), (0, 1)]),
-                LinearRing([(0, 0), (-1, 1), (-1, -1), (1, -1)]),
+                # Errors for LinearRing: issue #2120
+                # LinearRing([(0, 0), (1, 1), (1, -1), (0, 1)]),
+                # LinearRing([(0, 0), (-1, 1), (-1, -1), (1, -1)]),
             ]
         )
         result = s.is_simple
-        expected = pd.Series([False, True, False, True])
+        expected = pd.Series([False, True])
+        # Removed LinearRing cases: False, True]
         assert_series_equal(result.to_pandas(), expected)
 
     def test_is_ring(self):

--- a/python/tests/geopandas/test_match_geopandas_dataframe.py
+++ b/python/tests/geopandas/test_match_geopandas_dataframe.py
@@ -18,6 +18,7 @@
 import pytest
 import shutil
 import tempfile
+import shapely
 from shapely.geometry import (
     Point,
     Polygon,
@@ -36,6 +37,10 @@ from tests.geopandas.test_geopandas_base import TestGeopandasBase
 import pyspark.pandas as ps
 
 
+@pytest.mark.skipif(
+    parse_version(shapely.__version__) < parse_version("2.0.0"),
+    reason=f"Tests require shapely>=2.0.0, but found v{shapely.__version__}",
+)
 class TestMatchGeopandasDataFrame(TestGeopandasBase):
     def setup_method(self):
         self.tempdir = tempfile.mkdtemp()

--- a/python/tests/geopandas/test_match_geopandas_series.py
+++ b/python/tests/geopandas/test_match_geopandas_series.py
@@ -323,7 +323,7 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
             gpd_result = gpd.GeoSeries(geom).fillna()
             self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
 
-        data = [None, None, None, None, Point(0, 1)]
+        data = [Point(1, 1), None, None, None, Point(0, 1)]
         sgpd_result = GeoSeries(data).fillna()
         gpd_result = gpd.GeoSeries(data).fillna()
         self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
@@ -479,8 +479,9 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
             LineString([(0, 0), (0, 0)]),
             LineString([(0, 0), (1, 1), (1, -1), (0, 1)]),
             LineString([(0, 0), (1, 1), (0, 0)]),
-            LinearRing([(0, 0), (1, 1), (1, 0), (0, 1), (0, 0)]),
-            LinearRing([(0, 0), (-1, 1), (-1, -1), (1, -1)]),
+            # Errors for LinearRing: issue #2120
+            # LinearRing([(0, 0), (1, 1), (1, 0), (0, 1), (0, 0)]),
+            # LinearRing([(0, 0), (-1, 1), (-1, -1), (1, -1)]),
         ]
         sgpd_result = GeoSeries(data).is_simple
         gpd_result = gpd.GeoSeries(data).is_simple

--- a/python/tests/geopandas/test_match_geopandas_series.py
+++ b/python/tests/geopandas/test_match_geopandas_series.py
@@ -41,6 +41,10 @@ import pyspark.pandas as ps
 from packaging.version import parse as parse_version
 
 
+@pytest.mark.skipif(
+    parse_version(shapely.__version__) < parse_version("2.0.0"),
+    reason=f"Tests require shapely>=2.0.0, but found v{shapely.__version__}",
+)
 class TestMatchGeopandasSeries(TestGeopandasBase):
     def setup_method(self):
         self.tempdir = tempfile.mkdtemp()

--- a/python/tests/geopandas/test_sjoin.py
+++ b/python/tests/geopandas/test_sjoin.py
@@ -17,12 +17,18 @@
 import shutil
 import tempfile
 import pytest
+import shapely
 
 from shapely.geometry import Polygon, Point, LineString
 from sedona.geopandas import GeoSeries, GeoDataFrame, sjoin
 from tests.test_base import TestBase
+from packaging.version import parse as parse_version
 
 
+@pytest.mark.skipif(
+    parse_version(shapely.__version__) < parse_version("2.0.0"),
+    reason=f"Tests require shapely>=2.0.0, but found v{shapely.__version__}",
+)
 class TestSpatialJoin(TestBase):
     def setup_method(self):
         self.tempdir = tempfile.mkdtemp()


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2095

## What changes were proposed in this PR?
- Implement scalable workaround by manually implementing logic for `ps.Series` from `ps.Series` instead of calling `to_pandas()`
- Revert the changes from https://github.com/apache/sedona/pull/2080
  - It didn't work properly with the once we used proper ps.Series because the serialization format conflicted.
  - After digging into the C code, it turns out the serialization method does include the SRID information, I just needed to know how to access it.
- Modify tests to avoid small edge cases that we no longer handle
- Remove shapely 1.X support for geopandas because the `get_srid()` function in 2.0+ is now necessary.

## How was this patch tested?
Ensured existing tests still pass. Also I fixed up the dataframe test_area test in the process (the logic was previously wrong).

Switching to using proper geometry serialization means we no longer handle the following edge cases. There are open PRs or issues for each of them
- UDT arrays where the first element is None
- LinearRing geometry type

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.