### PR TITLE
[GH-2252] Deprecation warnings pop up in the wrong place

### DIFF
--- a/python/sedona/__init__.py
+++ b/python/sedona/__init__.py
@@ -14,13 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import warnings
-
-warnings.warn(
-    "The 'sedona' package structure has been reorganized. Please update your imports to use 'sedona.spark' prefix instead.",
-    DeprecationWarning,
-    stacklevel=2,
-)
 from .version import version
 
 __all__ = ["version"]

--- a/python/sedona/core/spatialOperator/__init__.py
+++ b/python/sedona/core/spatialOperator/__init__.py
@@ -14,14 +14,22 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
 import warnings
-from sedona.spark.core.spatialOperator import (
-    JoinQuery,
-    JoinQueryRaw,
-    KNNQuery,
-    RangeQuery,
-)
+from sedona.spark.core import spatialOperator
+
+
+def __getattr__(name):
+    if hasattr(spatialOperator, name):
+        warnings.warn(
+            f"Importing '{name}' from 'sedona.core.spatialOperator' is deprecated. Please use 'sedona.spark.core.spatialOperator.{name}' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return getattr(spatialOperator, name)
+    raise AttributeError(
+        f"module 'sedona.core.spatialOperator' has no attribute '{name}'"
+    )
+
 
 warnings.warn(
     "Importing from 'sedona.core.spatialOperator' is deprecated. Please use 'sedona.spark.core.spatialOperator' instead.",
@@ -29,4 +37,4 @@ warnings.warn(
     stacklevel=2,
 )
 
-__all__ = ["JoinQuery", "JoinQueryRaw", "KNNQuery", "RangeQuery"]
+__all__ = spatialOperator.__all__

--- a/python/sedona/raster_utils/SedonaUtils.py
+++ b/python/sedona/raster_utils/SedonaUtils.py
@@ -14,7 +14,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+import warnings
 from sedona.spark.raster_utils.SedonaUtils import SedonaUtils
+
+warnings.warn(
+    "Importing from 'sedona.raster_utils.SedonaUtils' is deprecated. Please use 'sedona.spark.raster_utils.SedonaUtils' instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 __all__ = ["SedonaUtils"]

--- a/python/sedona/sql/__init__.py
+++ b/python/sedona/sql/__init__.py
@@ -14,9 +14,25 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-# These allow use to access the __all__
-from sedona.spark.sql import *
+import warnings
 from sedona.spark import sql
+
+
+def __getattr__(name):
+    if hasattr(sql, name):
+        warnings.warn(
+            f"Importing '{name}' from 'sedona.sql' is deprecated. Please use 'sedona.spark.sql.{name}' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return getattr(sql, name)
+    raise AttributeError(f"module 'sedona.sql' has no attribute '{name}'")
+
+
+warnings.warn(
+    "Importing from 'sedona.sql' is deprecated. Please use 'sedona.spark.sql' instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 __all__ = sql.__all__

--- a/python/sedona/stac/__init__.py
+++ b/python/sedona/stac/__init__.py
@@ -14,17 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-from sedona.spark.stac.client import Client
-
-import warnings
-
-warnings.warn(
-    "The 'sedona.stac' module is deprecated and will be removed in future versions. Please use 'sedona.spark.stac' instead.",
-    DeprecationWarning,
-    stacklevel=2,
-)
-
-__all__ = [
-    "Client",
-]

--- a/python/sedona/stats/clustering/dbscan/__init__.py
+++ b/python/sedona/stats/clustering/dbscan/__init__.py
@@ -20,7 +20,7 @@ from sedona.spark.stats.clustering.dbscan import dbscan
 import warnings
 
 warnings.warn(
-    "The 'sedona.stats.clustering.dbscan' module is deprecated and will be removed in future versions. Please use 'sedona.spark.stats' instead.",
+    "Importing from 'sedona.stats.clustering.dbscan' is deprecated and will be removed in future versions. Please use 'sedona.spark.stats.clustering' instead.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/python/sedona/stats/clustering/dbscan/__init__.py
+++ b/python/sedona/stats/clustering/dbscan/__init__.py
@@ -20,7 +20,7 @@ from sedona.spark.stats.clustering.dbscan import dbscan
 import warnings
 
 warnings.warn(
-    "Importing from 'sedona.stats.clustering.dbscan' is deprecated and will be removed in future versions. Please use 'sedona.spark.stats.clustering' instead.",
+    "Importing from 'sedona.stats.clustering.dbscan' is deprecated and will be removed in future versions. Please use 'sedona.spark.stats.clustering.dbscan' instead.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/python/sedona/stats/hotspot_detection/getis_ord/__init__.py
+++ b/python/sedona/stats/hotspot_detection/getis_ord/__init__.py
@@ -20,7 +20,7 @@ from sedona.spark.stats.hotspot_detection.getis_ord import g_local
 import warnings
 
 warnings.warn(
-    "The 'sedona.stats.hotspot_detection.getis_ord' module is deprecated and will be removed in future versions. Please use 'sedona.spark.stats' instead.",
+    "Importing from 'sedona.stats.hotspot_detection.getis_ord' is deprecated. Please use 'sedona.spark.stats.hotspot_detection.getis_ord' instead.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/python/sedona/stats/weighting/__init__.py
+++ b/python/sedona/stats/weighting/__init__.py
@@ -23,7 +23,7 @@ from sedona.spark.stats.weighting import (
 import warnings
 
 warnings.warn(
-    "The 'sedona.stats.weighting' module is deprecated and will be removed in future versions. Please use 'sedona.spark.stats' instead.",
+    "Importing from 'sedona.stats.weighting' is deprecated. Please use 'sedona.spark.stats.weighting' instead.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/python/sedona/utils/__init__.py
+++ b/python/sedona/utils/__init__.py
@@ -15,12 +15,24 @@
 # specific language governing permissions and limitations
 # under the License.
 import warnings
-from sedona.spark.utils.serde import KryoSerializer, SedonaKryoRegistrator
+from sedona.spark import utils
+
+
+def __getattr__(name):
+    if hasattr(utils, name):
+        warnings.warn(
+            f"Importing '{name}' from 'sedona.utils' is deprecated. Please use 'sedona.spark.utils.{name}' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return getattr(utils, name)
+    raise AttributeError(f"module 'sedona.utils' has no attribute '{name}'")
+
 
 warnings.warn(
-    "The 'sedona.utils' package structure has been reorganized. Please update your imports to use 'sedona.spark.utils' prefix instead.",
+    "Importing from 'sedona.utils' is deprecated. Please use 'sedona.spark.utils' instead.",
     DeprecationWarning,
     stacklevel=2,
 )
 
-__all__ = ["KryoSerializer", "SedonaKryoRegistrator"]
+__all__ = utils.__all__

--- a/python/sedona/utils/structured_adapter/__init__.py
+++ b/python/sedona/utils/structured_adapter/__init__.py
@@ -20,7 +20,7 @@ from sedona.spark.utils.structured_adapter import StructuredAdapter
 import warnings
 
 warnings.warn(
-    "The 'sedona.utils.structured_adapter' module is deprecated and will be removed in future versions. Please use 'sedona.spark.utils.structured_adapter' instead.",
+    "Importing from 'sedona.utils.structured_adapter' is deprecated. Please use 'sedona.spark.utils.structured_adapter' instead.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/python/tests/test_path_compatibility.py
+++ b/python/tests/test_path_compatibility.py
@@ -46,6 +46,7 @@ from sedona.stats.weighting import (
 )
 from sedona.utils.adapter import Adapter
 from sedona.utils.spatial_rdd_parser import GeoData
+from sedona.utils.structured_adapter import StructuredAdapter
 from tests.test_base import TestBase
 from sedona.raster_utils.SedonaUtils import SedonaUtils
 from sedona.sql import ST_MakePoint, ST_Y, ST_Touches, ST_Envelope_Aggr
@@ -107,6 +108,7 @@ class TestPathCompatibility(TestBase):
         # Test utility imports
         assert Adapter is not None
         assert GeoData is not None
+        assert StructuredAdapter is not None
 
     def test_format_mapper_imports(self):
         # Test GeoJsonReader and ShapefileReader imports

--- a/python/tests/test_path_compatibility_all.py
+++ b/python/tests/test_path_compatibility_all.py
@@ -93,6 +93,13 @@ class TestPathCompatibilityAll(TestBase):
         # Test raster utils imports
         assert SedonaUtils is not None
 
+    def test_import_df_functions_from_sedona_sql(self):
+        # one from each module
+        assert ST_MakePoint is not None
+        assert ST_Y is not None
+        assert ST_Touches is not None
+        assert ST_Envelope_Aggr is not None
+
     def test_geoarrow_imports(self):
         assert create_spatial_dataframe is not None
         assert dataframe_to_arrow is not None


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2252 


## What changes were proposed in this PR?

* Fixed all missing warnings
* Removed wrong warnings in `from sedona.spark import SedonaContext`
* Unified all warning messages

## How was this patch tested?

Passed locally and manually tests

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
