### PR TITLE
[GH-2269] Geopandas: Fix geodataframe.copy() to properly create a copy

### DIFF
--- a/python/sedona/spark/geopandas/geodataframe.py
+++ b/python/sedona/spark/geopandas/geodataframe.py
@@ -574,7 +574,7 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
         if inplace:
             frame = self
         else:
-            frame = self.copy(deep=False)
+            frame = self.copy()
 
         geo_column_name = self._geometry_column_name
         new_series = False
@@ -785,7 +785,7 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
         """
         return pspd.DataFrame(self._internal)
 
-    def copy(self, deep=False):
+    def copy(self, deep=False) -> GeoDataFrame:
         """
         Make a copy of this GeoDataFrame object.
 
@@ -810,12 +810,10 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
            geometry  value1  value2
         0  POINT (1 1)       2       3
         """
-        if deep:
-            return GeoDataFrame(
-                self._anchor.copy(), dtype=self.dtypes, index=self._col_label
-            )
-        else:
-            return self  # GeoDataFrame(self._internal.spark_frame.copy())  "this parameter is not supported but just dummy parameter to match pandas."
+        # Note: The deep parameter is a dummy parameter just as it is in PySpark pandas
+        return GeoDataFrame(
+            pspd.DataFrame(self._internal.copy()), geometry=self.active_geometry_name
+        )
 
     def _safe_get_crs(self):
         """


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2269

## What changes were proposed in this PR?
- Previously, `df.copy()` would just return `self`, causing operations that rely on `.copy()` to actually modify the geodataframe object in place unintentionally. This PR fixes that. The implementation exactly follows the pyspark pandas implementation with the exception that I wrap it with GeoDataframe and manually set the active geometry column.
- Also I removed the logic for `deep=True` because that code actually errors. Also pyspark pandas does not implement that parameter either. We already had documentation to say that `deep` was a dummy parameter.

## How was this patch tested?
Added tests to all functions that rely on `.copy()` to ensure that the original dataframe is not modified inplace.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation. Documentation already said the following "This parameter is not supported but just a dummy parameter to match pandas.", but I didn't remove the code for deep=True until now.