### PR TITLE
docs: Update documented output for ST_GeometryType to not be all caps

### DIFF
--- a/docs/api/sql/Function.md
+++ b/docs/api/sql/Function.md
@@ -1920,7 +1920,7 @@ SELECT ST_GeometryType(ST_GeomFromText('LINESTRING(77.29 29.07,77.42 29.26,77.27
 Output:
 
 ```
-ST_LINESTRING
+ST_LineString
 ```
 
 ## ST_GLocal


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a documentation update. The PR name follows the format `[DOCS] my subject`

## What changes were proposed in this PR?
I was referencing the docs to see the exact string output of `ST_GeometryType`. Turns out it's incorrectly documents the output to be in all caps. This PR updates the docs to show the exact actual output.

## How was this patch tested?
N/A

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.
