### PR TITLE
[CI] pre-commit: add hook `chmod` with `manual` stage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,6 +64,11 @@ repos:
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.5
     hooks:
+      - id: chmod
+        name: set file permissions
+        args: ['644']
+        files: \.md$
+        stages: [manual]
       - id: insert-license
         name: add license for all .c files
         files: \.c$


### PR DESCRIPTION
Can you run chmod on Windows?

The name is an abbreviation of change mode, which does not exist in Windows OS

Set this hook to manual since chmod doesn't run on Windows.

Allows Windows users to still run the standard pre-commit workflow.

The manual stage can be run by Mac and Linux users.

We can setup the manual stage to run on GitHub actions so we don't lose coverage and there is another PR for that with other hooks that have manual stages.

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

Described above

https://github.com/Lucas-C/pre-commit-hooks?tab=readme-ov-file#usage

## How was this patch tested?

```
(.venv) committer@asf:sedona$ git status
On branch markdown-chmod-644
nothing to commit, working tree clean
(.venv) committer@asf:sedona$ stat -c '%a %n' docs/download.md 
644 docs/download.md
(.venv) committer@asf:sedona$ chmod +x docs/download.md 
(.venv) committer@asf:sedona$ stat -c '%a %n' docs/download.md 
755 docs/download.md
(.venv) committer@asf:sedona$ pre-commit run chmod --all-files --hook-stage manual
set file permissions.....................................................Failed
- hook id: chmod
- exit code: 1
- files were modified by this hook

Fixing file permissions on docs/download.md: 0o755 -> 0o644

(.venv) committer@asf:sedona$ stat -c '%a %n' docs/download.md 
644 docs/download.md
(.venv) committer@asf:sedona$ 
```

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
