### PR TITLE
[GH-2218] Fix index retaining behavior for row_wise_operations on dataframes

### DIFF
--- a/python/sedona/geopandas/geoseries.py
+++ b/python/sedona/geopandas/geoseries.py
@@ -2948,8 +2948,7 @@ e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3
         else:
             renamed = self
 
-        # to_spark() is important here to ensure that the spark column names are set to the pandas column ones
-        return GeoDataFrame(pspd.DataFrame(renamed._internal).to_spark())
+        return GeoDataFrame(pspd.DataFrame(renamed._internal))
 
 
 # -----------------------------------------------------------------------------

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -1451,8 +1451,6 @@ e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3
         assert_series_equal(df_result.to_pandas(), expected)
 
     def test_intersection(self):
-        import pyspark.pandas as ps
-
         s = sgpd.GeoSeries(
             [
                 Polygon([(0, 0), (2, 2), (0, 2)]),
@@ -1559,6 +1557,10 @@ e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3
         # Ensure result of align=False retains the left's index
         assert result.index.to_pandas().equals(expected.index)
 
+        # Check that GeoDataFrame works too
+        df_result = s2.to_geoframe().intersection(s, align=False)
+        self.check_sgpd_equals_gpd(df_result, expected)
+
     def test_snap(self):
         s = GeoSeries(
             [
@@ -1649,6 +1651,10 @@ e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3
         result = s2.contains(s, align=False)
         expected = pd.Series([True, False, True, True], index=range(1, 5))
         assert_series_equal(result.to_pandas(), expected)
+
+        # Check that GeoDataFrame works too
+        df_result = s2.to_geoframe().contains(s, align=False)
+        assert_series_equal(df_result.to_pandas(), expected)
 
     def test_contains_properly(self):
         pass


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2218

## What changes were proposed in this PR?
Fixes the case where performing a row_wise operation like intersection or contains from a geodataframe will lose the index (traditional pandas index, not spatial index)

## How was this patch tested?
Added tests

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
