### PR TITLE
[GH-2432] Fix `first-interaction` workflow by adding permissions

### DIFF
--- a/.github/workflows/first-interaction.yml
+++ b/.github/workflows/first-interaction.yml
@@ -23,6 +23,10 @@ on:
   pull_request:
     types: [opened]
 
+permissions:
+  issues: write
+  pull-requests: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2432 

## What changes were proposed in this PR?

Added the missing workflow permissions:

https://github.com/actions/first-interaction?tab=readme-ov-file#usage

## How was this patch tested?


## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
