### PR TITLE
[GH-2122] Fix deserialization of geometry SRID in python

### DIFF
--- a/python/src/geom_buf.c
+++ b/python/src/geom_buf.c
@@ -221,8 +221,8 @@ SedonaErrorCode read_geom_buf_header(const char *buf, int buf_size,
   int geom_type_id = preamble >> 4;
   int coord_type = (preamble & 0x0F) >> 1;
   if ((preamble & 0x01) != 0) {
-    srid = (((unsigned int)buf[1]) << 16) | (((unsigned int)buf[2]) << 8) |
-           ((unsigned int)buf[3]);
+    srid = (((unsigned int)buf[1] & 0xFF) << 16) | (((unsigned int)buf[2] & 0xFF) << 8) |
+           ((unsigned int)buf[3] & 0xFF);
   }
   int num_coords = ((int *)buf)[1];
   if (geom_type_id < 0 || geom_type_id > GEOMETRYCOLLECTION) {

--- a/python/src/geom_buf.c
+++ b/python/src/geom_buf.c
@@ -221,8 +221,8 @@ SedonaErrorCode read_geom_buf_header(const char *buf, int buf_size,
   int geom_type_id = preamble >> 4;
   int coord_type = (preamble & 0x0F) >> 1;
   if ((preamble & 0x01) != 0) {
-    srid = (((unsigned int)buf[1] & 0xFF) << 16) | (((unsigned int)buf[2] & 0xFF) << 8) |
-           ((unsigned int)buf[3] & 0xFF);
+    srid = (((unsigned int)buf[1] & 0xFF) << 16) |
+           (((unsigned int)buf[2] & 0xFF) << 8) | ((unsigned int)buf[3] & 0xFF);
   }
   int num_coords = ((int *)buf)[1];
   if (geom_type_id < 0 || geom_type_id > GEOMETRYCOLLECTION) {

--- a/python/tests/utils/test_geomserde_speedup.py
+++ b/python/tests/utils/test_geomserde_speedup.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import pytest
 import shapely
 from shapely.geometry import (
     GeometryCollection,
@@ -136,6 +137,9 @@ class TestGeomSerdeSpeedup:
         ]
         self._test_serde_roundtrip(geometry_collections)
 
+    @pytest.mark.skipif(
+        shapely.__version__ < "2", reason="SRID functions require Shapely >= 2.0"
+    )
     def test_srid_roundtrip(self):
         point = wkt_loads("POINT (1 2)")
         point = shapely.set_srid(point, 1000)

--- a/python/tests/utils/test_geomserde_speedup.py
+++ b/python/tests/utils/test_geomserde_speedup.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import shapely
 from shapely.geometry import (
     GeometryCollection,
     LineString,
@@ -134,6 +135,12 @@ class TestGeomSerdeSpeedup:
             ),
         ]
         self._test_serde_roundtrip(geometry_collections)
+
+    def test_srid_roundtrip(self):
+        point = wkt_loads("POINT (1 2)")
+        point = shapely.set_srid(point, 1000)
+        point2 = TestGeomSerdeSpeedup.serde_roundtrip(point)
+        assert shapely.get_srid(point2) == 1000
 
     @staticmethod
     def _test_serde_roundtrip(geoms):


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2122 

## What changes were proposed in this PR?

SRID was not deserialized correctly in the Python extension. This PR fix it.

The new geometry serialization format was introduced before we support Shapely 2.0, Shapely 1.8 does not support SRID back then so SRID serialization in Python extension was only implemented but not tested.

**ATTENTION**: This patch only fixes the C extension (fast implementation), there's a slower fallback implementation in pure Python (https://github.com/apache/sedona/blob/master/python/sedona/spark/utils/geometry_serde_general.py) not supporting serialization and deserialization of SRID at all. We need to fix that in a follow-up PR.

## How was this patch tested?

Added new unit test

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
