### PR TITLE
[GH-2279] Geopandas: Support sjoin with `covers` and `covered_by` predicates

### DIFF
--- a/python/sedona/spark/geopandas/geodataframe.py
+++ b/python/sedona/spark/geopandas/geodataframe.py
@@ -1463,7 +1463,7 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
             * 'right': use keys from right_df; retain only right_df geometry column
             * 'inner': use intersection of keys from both dfs; retain only left_df geometry column
         predicate : str, default 'intersects'
-            Binary predicate. Valid values: 'intersects', 'contains', 'within', 'dwithin'
+            Binary predicate. Valid values: 'intersects', 'contains', 'within', 'dwithin', 'touches', 'crosses', 'overlaps', 'covers', 'covered_by'
         lsuffix : str, default 'left'
             Suffix to apply to overlapping column names (left GeoDataFrame).
         rsuffix : str, default 'right'

--- a/python/sedona/spark/geopandas/tools/sjoin.py
+++ b/python/sedona/spark/geopandas/tools/sjoin.py
@@ -73,6 +73,9 @@ def _frame_join(
         "crosses": "ST_Crosses",
         "overlaps": "ST_Overlaps",
         "dwithin": "ST_DWithin",
+        "covers": "ST_Covers",
+        "covered_by": "ST_CoveredBy",
+        # "contains_properly": "ST_ContainsProperly",  # not supported by Sedona yet
     }
 
     if predicate not in predicate_map:

--- a/python/tests/geopandas/test_sjoin.py
+++ b/python/tests/geopandas/test_sjoin.py
@@ -117,6 +117,9 @@ class TestSpatialJoin(TestGeopandasBase):
             "touches",
             "crosses",
             "overlaps",
+            "covers",
+            "covered_by",
+            # "contains_properly",  # not supported by Sedona yet
         ]
 
         for predicate in predicates:


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2279

## What changes were proposed in this PR?
Added support for covers and covered_by

## How was this patch tested?
Added tests

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.
