### PR TITLE
[GH-2164] fix RasterType legacy import path

### DIFF
--- a/python/sedona/sql/types.py
+++ b/python/sedona/sql/types.py
@@ -16,7 +16,7 @@
 # under the License.
 
 import warnings
-from sedona.spark.sql.types import GeographyType, GeometryType
+from sedona.spark.sql.types import GeographyType, GeometryType, RasterType
 
 warnings.warn(
     "Importing from 'sedona.sql.types' is deprecated. Please use 'sedona.spark.sql.types' instead.",
@@ -24,4 +24,4 @@ warnings.warn(
     stacklevel=2,
 )
 
-__all__ = ["GeographyType", "GeometryType"]
+__all__ = ["GeographyType", "GeometryType", "RasterType"]

--- a/python/tests/test_path_compatibility.py
+++ b/python/tests/test_path_compatibility.py
@@ -35,7 +35,7 @@ from sedona.sql.st_aggregates import ST_Union_Aggr
 from sedona.sql.st_constructors import ST_MakePoint
 from sedona.sql.st_functions import ST_X
 from sedona.sql.st_predicates import ST_Intersects
-from sedona.sql.types import GeographyType, GeometryType
+from sedona.sql.types import GeographyType, GeometryType, RasterType
 from sedona.stac.client import Client
 from sedona.stac.collection_client import CollectionClient
 from sedona.stats.clustering import dbscan
@@ -74,6 +74,7 @@ class TestPathCompatibility(TestBase):
         # Test GeographyType and GeometryType imports
         assert GeographyType is not None
         assert GeometryType is not None
+        assert RasterType is not None
 
     def test_spatial_operators_imports(self):
         # Test JoinQuery, KNNQuery, RangeQuery imports

--- a/python/tests/test_path_compatibility_all.py
+++ b/python/tests/test_path_compatibility_all.py
@@ -46,6 +46,7 @@ class TestPathCompatibilityAll(TestBase):
         # Test GeographyType and GeometryType imports
         assert GeographyType is not None
         assert GeometryType is not None
+        assert RasterType is not None
 
     def test_spatial_operators_imports(self):
         # Test JoinQuery, KNNQuery, RangeQuery imports


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2164

## What changes were proposed in this PR?
maintain backwards compatbility with RasterType import

## How was this patch tested?
added unit tests

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
