### PR TITLE
[GH-2365] Fix mike command when running docs workflow on master branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -109,11 +109,11 @@ jobs:
         run: |
           if [[ "${GITHUB_REF##*/}" == "master" ]]; then
             git fetch origin website --depth=1
-            mike deploy latest-snapshot -b website -p
+            uv run mike deploy latest-snapshot -b website -p
           elif [[ "${GITHUB_REF##*/}" =~ ^branch-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             git fetch origin website --depth=1
             version="${GITHUB_REF##*/branch-}"
-            mike deploy --update-aliases "$version" latest -b website -p
+            uv run mike deploy --update-aliases "$version" latest -b website -p
           fi
       - run: mkdir staging
       - run: cp -r site/* staging/


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2365 

## What changes were proposed in this PR?

This PR fixes a problem of the previous PR https://github.com/apache/sedona/pull/2401. `mike` was not ran using `uv run` so the docs.yml workflow failed: https://github.com/apache/sedona/actions/runs/18636890955/job/53129291199

## How was this patch tested?

Tested `uv run mike` locally to make sure that mike exists in the virtual env. Need to test this by merging it.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
