### PR TITLE
[GH-2348] Fix STAC tests resilience to external server failures in Scala

### DIFF
--- a/spark/common/src/test/resources/stac/collections/copernicus-dem.json
+++ b/spark/common/src/test/resources/stac/collections/copernicus-dem.json
@@ -1,0 +1,63 @@
+{
+  "id": "copernicus-dem",
+  "type": "Collection",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+  ],
+  "stac_version": "1.0.0",
+  "description": "Mock Copernicus DEM collection for testing",
+  "title": "Mock Copernicus Digital Elevation Model",
+  "keywords": [
+    "copernicus",
+    "dem",
+    "elevation"
+  ],
+  "providers": [
+    {
+      "name": "Mock Earth Data Hub",
+      "description": "Mock Copernicus Earth Data Hub",
+      "roles": [
+        "producer"
+      ],
+      "url": "http://mock-earthdatahub.example.com"
+    }
+  ],
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [
+          -180.0,
+          -90.0,
+          180.0,
+          90.0
+        ]
+      ]
+    },
+    "temporal": {
+      "interval": [
+        [
+          "2021-01-01T00:00:00Z",
+          "2021-12-31T23:59:59Z"
+        ]
+      ]
+    }
+  },
+  "license": "proprietary",
+  "links": [
+    {
+      "rel": "root",
+      "href": "collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "self",
+      "href": "collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "item",
+      "href": "mock-dem-item.json",
+      "type": "application/json"
+    }
+  ]
+}

--- a/spark/common/src/test/resources/stac/collections/earthview-catalog.json
+++ b/spark/common/src/test/resources/stac/collections/earthview-catalog.json
@@ -1,0 +1,60 @@
+{
+  "id": "earthview-catalog",
+  "type": "Catalog",
+  "stac_version": "1.0.0",
+  "description": "Mock Satellogic EarthView catalog for testing",
+  "title": "Mock Satellogic EarthView Catalog",
+  "keywords": [
+    "satellogic",
+    "earthview",
+    "satellite"
+  ],
+  "providers": [
+    {
+      "name": "Mock Satellogic",
+      "description": "Mock Satellogic EarthView",
+      "roles": [
+        "producer"
+      ],
+      "url": "http://mock-satellogic.example.com"
+    }
+  ],
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [
+          -180.0,
+          -90.0,
+          180.0,
+          90.0
+        ]
+      ]
+    },
+    "temporal": {
+      "interval": [
+        [
+          "2020-01-01T00:00:00Z",
+          "2023-12-31T23:59:59Z"
+        ]
+      ]
+    }
+  },
+  "license": "proprietary",
+  "links": [
+    {
+      "rel": "root",
+      "href": "catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "self",
+      "href": "catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "item",
+      "href": "mock-earthview-item.json",
+      "type": "application/json"
+    }
+  ]
+}

--- a/spark/common/src/test/resources/stac/collections/naip.json
+++ b/spark/common/src/test/resources/stac/collections/naip.json
@@ -1,0 +1,64 @@
+{
+  "id": "naip",
+  "type": "Collection",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+  ],
+  "stac_version": "1.0.0",
+  "description": "Mock NAIP (National Agriculture Imagery Program) collection for testing",
+  "title": "Mock NAIP: National Agriculture Imagery Program",
+  "keywords": [
+    "naip",
+    "aerial",
+    "imagery"
+  ],
+  "providers": [
+    {
+      "name": "Mock Planetary Computer",
+      "description": "Mock Microsoft Planetary Computer",
+      "roles": [
+        "host"
+      ],
+      "url": "http://mock-planetarycomputer.example.com"
+    }
+  ],
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [
+          -160.0,
+          18.0,
+          -64.0,
+          50.0
+        ]
+      ]
+    },
+    "temporal": {
+      "interval": [
+        [
+          "2009-01-01T00:00:00Z",
+          "2022-12-31T23:59:59Z"
+        ]
+      ]
+    }
+  },
+  "license": "proprietary",
+  "links": [
+    {
+      "rel": "root",
+      "href": "collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "self",
+      "href": "collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "item",
+      "href": "mock-naip-item.json",
+      "type": "application/json"
+    }
+  ]
+}

--- a/spark/common/src/test/resources/stac/collections/sentinel-2-pre-c1-l2a.json
+++ b/spark/common/src/test/resources/stac/collections/sentinel-2-pre-c1-l2a.json
@@ -1,0 +1,103 @@
+{
+  "id": "sentinel-2-pre-c1-l2a",
+  "type": "Collection",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json"
+  ],
+  "stac_version": "1.0.0",
+  "description": "Mock Sentinel-2 Pre-Collection 1 Level-2A collection for testing",
+  "title": "Mock Sentinel-2 Pre-Collection 1 Level-2A",
+  "keywords": [
+    "sentinel",
+    "earth observation",
+    "esa"
+  ],
+  "providers": [
+    {
+      "name": "Mock Earth Search",
+      "description": "Mock provider for testing",
+      "roles": [
+        "producer",
+        "processor"
+      ],
+      "url": "http://mock-earth-search.example.com"
+    }
+  ],
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [
+          -180.0,
+          -90.0,
+          180.0,
+          90.0
+        ]
+      ]
+    },
+    "temporal": {
+      "interval": [
+        [
+          "2015-06-23T00:00:00Z",
+          "2021-12-31T23:59:59Z"
+        ]
+      ]
+    }
+  },
+  "license": "proprietary",
+  "links": [
+    {
+      "rel": "root",
+      "href": "https://earth-search.aws.element84.com/v1",
+      "type": "application/json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://earth-search.aws.element84.com/v1",
+      "type": "application/json"
+    },
+    {
+      "rel": "self",
+      "href": "https://earth-search.aws.element84.com/v1/collections/sentinel-2-pre-c1-l2a",
+      "type": "application/json"
+    },
+    {
+      "rel": "item",
+      "href": "mock-item-1.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "item",
+      "href": "mock-item-2.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "item",
+      "href": "mock-item-3.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "item",
+      "href": "mock-item-4.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "item",
+      "href": "mock-item-5.json",
+      "type": "application/json"
+    }
+  ],
+  "summaries": {
+    "platform": [
+      "sentinel-2a",
+      "sentinel-2b"
+    ],
+    "constellation": [
+      "sentinel-2"
+    ],
+    "instruments": [
+      "msi"
+    ]
+  }
+}

--- a/spark/common/src/test/resources/stac/collections/vegetation-collection.json
+++ b/spark/common/src/test/resources/stac/collections/vegetation-collection.json
@@ -1,0 +1,63 @@
+{
+  "id": "vegetation-collection",
+  "type": "Collection",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+  ],
+  "stac_version": "1.0.0",
+  "description": "Mock vegetation collection for testing",
+  "title": "Mock Vegetation Collection",
+  "keywords": [
+    "vegetation",
+    "canopy",
+    "height"
+  ],
+  "providers": [
+    {
+      "name": "Mock CFO",
+      "description": "Mock California Forest Observatory",
+      "roles": [
+        "producer"
+      ],
+      "url": "http://mock-cfo.example.com"
+    }
+  ],
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [
+          -124.4096,
+          32.5342,
+          -114.1308,
+          42.0095
+        ]
+      ]
+    },
+    "temporal": {
+      "interval": [
+        [
+          "2016-01-01T00:00:00Z",
+          "2016-12-31T23:59:59Z"
+        ]
+      ]
+    }
+  },
+  "license": "CC-BY-4.0",
+  "links": [
+    {
+      "rel": "root",
+      "href": "collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "self",
+      "href": "collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "item",
+      "href": "California-Vegetation-CanopyBaseHeight-2016-Summer-00010m.json",
+      "type": "application/json"
+    }
+  ]
+}

--- a/spark/common/src/test/resources/stac/collections/wildfire-collection.json
+++ b/spark/common/src/test/resources/stac/collections/wildfire-collection.json
@@ -1,0 +1,63 @@
+{
+  "id": "wildfire-collection",
+  "type": "Collection",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+  ],
+  "stac_version": "1.0.0",
+  "description": "Mock wildfire collection for testing",
+  "title": "Mock Wildfire Collection",
+  "keywords": [
+    "wildfire",
+    "fire",
+    "severity"
+  ],
+  "providers": [
+    {
+      "name": "Mock CFO",
+      "description": "Mock California Forest Observatory",
+      "roles": [
+        "producer"
+      ],
+      "url": "http://mock-cfo.example.com"
+    }
+  ],
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [
+          -124.4096,
+          32.5342,
+          -114.1308,
+          42.0095
+        ]
+      ]
+    },
+    "temporal": {
+      "interval": [
+        [
+          "2020-01-01T00:00:00Z",
+          "2020-12-31T23:59:59Z"
+        ]
+      ]
+    }
+  },
+  "license": "CC-BY-4.0",
+  "links": [
+    {
+      "rel": "root",
+      "href": "collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "self",
+      "href": "collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "item",
+      "href": "mock-wildfire-item.json",
+      "type": "application/json"
+    }
+  ]
+}

--- a/spark/common/src/test/resources/stac/items/sentinel-2-items.json
+++ b/spark/common/src/test/resources/stac/items/sentinel-2-items.json
@@ -1,0 +1,445 @@
+{
+  "type": "FeatureCollection",
+  "stac_version": "1.0.0",
+  "stac_extensions": [],
+  "context": {
+    "page": 1,
+    "limit": 10,
+    "matched": 10,
+    "returned": 10
+  },
+  "features": [
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "id": "S2A_MSIL2A_20220101T100001_N0400_R122_T33UUP_20220101T100001",
+      "properties": {
+        "datetime": "2022-01-01T10:00:01.000Z",
+        "platform": "sentinel-2a",
+        "constellation": "sentinel-2",
+        "instruments": ["msi"],
+        "gsd": 10,
+        "proj:epsg": 32633,
+        "view:sun_azimuth": 180.5,
+        "view:sun_elevation": 25.3
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [10.0, 50.0],
+            [11.0, 50.0],
+            [11.0, 51.0],
+            [10.0, 51.0],
+            [10.0, 50.0]
+          ]
+        ]
+      },
+      "bbox": [10.0, 50.0, 11.0, 51.0],
+      "assets": {
+        "thumbnail": {
+          "href": "mock-thumbnail.jpg",
+          "type": "image/jpeg",
+          "title": "Thumbnail"
+        }
+      },
+      "links": [
+        {
+          "rel": "self",
+          "href": "mock-item-1.json",
+          "type": "application/json"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "id": "S2A_MSIL2A_20220102T100001_N0400_R122_T33UUP_20220102T100001",
+      "properties": {
+        "datetime": "2022-01-02T10:00:01.000Z",
+        "platform": "sentinel-2a",
+        "constellation": "sentinel-2",
+        "instruments": ["msi"],
+        "gsd": 10,
+        "proj:epsg": 32633,
+        "view:sun_azimuth": 181.2,
+        "view:sun_elevation": 25.8
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [10.5, 50.5],
+            [11.5, 50.5],
+            [11.5, 51.5],
+            [10.5, 51.5],
+            [10.5, 50.5]
+          ]
+        ]
+      },
+      "bbox": [10.5, 50.5, 11.5, 51.5],
+      "assets": {
+        "thumbnail": {
+          "href": "mock-thumbnail-2.jpg",
+          "type": "image/jpeg",
+          "title": "Thumbnail"
+        }
+      },
+      "links": [
+        {
+          "rel": "self",
+          "href": "mock-item-2.json",
+          "type": "application/json"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "id": "S2A_MSIL2A_20220103T100001_N0400_R122_T33UUP_20220103T100001",
+      "properties": {
+        "datetime": "2022-01-03T10:00:01.000Z",
+        "platform": "sentinel-2a",
+        "constellation": "sentinel-2",
+        "instruments": ["msi"],
+        "gsd": 10,
+        "proj:epsg": 32633,
+        "view:sun_azimuth": 182.1,
+        "view:sun_elevation": 26.2
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [11.0, 51.0],
+            [12.0, 51.0],
+            [12.0, 52.0],
+            [11.0, 52.0],
+            [11.0, 51.0]
+          ]
+        ]
+      },
+      "bbox": [11.0, 51.0, 12.0, 52.0],
+      "assets": {
+        "thumbnail": {
+          "href": "mock-thumbnail-3.jpg",
+          "type": "image/jpeg",
+          "title": "Thumbnail"
+        }
+      },
+      "links": [
+        {
+          "rel": "self",
+          "href": "mock-item-3.json",
+          "type": "application/json"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "id": "S2A_MSIL2A_20220104T100001_N0400_R122_T33UUP_20220104T100001",
+      "properties": {
+        "datetime": "2022-01-04T10:00:01.000Z",
+        "platform": "sentinel-2a",
+        "constellation": "sentinel-2",
+        "instruments": ["msi"],
+        "gsd": 10,
+        "proj:epsg": 32633,
+        "view:sun_azimuth": 183.0,
+        "view:sun_elevation": 26.7
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [11.5, 51.5],
+            [12.5, 51.5],
+            [12.5, 52.5],
+            [11.5, 52.5],
+            [11.5, 51.5]
+          ]
+        ]
+      },
+      "bbox": [11.5, 51.5, 12.5, 52.5],
+      "assets": {
+        "thumbnail": {
+          "href": "mock-thumbnail-4.jpg",
+          "type": "image/jpeg",
+          "title": "Thumbnail"
+        }
+      },
+      "links": [
+        {
+          "rel": "self",
+          "href": "mock-item-4.json",
+          "type": "application/json"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "id": "S2A_MSIL2A_20220105T100001_N0400_R122_T33UUP_20220105T100001",
+      "properties": {
+        "datetime": "2022-01-05T10:00:01.000Z",
+        "platform": "sentinel-2a",
+        "constellation": "sentinel-2",
+        "instruments": ["msi"],
+        "gsd": 10,
+        "proj:epsg": 32633,
+        "view:sun_azimuth": 183.8,
+        "view:sun_elevation": 27.1
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [12.0, 52.0],
+            [13.0, 52.0],
+            [13.0, 53.0],
+            [12.0, 53.0],
+            [12.0, 52.0]
+          ]
+        ]
+      },
+      "bbox": [12.0, 52.0, 13.0, 53.0],
+      "assets": {
+        "thumbnail": {
+          "href": "mock-thumbnail-5.jpg",
+          "type": "image/jpeg",
+          "title": "Thumbnail"
+        }
+      },
+      "links": [
+        {
+          "rel": "self",
+          "href": "mock-item-5.json",
+          "type": "application/json"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "id": "S2A_MSIL2A_20220106T100001_N0400_R122_T33UUP_20220106T100001",
+      "properties": {
+        "datetime": "2022-01-06T10:00:01.000Z",
+        "platform": "sentinel-2a",
+        "constellation": "sentinel-2",
+        "instruments": ["msi"],
+        "gsd": 10,
+        "proj:epsg": 32633,
+        "view:sun_azimuth": 184.5,
+        "view:sun_elevation": 27.5
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [12.5, 52.5],
+            [13.5, 52.5],
+            [13.5, 53.5],
+            [12.5, 53.5],
+            [12.5, 52.5]
+          ]
+        ]
+      },
+      "bbox": [12.5, 52.5, 13.5, 53.5],
+      "assets": {
+        "thumbnail": {
+          "href": "mock-thumbnail-6.jpg",
+          "type": "image/jpeg",
+          "title": "Thumbnail"
+        }
+      },
+      "links": [
+        {
+          "rel": "self",
+          "href": "mock-item-6.json",
+          "type": "application/json"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "id": "S2A_MSIL2A_20220107T100001_N0400_R122_T33UUP_20220107T100001",
+      "properties": {
+        "datetime": "2022-01-07T10:00:01.000Z",
+        "platform": "sentinel-2a",
+        "constellation": "sentinel-2",
+        "instruments": ["msi"],
+        "gsd": 10,
+        "proj:epsg": 32633,
+        "view:sun_azimuth": 185.2,
+        "view:sun_elevation": 27.9
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [13.0, 53.0],
+            [14.0, 53.0],
+            [14.0, 54.0],
+            [13.0, 54.0],
+            [13.0, 53.0]
+          ]
+        ]
+      },
+      "bbox": [13.0, 53.0, 14.0, 54.0],
+      "assets": {
+        "thumbnail": {
+          "href": "mock-thumbnail-7.jpg",
+          "type": "image/jpeg",
+          "title": "Thumbnail"
+        }
+      },
+      "links": [
+        {
+          "rel": "self",
+          "href": "mock-item-7.json",
+          "type": "application/json"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "id": "S2A_MSIL2A_20220108T100001_N0400_R122_T33UUP_20220108T100001",
+      "properties": {
+        "datetime": "2022-01-08T10:00:01.000Z",
+        "platform": "sentinel-2a",
+        "constellation": "sentinel-2",
+        "instruments": ["msi"],
+        "gsd": 10,
+        "proj:epsg": 32633,
+        "view:sun_azimuth": 185.9,
+        "view:sun_elevation": 28.3
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [13.5, 53.5],
+            [14.5, 53.5],
+            [14.5, 54.5],
+            [13.5, 54.5],
+            [13.5, 53.5]
+          ]
+        ]
+      },
+      "bbox": [13.5, 53.5, 14.5, 54.5],
+      "assets": {
+        "thumbnail": {
+          "href": "mock-thumbnail-8.jpg",
+          "type": "image/jpeg",
+          "title": "Thumbnail"
+        }
+      },
+      "links": [
+        {
+          "rel": "self",
+          "href": "mock-item-8.json",
+          "type": "application/json"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "id": "S2A_MSIL2A_20220109T100001_N0400_R122_T33UUP_20220109T100001",
+      "properties": {
+        "datetime": "2022-01-09T10:00:01.000Z",
+        "platform": "sentinel-2a",
+        "constellation": "sentinel-2",
+        "instruments": ["msi"],
+        "gsd": 10,
+        "proj:epsg": 32633,
+        "view:sun_azimuth": 186.6,
+        "view:sun_elevation": 28.7
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [14.0, 54.0],
+            [15.0, 54.0],
+            [15.0, 55.0],
+            [14.0, 55.0],
+            [14.0, 54.0]
+          ]
+        ]
+      },
+      "bbox": [14.0, 54.0, 15.0, 55.0],
+      "assets": {
+        "thumbnail": {
+          "href": "mock-thumbnail-9.jpg",
+          "type": "image/jpeg",
+          "title": "Thumbnail"
+        }
+      },
+      "links": [
+        {
+          "rel": "self",
+          "href": "mock-item-9.json",
+          "type": "application/json"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "id": "S2A_MSIL2A_20220110T100001_N0400_R122_T33UUP_20220110T100001",
+      "properties": {
+        "datetime": "2022-01-10T10:00:01.000Z",
+        "platform": "sentinel-2a",
+        "constellation": "sentinel-2",
+        "instruments": ["msi"],
+        "gsd": 10,
+        "proj:epsg": 32633,
+        "view:sun_azimuth": 187.3,
+        "view:sun_elevation": 29.1
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [14.5, 54.5],
+            [15.5, 54.5],
+            [15.5, 55.5],
+            [14.5, 55.5],
+            [14.5, 54.5]
+          ]
+        ]
+      },
+      "bbox": [14.5, 54.5, 15.5, 55.5],
+      "assets": {
+        "thumbnail": {
+          "href": "mock-thumbnail-10.jpg",
+          "type": "image/jpeg",
+          "title": "Thumbnail"
+        }
+      },
+      "links": [
+        {
+          "rel": "self",
+          "href": "mock-item-10.json",
+          "type": "application/json"
+        }
+      ]
+    }
+  ],
+  "links": [
+    {
+      "rel": "self",
+      "href": "sentinel-2-items.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "root",
+      "href": "../collections/sentinel-2-pre-c1-l2a.json",
+      "type": "application/json"
+    }
+  ]
+}

--- a/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacBatchTest.scala
+++ b/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacBatchTest.scala
@@ -33,18 +33,9 @@ class StacBatchTest extends TestBaseScala {
     Source.fromResource(resourceFilePath).getLines().mkString("\n")
   }
 
-  def getAbsolutePathOfResource(resourceFilePath: String): String = {
-    val resourceUrl = getClass.getClassLoader.getResource(resourceFilePath)
-    if (resourceUrl != null) {
-      resourceUrl.getPath
-    } else {
-      throw new IllegalArgumentException(s"Resource not found: $resourceFilePath")
-    }
-  }
-
   it("collectItemLinks should collect correct item links") {
     val collectionUrl =
-      "file://" + getAbsolutePathOfResource("stac/collections/sentinel-2-pre-c1-l2a.json")
+      StacTestUtils.getFileUrlOfResource("stac/collections/sentinel-2-pre-c1-l2a.json")
     val stacCollectionJson = StacUtils.loadStacCollectionToJson(collectionUrl)
     val opts = mutable
       .Map(
@@ -94,7 +85,7 @@ class StacBatchTest extends TestBaseScala {
 
     val opts = mutable.Map("numPartitions" -> "2", "itemsLimitMax" -> "20").toMap
     val collectionUrl =
-      "file://" + getAbsolutePathOfResource("stac/collections/vegetation-collection.json")
+      StacTestUtils.getFileUrlOfResource("stac/collections/vegetation-collection.json")
 
     val stacBatch =
       StacBatch(
@@ -123,7 +114,7 @@ class StacBatchTest extends TestBaseScala {
 
     val opts = mutable.Map("numPartitions" -> "2", "itemsLimitMax" -> "20").toMap
     val collectionUrl =
-      "file://" + getAbsolutePathOfResource("stac/collections/vegetation-collection.json")
+      StacTestUtils.getFileUrlOfResource("stac/collections/vegetation-collection.json")
 
     val stacBatch =
       StacBatch(
@@ -144,7 +135,7 @@ class StacBatchTest extends TestBaseScala {
     val rootJsonFile = "datasource_stac/collection.json"
     val stacCollectionJson = loadJsonFromResource(rootJsonFile)
     val opts = mutable.Map("numPartitions" -> "3", "itemsLimitMax" -> "20").toMap
-    val collectionUrl = getAbsolutePathOfResource(rootJsonFile)
+    val collectionUrl = StacTestUtils.getFileUrlOfResource(rootJsonFile)
 
     val stacBatch =
       StacBatch(

--- a/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacBatchTest.scala
+++ b/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacBatchTest.scala
@@ -44,7 +44,7 @@ class StacBatchTest extends TestBaseScala {
 
   it("collectItemLinks should collect correct item links") {
     val collectionUrl =
-      "https://earth-search.aws.element84.com/v1/collections/sentinel-2-pre-c1-l2a"
+      "file://" + getAbsolutePathOfResource("stac/collections/sentinel-2-pre-c1-l2a.json")
     val stacCollectionJson = StacUtils.loadStacCollectionToJson(collectionUrl)
     val opts = mutable
       .Map(
@@ -85,15 +85,16 @@ class StacBatchTest extends TestBaseScala {
         |  "id": "sample-collection",
         |  "description": "A sample STAC collection",
         |  "links": [
-        |    {"rel": "item", "href": "https://storage.googleapis.com/cfo-public/vegetation/California-Vegetation-CanopyBaseHeight-2016-Summer-00010m.json"},
-        |    {"rel": "item", "href": "https://storage.googleapis.com/cfo-public/vegetation/California-Vegetation-CanopyBaseHeight-2016-Summer-00010m.json"},
-        |    {"rel": "item", "href": "https://storage.googleapis.com/cfo-public/vegetation/California-Vegetation-CanopyBaseHeight-2016-Summer-00010m.json"}
+        |    {"rel": "item", "href": "mock-item-1.json"},
+        |    {"rel": "item", "href": "mock-item-2.json"},
+        |    {"rel": "item", "href": "mock-item-3.json"}
         |  ]
         |}
       """.stripMargin
 
     val opts = mutable.Map("numPartitions" -> "2", "itemsLimitMax" -> "20").toMap
-    val collectionUrl = "https://storage.googleapis.com/cfo-public/vegetation/collection.json"
+    val collectionUrl =
+      "file://" + getAbsolutePathOfResource("stac/collections/vegetation-collection.json")
 
     val stacBatch =
       StacBatch(
@@ -121,7 +122,8 @@ class StacBatchTest extends TestBaseScala {
       """.stripMargin
 
     val opts = mutable.Map("numPartitions" -> "2", "itemsLimitMax" -> "20").toMap
-    val collectionUrl = "https://path/to/collection.json"
+    val collectionUrl =
+      "file://" + getAbsolutePathOfResource("stac/collections/vegetation-collection.json")
 
     val stacBatch =
       StacBatch(

--- a/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacDataSourceTest.scala
+++ b/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacDataSourceTest.scala
@@ -24,25 +24,16 @@ import org.apache.spark.sql.types._
 
 class StacDataSourceTest extends TestBaseScala {
 
-  def getAbsolutePathOfResource(resourceFilePath: String): String = {
-    val resourceUrl = getClass.getClassLoader.getResource(resourceFilePath)
-    if (resourceUrl != null) {
-      resourceUrl.getPath
-    } else {
-      throw new IllegalArgumentException(s"Resource not found: $resourceFilePath")
-    }
-  }
-
   val STAC_COLLECTION_LOCAL: String = resourceFolder + "datasource_stac/collection.json"
   val STAC_ITEM_LOCAL: String = resourceFolder + "geojson/core-item.json"
 
   val STAC_COLLECTION_MOCK: List[String] = List(
-    "file://" + getAbsolutePathOfResource("stac/collections/sentinel-2-pre-c1-l2a.json"),
-    "file://" + getAbsolutePathOfResource("stac/collections/vegetation-collection.json"),
-    "file://" + getAbsolutePathOfResource("stac/collections/wildfire-collection.json"),
-    "file://" + getAbsolutePathOfResource("stac/collections/copernicus-dem.json"),
-    "file://" + getAbsolutePathOfResource("stac/collections/naip.json"),
-    "file://" + getAbsolutePathOfResource("stac/collections/earthview-catalog.json"))
+    StacTestUtils.getFileUrlOfResource("stac/collections/sentinel-2-pre-c1-l2a.json"),
+    StacTestUtils.getFileUrlOfResource("stac/collections/vegetation-collection.json"),
+    StacTestUtils.getFileUrlOfResource("stac/collections/wildfire-collection.json"),
+    StacTestUtils.getFileUrlOfResource("stac/collections/copernicus-dem.json"),
+    StacTestUtils.getFileUrlOfResource("stac/collections/naip.json"),
+    StacTestUtils.getFileUrlOfResource("stac/collections/earthview-catalog.json"))
 
   it("basic df load from local file should work") {
     val dfStac = sparkSession.read.format("stac").load(STAC_COLLECTION_LOCAL)

--- a/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacDataSourceTest.scala
+++ b/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacDataSourceTest.scala
@@ -24,16 +24,25 @@ import org.apache.spark.sql.types._
 
 class StacDataSourceTest extends TestBaseScala {
 
+  def getAbsolutePathOfResource(resourceFilePath: String): String = {
+    val resourceUrl = getClass.getClassLoader.getResource(resourceFilePath)
+    if (resourceUrl != null) {
+      resourceUrl.getPath
+    } else {
+      throw new IllegalArgumentException(s"Resource not found: $resourceFilePath")
+    }
+  }
+
   val STAC_COLLECTION_LOCAL: String = resourceFolder + "datasource_stac/collection.json"
   val STAC_ITEM_LOCAL: String = resourceFolder + "geojson/core-item.json"
 
-  val STAC_COLLECTION_REMOTE: List[String] = List(
-    "https://earth-search.aws.element84.com/v1/collections/sentinel-2-pre-c1-l2a",
-    "https://storage.googleapis.com/cfo-public/vegetation/collection.json",
-    "https://storage.googleapis.com/cfo-public/wildfire/collection.json",
-    "https://earthdatahub.destine.eu/api/stac/v1/collections/copernicus-dem",
-    "https://planetarycomputer.microsoft.com/api/stac/v1/collections/naip",
-    "https://satellogic-earthview.s3.us-west-2.amazonaws.com/stac/catalog.json")
+  val STAC_COLLECTION_MOCK: List[String] = List(
+    "file://" + getAbsolutePathOfResource("stac/collections/sentinel-2-pre-c1-l2a.json"),
+    "file://" + getAbsolutePathOfResource("stac/collections/vegetation-collection.json"),
+    "file://" + getAbsolutePathOfResource("stac/collections/wildfire-collection.json"),
+    "file://" + getAbsolutePathOfResource("stac/collections/copernicus-dem.json"),
+    "file://" + getAbsolutePathOfResource("stac/collections/naip.json"),
+    "file://" + getAbsolutePathOfResource("stac/collections/earthview-catalog.json"))
 
   it("basic df load from local file should work") {
     val dfStac = sparkSession.read.format("stac").load(STAC_COLLECTION_LOCAL)
@@ -49,8 +58,8 @@ class StacDataSourceTest extends TestBaseScala {
     assert(rowCount > 0)
   }
 
-  it("basic df load from remote service endpoints should work") {
-    STAC_COLLECTION_REMOTE.foreach { endpoint =>
+  it("basic df load from mock service endpoints should work") {
+    STAC_COLLECTION_MOCK.foreach { endpoint =>
       val dfStac = sparkSession.read.format("stac").load(endpoint)
       assertSchema(dfStac.schema)
     }

--- a/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacPartitionReaderTest.scala
+++ b/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacPartitionReaderTest.scala
@@ -27,14 +27,23 @@ import scala.jdk.CollectionConverters._
 
 class StacPartitionReaderTest extends TestBaseScala {
 
+  def getAbsolutePathOfResource(resourceFilePath: String): String = {
+    val resourceUrl = getClass.getClassLoader.getResource(resourceFilePath)
+    if (resourceUrl != null) {
+      resourceUrl.getPath
+    } else {
+      throw new IllegalArgumentException(s"Resource not found: $resourceFilePath")
+    }
+  }
+
   val TEST_DATA_FOLDER: String =
     System.getProperty("user.dir") + "/src/test/resources/datasource_stac"
   val JSON_STAC_ITEM_SIMPLE: String = s"file://$TEST_DATA_FOLDER/simple-item.json"
   val JSON_STAC_ITEM_CORE: String = s"file://$TEST_DATA_FOLDER/core-item.json"
   val JSON_STAC_ITEM_EXTENDED: String = s"file://$TEST_DATA_FOLDER/extended-item.json"
   val JSON_STAC_ITEM_FEATURES: String = s"file://$TEST_DATA_FOLDER/collection-items.json"
-  val HTTPS_STAC_ITEM_FEATURES: String =
-    "https://earth-search.aws.element84.com/v1/collections/sentinel-2-pre-c1-l2a/items"
+  val MOCK_STAC_ITEM_FEATURES: String =
+    "file://" + getAbsolutePathOfResource("stac/items/sentinel-2-items.json")
 
   it("StacPartitionReader should read feature files from local files") {
     val jsonFiles =
@@ -81,8 +90,8 @@ class StacPartitionReaderTest extends TestBaseScala {
     reader.close()
   }
 
-  it("StacPartitionReader should read features collection file from https endpoint") {
-    val jsonFiles = Seq(HTTPS_STAC_ITEM_FEATURES).toArray
+  it("StacPartitionReader should read features collection file from mock endpoint") {
+    val jsonFiles = Seq(MOCK_STAC_ITEM_FEATURES).toArray
     val partition = StacPartition(0, jsonFiles, Map.empty[String, String].asJava)
     val reader =
       new StacPartitionReader(

--- a/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacPartitionReaderTest.scala
+++ b/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacPartitionReaderTest.scala
@@ -27,15 +27,6 @@ import scala.jdk.CollectionConverters._
 
 class StacPartitionReaderTest extends TestBaseScala {
 
-  def getAbsolutePathOfResource(resourceFilePath: String): String = {
-    val resourceUrl = getClass.getClassLoader.getResource(resourceFilePath)
-    if (resourceUrl != null) {
-      resourceUrl.getPath
-    } else {
-      throw new IllegalArgumentException(s"Resource not found: $resourceFilePath")
-    }
-  }
-
   val TEST_DATA_FOLDER: String =
     System.getProperty("user.dir") + "/src/test/resources/datasource_stac"
   val JSON_STAC_ITEM_SIMPLE: String = s"file://$TEST_DATA_FOLDER/simple-item.json"
@@ -43,7 +34,7 @@ class StacPartitionReaderTest extends TestBaseScala {
   val JSON_STAC_ITEM_EXTENDED: String = s"file://$TEST_DATA_FOLDER/extended-item.json"
   val JSON_STAC_ITEM_FEATURES: String = s"file://$TEST_DATA_FOLDER/collection-items.json"
   val MOCK_STAC_ITEM_FEATURES: String =
-    "file://" + getAbsolutePathOfResource("stac/items/sentinel-2-items.json")
+    StacTestUtils.getFileUrlOfResource("stac/items/sentinel-2-items.json")
 
   it("StacPartitionReader should read feature files from local files") {
     val jsonFiles =

--- a/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacTestUtils.scala
+++ b/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacTestUtils.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.spark.sql.sedona_sql.io.stac
+
+object StacTestUtils {
+
+  def getAbsolutePathOfResource(resourceFilePath: String): String = {
+    val resourceUrl = getClass.getClassLoader.getResource(resourceFilePath)
+    if (resourceUrl != null) {
+      resourceUrl.getPath
+    } else {
+      throw new IllegalArgumentException(s"Resource not found: $resourceFilePath")
+    }
+  }
+
+  def getFileUrlOfResource(resourceFilePath: String): String = {
+    "file://" + getAbsolutePathOfResource(resourceFilePath)
+  }
+}


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #<issue_number>

## What changes were proposed in this PR?
  
This PR makes STAC tests resilient to external server failures by implementing mock-based testing for Python and local test resources for Scala, ensuring tests run reliably without network dependencies.
  - Created mock STAC collection JSON files in `/spark/common/src/test/resources/stac/`:
  - 6 collection files (sentinel-2, vegetation, wildfire, copernicus-dem, naip, earthview)
  - 1 items file with 10 mock STAC items

## How was this patch tested?
  - Updated `StacDataSourceTest.scala` to use local mock files instead of remote URLs
  - Updated `StacBatchTest.scala` to use local resource files with `file://` protocol
  - Updated `StacPartitionReaderTest.scala` to use mock items file

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
