### PR TITLE
[GH-2465] Log4j Class Initialization Deadlock in SedonaKryoRegistrator Class. Closes issue #2465

### DIFF
--- a/spark/common/src/main/java/org/apache/sedona/core/serde/SedonaKryoRegistrator.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/serde/SedonaKryoRegistrator.java
@@ -19,7 +19,6 @@
 package org.apache.sedona.core.serde;
 
 import com.esotericsoftware.kryo.Kryo;
-import org.apache.log4j.Logger;
 import org.apache.sedona.common.geometryObjects.Circle;
 import org.apache.sedona.common.geometrySerde.GeometrySerde;
 import org.apache.sedona.common.geometrySerde.SpatialIndexSerde;
@@ -37,14 +36,10 @@ import org.locationtech.jts.index.strtree.STRtree;
 
 public class SedonaKryoRegistrator implements KryoRegistrator {
 
-  static final Logger log = Logger.getLogger(SedonaKryoRegistrator.class);
-
   @Override
   public void registerClasses(Kryo kryo) {
     GeometrySerde serializer = new GeometrySerde();
     SpatialIndexSerde indexSerializer = new SpatialIndexSerde(serializer);
-
-    log.info("Registering custom serializers for geometry types");
 
     kryo.register(Point.class, serializer);
     kryo.register(LineString.class, serializer);

--- a/spark/common/src/main/java/org/apache/sedona/viz/core/Serde/SedonaVizKryoRegistrator.java
+++ b/spark/common/src/main/java/org/apache/sedona/viz/core/Serde/SedonaVizKryoRegistrator.java
@@ -19,14 +19,12 @@
 package org.apache.sedona.viz.core.Serde;
 
 import com.esotericsoftware.kryo.Kryo;
-import org.apache.log4j.Logger;
 import org.apache.sedona.core.serde.SedonaKryoRegistrator;
 import org.apache.sedona.viz.core.ImageSerializableWrapper;
 import org.apache.sedona.viz.utils.Pixel;
 import org.apache.spark.serializer.KryoRegistrator;
 
 public class SedonaVizKryoRegistrator implements KryoRegistrator {
-  static final Logger log = Logger.getLogger(SedonaVizKryoRegistrator.class);
 
   @Override
   public void registerClasses(Kryo kryo) {
@@ -34,7 +32,7 @@ public class SedonaVizKryoRegistrator implements KryoRegistrator {
     ImageWrapperSerializer imageWrapperSerializer = new ImageWrapperSerializer();
     PixelSerializer pixelSerializer = new PixelSerializer();
     sedonaKryoRegistrator.registerClasses(kryo);
-    log.info("Registering custom serializers for visualization related types");
+
     kryo.register(ImageSerializableWrapper.class, imageWrapperSerializer);
     kryo.register(Pixel.class, pixelSerializer);
   }


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #<issue_number>

## What changes were proposed in this PR?

Spark 3.x is currently including log4j2 version `2.20.0`, that can cause deadlock on Spark executor initialization.
This PR removes logger initialization from Kryo registrators to mitigate possible risk of deadlock. The downside is that there's no easy way to debug anymore Kryo registration, but this downside should be still acceptable than using Classes that are not thread safe and potentially cause Deadlock in Spark executor initialization..

For further information about the deadlock see https://github.com/apache/sedona/issues/2465

## How was this patch tested?

Code complies, tests pass and  pre-commit passes.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
