### PR TITLE
[CI] pre-commit add hook `check-zip-file-is-not-committed`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,14 @@ repos:
         files: \.(js|ya?ml)$
         language: node
         additional_dependencies: ['prettier@3.6.2']
+      - id: check-zip-file-is-not-committed
+        name: check no zip files are committed
+        description: Zip files are not allowed in the repository
+        language: fail
+        entry: |
+          Zip files are not allowed in the repository as they are hard to
+          track and have security implications. Please remove the zip file from the repository.
+        files: \.zip$
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.5
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
         entry: |
           Zip files are not allowed in the repository as they are hard to
           track and have security implications. Please remove the zip file from the repository.
-        files: \.zip$
+        files: (?i)\.zip$
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.5
     hooks:


### PR DESCRIPTION
Zip files should not be allowed in the repository as they are hard to track and have security implications

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

Added another hook to our pre-commit framework.

## How was this patch tested?

Tested by adding a ZIP file locally and then ran `pre-commit run --all-files` and this hook failed.

When there are no ZIP files the hook passes.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
