### PR TITLE
[DOCS] Add `sphinx-autobuild` dependency for docs hot reloading

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,4 +48,5 @@ docs = [
   "blacken-docs",
   "sphinx",
   "sphinx_rtd_theme",
+  "sphinx-autobuild",
 ]

--- a/python/sedona/doc/Makefile
+++ b/python/sedona/doc/Makefile
@@ -29,9 +29,12 @@ BUILDDIR      = _build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+.PHONY: help Makefile livehtml
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+livehtml:
+	sphinx-autobuild "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/python/sedona/doc/make.bat
+++ b/python/sedona/doc/make.bat
@@ -24,9 +24,17 @@ if errorlevel 9009 (
 )
 
 if "%1" == "" goto help
+REM --- Added section for 'livehtml' ---
+if "%1" == "livehtml" goto livehtml
+REM -------------------------------------
 
 %SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
 goto end
+
+:livehtml
+	REM
+	sphinx-autobuild "%SOURCEDIR%" "%BUILDDIR%" %SPHINXOPTS% %O%
+	goto end
 
 :help
 %SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a documentation update. The PR name follows the format `[DOCS] my subject`

## What changes were proposed in this PR?

Adds `sphinx-autobuild` to the `pyproject.toml` root `docs` dependency group.

https://github.com/sphinx-doc/sphinx-autobuild

https://github.com/sphinx-doc/sphinx-autobuild?tab=readme-ov-file#using-with-makefile

Listed as one of the best Sphinx extensions:

https://sphinx-extensions.readthedocs.io/en/latest/

## How was this patch tested?

I have only tested on Linux so we need another dev to test the batch file

Ran: `uv pip install -r pyproject.toml --group docs`

Then ` cd python/sedona/doc/`

Next: `make livehtml` for docs hot reloading.

A much more modern development experience.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
