### PR TITLE
[GH-2102] make ST_ and RS_ function expression classes package private

### DIFF
--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/AggregateFunctions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/AggregateFunctions.scala
@@ -54,7 +54,7 @@ trait TraitSTAggregateExec {
   def finish(out: Geometry): Geometry = out
 }
 
-class ST_Union_Aggr(bufferSize: Int = 1000)
+private[apache] class ST_Union_Aggr(bufferSize: Int = 1000)
     extends Aggregator[Geometry, ListBuffer[Geometry], Geometry] {
 
   val serde = ExpressionEncoder[Geometry]()
@@ -98,7 +98,7 @@ class ST_Union_Aggr(bufferSize: Int = 1000)
 /**
  * Return the envelope boundary of the entire column
  */
-class ST_Envelope_Aggr
+private[apache] class ST_Envelope_Aggr
     extends Aggregator[Geometry, Geometry, Geometry]
     with TraitSTAggregateExec {
 
@@ -176,7 +176,7 @@ class ST_Envelope_Aggr
 /**
  * Return the polygon intersection of all Polygon in the given column
  */
-class ST_Intersection_Aggr
+private[apache] class ST_Intersection_Aggr
     extends Aggregator[Geometry, Geometry, Geometry]
     with TraitSTAggregateExec {
   def reduce(buffer: Geometry, input: Geometry): Geometry = {

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Constructors.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Constructors.scala
@@ -38,7 +38,7 @@ import org.apache.spark.unsafe.types.UTF8String
  *   This function takes 2 parameters. The first parameter is the input geometry string, the
  *   second parameter is the delimiter. String format should be similar to CSV/TSV
  */
-case class ST_PointFromText(inputExpressions: Seq[Expression])
+private[apache] case class ST_PointFromText(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.pointFromText _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
@@ -51,7 +51,7 @@ case class ST_PointFromText(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_PolygonFromText(inputExpressions: Seq[Expression])
+private[apache] case class ST_PolygonFromText(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.polygonFromText _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
@@ -64,7 +64,7 @@ case class ST_PolygonFromText(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_LineFromText(inputExpressions: Seq[Expression])
+private[apache] case class ST_LineFromText(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.lineFromText _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
@@ -77,7 +77,7 @@ case class ST_LineFromText(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_LineStringFromText(inputExpressions: Seq[Expression])
+private[apache] case class ST_LineStringFromText(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.lineStringFromText _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
@@ -90,7 +90,7 @@ case class ST_LineStringFromText(inputExpressions: Seq[Expression])
  * @param inputExpressions
  *   This function takes a geometry string and a srid. The string format must be WKT.
  */
-case class ST_GeomFromWKT(inputExpressions: Seq[Expression])
+private[apache] case class ST_GeomFromWKT(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.geomFromWKT _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -104,7 +104,7 @@ case class ST_GeomFromWKT(inputExpressions: Seq[Expression])
  * @param inputExpressions
  *   This function takes a geometry string and a srid. The string format must be WKT.
  */
-case class ST_GeogFromWKT(inputExpressions: Seq[Expression])
+private[apache] case class ST_GeogFromWKT(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.geogFromWKT _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -119,7 +119,7 @@ case class ST_GeogFromWKT(inputExpressions: Seq[Expression])
  *   This function takes a geometry string. The string format must be OGC Extended Well-Known text
  *   (EWKT) representation.
  */
-case class ST_GeomFromEWKT(inputExpressions: Seq[Expression])
+private[apache] case class ST_GeomFromEWKT(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.geomFromEWKT _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -133,7 +133,7 @@ case class ST_GeomFromEWKT(inputExpressions: Seq[Expression])
  * @param inputExpressions
  *   This function takes a geometry string and a srid. The string format must be WKT.
  */
-case class ST_GeometryFromText(inputExpressions: Seq[Expression])
+private[apache] case class ST_GeometryFromText(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.geomFromWKT _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -147,7 +147,7 @@ case class ST_GeometryFromText(inputExpressions: Seq[Expression])
  * @param inputExpressions
  *   This function takes a geometry string and a srid. The string format must be WKT.
  */
-case class ST_GeomFromText(inputExpressions: Seq[Expression])
+private[apache] case class ST_GeomFromText(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.geomFromWKT _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -162,7 +162,7 @@ case class ST_GeomFromText(inputExpressions: Seq[Expression])
  *   This function takes 1 parameter which is the utf-8 encoded geometry wkb string or the binary
  *   wkb array.
  */
-case class ST_GeomFromWKB(inputExpressions: Seq[Expression])
+private[apache] case class ST_GeomFromWKB(inputExpressions: Seq[Expression])
     extends Expression
     with FoldableExpression
     with ImplicitCastInputTypes
@@ -202,7 +202,7 @@ case class ST_GeomFromWKB(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_GeomFromEWKB(inputExpressions: Seq[Expression])
+private[apache] case class ST_GeomFromEWKB(inputExpressions: Seq[Expression])
     extends Expression
     with FoldableExpression
     with ImplicitCastInputTypes
@@ -242,7 +242,7 @@ case class ST_GeomFromEWKB(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_LineFromWKB(inputExpressions: Seq[Expression])
+private[apache] case class ST_LineFromWKB(inputExpressions: Seq[Expression])
     extends Expression
     with FoldableExpression
     with ImplicitCastInputTypes
@@ -299,7 +299,7 @@ case class ST_LineFromWKB(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_LinestringFromWKB(inputExpressions: Seq[Expression])
+private[apache] case class ST_LinestringFromWKB(inputExpressions: Seq[Expression])
     extends Expression
     with FoldableExpression
     with ImplicitCastInputTypes
@@ -356,7 +356,7 @@ case class ST_LinestringFromWKB(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_PointFromWKB(inputExpressions: Seq[Expression])
+private[apache] case class ST_PointFromWKB(inputExpressions: Seq[Expression])
     extends Expression
     with FoldableExpression
     with ImplicitCastInputTypes
@@ -420,7 +420,7 @@ case class ST_PointFromWKB(inputExpressions: Seq[Expression])
  *   This function takes 1 parameter which is the geometry string. The string format must be
  *   GeoJson.
  */
-case class ST_GeomFromGeoJSON(inputExpressions: Seq[Expression])
+private[apache] case class ST_GeomFromGeoJSON(inputExpressions: Seq[Expression])
     extends Expression
     with FoldableExpression
     with CodegenFallback
@@ -464,7 +464,7 @@ case class ST_GeomFromGeoJSON(inputExpressions: Seq[Expression])
  * @param inputExpressions
  *   This function takes 2 parameter which are point x, y.
  */
-case class ST_Point(inputExpressions: Seq[Expression])
+private[apache] case class ST_Point(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.point _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -478,7 +478,7 @@ case class ST_Point(inputExpressions: Seq[Expression])
  * @param inputExpressions
  *   This function takes 4 parameter which are point x, y, z and srid (default 0).
  */
-case class ST_PointZ(inputExpressions: Seq[Expression])
+private[apache] case class ST_PointZ(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.pointZ _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -492,7 +492,7 @@ case class ST_PointZ(inputExpressions: Seq[Expression])
  * @param inputExpressions
  *   This function takes 4 parameter which are point x, y, m and srid (default 0).
  */
-case class ST_PointM(inputExpressions: Seq[Expression])
+private[apache] case class ST_PointM(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.pointM _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -500,7 +500,7 @@ case class ST_PointM(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_PointZM(inputExpressions: Seq[Expression])
+private[apache] case class ST_PointZM(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.pointZM _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -508,7 +508,7 @@ case class ST_PointZM(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_MakePointM(inputExpressions: Seq[Expression])
+private[apache] case class ST_MakePointM(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.makePointM _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -516,7 +516,7 @@ case class ST_MakePointM(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_MakePoint(inputExpressions: Seq[Expression])
+private[apache] case class ST_MakePoint(inputExpressions: Seq[Expression])
     extends InferredExpression(nullTolerantInferrableFunction4(Constructors.makePoint)) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -529,7 +529,7 @@ case class ST_MakePoint(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_MakeEnvelope(inputExpressions: Seq[Expression])
+private[apache] case class ST_MakeEnvelope(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction5(Constructors.makeEnvelope),
       inferrableFunction4(Constructors.makeEnvelope)) {
@@ -544,7 +544,7 @@ case class ST_MakeEnvelope(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_PolygonFromEnvelope(inputExpressions: Seq[Expression])
+private[apache] case class ST_PolygonFromEnvelope(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.polygonFromEnvelope _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -552,7 +552,7 @@ case class ST_PolygonFromEnvelope(inputExpressions: Seq[Expression])
   }
 }
 
-trait UserDataGenerator {
+private[apache] trait UserDataGenerator {
   def generateUserData(
       minInputLength: Integer,
       inputExpressions: Seq[Expression],
@@ -568,28 +568,28 @@ trait UserDataGenerator {
   }
 }
 
-case class ST_GeomFromGeoHash(inputExpressions: Seq[Expression])
+private[apache] case class ST_GeomFromGeoHash(inputExpressions: Seq[Expression])
     extends InferredExpression(InferrableFunction.allowRightNull(Constructors.geomFromGeoHash)) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class ST_PointFromGeoHash(inputExpressions: Seq[Expression])
+private[apache] case class ST_PointFromGeoHash(inputExpressions: Seq[Expression])
     extends InferredExpression(InferrableFunction.allowRightNull(Constructors.pointFromGeoHash)) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class ST_GeomFromGML(inputExpressions: Seq[Expression])
+private[apache] case class ST_GeomFromGML(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.geomFromGML _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class ST_GeomFromKML(inputExpressions: Seq[Expression])
+private[apache] case class ST_GeomFromKML(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.geomFromKML _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
@@ -602,7 +602,7 @@ case class ST_GeomFromKML(inputExpressions: Seq[Expression])
  * @param inputExpressions
  *   This function takes a geometry string and a srid. The string format must be WKT.
  */
-case class ST_MPolyFromText(inputExpressions: Seq[Expression])
+private[apache] case class ST_MPolyFromText(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.mPolyFromText _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
@@ -615,7 +615,7 @@ case class ST_MPolyFromText(inputExpressions: Seq[Expression])
  * @param inputExpressions
  *   This function takes a geometry string and a srid. The string format must be WKT.
  */
-case class ST_MLineFromText(inputExpressions: Seq[Expression])
+private[apache] case class ST_MLineFromText(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.mLineFromText _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -623,7 +623,7 @@ case class ST_MLineFromText(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_MPointFromText(inputExpressions: Seq[Expression])
+private[apache] case class ST_MPointFromText(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.mPointFromText _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -631,7 +631,7 @@ case class ST_MPointFromText(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_GeomCollFromText(inputExpressions: Seq[Expression])
+private[apache] case class ST_GeomCollFromText(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.geomCollFromText _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
@@ -40,7 +40,7 @@ import org.apache.spark.util.Utils
 import com.mapzen.jpostal.{AddressExpander, AddressParser}
 import org.apache.spark.sql.catalyst.expressions.codegen.Block.BlockHelper
 
-case class ST_LabelPoint(inputExpressions: Seq[Expression])
+private[apache] case class ST_LabelPoint(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction1(Functions.labelPoint),
       inferrableFunction2(Functions.labelPoint),
@@ -57,7 +57,7 @@ case class ST_LabelPoint(inputExpressions: Seq[Expression])
  * @param inputExpressions
  *   This function takes two geometries and calculates the distance between two objects.
  */
-case class ST_Distance(inputExpressions: Seq[Expression])
+private[apache] case class ST_Distance(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.distance _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -65,7 +65,7 @@ case class ST_Distance(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_YMax(inputExpressions: Seq[Expression])
+private[apache] case class ST_YMax(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.yMax _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -73,7 +73,7 @@ case class ST_YMax(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_YMin(inputExpressions: Seq[Expression])
+private[apache] case class ST_YMin(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.yMin _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -87,7 +87,7 @@ case class ST_YMin(inputExpressions: Seq[Expression])
  * @param inputExpressions
  *   This function takes a geometry and returns the maximum of all Z-coordinate values.
  */
-case class ST_ZMax(inputExpressions: Seq[Expression])
+private[apache] case class ST_ZMax(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.zMax _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -101,7 +101,7 @@ case class ST_ZMax(inputExpressions: Seq[Expression])
  * @param inputExpressions
  *   This function takes a geometry and returns the minimum of all Z-coordinate values.
  */
-case class ST_ZMin(inputExpressions: Seq[Expression])
+private[apache] case class ST_ZMin(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.zMin _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -109,7 +109,7 @@ case class ST_ZMin(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_3DDistance(inputExpressions: Seq[Expression])
+private[apache] case class ST_3DDistance(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.distance3d _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -122,7 +122,7 @@ case class ST_3DDistance(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_ConcaveHull(inputExpressions: Seq[Expression])
+private[apache] case class ST_ConcaveHull(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.concaveHull _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Expression = {
@@ -135,7 +135,7 @@ case class ST_ConcaveHull(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_ConvexHull(inputExpressions: Seq[Expression])
+private[apache] case class ST_ConvexHull(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.convexHull _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -143,7 +143,7 @@ case class ST_ConvexHull(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_CrossesDateLine(inputExpressions: Seq[Expression])
+private[apache] case class ST_CrossesDateLine(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.crossesDateLine _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -156,7 +156,7 @@ case class ST_CrossesDateLine(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_NPoints(inputExpressions: Seq[Expression])
+private[apache] case class ST_NPoints(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.nPoints _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -169,7 +169,7 @@ case class ST_NPoints(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_NDims(inputExpressions: Seq[Expression])
+private[apache] case class ST_NDims(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.nDims _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -183,7 +183,7 @@ case class ST_NDims(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Buffer(inputExpressions: Seq[Expression])
+private[apache] case class ST_Buffer(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(Functions.buffer),
       inferrableFunction3(Functions.buffer),
@@ -194,7 +194,7 @@ case class ST_Buffer(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_BestSRID(inputExpressions: Seq[Expression])
+private[apache] case class ST_BestSRID(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.bestSRID _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -202,7 +202,7 @@ case class ST_BestSRID(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_ShiftLongitude(inputExpressions: Seq[Expression])
+private[apache] case class ST_ShiftLongitude(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.shiftLongitude _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -215,7 +215,7 @@ case class ST_ShiftLongitude(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Envelope(inputExpressions: Seq[Expression])
+private[apache] case class ST_Envelope(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.envelope _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -223,7 +223,7 @@ case class ST_Envelope(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Expand(inputExpressions: Seq[Expression])
+private[apache] case class ST_Expand(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction4(Functions.expand),
       inferrableFunction3(Functions.expand),
@@ -239,7 +239,7 @@ case class ST_Expand(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Length(inputExpressions: Seq[Expression])
+private[apache] case class ST_Length(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.length _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -252,7 +252,7 @@ case class ST_Length(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Length2D(inputExpressions: Seq[Expression])
+private[apache] case class ST_Length2D(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.length _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -265,7 +265,7 @@ case class ST_Length2D(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Area(inputExpressions: Seq[Expression])
+private[apache] case class ST_Area(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.area _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -278,7 +278,7 @@ case class ST_Area(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Centroid(inputExpressions: Seq[Expression])
+private[apache] case class ST_Centroid(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.getCentroid _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -292,7 +292,7 @@ case class ST_Centroid(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Transform(inputExpressions: Seq[Expression])
+private[apache] case class ST_Transform(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction4(FunctionsGeoTools.transform),
       inferrableFunction3(FunctionsGeoTools.transform),
@@ -308,7 +308,7 @@ case class ST_Transform(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Intersection(inputExpressions: Seq[Expression])
+private[apache] case class ST_Intersection(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.intersection _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -322,7 +322,7 @@ case class ST_Intersection(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_MakeValid(inputExpressions: Seq[Expression])
+private[apache] case class ST_MakeValid(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.makeValid _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -330,7 +330,7 @@ case class ST_MakeValid(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_IsValidDetail(children: Seq[Expression])
+private[apache] case class ST_IsValidDetail(children: Seq[Expression])
     extends Expression
     with ExpectsInputTypes
     with CodegenFallback {
@@ -388,7 +388,7 @@ case class ST_IsValidDetail(children: Seq[Expression])
     .add("location", GeometryUDT, nullable = true)
 }
 
-case class ST_IsValidTrajectory(inputExpressions: Seq[Expression])
+private[apache] case class ST_IsValidTrajectory(inputExpressions: Seq[Expression])
     extends InferredExpression(inferrableFunction1(Functions.isValidTrajectory)) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -401,7 +401,7 @@ case class ST_IsValidTrajectory(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_IsValid(inputExpressions: Seq[Expression])
+private[apache] case class ST_IsValid(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(Functions.isValid),
       inferrableFunction1(Functions.isValid)) {
@@ -416,7 +416,7 @@ case class ST_IsValid(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_IsSimple(inputExpressions: Seq[Expression])
+private[apache] case class ST_IsSimple(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.isSimple _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -434,7 +434,7 @@ case class ST_IsSimple(inputExpressions: Seq[Expression])
  *   first arg is geometry second arg is distance tolerance for the simplification(all vertices in
  *   the simplified geometry will be within this distance of the original geometry)
  */
-case class ST_SimplifyPreserveTopology(inputExpressions: Seq[Expression])
+private[apache] case class ST_SimplifyPreserveTopology(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.simplifyPreserveTopology _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -450,7 +450,7 @@ case class ST_SimplifyPreserveTopology(inputExpressions: Seq[Expression])
  *   decimal places of the new coordinate. The last decimal place will be rounded to the nearest
  *   number.
  */
-case class ST_ReducePrecision(inputExpressions: Seq[Expression])
+private[apache] case class ST_ReducePrecision(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.reducePrecision _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -458,7 +458,7 @@ case class ST_ReducePrecision(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Simplify(inputExpressions: Seq[Expression])
+private[apache] case class ST_Simplify(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.simplify _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -466,7 +466,7 @@ case class ST_Simplify(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_SimplifyVW(inputExpressions: Seq[Expression])
+private[apache] case class ST_SimplifyVW(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.simplifyVW _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -474,7 +474,7 @@ case class ST_SimplifyVW(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_SimplifyPolygonHull(inputExpressions: Seq[Expression])
+private[apache] case class ST_SimplifyPolygonHull(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(Functions.simplifyPolygonHull),
       inferrableFunction3(Functions.simplifyPolygonHull)) {
@@ -484,7 +484,7 @@ case class ST_SimplifyPolygonHull(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_AsText(inputExpressions: Seq[Expression])
+private[apache] case class ST_AsText(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.asWKT _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -492,7 +492,7 @@ case class ST_AsText(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_AsGeoJSON(inputExpressions: Seq[Expression])
+private[apache] case class ST_AsGeoJSON(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction1(Functions.asGeoJson),
       inferrableFunction2(Functions.asGeoJson)) {
@@ -502,7 +502,7 @@ case class ST_AsGeoJSON(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_AsBinary(inputExpressions: Seq[Expression])
+private[apache] case class ST_AsBinary(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.asWKB _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -510,7 +510,7 @@ case class ST_AsBinary(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_AsEWKB(inputExpressions: Seq[Expression])
+private[apache] case class ST_AsEWKB(inputExpressions: Seq[Expression])
     extends InferredExpression(
       (geom: Geometry) => Functions.asEWKB(geom),
       (geog: Geography) => Functions.asEWKB(geog)) {
@@ -520,7 +520,7 @@ case class ST_AsEWKB(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_AsHEXEWKB(inputExpressions: Seq[Expression])
+private[apache] case class ST_AsHEXEWKB(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(Functions.asHexEWKB),
       inferrableFunction1(Functions.asHexEWKB)) {
@@ -530,7 +530,7 @@ case class ST_AsHEXEWKB(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_SRID(inputExpressions: Seq[Expression])
+private[apache] case class ST_SRID(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.getSRID _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -538,7 +538,7 @@ case class ST_SRID(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_SetSRID(inputExpressions: Seq[Expression])
+private[apache] case class ST_SetSRID(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.setSRID _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -546,7 +546,7 @@ case class ST_SetSRID(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_GeometryType(inputExpressions: Seq[Expression])
+private[apache] case class ST_GeometryType(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.geometryType _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -562,7 +562,7 @@ case class ST_GeometryType(inputExpressions: Seq[Expression])
  * @param inputExpressions
  *   Geometry
  */
-case class ST_LineMerge(inputExpressions: Seq[Expression])
+private[apache] case class ST_LineMerge(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.lineMerge _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -570,7 +570,7 @@ case class ST_LineMerge(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Azimuth(inputExpressions: Seq[Expression])
+private[apache] case class ST_Azimuth(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.azimuth _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -578,28 +578,31 @@ case class ST_Azimuth(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_X(inputExpressions: Seq[Expression]) extends InferredExpression(Functions.x _) {
+private[apache] case class ST_X(inputExpressions: Seq[Expression])
+    extends InferredExpression(Functions.x _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class ST_Y(inputExpressions: Seq[Expression]) extends InferredExpression(Functions.y _) {
+private[apache] case class ST_Y(inputExpressions: Seq[Expression])
+    extends InferredExpression(Functions.y _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class ST_Z(inputExpressions: Seq[Expression]) extends InferredExpression(Functions.z _) {
+private[apache] case class ST_Z(inputExpressions: Seq[Expression])
+    extends InferredExpression(Functions.z _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class ST_Zmflag(inputExpressions: Seq[Expression])
+private[apache] case class ST_Zmflag(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.zmFlag _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -607,7 +610,7 @@ case class ST_Zmflag(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_StartPoint(inputExpressions: Seq[Expression])
+private[apache] case class ST_StartPoint(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.startPoint _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -615,7 +618,7 @@ case class ST_StartPoint(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Snap(inputExpressions: Seq[Expression])
+private[apache] case class ST_Snap(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.snap _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -623,7 +626,7 @@ case class ST_Snap(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Boundary(inputExpressions: Seq[Expression])
+private[apache] case class ST_Boundary(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.boundary _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -631,7 +634,7 @@ case class ST_Boundary(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_MinimumClearance(inputExpressions: Seq[Expression])
+private[apache] case class ST_MinimumClearance(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.minimumClearance _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -639,7 +642,7 @@ case class ST_MinimumClearance(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_MinimumClearanceLine(inputExpressions: Seq[Expression])
+private[apache] case class ST_MinimumClearanceLine(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.minimumClearanceLine _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -647,7 +650,7 @@ case class ST_MinimumClearanceLine(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_MinimumBoundingRadius(inputExpressions: Seq[Expression])
+private[apache] case class ST_MinimumBoundingRadius(inputExpressions: Seq[Expression])
     extends Expression
     with FoldableExpression
     with CodegenFallback {
@@ -690,7 +693,7 @@ case class ST_MinimumBoundingRadius(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_MinimumBoundingCircle(inputExpressions: Seq[Expression])
+private[apache] case class ST_MinimumBoundingCircle(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.minimumBoundingCircle _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -698,7 +701,7 @@ case class ST_MinimumBoundingCircle(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_HasZ(inputExpressions: Seq[Expression])
+private[apache] case class ST_HasZ(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.hasZ _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -706,7 +709,7 @@ case class ST_HasZ(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_HasM(inputExpressions: Seq[Expression])
+private[apache] case class ST_HasM(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.hasM _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -714,14 +717,15 @@ case class ST_HasM(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_M(inputExpressions: Seq[Expression]) extends InferredExpression(Functions.m _) {
+private[apache] case class ST_M(inputExpressions: Seq[Expression])
+    extends InferredExpression(Functions.m _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class ST_MMin(inputExpressions: Seq[Expression])
+private[apache] case class ST_MMin(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.mMin _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -729,7 +733,7 @@ case class ST_MMin(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_MMax(inputExpressions: Seq[Expression])
+private[apache] case class ST_MMax(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.mMax _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -737,7 +741,7 @@ case class ST_MMax(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_LineSegments(inputExpressions: Seq[Expression])
+private[apache] case class ST_LineSegments(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(Functions.lineSegments),
       inferrableFunction1(Functions.lineSegments)) {
@@ -753,7 +757,7 @@ case class ST_LineSegments(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_LineSubstring(inputExpressions: Seq[Expression])
+private[apache] case class ST_LineSubstring(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.lineSubString _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -768,7 +772,7 @@ case class ST_LineSubstring(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_LineInterpolatePoint(inputExpressions: Seq[Expression])
+private[apache] case class ST_LineInterpolatePoint(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.lineInterpolatePoint _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -782,7 +786,7 @@ case class ST_LineInterpolatePoint(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_LineLocatePoint(inputExpressions: Seq[Expression])
+private[apache] case class ST_LineLocatePoint(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.lineLocatePoint _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -790,7 +794,7 @@ case class ST_LineLocatePoint(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_EndPoint(inputExpressions: Seq[Expression])
+private[apache] case class ST_EndPoint(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.endPoint _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -798,7 +802,7 @@ case class ST_EndPoint(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_ExteriorRing(inputExpressions: Seq[Expression])
+private[apache] case class ST_ExteriorRing(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.exteriorRing _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -806,7 +810,7 @@ case class ST_ExteriorRing(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_GeometryN(inputExpressions: Seq[Expression])
+private[apache] case class ST_GeometryN(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.geometryN _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -814,7 +818,7 @@ case class ST_GeometryN(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_InteriorRingN(inputExpressions: Seq[Expression])
+private[apache] case class ST_InteriorRingN(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.interiorRingN _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -822,7 +826,7 @@ case class ST_InteriorRingN(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Dump(inputExpressions: Seq[Expression])
+private[apache] case class ST_Dump(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.dump _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -830,7 +834,7 @@ case class ST_Dump(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_DumpPoints(inputExpressions: Seq[Expression])
+private[apache] case class ST_DumpPoints(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.dumpPoints _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -838,7 +842,7 @@ case class ST_DumpPoints(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_IsClosed(inputExpressions: Seq[Expression])
+private[apache] case class ST_IsClosed(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.isClosed _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -846,7 +850,7 @@ case class ST_IsClosed(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_NumInteriorRings(inputExpressions: Seq[Expression])
+private[apache] case class ST_NumInteriorRings(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.numInteriorRings _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -854,7 +858,7 @@ case class ST_NumInteriorRings(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_NumInteriorRing(inputExpressions: Seq[Expression])
+private[apache] case class ST_NumInteriorRing(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.numInteriorRings _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -862,7 +866,7 @@ case class ST_NumInteriorRing(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_AddMeasure(inputExpressions: Seq[Expression])
+private[apache] case class ST_AddMeasure(inputExpressions: Seq[Expression])
     extends InferredExpression(inferrableFunction3(Functions.addMeasure)) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -870,7 +874,7 @@ case class ST_AddMeasure(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_AddPoint(inputExpressions: Seq[Expression])
+private[apache] case class ST_AddPoint(inputExpressions: Seq[Expression])
     extends InferredExpression(inferrableFunction3(Functions.addPoint)) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -878,7 +882,7 @@ case class ST_AddPoint(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_RemovePoint(inputExpressions: Seq[Expression])
+private[apache] case class ST_RemovePoint(inputExpressions: Seq[Expression])
     extends InferredExpression(inferrableFunction2(Functions.removePoint)) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -886,7 +890,7 @@ case class ST_RemovePoint(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_RemoveRepeatedPoints(inputExpressions: Seq[Expression])
+private[apache] case class ST_RemoveRepeatedPoints(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(Functions.removeRepeatedPoints),
       inferrableFunction1(Functions.removeRepeatedPoints)) {
@@ -896,7 +900,7 @@ case class ST_RemoveRepeatedPoints(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_SetPoint(inputExpressions: Seq[Expression])
+private[apache] case class ST_SetPoint(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.setPoint _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -904,7 +908,7 @@ case class ST_SetPoint(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_ClosestPoint(inputExpressions: Seq[Expression])
+private[apache] case class ST_ClosestPoint(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.closestPoint _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -912,14 +916,14 @@ case class ST_ClosestPoint(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_IsPolygonCW(inputExpressions: Seq[Expression])
+private[apache] case class ST_IsPolygonCW(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.isPolygonCW _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class ST_IsRing(inputExpressions: Seq[Expression])
+private[apache] case class ST_IsRing(inputExpressions: Seq[Expression])
     extends InferredExpression(ST_IsRing.isRing _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -927,7 +931,7 @@ case class ST_IsRing(inputExpressions: Seq[Expression])
   }
 }
 
-object ST_IsRing {
+private[apache] object ST_IsRing {
   def isRing(geom: Geometry): Option[Boolean] = {
     geom match {
       case _: LineString => Some(Functions.isRing(geom))
@@ -945,7 +949,7 @@ object ST_IsRing {
  * @param inputExpressions
  *   Geometry
  */
-case class ST_NumGeometries(inputExpressions: Seq[Expression])
+private[apache] case class ST_NumGeometries(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.numGeometries _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -959,7 +963,7 @@ case class ST_NumGeometries(inputExpressions: Seq[Expression])
  * @param inputExpressions
  *   Geometry
  */
-case class ST_FlipCoordinates(inputExpressions: Seq[Expression])
+private[apache] case class ST_FlipCoordinates(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.flipCoordinates _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -967,7 +971,7 @@ case class ST_FlipCoordinates(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_SubDivide(inputExpressions: Seq[Expression])
+private[apache] case class ST_SubDivide(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.subDivide _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -975,7 +979,9 @@ case class ST_SubDivide(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_SubDivideExplode(children: Seq[Expression]) extends Generator with CodegenFallback {
+private[apache] case class ST_SubDivideExplode(children: Seq[Expression])
+    extends Generator
+    with CodegenFallback {
   children.validateLength(2)
 
   override def eval(input: InternalRow): TraversableOnce[InternalRow] = {
@@ -1010,7 +1016,7 @@ case class ST_SubDivideExplode(children: Seq[Expression]) extends Generator with
   }
 }
 
-case class ST_MakeLine(inputExpressions: Seq[Expression])
+private[apache] case class ST_MakeLine(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(Functions.makeLine),
       inferrableFunction1(Functions.makeLine)) {
@@ -1020,7 +1026,7 @@ case class ST_MakeLine(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Perimeter(inputExpressions: Seq[Expression])
+private[apache] case class ST_Perimeter(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction3(Functions.perimeter),
       inferrableFunction2(Functions.perimeter),
@@ -1031,7 +1037,7 @@ case class ST_Perimeter(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Perimeter2D(inputExpressions: Seq[Expression])
+private[apache] case class ST_Perimeter2D(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction3(Functions.perimeter),
       inferrableFunction2(Functions.perimeter),
@@ -1042,7 +1048,7 @@ case class ST_Perimeter2D(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Points(inputExpressions: Seq[Expression])
+private[apache] case class ST_Points(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.points _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1050,7 +1056,7 @@ case class ST_Points(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Polygon(inputExpressions: Seq[Expression])
+private[apache] case class ST_Polygon(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.makepolygonWithSRID _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1058,7 +1064,7 @@ case class ST_Polygon(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Polygonize(inputExpressions: Seq[Expression])
+private[apache] case class ST_Polygonize(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.polygonize _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1066,7 +1072,7 @@ case class ST_Polygonize(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Project(inputExpressions: Seq[Expression])
+private[apache] case class ST_Project(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction4(Functions.project),
       inferrableFunction3(Functions.project)) {
@@ -1076,7 +1082,7 @@ case class ST_Project(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_MakePolygon(inputExpressions: Seq[Expression])
+private[apache] case class ST_MakePolygon(inputExpressions: Seq[Expression])
     extends InferredExpression(InferrableFunction.allowRightNull(Functions.makePolygon)) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1084,7 +1090,7 @@ case class ST_MakePolygon(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_MaximumInscribedCircle(children: Seq[Expression])
+private[apache] case class ST_MaximumInscribedCircle(children: Seq[Expression])
     extends Expression
     with CodegenFallback {
 
@@ -1118,7 +1124,7 @@ case class ST_MaximumInscribedCircle(children: Seq[Expression])
     .add("radius", DoubleType, nullable = false)
 }
 
-case class ST_MaxDistance(inputExpressions: Seq[Expression])
+private[apache] case class ST_MaxDistance(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.maxDistance _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1126,7 +1132,7 @@ case class ST_MaxDistance(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_GeoHash(inputExpressions: Seq[Expression])
+private[apache] case class ST_GeoHash(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.geohash _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1139,7 +1145,7 @@ case class ST_GeoHash(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Difference(inputExpressions: Seq[Expression])
+private[apache] case class ST_Difference(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.difference _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1152,7 +1158,7 @@ case class ST_Difference(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_SymDifference(inputExpressions: Seq[Expression])
+private[apache] case class ST_SymDifference(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.symDifference _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1160,7 +1166,7 @@ case class ST_SymDifference(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_UnaryUnion(inputExpressions: Seq[Expression])
+private[apache] case class ST_UnaryUnion(inputExpressions: Seq[Expression])
     extends InferredExpression(inferrableFunction1(Functions.unaryUnion)) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1173,7 +1179,7 @@ case class ST_UnaryUnion(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Union(inputExpressions: Seq[Expression])
+private[apache] case class ST_Union(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(Functions.union),
       inferrableFunction1(Functions.union)) {
@@ -1183,7 +1189,7 @@ case class ST_Union(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Multi(inputExpressions: Seq[Expression])
+private[apache] case class ST_Multi(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.createMultiGeometryFromOneElement _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1197,7 +1203,7 @@ case class ST_Multi(inputExpressions: Seq[Expression])
  * @param inputExpressions
  *   Geometry
  */
-case class ST_PointOnSurface(inputExpressions: Seq[Expression])
+private[apache] case class ST_PointOnSurface(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.pointOnSurface _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1210,7 +1216,7 @@ case class ST_PointOnSurface(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Reverse(inputExpressions: Seq[Expression])
+private[apache] case class ST_Reverse(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.reverse _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1224,7 +1230,7 @@ case class ST_Reverse(inputExpressions: Seq[Expression])
  * @param inputExpressions
  *   sequence of 2 input arguments, a geometry and a value 'n'
  */
-case class ST_PointN(inputExpressions: Seq[Expression])
+private[apache] case class ST_PointN(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.pointN _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1237,7 +1243,7 @@ case class ST_PointN(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Force_2D(inputExpressions: Seq[Expression])
+private[apache] case class ST_Force_2D(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.force2D _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1250,7 +1256,7 @@ case class ST_Force_2D(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Force2D(inputExpressions: Seq[Expression])
+private[apache] case class ST_Force2D(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.force2D _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1263,7 +1269,7 @@ case class ST_Force2D(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_AsEWKT(inputExpressions: Seq[Expression])
+private[apache] case class ST_AsEWKT(inputExpressions: Seq[Expression])
     extends InferredExpression(
       (geom: Geometry) => Functions.asEWKT(geom),
       (geog: Geography) => Functions.asEWKT(geog)) {
@@ -1273,7 +1279,7 @@ case class ST_AsEWKT(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_AsGML(inputExpressions: Seq[Expression])
+private[apache] case class ST_AsGML(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.asGML _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1281,7 +1287,7 @@ case class ST_AsGML(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_AsKML(inputExpressions: Seq[Expression])
+private[apache] case class ST_AsKML(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.asKML _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1294,7 +1300,7 @@ case class ST_AsKML(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_IsEmpty(inputExpressions: Seq[Expression])
+private[apache] case class ST_IsEmpty(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.isEmpty _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1307,7 +1313,7 @@ case class ST_IsEmpty(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_XMax(inputExpressions: Seq[Expression])
+private[apache] case class ST_XMax(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.xMax _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1320,7 +1326,7 @@ case class ST_XMax(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_XMin(inputExpressions: Seq[Expression])
+private[apache] case class ST_XMin(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.xMin _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1334,7 +1340,7 @@ case class ST_XMin(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_BuildArea(inputExpressions: Seq[Expression])
+private[apache] case class ST_BuildArea(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.buildArea _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Expression = {
@@ -1347,7 +1353,7 @@ case class ST_BuildArea(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Normalize(inputExpressions: Seq[Expression])
+private[apache] case class ST_Normalize(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.normalize _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Expression = {
@@ -1360,7 +1366,7 @@ case class ST_Normalize(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_LineFromMultiPoint(inputExpressions: Seq[Expression])
+private[apache] case class ST_LineFromMultiPoint(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.lineFromMultiPoint _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1374,7 +1380,7 @@ case class ST_LineFromMultiPoint(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Split(inputExpressions: Seq[Expression])
+private[apache] case class ST_Split(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.split _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1382,7 +1388,7 @@ case class ST_Split(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_S2CellIDs(inputExpressions: Seq[Expression])
+private[apache] case class ST_S2CellIDs(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.s2CellIDs _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1390,14 +1396,14 @@ case class ST_S2CellIDs(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_S2ToGeom(inputExpressions: Seq[Expression])
+private[apache] case class ST_S2ToGeom(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.s2ToGeom _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class ST_H3CellIDs(inputExpressions: Seq[Expression])
+private[apache] case class ST_H3CellIDs(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.h3CellIDs _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1405,7 +1411,7 @@ case class ST_H3CellIDs(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_H3CellDistance(inputExpressions: Seq[Expression])
+private[apache] case class ST_H3CellDistance(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.h3CellDistance _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1413,7 +1419,7 @@ case class ST_H3CellDistance(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_H3KRing(inputExpressions: Seq[Expression])
+private[apache] case class ST_H3KRing(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.h3KRing _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1421,7 +1427,7 @@ case class ST_H3KRing(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_H3ToGeom(inputExpressions: Seq[Expression])
+private[apache] case class ST_H3ToGeom(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.h3ToGeom _)
     with FoldableExpression {
 
@@ -1430,7 +1436,7 @@ case class ST_H3ToGeom(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_CollectionExtract(inputExpressions: Seq[Expression])
+private[apache] case class ST_CollectionExtract(inputExpressions: Seq[Expression])
     extends InferredExpression(InferrableFunction.allowRightNull(Functions.collectionExtract)) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1446,7 +1452,7 @@ case class ST_CollectionExtract(inputExpressions: Seq[Expression])
  * @param inputExpressions
  *   Geometry
  */
-case class ST_GeometricMedian(inputExpressions: Seq[Expression])
+private[apache] case class ST_GeometricMedian(inputExpressions: Seq[Expression])
     extends InferredExpression(inferrableFunction4(Functions.geometricMedian))
     with FoldableExpression {
 
@@ -1455,7 +1461,7 @@ case class ST_GeometricMedian(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_DistanceSphere(inputExpressions: Seq[Expression])
+private[apache] case class ST_DistanceSphere(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(Haversine.distance),
       inferrableFunction3(Haversine.distance)) {
@@ -1465,7 +1471,7 @@ case class ST_DistanceSphere(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_DistanceSpheroid(inputExpressions: Seq[Expression])
+private[apache] case class ST_DistanceSpheroid(inputExpressions: Seq[Expression])
     extends InferredExpression(Spheroid.distance _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1473,7 +1479,7 @@ case class ST_DistanceSpheroid(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_AreaSpheroid(inputExpressions: Seq[Expression])
+private[apache] case class ST_AreaSpheroid(inputExpressions: Seq[Expression])
     extends InferredExpression(Spheroid.area _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1481,7 +1487,7 @@ case class ST_AreaSpheroid(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_LengthSpheroid(inputExpressions: Seq[Expression])
+private[apache] case class ST_LengthSpheroid(inputExpressions: Seq[Expression])
     extends InferredExpression(Spheroid.length _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1489,7 +1495,7 @@ case class ST_LengthSpheroid(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_LocateAlong(inputExpressions: Seq[Expression])
+private[apache] case class ST_LocateAlong(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction3(Functions.locateAlong),
       inferrableFunction2(Functions.locateAlong)) {
@@ -1499,7 +1505,7 @@ case class ST_LocateAlong(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_LongestLine(inputExpressions: Seq[Expression])
+private[apache] case class ST_LongestLine(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.longestLine _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1507,14 +1513,14 @@ case class ST_LongestLine(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_NumPoints(inputExpressions: Seq[Expression])
+private[apache] case class ST_NumPoints(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.numPoints _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class ST_Force3D(inputExpressions: Seq[Expression])
+private[apache] case class ST_Force3D(inputExpressions: Seq[Expression])
     extends InferredExpression(inferrableFunction2(Functions.force3D)) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1522,7 +1528,7 @@ case class ST_Force3D(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Force3DZ(inputExpressions: Seq[Expression])
+private[apache] case class ST_Force3DZ(inputExpressions: Seq[Expression])
     extends InferredExpression(inferrableFunction2(Functions.force3D)) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1530,7 +1536,7 @@ case class ST_Force3DZ(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Force3DM(inputExpressions: Seq[Expression])
+private[apache] case class ST_Force3DM(inputExpressions: Seq[Expression])
     extends InferredExpression(inferrableFunction2(Functions.force3DM)) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1538,7 +1544,7 @@ case class ST_Force3DM(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Force4D(inputExpressions: Seq[Expression])
+private[apache] case class ST_Force4D(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction3(Functions.force4D),
       inferrableFunction1(Functions.force4D)) {
@@ -1548,7 +1554,7 @@ case class ST_Force4D(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_ForceCollection(inputExpressions: Seq[Expression])
+private[apache] case class ST_ForceCollection(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.forceCollection _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1556,21 +1562,21 @@ case class ST_ForceCollection(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_ForcePolygonCW(inputExpressions: Seq[Expression])
+private[apache] case class ST_ForcePolygonCW(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.forcePolygonCW _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class ST_ForceRHR(inputExpressions: Seq[Expression])
+private[apache] case class ST_ForceRHR(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.forcePolygonCW _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class ST_GeneratePoints(inputExpressions: Seq[Expression], randomSeed: Long)
+private[apache] case class ST_GeneratePoints(inputExpressions: Seq[Expression], randomSeed: Long)
     extends Expression
     with CodegenFallback
     with ExpectsInputTypes
@@ -1622,28 +1628,28 @@ case class ST_GeneratePoints(inputExpressions: Seq[Expression], randomSeed: Long
   }
 }
 
-case class ST_NRings(inputExpressions: Seq[Expression])
+private[apache] case class ST_NRings(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.nRings _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class ST_IsPolygonCCW(inputExpressions: Seq[Expression])
+private[apache] case class ST_IsPolygonCCW(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.isPolygonCCW _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class ST_ForcePolygonCCW(inputExpressions: Seq[Expression])
+private[apache] case class ST_ForcePolygonCCW(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.forcePolygonCCW _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class ST_Translate(inputExpressions: Seq[Expression])
+private[apache] case class ST_Translate(inputExpressions: Seq[Expression])
     extends InferredExpression(inferrableFunction4(Functions.translate))
     with FoldableExpression {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1651,7 +1657,7 @@ case class ST_Translate(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_TriangulatePolygon(inputExpressions: Seq[Expression])
+private[apache] case class ST_TriangulatePolygon(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.triangulatePolygon _)
     with FoldableExpression {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1659,7 +1665,7 @@ case class ST_TriangulatePolygon(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_VoronoiPolygons(inputExpressions: Seq[Expression])
+private[apache] case class ST_VoronoiPolygons(inputExpressions: Seq[Expression])
     extends InferredExpression(nullTolerantInferrableFunction3(FunctionsGeoTools.voronoiPolygons))
     with FoldableExpression {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1667,7 +1673,7 @@ case class ST_VoronoiPolygons(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_FrechetDistance(inputExpressions: Seq[Expression])
+private[apache] case class ST_FrechetDistance(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.frechetDistance _)
     with FoldableExpression {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1675,7 +1681,7 @@ case class ST_FrechetDistance(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Affine(inputExpressions: Seq[Expression])
+private[apache] case class ST_Affine(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction13(Functions.affine),
       inferrableFunction7(Functions.affine)) {
@@ -1684,7 +1690,7 @@ case class ST_Affine(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Dimension(inputExpressions: Seq[Expression])
+private[apache] case class ST_Dimension(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.dimension _)
     with FoldableExpression {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1692,14 +1698,14 @@ case class ST_Dimension(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_BoundingDiagonal(inputExpressions: Seq[Expression])
+private[apache] case class ST_BoundingDiagonal(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.boundingDiagonal _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class ST_HausdorffDistance(inputExpressions: Seq[Expression])
+private[apache] case class ST_HausdorffDistance(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction3(Functions.hausdorffDistance),
       inferrableFunction2(Functions.hausdorffDistance)) {
@@ -1708,7 +1714,7 @@ case class ST_HausdorffDistance(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Angle(inputExpressions: Seq[Expression])
+private[apache] case class ST_Angle(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction4(Functions.angle _),
       inferrableFunction3(Functions.angle _),
@@ -1719,7 +1725,7 @@ case class ST_Angle(inputExpressions: Seq[Expression])
   }
 }
 
-case class GeometryType(inputExpressions: Seq[Expression])
+private[apache] case class GeometryType(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.geometryTypeWithMeasured _)
     with FoldableExpression {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1727,7 +1733,7 @@ case class GeometryType(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Degrees(inputExpressions: Seq[Expression])
+private[apache] case class ST_Degrees(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.degrees _)
     with FoldableExpression {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1735,7 +1741,7 @@ case class ST_Degrees(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_DelaunayTriangles(inputExpressions: Seq[Expression])
+private[apache] case class ST_DelaunayTriangles(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction3(Functions.delaunayTriangle),
       inferrableFunction2(Functions.delaunayTriangle),
@@ -1751,7 +1757,7 @@ case class ST_DelaunayTriangles(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_CoordDim(inputExpressions: Seq[Expression])
+private[apache] case class ST_CoordDim(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.nDims _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Expression = {
     copy(inputExpressions = newChildren)
@@ -1763,7 +1769,7 @@ case class ST_CoordDim(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_IsCollection(inputExpressions: Seq[Expression])
+private[apache] case class ST_IsCollection(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.isCollection _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Expression = {
     copy(inputExpressions = newChildren)
@@ -1781,7 +1787,7 @@ case class ST_IsCollection(inputExpressions: Seq[Expression])
  * @return
  *   A string describing the validity of the geometry.
  */
-case class ST_IsValidReason(inputExpressions: Seq[Expression])
+private[apache] case class ST_IsValidReason(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(Functions.isValidReason),
       inferrableFunction1(Functions.isValidReason)) {
@@ -1790,14 +1796,14 @@ case class ST_IsValidReason(inputExpressions: Seq[Expression])
     copy(inputExpressions = newChildren)
 }
 
-case class ST_Scale(inputExpressions: Seq[Expression])
+private[apache] case class ST_Scale(inputExpressions: Seq[Expression])
     extends InferredExpression(inferrableFunction3(Functions.scale)) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) =
     copy(inputExpressions = newChildren)
 }
 
-case class ST_ScaleGeom(inputExpressions: Seq[Expression])
+private[apache] case class ST_ScaleGeom(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction3(Functions.scaleGeom),
       inferrableFunction2(Functions.scaleGeom)) {
@@ -1806,21 +1812,21 @@ case class ST_ScaleGeom(inputExpressions: Seq[Expression])
     copy(inputExpressions = newChildren)
 }
 
-case class ST_RotateX(inputExpressions: Seq[Expression])
+private[apache] case class ST_RotateX(inputExpressions: Seq[Expression])
     extends InferredExpression(inferrableFunction2(Functions.rotateX)) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) =
     copy(inputExpressions = newChildren)
 }
 
-case class ST_RotateY(inputExpressions: Seq[Expression])
+private[apache] case class ST_RotateY(inputExpressions: Seq[Expression])
     extends InferredExpression(inferrableFunction2(Functions.rotateY)) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) =
     copy(inputExpressions = newChildren)
 }
 
-case class ST_Rotate(inputExpressions: Seq[Expression])
+private[apache] case class ST_Rotate(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(Functions.rotate),
       inferrableFunction3(Functions.rotate),
@@ -1830,13 +1836,13 @@ case class ST_Rotate(inputExpressions: Seq[Expression])
     copy(inputExpressions = newChildren)
 }
 
-case class ST_InterpolatePoint(inputExpressions: Seq[Expression])
+private[apache] case class ST_InterpolatePoint(inputExpressions: Seq[Expression])
     extends InferredExpression(inferrableFunction2(Functions.interpolatePoint)) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) =
     copy(inputExpressions = newChildren)
 }
 
-case class ExpandAddress(address: Expression)
+private[apache] case class ExpandAddress(address: Expression)
     extends UnaryExpression
     with ImplicitCastInputTypes
     with CodegenFallback
@@ -1899,7 +1905,7 @@ case class ExpandAddress(address: Expression)
     ExpandAddress(newChild)
 }
 
-case class ParseAddress(address: Expression)
+private[apache] case class ParseAddress(address: Expression)
     extends UnaryExpression
     with ImplicitCastInputTypes
     with CodegenFallback

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/GeoStatsFunctions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/GeoStatsFunctions.scala
@@ -29,7 +29,8 @@ import org.apache.spark.sql.functions.{col, struct}
 import org.apache.spark.sql.sedona_sql.UDT.GeometryUDT
 import org.apache.spark.sql.types._
 
-case class ST_DBSCAN(children: Seq[Expression]) extends DataframePhysicalFunction {
+private[apache] case class ST_DBSCAN(children: Seq[Expression])
+    extends DataframePhysicalFunction {
 
   override def dataType: DataType =
     StructType(Seq(StructField("isCore", BooleanType), StructField("cluster", LongType)))
@@ -67,7 +68,8 @@ case class ST_DBSCAN(children: Seq[Expression]) extends DataframePhysicalFunctio
   }
 }
 
-case class ST_LocalOutlierFactor(children: Seq[Expression]) extends DataframePhysicalFunction {
+private[apache] case class ST_LocalOutlierFactor(children: Seq[Expression])
+    extends DataframePhysicalFunction {
 
   override def dataType: DataType = DoubleType
 
@@ -90,7 +92,8 @@ case class ST_LocalOutlierFactor(children: Seq[Expression]) extends DataframePhy
   }
 }
 
-case class ST_GLocal(children: Seq[Expression]) extends DataframePhysicalFunction {
+private[apache] case class ST_GLocal(children: Seq[Expression])
+    extends DataframePhysicalFunction {
 
   override def dataType: DataType = StructType(
     Seq(
@@ -129,7 +132,7 @@ case class ST_GLocal(children: Seq[Expression]) extends DataframePhysicalFunctio
   }
 }
 
-case class ST_BinaryDistanceBandColumn(children: Seq[Expression])
+private[apache] case class ST_BinaryDistanceBandColumn(children: Seq[Expression])
     extends DataframePhysicalFunction {
   override def dataType: DataType = ArrayType(
     StructType(
@@ -162,7 +165,7 @@ case class ST_BinaryDistanceBandColumn(children: Seq[Expression])
   }
 }
 
-case class ST_WeightedDistanceBandColumn(children: Seq[Expression])
+private[apache] case class ST_WeightedDistanceBandColumn(children: Seq[Expression])
     extends DataframePhysicalFunction {
 
   override def dataType: DataType = ArrayType(

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Predicates.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Predicates.scala
@@ -78,7 +78,7 @@ abstract class ST_Predicate
  *
  * @param inputExpressions
  */
-case class ST_Contains(inputExpressions: Seq[Expression])
+private[apache] case class ST_Contains(inputExpressions: Seq[Expression])
     extends ST_Predicate
     with CodegenFallback {
 
@@ -96,7 +96,7 @@ case class ST_Contains(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Intersects(inputExpressions: Seq[Expression])
+private[apache] case class ST_Intersects(inputExpressions: Seq[Expression])
     extends ST_Predicate
     with CodegenFallback {
 
@@ -114,7 +114,7 @@ case class ST_Intersects(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Within(inputExpressions: Seq[Expression])
+private[apache] case class ST_Within(inputExpressions: Seq[Expression])
     extends ST_Predicate
     with CodegenFallback {
 
@@ -132,7 +132,7 @@ case class ST_Within(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Covers(inputExpressions: Seq[Expression])
+private[apache] case class ST_Covers(inputExpressions: Seq[Expression])
     extends ST_Predicate
     with CodegenFallback {
 
@@ -150,7 +150,7 @@ case class ST_Covers(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_CoveredBy(inputExpressions: Seq[Expression])
+private[apache] case class ST_CoveredBy(inputExpressions: Seq[Expression])
     extends ST_Predicate
     with CodegenFallback {
 
@@ -168,7 +168,7 @@ case class ST_CoveredBy(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Crosses(inputExpressions: Seq[Expression])
+private[apache] case class ST_Crosses(inputExpressions: Seq[Expression])
     extends ST_Predicate
     with CodegenFallback {
 
@@ -186,7 +186,7 @@ case class ST_Crosses(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Overlaps(inputExpressions: Seq[Expression])
+private[apache] case class ST_Overlaps(inputExpressions: Seq[Expression])
     extends ST_Predicate
     with CodegenFallback {
 
@@ -204,7 +204,7 @@ case class ST_Overlaps(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Touches(inputExpressions: Seq[Expression])
+private[apache] case class ST_Touches(inputExpressions: Seq[Expression])
     extends ST_Predicate
     with CodegenFallback {
 
@@ -217,7 +217,7 @@ case class ST_Touches(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Relate(inputExpressions: Seq[Expression])
+private[apache] case class ST_Relate(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction3(Predicates.relate),
       inferrableFunction2(Predicates.relate)) {
@@ -227,7 +227,7 @@ case class ST_Relate(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_RelateMatch(inputExpressions: Seq[Expression])
+private[apache] case class ST_RelateMatch(inputExpressions: Seq[Expression])
     extends InferredExpression(inferrableFunction2(Predicates.relateMatch)) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -240,7 +240,7 @@ case class ST_RelateMatch(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Equals(inputExpressions: Seq[Expression])
+private[apache] case class ST_Equals(inputExpressions: Seq[Expression])
     extends ST_Predicate
     with CodegenFallback {
 
@@ -259,7 +259,7 @@ case class ST_Equals(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Disjoint(inputExpressions: Seq[Expression])
+private[apache] case class ST_Disjoint(inputExpressions: Seq[Expression])
     extends ST_Predicate
     with CodegenFallback {
 
@@ -277,7 +277,7 @@ case class ST_Disjoint(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_OrderingEquals(inputExpressions: Seq[Expression])
+private[apache] case class ST_OrderingEquals(inputExpressions: Seq[Expression])
     extends ST_Predicate
     with CodegenFallback {
 
@@ -290,7 +290,7 @@ case class ST_OrderingEquals(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_DWithin(inputExpressions: Seq[Expression])
+private[apache] case class ST_DWithin(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction3(Predicates.dWithin),
       inferrableFunction4(Predicates.dWithin)) {
@@ -306,7 +306,7 @@ case class ST_DWithin(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_KNN(inputExpressions: Seq[Expression])
+private[apache] case class ST_KNN(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction3(Predicates.knn),
       inferrableFunction4(Predicates.knn)) {

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/collect/ST_Collect.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/collect/ST_Collect.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.sedona_sql.expressions.{InferredExpression, SerdeAwa
 import org.apache.spark.sql.types.{ArrayType, _}
 import org.locationtech.jts.geom.Geometry
 
-case class ST_Collect(inputExpressions: Seq[Expression])
+private[apache] case class ST_Collect(inputExpressions: Seq[Expression])
     extends Expression
     with SerdeAware
     with CodegenFallback {

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/GeometryFunctions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/GeometryFunctions.scala
@@ -24,21 +24,21 @@ import org.apache.spark.sql.sedona_sql.expressions.InferredExpression
 import org.apache.spark.sql.sedona_sql.expressions.InferrableFunctionConverter._
 import org.apache.spark.sql.sedona_sql.expressions.InferrableRasterTypes._
 
-case class RS_ConvexHull(inputExpressions: Seq[Expression])
+private[apache] case class RS_ConvexHull(inputExpressions: Seq[Expression])
     extends InferredExpression(GeometryFunctions.convexHull _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_Envelope(inputExpressions: Seq[Expression])
+private[apache] case class RS_Envelope(inputExpressions: Seq[Expression])
     extends InferredExpression(GeometryFunctions.envelope _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_MinConvexHull(inputExpressions: Seq[Expression])
+private[apache] case class RS_MinConvexHull(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(GeometryFunctions.minConvexHull),
       inferrableFunction1(GeometryFunctions.minConvexHull)) {

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/IO.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/IO.scala
@@ -20,19 +20,12 @@ package org.apache.spark.sql.sedona_sql.expressions.raster
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
-import org.apache.spark.sql.catalyst.expressions.{Expression, ImplicitCastInputTypes, UnsafeArrayData}
+import org.apache.spark.sql.catalyst.expressions.{Expression, ImplicitCastInputTypes}
 import org.apache.spark.sql.catalyst.util.GenericArrayData
 import org.apache.spark.sql.sedona_sql.expressions.UserDataGenerator
 import org.apache.spark.sql.types._
-import org.apache.spark.unsafe.types.UTF8String
 
-import java.awt.Color
-import java.awt.image.BufferedImage
-import java.io.ByteArrayOutputStream
-import java.util.Base64
-import javax.imageio.ImageIO
-
-case class RS_Array(inputExpressions: Seq[Expression])
+private[apache] case class RS_Array(inputExpressions: Seq[Expression])
     extends Expression
     with ImplicitCastInputTypes
     with CodegenFallback

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/PixelFunctionEditors.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/PixelFunctionEditors.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.sedona_sql.expressions.InferrableFunctionConverter._
 import org.apache.spark.sql.sedona_sql.expressions.InferrableRasterTypes._
 import org.apache.spark.sql.sedona_sql.expressions.InferredExpression
 
-case class RS_SetValues(inputExpressions: Seq[Expression])
+private[apache] case class RS_SetValues(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction8(PixelFunctionEditors.setValues),
       inferrableFunction7(PixelFunctionEditors.setValues),
@@ -36,7 +36,7 @@ case class RS_SetValues(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_SetValue(inputExpressions: Seq[Expression])
+private[apache] case class RS_SetValue(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction5(PixelFunctionEditors.setValue),
       inferrableFunction4(PixelFunctionEditors.setValue)) {

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/PixelFunctions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/PixelFunctions.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.types.{AbstractDataType, ArrayType, DataType, Double
 
 import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
 
-case class RS_Value(inputExpressions: Seq[Expression])
+private[apache] case class RS_Value(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(PixelFunctions.value),
       inferrableFunction3(PixelFunctions.value),
@@ -43,14 +43,14 @@ case class RS_Value(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_PixelAsPoint(inputExpressions: Seq[Expression])
+private[apache] case class RS_PixelAsPoint(inputExpressions: Seq[Expression])
     extends InferredExpression(PixelFunctions.getPixelAsPoint _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_PixelAsPoints(inputExpressions: Seq[Expression])
+private[apache] case class RS_PixelAsPoints(inputExpressions: Seq[Expression])
     extends Expression
     with CodegenFallback
     with ExpectsInputTypes {
@@ -91,14 +91,14 @@ case class RS_PixelAsPoints(inputExpressions: Seq[Expression])
   override def inputTypes: Seq[AbstractDataType] = Seq(RasterUDT, IntegerType)
 }
 
-case class RS_PixelAsPolygon(inputExpressions: Seq[Expression])
+private[apache] case class RS_PixelAsPolygon(inputExpressions: Seq[Expression])
     extends InferredExpression(PixelFunctions.getPixelAsPolygon _) {
   protected def withNewChildrenInternal(newChilren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChilren)
   }
 }
 
-case class RS_PixelAsPolygons(inputExpressions: Seq[Expression])
+private[apache] case class RS_PixelAsPolygons(inputExpressions: Seq[Expression])
     extends Expression
     with CodegenFallback
     with ExpectsInputTypes {
@@ -140,14 +140,14 @@ case class RS_PixelAsPolygons(inputExpressions: Seq[Expression])
   override def inputTypes: Seq[AbstractDataType] = Seq(RasterUDT, IntegerType)
 }
 
-case class RS_PixelAsCentroid(inputExpressions: Seq[Expression])
+private[apache] case class RS_PixelAsCentroid(inputExpressions: Seq[Expression])
     extends InferredExpression(PixelFunctions.getPixelAsCentroid _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_PixelAsCentroids(inputExpressions: Seq[Expression])
+private[apache] case class RS_PixelAsCentroids(inputExpressions: Seq[Expression])
     extends Expression
     with CodegenFallback
     with ExpectsInputTypes {
@@ -189,7 +189,7 @@ case class RS_PixelAsCentroids(inputExpressions: Seq[Expression])
   override def inputTypes: Seq[AbstractDataType] = Seq(RasterUDT, IntegerType)
 }
 
-case class RS_Values(inputExpressions: Seq[Expression])
+private[apache] case class RS_Values(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(PixelFunctions.values),
       inferrableFunction3(PixelFunctions.values),

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterAccessors.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterAccessors.scala
@@ -24,63 +24,63 @@ import org.apache.spark.sql.sedona_sql.expressions.InferrableFunctionConverter._
 import org.apache.spark.sql.sedona_sql.expressions.InferrableRasterTypes._
 import org.apache.spark.sql.sedona_sql.expressions.InferredExpression
 
-case class RS_NumBands(inputExpressions: Seq[Expression])
+private[apache] case class RS_NumBands(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterAccessors.numBands _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_SRID(inputExpressions: Seq[Expression])
+private[apache] case class RS_SRID(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterAccessors.srid _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_Width(inputExpressions: Seq[Expression])
+private[apache] case class RS_Width(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterAccessors.getWidth _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_UpperLeftX(inputExpressions: Seq[Expression])
+private[apache] case class RS_UpperLeftX(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterAccessors.getUpperLeftX _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_UpperLeftY(inputExpressions: Seq[Expression])
+private[apache] case class RS_UpperLeftY(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterAccessors.getUpperLeftY _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_Height(inputExpressions: Seq[Expression])
+private[apache] case class RS_Height(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterAccessors.getHeight _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_ScaleX(inputExpressions: Seq[Expression])
+private[apache] case class RS_ScaleX(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterAccessors.getScaleX _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_ScaleY(inputExpressions: Seq[Expression])
+private[apache] case class RS_ScaleY(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterAccessors.getScaleY _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_GeoReference(inputExpressions: Seq[Expression])
+private[apache] case class RS_GeoReference(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(RasterAccessors.getGeoReference),
       inferrableFunction1(RasterAccessors.getGeoReference)) {
@@ -89,49 +89,49 @@ case class RS_GeoReference(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_Rotation(inputExpressions: Seq[Expression])
+private[apache] case class RS_Rotation(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterAccessors.getRotation _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_SkewX(inputExpressions: Seq[Expression])
+private[apache] case class RS_SkewX(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterAccessors.getSkewX _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Expression = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_SkewY(inputExpressions: Seq[Expression])
+private[apache] case class RS_SkewY(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterAccessors.getSkewY _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Expression = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_RasterToWorldCoordX(inputExpressions: Seq[Expression])
+private[apache] case class RS_RasterToWorldCoordX(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterAccessors.getWorldCoordX _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_RasterToWorldCoordY(inputExpressions: Seq[Expression])
+private[apache] case class RS_RasterToWorldCoordY(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterAccessors.getWorldCoordY _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_RasterToWorldCoord(inputExpressions: Seq[Expression])
+private[apache] case class RS_RasterToWorldCoord(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterAccessors.getWorldCoord _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_WorldToRasterCoord(inputExpressions: Seq[Expression])
+private[apache] case class RS_WorldToRasterCoord(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction3(RasterAccessors.getGridCoord),
       inferrableFunction2(RasterAccessors.getGridCoord)) {
@@ -140,7 +140,7 @@ case class RS_WorldToRasterCoord(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_WorldToRasterCoordX(inputExpressions: Seq[Expression])
+private[apache] case class RS_WorldToRasterCoordX(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction3(RasterAccessors.getGridCoordX),
       inferrableFunction2(RasterAccessors.getGridCoordX)) {
@@ -149,7 +149,7 @@ case class RS_WorldToRasterCoordX(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_WorldToRasterCoordY(inputExpressions: Seq[Expression])
+private[apache] case class RS_WorldToRasterCoordY(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction3(RasterAccessors.getGridCoordY),
       inferrableFunction2(RasterAccessors.getGridCoordY)) {

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterBandAccessors.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterBandAccessors.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.sedona_sql.expressions.raster.implicits.RasterInputE
 import org.apache.spark.sql.sedona_sql.expressions.InferredExpression
 import org.geotools.coverage.grid.GridCoverage2D
 
-case class RS_BandNoDataValue(inputExpressions: Seq[Expression])
+private[apache] case class RS_BandNoDataValue(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(RasterBandAccessors.getBandNoDataValue),
       inferrableFunction1(RasterBandAccessors.getBandNoDataValue)) {
@@ -38,7 +38,7 @@ case class RS_BandNoDataValue(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_Count(inputExpressions: Seq[Expression])
+private[apache] case class RS_Count(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(RasterBandAccessors.getCount),
       inferrableFunction1(RasterBandAccessors.getCount),
@@ -48,7 +48,7 @@ case class RS_Count(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_ZonalStats(inputExpressions: Seq[Expression])
+private[apache] case class RS_ZonalStats(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction7(RasterBandAccessors.getZonalStats),
       inferrableFunction6(RasterBandAccessors.getZonalStats),
@@ -60,7 +60,7 @@ case class RS_ZonalStats(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_SummaryStats(inputExpressions: Seq[Expression])
+private[apache] case class RS_SummaryStats(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(RasterBandAccessors.getSummaryStats),
       inferrableFunction3(RasterBandAccessors.getSummaryStats),
@@ -70,7 +70,7 @@ case class RS_SummaryStats(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_Band(inputExpressions: Seq[Expression])
+private[apache] case class RS_Band(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterBandAccessors.getBand _) {
 
   override def evalWithoutSerialization(input: InternalRow): Any = {
@@ -93,7 +93,7 @@ case class RS_Band(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_BandPixelType(inputExpressions: Seq[Expression])
+private[apache] case class RS_BandPixelType(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(RasterBandAccessors.getBandType),
       inferrableFunction1(RasterBandAccessors.getBandType)) {
@@ -102,7 +102,7 @@ case class RS_BandPixelType(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_BandIsNoData(inputExpressions: Seq[Expression])
+private[apache] case class RS_BandIsNoData(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(RasterBandAccessors.bandIsNoData),
       inferrableFunction1(RasterBandAccessors.bandIsNoData)) {

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterBandEditors.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterBandEditors.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.sedona_sql.expressions.InferrableFunctionConverter._
 import org.apache.spark.sql.sedona_sql.expressions.InferrableRasterTypes._
 import org.apache.spark.sql.sedona_sql.expressions.InferredExpression
 
-case class RS_SetBandNoDataValue(inputExpressions: Seq[Expression])
+private[apache] case class RS_SetBandNoDataValue(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction4(RasterBandEditors.setBandNoDataValue),
       inferrableFunction3(RasterBandEditors.setBandNoDataValue),
@@ -34,7 +34,7 @@ case class RS_SetBandNoDataValue(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_AddBand(inputExpressions: Seq[Expression])
+private[apache] case class RS_AddBand(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction4(RasterBandEditors.addBand),
       inferrableFunction3(RasterBandEditors.addBand),
@@ -44,7 +44,7 @@ case class RS_AddBand(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_Union(inputExpressions: Seq[Expression])
+private[apache] case class RS_Union(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(RasterBandEditors.rasterUnion),
       inferrableFunction3(RasterBandEditors.rasterUnion),
@@ -57,7 +57,7 @@ case class RS_Union(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_Clip(inputExpressions: Seq[Expression])
+private[apache] case class RS_Clip(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction7(RasterBandEditors.clip),
       inferrableFunction6(RasterBandEditors.clip),

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterConstructors.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterConstructors.scala
@@ -19,7 +19,6 @@
 package org.apache.spark.sql.sedona_sql.expressions.raster
 
 import org.apache.sedona.common.raster.{RasterConstructors, RasterConstructorsForTesting}
-import org.apache.sedona.sql.utils.RasterSerializer
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
 import org.apache.spark.sql.catalyst.expressions.{CreateArray, Expression, Generator, Literal}
@@ -29,9 +28,9 @@ import org.apache.spark.sql.sedona_sql.expressions.InferrableFunctionConverter._
 import org.apache.spark.sql.sedona_sql.expressions.InferrableRasterTypes._
 import org.apache.spark.sql.sedona_sql.expressions.InferredExpression
 import org.apache.spark.sql.sedona_sql.expressions.raster.implicits.{RasterEnhancer, RasterInputExpressionEnhancer}
-import org.apache.spark.sql.types.{ArrayType, BooleanType, Decimal, IntegerType, NullType, StructType}
+import org.apache.spark.sql.types._
 
-case class RS_FromArcInfoAsciiGrid(inputExpressions: Seq[Expression])
+private[apache] case class RS_FromArcInfoAsciiGrid(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterConstructors.fromArcInfoAsciiGrid _) {
   override def foldable: Boolean = false
 
@@ -40,7 +39,7 @@ case class RS_FromArcInfoAsciiGrid(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_AsRaster(inputExpressions: Seq[Expression])
+private[apache] case class RS_AsRaster(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction3(RasterConstructors.asRaster),
       inferrableFunction4(RasterConstructors.asRaster),
@@ -52,7 +51,7 @@ case class RS_AsRaster(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_FromGeoTiff(inputExpressions: Seq[Expression])
+private[apache] case class RS_FromGeoTiff(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterConstructors.fromGeoTiff _) {
 
   override def foldable: Boolean = false
@@ -62,7 +61,7 @@ case class RS_FromGeoTiff(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_MakeEmptyRaster(inputExpressions: Seq[Expression])
+private[apache] case class RS_MakeEmptyRaster(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction6(RasterConstructors.makeEmptyRaster),
       inferrableFunction7(RasterConstructors.makeEmptyRaster),
@@ -76,21 +75,21 @@ case class RS_MakeEmptyRaster(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_MakeRaster(inputExpressions: Seq[Expression])
+private[apache] case class RS_MakeRaster(inputExpressions: Seq[Expression])
     extends InferredExpression(inferrableFunction3(RasterConstructors.makeNonEmptyRaster)) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_MakeRasterForTesting(inputExpressions: Seq[Expression])
+private[apache] case class RS_MakeRasterForTesting(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterConstructorsForTesting.makeRasterForTesting _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_Tile(inputExpressions: Seq[Expression])
+private[apache] case class RS_Tile(inputExpressions: Seq[Expression])
     extends InferredExpression(
       nullTolerantInferrableFunction3(RasterConstructors.rsTile),
       nullTolerantInferrableFunction4(RasterConstructors.rsTile),
@@ -101,7 +100,9 @@ case class RS_Tile(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_TileExplode(children: Seq[Expression]) extends Generator with CodegenFallback {
+private[apache] case class RS_TileExplode(children: Seq[Expression])
+    extends Generator
+    with CodegenFallback {
   private val arguments = RS_TileExplode.arguments(children)
 
   override def eval(input: InternalRow): TraversableOnce[InternalRow] = {
@@ -205,7 +206,7 @@ object RS_TileExplode {
   }
 }
 
-case class RS_FromNetCDF(inputExpressions: Seq[Expression])
+private[apache] case class RS_FromNetCDF(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(RasterConstructors.fromNetCDF),
       inferrableFunction4(RasterConstructors.fromNetCDF)) {
@@ -216,7 +217,7 @@ case class RS_FromNetCDF(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_NetCDFInfo(inputExpressions: Seq[Expression])
+private[apache] case class RS_NetCDFInfo(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterConstructors.getRecordInfo _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterEditors.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterEditors.scala
@@ -24,14 +24,14 @@ import org.apache.spark.sql.sedona_sql.expressions.InferrableFunctionConverter._
 import org.apache.spark.sql.sedona_sql.expressions.InferrableRasterTypes._
 import org.apache.spark.sql.sedona_sql.expressions.InferredExpression
 
-case class RS_SetSRID(inputExpressions: Seq[Expression])
+private[apache] case class RS_SetSRID(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterEditors.setSrid _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_SetGeoReference(inputExpressions: Seq[Expression])
+private[apache] case class RS_SetGeoReference(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(RasterEditors.setGeoReference),
       inferrableFunction3(RasterEditors.setGeoReference),
@@ -41,14 +41,14 @@ case class RS_SetGeoReference(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_SetPixelType(inputExpressions: Seq[Expression])
+private[apache] case class RS_SetPixelType(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterEditors.setPixelType _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_Resample(inputExpressions: Seq[Expression])
+private[apache] case class RS_Resample(inputExpressions: Seq[Expression])
     extends InferredExpression(
       nullTolerantInferrableFunction4(RasterEditors.resample),
       nullTolerantInferrableFunction5(RasterEditors.resample),
@@ -58,7 +58,7 @@ case class RS_Resample(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_NormalizeAll(inputExpressions: Seq[Expression])
+private[apache] case class RS_NormalizeAll(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction1(RasterEditors.normalizeAll),
       inferrableFunction3(RasterEditors.normalizeAll),
@@ -71,14 +71,14 @@ case class RS_NormalizeAll(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_ReprojectMatch(inputExpressions: Seq[Expression])
+private[apache] case class RS_ReprojectMatch(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterEditors.reprojectMatch _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_Interpolate(inputExpressions: Seq[Expression])
+private[apache] case class RS_Interpolate(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction1(RasterEditors.interpolate),
       inferrableFunction2(RasterEditors.interpolate),

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterFunctions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterFunctions.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.sedona_sql.expressions.implicits.InputExpressionEnha
 import org.apache.spark.sql.sedona_sql.expressions.raster.implicits.RasterInputExpressionEnhancer
 import org.apache.spark.sql.types.{AbstractDataType, BooleanType, DataType, DoubleType, IntegerType, StructField, StructType}
 
-case class RS_Metadata(inputExpressions: Seq[Expression])
+private[apache] case class RS_Metadata(inputExpressions: Seq[Expression])
     extends Expression
     with CodegenFallback
     with ExpectsInputTypes {
@@ -86,7 +86,7 @@ case class RS_Metadata(inputExpressions: Seq[Expression])
   override def inputTypes: Seq[AbstractDataType] = Seq(RasterUDT)
 }
 
-case class RS_SummaryStatsAll(inputExpressions: Seq[Expression])
+private[apache] case class RS_SummaryStatsAll(inputExpressions: Seq[Expression])
     extends Expression
     with CodegenFallback
     with ExpectsInputTypes {
@@ -150,7 +150,7 @@ case class RS_SummaryStatsAll(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_ZonalStatsAll(inputExpressions: Seq[Expression])
+private[apache] case class RS_ZonalStatsAll(inputExpressions: Seq[Expression])
     extends Expression
     with CodegenFallback
     with ExpectsInputTypes {
@@ -235,7 +235,7 @@ case class RS_ZonalStatsAll(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_GeoTransform(inputExpressions: Seq[Expression])
+private[apache] case class RS_GeoTransform(inputExpressions: Seq[Expression])
     extends Expression
     with CodegenFallback
     with ExpectsInputTypes {

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterOutputs.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterOutputs.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.sedona_sql.expressions.InferrableFunctionConverter._
 import org.apache.spark.sql.sedona_sql.expressions.InferrableRasterTypes._
 import org.apache.spark.sql.sedona_sql.expressions.InferredExpression
 
-case class RS_AsGeoTiff(inputExpressions: Seq[Expression])
+private[apache] case class RS_AsGeoTiff(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction3(RasterOutputs.asGeoTiff),
       inferrableFunction1(RasterOutputs.asGeoTiff)) {
@@ -33,7 +33,7 @@ case class RS_AsGeoTiff(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_AsArcGrid(inputExpressions: Seq[Expression])
+private[apache] case class RS_AsArcGrid(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(RasterOutputs.asArcGrid),
       inferrableFunction1(RasterOutputs.asArcGrid)) {
@@ -42,7 +42,7 @@ case class RS_AsArcGrid(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_AsPNG(inputExpressions: Seq[Expression])
+private[apache] case class RS_AsPNG(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction1(RasterOutputs.asPNG),
       inferrableFunction2(RasterOutputs.asPNG)) {
@@ -51,7 +51,7 @@ case class RS_AsPNG(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_AsBase64(inputExpressions: Seq[Expression])
+private[apache] case class RS_AsBase64(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction1(RasterOutputs.asBase64),
       inferrableFunction2(RasterOutputs.asBase64)) {
@@ -60,7 +60,7 @@ case class RS_AsBase64(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_AsMatrix(inputExpressions: Seq[Expression])
+private[apache] case class RS_AsMatrix(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction3(RasterOutputs.asMatrix),
       inferrableFunction2(RasterOutputs.asMatrix),
@@ -70,7 +70,7 @@ case class RS_AsMatrix(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_AsImage(inputExpressions: Seq[Expression])
+private[apache] case class RS_AsImage(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(RasterOutputs.createHTMLString),
       inferrableFunction1(RasterOutputs.createHTMLString)) {

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterPredicates.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterPredicates.scala
@@ -99,7 +99,7 @@ abstract class RS_Predicate
   def evalRasters(leftRaster: GridCoverage2D, rightRaster: GridCoverage2D): Boolean
 }
 
-case class RS_Intersects(inputExpressions: Seq[Expression])
+private[apache] case class RS_Intersects(inputExpressions: Seq[Expression])
     extends RS_Predicate
     with CodegenFallback {
 
@@ -118,7 +118,7 @@ case class RS_Intersects(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_Contains(inputExpressions: Seq[Expression])
+private[apache] case class RS_Contains(inputExpressions: Seq[Expression])
     extends RS_Predicate
     with CodegenFallback {
 
@@ -137,7 +137,7 @@ case class RS_Contains(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_Within(inputExpressions: Seq[Expression])
+private[apache] case class RS_Within(inputExpressions: Seq[Expression])
     extends RS_Predicate
     with CodegenFallback {
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?
- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2102

## What changes were proposed in this PR?
make the Function implementations package private so users don't get them in their autocompletes.
The does not affect the actual ST or RS function that users would use in the dataframe API.

## How was this patch tested?
unit tests

## Did this PR include necessary documentation updates?
- No, this PR does not affect any public API so no need to change the documentation.
