### PR TITLE
[DOCS] replace Pipfile reference with pyproject.toml (#2414)

### DIFF
--- a/docs/setup/install-python.md
+++ b/docs/setup/install-python.md
@@ -23,7 +23,7 @@ Apache Sedona extends pyspark functions which depends on libraries:
 * shapely
 * attrs
 
-You need to install necessary packages if your system does not have them installed. See ["packages" in our Pipfile](https://github.com/apache/sedona/blob/master/python/Pipfile).
+You need to install necessary packages if your system does not have them installed. Sedona now uses [uv](https://docs.astral.sh/uv/) for Python dependency management. See the dependency definitions in our [pyproject.toml](https://github.com/apache/sedona/blob/master/python/pyproject.toml).
 
 ### Install sedona
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- [x] Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- [x] No:
  - [x] this is a documentation update. The PR name follows the format `[DOCS] my subject`

## What changes were proposed in this PR?

This PR updates the Python installation documentation to reference `pyproject.toml` instead of the removed `Pipfile`.

Sedona has switched from **pipenv** to **uv** for Python dependency management, and dependencies are now defined in `python/pyproject.toml`.

## How was this patch tested?

No code changes were made; verified that the new documentation link correctly points to  
[`python/pyproject.toml`](https://github.com/apache/sedona/blob/master/python/pyproject.toml).

## Did this PR include necessary documentation updates?

- [x] Yes, I have updated the documentation.

---

**Closes #2414**