### PR TITLE
[CI] Optimize Dependabot PRs by using `groups`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,9 +22,17 @@ updates:
     open-pull-requests-limit: 2
     schedule:
       interval: monthly
+    groups:
+      github-dependencies:
+        patterns:
+          - '*'
 
   - package-ecosystem: pip
     directory: /docker
     open-pull-requests-limit: 2
     schedule:
       interval: monthly
+    groups:
+      github-dependencies:
+        patterns:
+          - '*'


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

closes #2245 

## How was this patch tested?

See at the next link the PR has bumped all the dependencies at once instead of creating individual PRs for each.

https://github.com/brisbanesocialchess/brisbanesocialchess.github.io/pull/877

So this reduces repository noise.

Example `dependabot.yml`:

https://github.com/brisbanesocialchess/brisbanesocialchess.github.io/blob/main/.github/dependabot.yml

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
