### PR TITLE
[GH-2456] chore(geopandas): remove 'IMPLEMENTATION_STATUS' global variables

### DIFF
--- a/python/sedona/spark/geopandas/geodataframe.py
+++ b/python/sedona/spark/geopandas/geodataframe.py
@@ -45,73 +45,6 @@ register_extension_dtype(GeometryDtype)
 # IMPLEMENTATION STATUS TRACKING
 # ============================================================================
 
-IMPLEMENTATION_STATUS = {
-    "IMPLEMENTED": [
-        "area",
-        "buffer",
-        "crs",
-        "geometry",
-        "active_geometry_name",
-        "sindex",
-        "rename_geometry",
-        "copy",
-        "sjoin",
-        "to_parquet",
-    ],
-    "NOT_IMPLEMENTED": [
-        "to_geopandas",
-        "_to_geopandas",
-        "geom_type",
-        "type",
-        "length",
-        "is_valid",
-        "is_valid_reason",
-        "is_empty",
-        "is_simple",
-        "is_ring",
-        "is_ccw",
-        "is_closed",
-        "has_z",
-        "boundary",
-        "centroid",
-        "convex_hull",
-        "envelope",
-        "exterior",
-        "interiors",
-        "unary_union",
-        "count_coordinates",
-        "count_geometries",
-        "count_interior_rings",
-        "get_precision",
-        "get_geometry",
-        "concave_hull",
-        "delaunay_triangles",
-        "voronoi_polygons",
-        "minimum_rotated_rectangle",
-        "extract_unique_points",
-        "offset_curve",
-        "remove_repeated_points",
-        "set_precision",
-        "representative_point",
-        "minimum_bounding_circle",
-        "minimum_bounding_radius",
-        "minimum_clearance",
-        "normalize",
-        "make_valid",
-        "reverse",
-        "segmentize",
-        "transform",
-        "force_2d",
-        "force_3d",
-        "line_merge",
-        "union_all",
-        "intersection_all",
-        "contains",
-        "contains_properly",
-    ],
-    "PARTIALLY_IMPLEMENTED": ["set_geometry"],  # Only drop=True case is not implemented
-}
-
 IMPLEMENTATION_PRIORITY = {
     "HIGH": [
         "to_geopandas",
@@ -254,7 +187,7 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
     - Uses Spark for distributed processing
     - Geometries are stored in WKB (Well-Known Binary) format internally
     - Some methods may have different performance characteristics
-    - Not all GeoPandas methods are implemented yet (see IMPLEMENTATION_STATUS)
+    - Not all GeoPandas methods are implemented yet (see Sedona GeoPandas docs).
 
     Performance Considerations:
     - Operations are distributed across Spark cluster

--- a/python/sedona/spark/geopandas/geoseries.py
+++ b/python/sedona/spark/geopandas/geoseries.py
@@ -60,100 +60,6 @@ from pyspark.pandas.internal import (
 # IMPLEMENTATION STATUS TRACKING
 # ============================================================================
 
-IMPLEMENTATION_STATUS = {
-    "IMPLEMENTED": [
-        "area",
-        "buffer",
-        "bounds",
-        "centroid",
-        "contains",
-        "crs",
-        "distance",
-        "envelope",
-        "geometry",
-        "intersection",
-        "intersects",
-        "is_empty",
-        "is_simple",
-        "is_valid",
-        "is_valid_reason",
-        "length",
-        "make_valid",
-        "relate",
-        "set_crs",
-        "to_crs",
-        "to_geopandas",
-        "to_wkb",
-        "to_wkt",
-        "x",
-        "y",
-        "z",
-        "has_z",
-        "get_geometry",
-        "boundary",
-        "total_bounds",
-        "estimate_utm_crs",
-        "isna",
-        "isnull",
-        "notna",
-        "notnull",
-        "from_xy",
-        "copy",
-        "geom_type",
-        "sindex",
-    ],
-    "NOT_IMPLEMENTED": [
-        "clip",
-        "contains_properly",
-        "convex_hull",
-        "count_coordinates",
-        "count_geometries",
-        "count_interior_rings",
-        "explode",
-        "force_2d",
-        "force_3d",
-        "from_file",
-        "from_shapely",
-        "from_arrow",
-        "line_merge",
-        "reverse",
-        "segmentize",
-        "to_json",
-        "to_arrow",
-        "to_file",
-        "transform",
-        "unary_union",
-        "union_all",
-        "intersection_all",
-        "type",
-        "is_ring",
-        "is_ccw",
-        "is_closed",
-        "get_precision",
-        "concave_hull",
-        "delaunay_triangles",
-        "voronoi_polygons",
-        "minimum_rotated_rectangle",
-        "exterior",
-        "extract_unique_points",
-        "offset_curve",
-        "interiors",
-        "remove_repeated_points",
-        "set_precision",
-        "representative_point",
-        "minimum_bounding_circle",
-        "minimum_bounding_radius",
-        "minimum_clearance",
-        "normalize",
-        "m",
-    ],
-    "PARTIALLY_IMPLEMENTED": [
-        "fillna",  # Limited parameter support (no 'limit' parameter)
-        "from_wkb",
-        "from_wkt",  # Limited error handling options (only 'raise' supported)
-    ],
-}
-
 IMPLEMENTATION_PRIORITY = {
     "HIGH": [
         "contains",
@@ -281,7 +187,7 @@ class GeoSeries(GeoFrame, pspd.Series):
     - Uses Spark for distributed processing
     - Geometries are stored in WKB (Well-Known Binary) format internally
     - Some methods may have different performance characteristics
-    - Not all GeoPandas methods are implemented yet (see IMPLEMENTATION_STATUS)
+    - Not all GeoPandas methods are implemented yet (see Sedona GeoPandas docs).
 
     Performance Considerations:
     - Operations are distributed across Spark cluster


### PR DESCRIPTION
## Did you read the Contributor Guide?

- [x] Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)
- [ ] No, I haven't read it.

---

## Is this PR related to a ticket?

- [x] Yes, and the PR name follows the format `[GH-2456] chore(geopandas): remove outdated IMPLEMENTATION_STATUS variable`.  
  Closes #2456
- [ ] No, this is a documentation or CI update.

---

## What changes were proposed in this PR?

This PR removes the unused global variable `IMPLEMENTATION_STATUS` from both  
`geoseries.py` and `geodataframe.py` under `sedona/spark/geopandas`.

- The variable was outdated and no longer referenced in the code.  
- Updated docstrings that previously mentioned `IMPLEMENTATION_STATUS` to refer instead to the Sedona GeoPandas documentation.

---

## Did this PR include necessary documentation updates?

- [x] No, this PR does not affect any public API, so no documentation changes are needed.
- [ ] Yes, documentation was updated.
