### PR TITLE
[DOC] Fix documentation structure after moving sedona.geopandas to sedona.spark.geopandas

### DIFF
--- a/python/sedona/doc/index.rst
+++ b/python/sedona/doc/index.rst
@@ -32,8 +32,8 @@ This documentation covers the Python API for Apache Sedona, providing comprehens
 
    modules
    sedona.flink
-   sedona.geopandas
    sedona.spark
+   sedona.spark.geopandas
    sedona.stac
    sedona.stats
    sedona.utils

--- a/python/sedona/doc/sedona.rst
+++ b/python/sedona/doc/sedona.rst
@@ -10,7 +10,6 @@ Subpackages
    sedona.core
    sedona.flink
    sedona.geoarrow
-   sedona.geopandas
    sedona.maps
    sedona.raster
    sedona.raster_utils

--- a/python/sedona/doc/sedona.spark.geopandas.api.rst
+++ b/python/sedona/doc/sedona.spark.geopandas.api.rst
@@ -1,0 +1,20 @@
+sedona.spark.geopandas package
+==============================
+
+.. Option: inherited-members: Series
+   Document all methods from the parent base 'GeoFrame' class, but ignore the methods in 'Series' class
+.. autoclass:: sedona.spark.geopandas.GeoSeries
+   :members:
+   :undoc-members:
+
+   :inherited-members: Series
+
+.. autoclass:: sedona.spark.geopandas.GeoDataFrame
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: sedona.spark.geopandas.sindex.SpatialIndex
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/python/sedona/doc/sedona.spark.geopandas.rst
+++ b/python/sedona/doc/sedona.spark.geopandas.rst
@@ -1,0 +1,61 @@
+sedona.spark.geopandas package
+==============================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   sedona.spark.geopandas.tools
+
+Submodules
+----------
+
+sedona.spark.geopandas.base module
+-----------------------------------
+
+.. automodule:: sedona.spark.geopandas.base
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+sedona.spark.geopandas.geodataframe module
+-------------------------------------------
+
+.. automodule:: sedona.spark.geopandas.geodataframe
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+sedona.spark.geopandas.geoseries module
+----------------------------------------
+
+.. automodule:: sedona.spark.geopandas.geoseries
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+sedona.spark.geopandas.io module
+---------------------------------
+
+.. automodule:: sedona.spark.geopandas.io
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+sedona.spark.geopandas.sindex module
+-------------------------------------
+
+.. automodule:: sedona.spark.geopandas.sindex
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: sedona.spark.geopandas
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/python/sedona/doc/sedona.spark.geopandas.tools.rst
+++ b/python/sedona/doc/sedona.spark.geopandas.tools.rst
@@ -1,0 +1,21 @@
+sedona.spark.geopandas.tools package
+=====================================
+
+Submodules
+----------
+
+sedona.spark.geopandas.tools.sjoin module
+------------------------------------------
+
+.. automodule:: sedona.spark.geopandas.tools.sjoin
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: sedona.spark.geopandas.tools
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/python/sedona/doc/sedona.spark.rst
+++ b/python/sedona/doc/sedona.spark.rst
@@ -9,6 +9,7 @@ Subpackages
 
    sedona.spark.core
    sedona.spark.geoarrow
+   sedona.spark.geopandas
    sedona.spark.maps
    sedona.spark.raster
    sedona.spark.raster_utils


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a documentation update. The PR name follows the format `[DOCS] my subject`

## What changes were proposed in this PR?
  - Updated Sphinx documentation to reflect the module reorganization from `sedona.geopandas` to
  `sedona.spark.geopandas` (PR #2225)
  - Created new RST documentation files for the relocated geopandas module under sedona.spark
  - Fixed RST formatting issue with single backticks

## How was this patch tested?
  - Documentation builds successfully: `make clean && make html`
  - Pre-commit hooks pass: `pre-commit run rst-backticks`
  - All module references resolve correctly in generated documentation

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.
