### PR TITLE
[GH-2308] Fix the precision lost issue in OSM PBF reader

### DIFF
--- a/spark/common/src/main/java/org/apache/sedona/sql/datasources/osmpbf/extractors/NodeExtractor.java
+++ b/spark/common/src/main/java/org/apache/sedona/sql/datasources/osmpbf/extractors/NodeExtractor.java
@@ -52,8 +52,8 @@ public class NodeExtractor {
     // https://wiki.openstreetmap.org/wiki/PBF_Format
     // latitude = .000000001 * (lat_offset + (granularity * lat))
     // longitude = .000000001 * (lon_offset + (granularity * lon))
-    float lat = (float) (.000000001 * (latOffset + (latitude * granularity)));
-    float lon = (float) (.000000001 * (lonOffset + (longitude * granularity)));
+    double lat = .000000001 * (latOffset + (latitude * granularity));
+    double lon = .000000001 * (lonOffset + (longitude * granularity));
 
     HashMap<String, String> tags =
         TagsResolver.resolveTags(node.getKeysCount(), node::getKeys, node::getVals, stringTable);


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-2308] my subject`. Closes #2308

## What changes were proposed in this PR?

Use `double` to store the lon lat values

## How was this patch tested?

Added one more unit test to test the precision lost issue

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
