### PR TITLE
Update requirements-docs.txt

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -5,3 +5,4 @@ mkdocs-jupyter
 mkdocs-macros-plugin
 mkdocs-material
 pymdown-extensions
+blacken-docs


### PR DESCRIPTION
Sedona seems to have added `blacken-docs` to the pre-commit check. Adding this to `requirements-docs.txt

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a documentation update. The PR name follows the format `[DOCS] my subject`
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

Adding blacken-docs to docs-requirements.txt


## How was this patch tested?

- Experienced blacken-docs pre-commit

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
