### PR TITLE
[GH-2316] Fix graphframes dependency across Spark major versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -601,6 +601,7 @@
                 <version>1.0</version>
                 <configuration>
                     <properties>
+                        <spark.major.version>${spark.major.version}</spark.major.version>
                         <spark.compat.version>${spark.compat.version}</spark.compat.version>
                         <scala.compat.version>${scala.compat.version}</scala.compat.version>
                         <spark.version>${spark.version}</spark.version>

--- a/spark/common/pom.xml
+++ b/spark/common/pom.xml
@@ -187,7 +187,6 @@
         <dependency>
             <groupId>io.graphframes</groupId>
             <artifactId>graphframes-spark${spark.major.version}_${scala.compat.version}</artifactId>
-            <version>${graphframes.version}</version>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -90,6 +90,11 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
+                <groupId>io.graphframes</groupId>
+                <artifactId>graphframes-spark${spark.major.version}_${scala.compat.version}</artifactId>
+                <version>${graphframes.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.scala-lang</groupId>
                 <artifactId>scala-library</artifactId>
                 <version>${scala.version}</version>


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

Closes #2316 

## What changes were proposed in this PR?
Add `spark.major.version` to the vars that get resolved in POMs so that the proper graphframes artifact is used for each Spark major version

## How was this patch tested?
Manually verified the resulting POM.

## Did this PR include necessary documentation updates?
- No, this PR does not affect any public API so no need to change the documentation.
