### PR TITLE
[CI] pre-commit: add hook to check Makefiles are indented with tabs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,6 +61,14 @@ repos:
           Zip files are not allowed in the repository as they are hard to
           track and have security implications. Please remove the zip file from the repository.
         files: (?i)\.zip$
+      - id: check-makefiles-tabs
+        name: check Makefiles files for tabs
+        entry: ./scripts/pre-commit/check_makefiles_for_tabs.sh # Path to your script
+        language: system
+        files: '(?i)makefile$'
+        pass_filenames: true # <-- Crucial change: pass filenames to the script
+        types: [file] # Ensure only regular files are passed, not directories
+        stages: [manual]
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.5
     hooks:

--- a/scripts/pre-commit/check_makefiles_for_tabs.sh
+++ b/scripts/pre-commit/check_makefiles_for_tabs.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# check_makefiles_for_tabs.sh
+
+# Iterate over all files passed as arguments by pre-commit
+for makefile in "$@"; do
+  # Check if the file exists and is a regular file
+  if [[ -f "$makefile" ]]; then
+    if grep -P '^\s' "$makefile" | grep -vP '^\t' > /dev/null; then
+      echo "Error: File '$makefile' contains spaces at the beginning of lines instead of tabs."
+      exit 1
+    fi
+  fi
+done
+exit 0


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

Manual stage hook we can run on Linux and Mac Machines.  Also can run on the GitHub Actions CI and we have another PR for that here #2197 

In future we can implement the pre-commit hooks into Docker and there is issue #2202 

Makefiles utilize tabs for indentation in command lines, also known as recipes, due to a historical design decision in the original make utility. This specific use of tabs serves a crucial purpose:

Distinguishing Recipes:
The leading tab character acts as a clear signal to make that the line is a command to be executed by the shell, rather than a line containing make syntax (like variable definitions or rules). This allows make to differentiate between its own syntax and shell commands within the same file.
Historical Precedent:
The original author of make, Stuart Feldman, implemented this parsing mechanism in the early versions of the utility. Changing this fundamental behavior would have disrupted the existing user base and the vast number of Makefiles already in circulation.
Parsing Efficiency:
This line-oriented parsing based on the leading character was a simple and efficient way for make to process the file and determine which lines were part of a recipe. 

In essence, the use of tabs for recipe indentation in Makefiles is a legacy feature that remains due to its historical implementation and the need to maintain backward compatibility. Using spaces instead of tabs for recipe indentation will result in errors, as make will not recognize the lines as commands.

## How was this patch tested?

Tried my best today:

```
(.venv) committer@asf:sedona$ git log --oneline -n 1
f3fcdf650a (HEAD -> makefile-tabs-hook, upstream/master, origin/master, origin/HEAD, master) [CI] Add Python API Documentation to CI/CD Pipeline (#2195)
(.venv) committer@asf:sedona$ git status
On branch makefile-tabs-hook
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
        new file:   scripts/pre-commit/check_makefiles_for_tabs.sh

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   .pre-commit-config.yaml
        modified:   Makefile

(.venv) committer@asf:sedona$ git diff
diff --git a/.pre-commit-config.yaml b/.pre-commit-config.yaml
index 06fb02f4ce..2e57d0491f 100644
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,6 +61,14 @@ repos:
           Zip files are not allowed in the repository as they are hard to
           track and have security implications. Please remove the zip file from the repository.
         files: (?i)\.zip$
+      - id: check-makefiles-tabs
+        name: check Makefiles files for tabs
+        entry: ./scripts/pre-commit/check_makefiles_for_tabs.sh # Path to your script
+        language: system
+        files: '(?i)makefile$'
+        pass_filenames: true # <-- Crucial change: pass filenames to the script
+        types: [file] # Ensure only regular files are passed, not directories
+        stages: [manual]
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.5
     hooks:
diff --git a/Makefile b/Makefile
index b861ed228c..e061bbcf6e 100644
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ MIKE := mike
 .PHONY: check checkinstall checkupdate install docsinstall docsbuild clean test

 check:
-       @echo "Running pre-commit checks..."
+  @echo "Running pre-commit checks..."
        @if ! command -v pre-commit >/dev/null 2>&1; then \
                echo "Error: pre-commit is not installed. Run 'make checkinstall' first."; \
                exit 1; \
(.venv) committer@asf:sedona$ git add .
(.venv) committer@asf:sedona$ git status
On branch makefile-tabs-hook
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
        modified:   .pre-commit-config.yaml
        modified:   Makefile
        new file:   scripts/pre-commit/check_makefiles_for_tabs.sh

(.venv) committer@asf:sedona$ pre-commit run check-makefiles-tabs --all-files --hook-stage manual
check Makefiles files for tabs...........................................Failed
- hook id: check-makefiles-tabs
- exit code: 1

Error: File 'Makefile' contains spaces at the beginning of lines instead of tabs.

(.venv) committer@asf:sedona$ git status
On branch makefile-tabs-hook
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
        modified:   .pre-commit-config.yaml
        modified:   Makefile
        new file:   scripts/pre-commit/check_makefiles_for_tabs.sh

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   Makefile

(.venv) committer@asf:sedona$ git diff
diff --git a/Makefile b/Makefile
index e061bbcf6e..b861ed228c 100644
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ MIKE := mike
 .PHONY: check checkinstall checkupdate install docsinstall docsbuild clean test

 check:
-  @echo "Running pre-commit checks..."
+       @echo "Running pre-commit checks..."
        @if ! command -v pre-commit >/dev/null 2>&1; then \
                echo "Error: pre-commit is not installed. Run 'make checkinstall' first."; \
                exit 1; \
(.venv) committer@asf:sedona$ git add .
(.venv) committer@asf:sedona$ git status
On branch makefile-tabs-hook
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
        modified:   .pre-commit-config.yaml
        new file:   scripts/pre-commit/check_makefiles_for_tabs.sh

(.venv) committer@asf:sedona$ pre-commit run check-makefiles-tabs --all-files --hook-stage manual
check Makefiles files for tabs...........................................Passed
(.venv) committer@asf:sedona$ git status
On branch makefile-tabs-hook
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
        modified:   .pre-commit-config.yaml
        new file:   scripts/pre-commit/check_makefiles_for_tabs.sh

(.venv) committer@asf:sedona$ git commit -m "[CI] pre-commit: add hook to check Makefiles are indented with tabs"
[INFO] Installing environment for local.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/Lucas-C/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/asottile/pyupgrade.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/psf/black-pre-commit-mirror.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/mirrors-clang-format.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/PyCQA/bandit.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/codespell-project/codespell.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/gitleaks/gitleaks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/igorshubovych/markdownlint-cli.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/shellcheck-py/shellcheck-py.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/adrienverge/yamllint.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/shssoichiro/oxipng.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
run identity check.......................................................Passed
- hook id: identity
- duration: 0.02s

.pre-commit-config.yaml
scripts/pre-commit/check_makefiles_for_tabs.sh

run check hooks apply....................................................Passed
run prettier.............................................................Passed
maven spotless apply.....................................................Passed
check no zip files are committed.....................(no files to check)Skipped
add license for all .c files.........................(no files to check)Skipped
add license for all .h files.........................(no files to check)Skipped
add license for all Java files.......................(no files to check)Skipped
add license for all Markdown files...................(no files to check)Skipped
add license for all Makefile files...................(no files to check)Skipped
add license for all R files..........................(no files to check)Skipped
add license for all Scala files......................(no files to check)Skipped
add license for all TOML files.......................(no files to check)Skipped
add license for all YAML files...........................................Passed
add license for all Python files.....................(no files to check)Skipped
add license for all other files......................(no files to check)Skipped
pyupgrade............................................(no files to check)Skipped
run black-jupyter....................................(no files to check)Skipped
run clang-format.....................................(no files to check)Skipped
run bandit...........................................(no files to check)Skipped
run codespell............................................................Passed
run gitleaks.............................................................Passed
run check-ast........................................(no files to check)Skipped
run check-builtin-literals...........................(no files to check)Skipped
run check-case-conflict..................................................Passed
run check-docstring-first............................(no files to check)Skipped
run check-executables-have-shebangs......................................Passed
run check-illegal-windows-names......................(no files to check)Skipped
run check-json.......................................(no files to check)Skipped
run check-merge-conflict.................................................Passed
run check-shebang-scripts-are-executable.................................Passed
run check-toml.......................................(no files to check)Skipped
check vcs permalinks.....................................................Passed
check xml............................................(no files to check)Skipped
check yaml...............................................................Passed
debug statements (python)............................(no files to check)Skipped
detect destroyed symlinks................................................Passed
detect aws credentials...................................................Passed
detect private key.......................................................Passed
fix end of files.........................................................Passed
file contents sorter.................................(no files to check)Skipped
fix utf-8 byte order marker..............................................Passed
forbid submodules....................................(no files to check)Skipped
mixed line ending........................................................Passed
python tests naming..................................(no files to check)Skipped
fix requirements.txt.................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
run markdownlint.....................................(no files to check)Skipped
run shellcheck...........................................................Passed
run yamllint.............................................................Passed
run oxipng...........................................(no files to check)Skipped
[makefile-tabs-hook 90c1ef0e30] [CI] pre-commit: add hook to check Makefiles are indented with tabs
 2 files changed, 22 insertions(+)
 create mode 100755 scripts/pre-commit/check_makefiles_for_tabs.sh
(.venv) committer@asf:sedona$ git status
On branch makefile-tabs-hook
nothing to commit, working tree clean
(.venv) committer@asf:sedona$ pre-commit run check-makefiles-tabs --all-files --hook-stage manual
check Makefiles files for tabs...........................................Passed
(.venv) committer@asf:sedona$
```

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
