### PR TITLE
[CI] pre-commit: run `maven-spotless-apply` and `oxipng` manually

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
         always_run:
           true # Ensures this hook runs even if no Java files are changed.
           # This is useful for spotless:apply which might affect files not staged.
-        stages: [pre-commit] # Specifies that this hook runs during the 'commit' stage.
+        stages: [manual]
       - id: check-zip-file-is-not-committed
         name: check no zip files are committed
         description: Zip files are not allowed in the repository
@@ -306,3 +306,4 @@ repos:
         name: run oxipng
         description: check PNG files with oxipng
         args: ['--fix', '-o', '4', '--strip', 'safe', '--alpha']
+        stages: [manual]


### PR DESCRIPTION
The "manual" stage in pre-commit refers to a specific hook stage designed for hooks that are not intended to run automatically during a standard git commit operation. Instead, these hooks are meant to be triggered explicitly by a user, typically when performing a full repository scan or a specific check.

This speeds up the standard `pre-commit run --all-files` run by not running these two hooks.

Both hooks are time consuming

Can run the manual hooks with:

`pre-commit run --all-files --hook-stage manual`

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

As described above.

## How was this patch tested?

Ran pre-commit both normally and manually.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
