### PR TITLE
[DOCS] link development guides in CONTRIBUTING.md (#2448)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,30 +15,19 @@
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
- -->
+-->
 
-# How to contribute to Apache Sedona
+# Contributing to Apache Sedona
 
-Welcome!  We'd love to have you contribute to Apache Sedona!
+Welcome! We'd love to have you contribute to Apache Sedona!
 
-## Did you find a bug?
+To set up your development environment, please refer to:
 
-Create an issue with a reproducible example.  Please specify the Sedona version, Java version, code snippet, and error message.
+- [Developing Sedona (Java Guide)](./docs/community/develop.md)
+- [Building Sedona from Source (Python Guide)](./docs/setup/compile.md)
 
-## Did you create a PR to fix a bug?
+For contribution rules and PR instructions, see the [Contributor Guide](https://sedona.apache.org/latest/community/rule/).
 
-See [here](https://sedona.apache.org/latest/community/rule/#make-a-pull-request) for instructions on how to open PRs.
+If you have questions or want to chat with the community, join our [Discord](https://discord.gg/9A3k5dEBsY).
 
-We appreciate bug fixes - thank you in advance!
-
-## Would you like to add a new feature or change existing code?
-
-If you would like to add a feature or change existing behavior, please make sure to create an issue/JIRA ticket and get the planned work approved by the core team first!
-
-It's always better to get aligned with the core devs before writing any code.
-
-## Do you have questions about the source code?
-
-Feel free to create an issue or join the [Discord](https://discord.gg/9A3k5dEBsY) with questions!
-
-Thanks for reading and looking forward to collaborating with you!
+Thank you for contributing to Apache Sedona!


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-2448] my subject`. Closes #2448
 - However, since this is a documentation-only change, `[DOCS]` is used instead of `[GH-2448]`.

## What changes were proposed in this PR?

This PR updates the `CONTRIBUTING.md` file to make it easier for new contributors to set up their development environment by:

- Adding links to the developer setup guides:
  - [Developing Sedona (Java Guide)](./docs/community/develop.md)
  - [Building Sedona from Source (Python Guide)](./docs/setup/compile.md)
- Simplifying the file structure to emphasize Sedona-specific resources
- Removing generic OSS contribution text to improve readability

## How was this patch tested?

- Verified that the Markdown links render correctly in GitHub preview
- Confirmed all links are valid and accessible

## Did this PR include necessary documentation updates?

- No, this PR only updates existing documentation for contributors (no API changes)

Fixes #2448