### PR TITLE
[GH-2266] Geopandas: Remove unnecessary old_crs check and in `to_crs`

### DIFF
--- a/python/sedona/spark/geopandas/geodataframe.py
+++ b/python/sedona/spark/geopandas/geodataframe.py
@@ -775,7 +775,7 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
                 # Use _to_geopandas instead of to_geopandas to avoid logging extra warnings
                 pd_df[col_name] = series._to_geopandas()
             else:
-                pd_df[col_name] = series.to_pandas()
+                pd_df[col_name] = series._to_pandas()
 
         return gpd.GeoDataFrame(pd_df, geometry=self._geometry_column_name)
 

--- a/python/sedona/spark/geopandas/geoseries.py
+++ b/python/sedona/spark/geopandas/geoseries.py
@@ -2351,14 +2351,6 @@ class GeoSeries(GeoFrame, pspd.Series):
 
         from pyproj import CRS
 
-        old_crs = self.crs
-        if old_crs is None:
-            raise ValueError(
-                "Cannot transform naive geometries.  "
-                "Please set a crs on the object first."
-            )
-        assert isinstance(old_crs, CRS)
-
         if crs is not None:
             crs = CRS.from_user_input(crs)
         elif epsg is not None:
@@ -2366,13 +2358,8 @@ class GeoSeries(GeoFrame, pspd.Series):
         else:
             raise ValueError("Must pass either crs or epsg.")
 
-        # skip if the input CRS and output CRS are the exact same
-        if old_crs.is_exact_same(crs):
-            return self
-
         spark_expr = stf.ST_Transform(
             self.spark.column,
-            F.lit(f"EPSG:{old_crs.to_epsg()}"),
             F.lit(f"EPSG:{crs.to_epsg()}"),
         )
         return self._query_geometry_column(

--- a/python/sedona/spark/geopandas/geoseries.py
+++ b/python/sedona/spark/geopandas/geoseries.py
@@ -2364,6 +2364,7 @@ class GeoSeries(GeoFrame, pspd.Series):
         )
         return self._query_geometry_column(
             spark_expr,
+            keep_name=True,
         )
 
     @property

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -405,7 +405,9 @@ class TestGeoSeries(TestGeopandasBase):
     def test_to_crs(self):
         from pyproj import CRS
 
-        geoseries = sgpd.GeoSeries([Point(1, 1), Point(2, 2), Point(3, 3)], crs=4326)
+        geoseries = sgpd.GeoSeries(
+            [Point(1, 1), Point(2, 2), Point(3, 3)], crs=4326, name="geometry"
+        )
         assert isinstance(geoseries.crs, CRS) and geoseries.crs.to_epsg() == 4326
         result = geoseries.to_crs(3857)
         assert isinstance(result.crs, CRS) and result.crs.to_epsg() == 3857
@@ -416,6 +418,7 @@ class TestGeoSeries(TestGeopandasBase):
                 Point(333958.4723798207, 334111.1714019597),
             ],
             crs=3857,
+            name="geometry",
         )
         self.check_sgpd_equals_gpd(result, expected)
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2266

## What changes were proposed in this PR?
- Removed an unnecessary check (eager `.crs` query) in `to_crs`. This was causing a non-neglible slow-down, when calling `to_crs`. Sedona's ST_Transform will naturally catch cases when crs is not set instead. This also makes `to_crs` lazy like `set_crs` is.
- Also adds a missing `keep_name=True` to `to_crs` query

## How was this patch tested?
Existing tests still pass

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
