### PR TITLE
[GH-2277] Geopandas: Fix to_file inferring parquet format instead of geoparquet

### DIFF
--- a/python/sedona/spark/geopandas/io.py
+++ b/python/sedona/spark/geopandas/io.py
@@ -96,7 +96,7 @@ def _to_file(
     """
 
     ext_to_driver = {
-        ".parquet": "Parquet",
+        ".parquet": "GeoParquet",
         ".json": "GeoJSON",
         ".geojson": "GeoJSON",
     }

--- a/python/tests/geopandas/test_io.py
+++ b/python/tests/geopandas/test_io.py
@@ -86,6 +86,7 @@ class TestIO(TestGeopandasBase):
         [
             partial(GeoDataFrame.from_file, format="geojson"),
             partial(read_file, format="GeoJSON"),
+            partial(read_file),  # check format inference works
         ],
     )
     def test_read_geojson(self, read_func):
@@ -102,6 +103,7 @@ class TestIO(TestGeopandasBase):
         [
             partial(GeoDataFrame.from_file, format="geoparquet"),
             partial(read_file, format="GeoParquet"),
+            partial(read_file),  # check format inference works
             read_parquet,
         ],
     )
@@ -121,6 +123,7 @@ class TestIO(TestGeopandasBase):
         [
             partial(GeoDataFrame.from_file, format="geopackage"),
             partial(read_file, format="GeoPackage"),
+            partial(read_file),  # check format inference works
         ],
     )
     def test_read_geopackage(self, read_func):
@@ -152,6 +155,7 @@ class TestIO(TestGeopandasBase):
         [
             partial(GeoDataFrame.to_file, driver="GeoParquet"),
             partial(GeoDataFrame.to_file, driver="geoparquet"),
+            partial(GeoDataFrame.to_file),  # check format inference works
             GeoDataFrame.to_parquet,
         ],
     )
@@ -174,6 +178,7 @@ class TestIO(TestGeopandasBase):
             partial(GeoDataFrame.to_file, driver="geojson"),  # index=None here is False
             partial(GeoDataFrame.to_file, driver="GeoJSON", index=True),
             partial(GeoDataFrame.to_file, driver="geojson", index=True),
+            partial(GeoDataFrame.to_file),  # check format inference works
         ],
     )
     def test_to_geojson(self, write_func):


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2277

## What changes were proposed in this PR?
Fixed a small bug where "Parquet" was specified instead of "GeoParquet" for writing.

## How was this patch tested?
Added tests to ensure format inference works along with other io tests that we should have and already pass

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
