### PR TITLE
[CI] pre-commit auto add license headers for batch files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,6 +84,15 @@ repos:
         files: \.md$
         stages: [manual]
       - id: insert-license
+        name: add license for all Batch files
+        files: \.bat$
+        args:
+          - --comment-style
+          - '|REM|'
+          - --license-filepath
+          - .github/workflows/license-templates/LICENSE.txt
+          - --fuzzy-match-generates-todo
+      - id: insert-license
         name: add license for all .c files
         files: \.c$
         args:

--- a/python/sedona/doc/make.bat
+++ b/python/sedona/doc/make.bat
@@ -1,3 +1,20 @@
+REM Licensed to the Apache Software Foundation (ASF) under one
+REM or more contributor license agreements.  See the NOTICE file
+REM distributed with this work for additional information
+REM regarding copyright ownership.  The ASF licenses this file
+REM to you under the Apache License, Version 2.0 (the
+REM "License"); you may not use this file except in compliance
+REM with the License.  You may obtain a copy of the License at
+REM
+REM   http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM Unless required by applicable law or agreed to in writing,
+REM software distributed under the License is distributed on an
+REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+REM KIND, either express or implied.  See the License for the
+REM specific language governing permissions and limitations
+REM under the License.
+
 @ECHO OFF
 
 pushd %~dp0


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

Using pre-commit auto added missing license headers for another file type batch files.

## How was this patch tested?

Ran `pre-commit run --all-files` both before and after the license header was auto inserted

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
