### PR TITLE
[DOC] Fix RST formatting: Use double backticks for inline code in documentation

### DIFF
--- a/python/sedona/doc/index.rst
+++ b/python/sedona/doc/index.rst
@@ -1,7 +1,7 @@
 .. sedona-python documentation master file, created by
    sphinx-quickstart on Sat Jul  5 08:38:02 2025.
    You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
+   contain the root ``toctree`` directive.
 
 Apache Sedona™ Python API Documentation
 ========================================


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a documentation update. The PR name follows the format `[DOCS] my subject`

## What changes were proposed in this PR?

The pre-commit hook `rst-backticks` was failing because RST requires double backticks for inline code, not single backticks. This is a common mistake when writing RST documentation.

## How was this patch tested?
pre-commit run rst-backticks --files python/sedona/doc/index.rst

please run this after https://github.com/apache/sedona/pull/2220 merged

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.
