### PR TITLE
[GH-2264] Geopandas: Support other of type GeoDataframe in row_wise_operations

### DIFF
--- a/python/sedona/spark/geopandas/geoseries.py
+++ b/python/sedona/spark/geopandas/geoseries.py
@@ -2874,7 +2874,9 @@ e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3
                 - Whether returned value was a single object extended into a series (useful for row-wise 'align' parameter)
         """
         # generator instead of a in-memory list
-        if not isinstance(value, pspd.Series):
+        if isinstance(value, GeoDataFrame):
+            return value.geometry, False
+        elif not isinstance(value, pspd.Series):
             lst = [value for _ in range(len(self))]
             if isinstance(value, BaseGeometry):
                 return GeoSeries(lst), True

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -1192,6 +1192,39 @@ e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3
         expected = GeometryCollection()
         self.check_geom_equals(result, expected)
 
+    def test_row_wise_dataframe(self):
+        s = GeoSeries(
+            [
+                Polygon([(0, 0), (1, 1), (0, 1)]),
+                Polygon([(0, 0), (1, 1), (0, 1)]),
+                Polygon([(0, 0), (1, 1), (0, 1)]),
+            ]
+        )
+        s2 = GeoSeries([Point(-5.5, 1), Point(1, 2), Point(3, 1)])
+
+        # self: GeoSeries, other: GeoDataFrame
+        expected = pd.Series([5.5, 1, 2])
+        result = s.distance(s2.to_geoframe())
+        self.check_pd_series_equal(result, expected)
+
+        # self: GeoDataFrame, other: GeoDataFrame
+        result = s.to_geoframe().distance(s2.to_geoframe())
+        assert_series_equal(result.to_pandas(), expected)
+
+        # Same but for overlay
+        expected = gpd.GeoSeries(
+            [
+                Polygon([(0, 0), (1, 1), (0, 1), (0, 0)]),
+                Polygon([(0, 0), (1, 1), (0, 1), (0, 0)]),
+                Polygon([(0, 0), (1, 1), (0, 1), (0, 0)]),
+            ]
+        )
+        result = s.difference(s2.to_geoframe())
+        self.check_sgpd_equals_gpd(result, expected)
+
+        result = s.to_geoframe().difference(s2.to_geoframe())
+        self.check_sgpd_equals_gpd(result, expected)
+
     def test_crosses(self):
         s = GeoSeries(
             [


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2264

## What changes were proposed in this PR?
Geopandas supports inputting a geodataframe as "other" for row wise opeartions like this:
```python
geoseries.difference(df)
```
This PR adds support for this. Previously, we could only accomplish this behavior by accessin the active geometry column directly.
```python
geoseries.difference(df.geometry)
```

## How was this patch tested?
Added test

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation. Geopandas doesn't explicitly mention in their documentation, so I don't see the need for us to either.