### PR TITLE
[DOC] Add the Python documentation links to the main navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ We provide a Docker image for Apache Sedona with Python JupyterLab and a single-
 * [Spatial SQL in Sedona](https://sedona.apache.org/latest-snapshot/tutorial/sql/)
 * [Integrate with GeoPandas and Shapely](https://sedona.apache.org/latest-snapshot/tutorial/geopandas-shapely/)
 * [Working with Spatial R in Sedona](https://sedona.apache.org/latest-snapshot/api/rdocs/)
+* [Sedona Python API Documentation](https://sedona.apache.org/latest-snapshot/api/pydocs/)
 
 Please visit [Apache Sedona website](http://sedona.apache.org/) for detailed information
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
           - Install Sedona Scala/Java: setup/install-scala.md
           - Install Sedona Python: setup/install-python.md
           - Install Sedona R: api/rdocs
+          - Sedona Python: api/pydocs
           - Install Sedona-Zeppelin: setup/zeppelin.md
           - Play Sedona in Docker: setup/docker.md
           - Install on Wherobots: setup/wherobots.md
@@ -59,6 +60,7 @@ nav:
           - Pure SQL environment: tutorial/sql-pure-sql.md
           - Spatial RDD app: tutorial/rdd.md
           - Sedona R: api/rdocs
+          - Sedona Python: api/pydocs
           - Work with GeoPandas and Shapely: tutorial/geopandas-shapely.md
           - Files:
               - CSV: tutorial/files/csv-geometry-sedona-spark.md
@@ -127,6 +129,7 @@ nav:
               - DataFrame/SQL: api/viz/sql.md
               - RDD: api/viz/java-api.md
           - Sedona R: api/rdocs
+          - Sedona Python: api/pydocs
       - Sedona with Apache Flink:
           - SQL:
               - Overview (Flink): api/flink/Overview.md


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a documentation update. The PR name follows the format `[DOCS] my subject`

## What changes were proposed in this PR?
  1. Added "Sedona Python: api/pydocs" to mkdocs.yml in three locations:
    - Under "Install with Apache Spark" section (after "Install Sedona R")
    - Under "Programming Guides > Sedona with Apache Spark" section (after "Sedona R")
    - Under "API Docs > Sedona with Apache Spark" section (after "Sedona R")
  2. Added a link in README.md to point to the Python API documentation alongside the existing R documentation link.

## How was this patch tested?
Python doc should be able to see on all three pages mentioned above.

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.
