### PR TITLE
[CI] pre-commit: add three hooks that target `RST` files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -229,7 +229,6 @@ repos:
     hooks:
       - id: rst-backticks
         name: detect common mistake of using single backticks when writing rst
-        exclude: ^python/sedona/doc/index\.rst$
       - id: rst-directive-colons
         name: detect mistake of rst directive not ending with double colon or space before the double colon
       - id: rst-inline-touching-normal

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -224,6 +224,16 @@ repos:
       - id: gitleaks
         name: run gitleaks
         description: check for secrets with gitleaks
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.10.0
+    hooks:
+      - id: rst-backticks
+        name: detect common mistake of using single backticks when writing rst
+        exclude: ^python/sedona/doc/index\.rst$
+      - id: rst-directive-colons
+        name: detect mistake of rst directive not ending with double colon or space before the double colon
+      - id: rst-inline-touching-normal
+        name: detect mistake of inline code touching normal text in rst
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:


### PR DESCRIPTION
https://github.com/pre-commit/pygrep-hooks/tags

https://github.com/pre-commit/pygrep-hooks

This PR adds some checks for the RST codebase helping to keep it standardized and correct

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

As described above

## How was this patch tested?

`pre-commit run --all-files`

I excluded one RST file from one hook `python/sedona/doc/index.rst` since it caused a pre-commit failure with one error.

I was unsure about this one small issue so used an exclude.

We can possibly remove the exclude in future PRs.  I am not exactly sure what the error message means since the `toctree` does exist.  Perhaps someone else has an idea ?

<img width="2006" height="375" alt="Screenshot from 2025-08-03 13-45-25" src="https://github.com/user-attachments/assets/23b50f2a-0470-4385-ac38-5b0ac9f08ca6" />





## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
