### PR TITLE
[CI] disable flakey STAC Reader tests

### DIFF
--- a/python/tests/stac/test_collection_client.py
+++ b/python/tests/stac/test_collection_client.py
@@ -19,12 +19,14 @@ from sedona.spark.stac.client import Client
 from sedona.spark.stac.collection_client import CollectionClient
 
 from tests.test_base import TestBase
+import pytest
 
 STAC_URLS = {
     "PLANETARY-COMPUTER": "https://planetarycomputer.microsoft.com/api/stac/v1"
 }
 
 
+@pytest.mark.skipif(True, reason="Disabled for being flakey")
 class TestStacReader(TestBase):
     def test_collection_client(self) -> None:
         client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)


## Is this PR related to a ticket?

  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?
disable these tests because they keep failing on unrelated PRs in the CI

## How was this patch tested?
none

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
