### PR TITLE
[CI] Update the pipfile version to require python 3.8

### DIFF
--- a/python/Pipfile
+++ b/python/Pipfile
@@ -33,4 +33,4 @@ pystac = "===1.5.0"
 rasterio = ">=1.2.10"
 
 [requires]
-python_version = "3.9"
+python_version = "3.8"


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

Since Python 3.7 reached end-of-life in June 2023, the Pipfile should be updated to support newer Python versions.

## How was this patch tested?
CI build should succeed

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
