### PR TITLE
[GH-2125] Fix STAC reader to accept tuples for datetime parameter

### DIFF
--- a/python/sedona/spark/stac/collection_client.py
+++ b/python/sedona/spark/stac/collection_client.py
@@ -366,8 +366,10 @@ class CollectionClient:
             if datetime:
                 if isinstance(datetime, (str, python_datetime.datetime)):
                     datetime = [self._expand_date(str(datetime))]
-                elif isinstance(datetime, list) and isinstance(datetime[0], str):
-                    datetime = [datetime]
+                elif isinstance(datetime, (list, tuple)) and isinstance(
+                    datetime[0], str
+                ):
+                    datetime = [list(datetime)]
             # Apply spatial and temporal filters
             df = self._apply_spatial_temporal_filters(df, bbox, datetime)
         # Limit the number of items if max_items is specified

--- a/python/tests/stac/test_collection_client.py
+++ b/python/tests/stac/test_collection_client.py
@@ -187,3 +187,41 @@ class TestStacReader(TestBase):
             # Optionally, you can load the file back and check its contents
             df_loaded = collection.spark.read.format("geoparquet").load(output_path)
             assert df_loaded.count() == 20, "Loaded GeoParquet file is empty"
+
+    def test_get_items_with_tuple_datetime(self) -> None:
+        """Test that tuples are properly handled as datetime input (same as lists)."""
+        client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])
+        collection = client.get_collection("aster-l1t")
+
+        # Test with tuple instead of list
+        datetime_tuple = ("2006-12-01T00:00:00Z", "2006-12-27T02:00:00Z")
+        items_with_tuple = list(collection.get_items(datetime=datetime_tuple))
+
+        # Test with list for comparison
+        datetime_list = ["2006-12-01T00:00:00Z", "2006-12-27T02:00:00Z"]
+        items_with_list = list(collection.get_items(datetime=datetime_list))
+
+        # Both should return the same number of items
+        assert items_with_tuple is not None
+        assert items_with_list is not None
+        assert len(items_with_tuple) == len(items_with_list)
+        assert len(items_with_tuple) == 16
+
+    def test_get_dataframe_with_tuple_datetime(self) -> None:
+        """Test that tuples are properly handled as datetime input for dataframes."""
+        client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])
+        collection = client.get_collection("aster-l1t")
+
+        # Test with tuple instead of list
+        datetime_tuple = ("2006-01-01T00:00:00Z", "2007-01-01T00:00:00Z")
+        df_with_tuple = collection.get_dataframe(datetime=datetime_tuple)
+
+        # Test with list for comparison
+        datetime_list = ["2006-01-01T00:00:00Z", "2007-01-01T00:00:00Z"]
+        df_with_list = collection.get_dataframe(datetime=datetime_list)
+
+        # Both should return the same count
+        assert df_with_tuple is not None
+        assert df_with_list is not None
+        assert df_with_tuple.count() == df_with_list.count()
+        assert df_with_tuple.count() > 0


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #<issue_number>

## What changes were proposed in this PR?
  Fixed a bug where the STAC reader would return 0 items when a tuple was passed as the datetime
  parameter, while the same data as a list would return expected results.

  Problem

  The CollectionClient.load_items_df() method only checked for list type when handling datetime
  parameters, causing tuples to be ignored and resulting in no temporal filtering being applied.

  Before:
  t = ("2025-01-01", "2025-02-01")
  items = client.search(datetime=t)  # Returns 0 items

  After:
  t = ("2025-01-01", "2025-02-01")
  items = client.search(datetime=t)  # Returns expected items

## How was this patch tested?
test_collection_client.py:
- test_get_items_with_tuple_datetime(): Verifies tuple datetime input works for get_items()
- test_get_dataframe_with_tuple_datetime(): Verifies tuple datetime input works for get_dataframe()

## Did this PR include necessary documentation updates?
- No, this PR does not affect any public API so no need to change the documentation.
