### PR TITLE
[GH-1643] Add `mvn spotless:apply` as a pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,19 @@ repos:
         files: \.(js|ya?ml)$
         language: node
         additional_dependencies: ['prettier@3.6.2']
+      - id: maven-spotless-apply
+        name: maven spotless apply
+        description: automatically formats Java and Scala code using mvn spotless:apply.
+        entry: mvn spotless:apply
+        language: system # Indicates that the 'entry' command should be run directly as a system command.
+        types: [java, scala] # Specifies that this hook should run on Java and Scala files.
+        pass_filenames:
+          false # Crucial: tells pre-commit NOT to pass filenames as arguments to 'mvn spotless:apply'.
+          # Spotless typically scans the whole project based on its configuration.
+        always_run:
+          true # Ensures this hook runs even if no Java files are changed.
+          # This is useful for spotless:apply which might affect files not staged.
+        stages: [pre-commit] # Specifies that this hook runs during the 'commit' stage.
       - id: check-zip-file-is-not-committed
         name: check no zip files are committed
         description: Zip files are not allowed in the repository


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #1643 

## What changes were proposed in this PR?

Added our first "Java" based hook to run `mvn spotless:apply`

## How was this patch tested?

Tested with Java 11.

Tested first with `pre-commit run --all-files` and also then with `git commit`

Tried failing the hook with messy Java and saw the correct reformat and the hook failed.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
