### PR TITLE
feat: Add dark/light theme toggle to documentation website

### DIFF
--- a/.github/workflows/pre-commit-reusable.yml
+++ b/.github/workflows/pre-commit-reusable.yml
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: _pre-commit-base
+
+on:
+  workflow_call:
+    inputs:
+      extra_args:
+        required: false
+        type: string
+        default: ''
+      job_id:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  run-hooks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout ${{ github.ref }} ( ${{ github.sha }} )'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.11'
+          architecture: 'x64'
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
+      - name: set PY
+        run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> "$GITHUB_ENV"
+      - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit|${{ inputs.job_id }}|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Run pre-commit
+        run: pre-commit run --color=always --all-files --show-diff-on-failure ${{ inputs.extra_args }} # zizmor: ignore[template-injection]

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,7 +17,13 @@
 
 name: pre-commit
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '*'
 
 permissions:
   contents: read
@@ -28,26 +34,7 @@ concurrency:
 
 jobs:
   pre-commit:
-    name: Run pre-commit # https://pre-commit.com/
-    runs-on: ubuntu-latest
-    steps:
-      - name: 'Checkout ${{ github.ref }} ( ${{ github.sha }} )'
-        uses: actions/checkout@v5
-      - uses: actions/setup-python@v6 # https://www.python.org/
-        with:
-          python-version: '3.10' # Version range or exact version of a Python version to use, using SemVer's version range syntax
-          architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
-      - name: Install dependencies # https://pip.pypa.io/en/stable/
-        run: |
-          python -m pip install --upgrade pip
-          pip install pre-commit
-      - name: set PY
-        run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
-      - uses: actions/cache@v4
-        with:
-          path: ~/.cache/pre-commit
-          key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
-      - name: Run pre-commit
-        run: pre-commit run --color=always --all-files
-      - name: Run manual pre-commit hooks
-        run: pre-commit run --color=always --all-files --hook-stage manual
+    name: Run pre-commit standard
+    uses: ./.github/workflows/pre-commit-reusable.yml
+    with:
+      job_id: 'standard'

--- a/docs-overrides/assets/stylesheets/_vars.scss
+++ b/docs-overrides/assets/stylesheets/_vars.scss
@@ -7,4 +7,19 @@
   --color-violet: #7142FF;
 
   --font-inter: 'Inter', sans-serif;
+
+  // Added variables for dark mode support
+  --hero-bg: linear-gradient(182.44deg, #9FD2F4 -17.31%, #F3F3F3 97.95%);
+  --section-bg-light: #E2ECF3;
+  --text-primary: #1C1C1C;
+  --text-secondary: rgba(28, 28, 28, 0.8);
+  --card-bg: #fff;
+}
+
+[data-md-color-scheme="slate"] {
+  --hero-bg: linear-gradient(182.44deg, #132f4c -17.31%, #0a1929 97.95%) !important;
+  --section-bg-light: #161b22 !important;
+  --text-primary: #f5f5f5 !important;
+  --text-secondary: rgba(245, 245, 245, 0.8) !important;
+  --card-bg: #161b22 !important;
 }

--- a/docs-overrides/assets/stylesheets/components/_header.scss
+++ b/docs-overrides/assets/stylesheets/components/_header.scss
@@ -14,6 +14,7 @@
       display: flex;
       justify-content: flex-start;
       align-items: center;
+      gap: 20px;
     }
 
     .right-part {
@@ -44,6 +45,15 @@
     // Title
     .md-header__title {
       font-size: 0;
+      display: none !important;
+
+      @media (min-width: 1220px) {
+        // Only show page title on non-homepage if you want
+        body:not(:has(.page-home)) & {
+           display: block !important;
+           font-size: 1rem;
+        }
+      }
     }
   }
 
@@ -199,4 +209,16 @@
     }
 
   }
+}
+// Fix palette toggle icons visibility (Material theme integration)
+// Fix palette toggle icons visibility (Material theme integration)
+[data-md-color-media] .md-header__option {
+  display: none !important;
+}
+
+// Show the option that matches the CURRENTLY ACTIVE scheme on the body
+[data-md-color-scheme="default"] .md-header__option[data-md-color-scheme="default"],
+[data-md-color-scheme="slate"] .md-header__option[data-md-color-scheme="slate"],
+body:not([data-md-color-scheme]) .md-header__option[data-md-color-media="(prefers-color-scheme)"] {
+  display: block !important;
 }

--- a/docs-overrides/assets/stylesheets/pages/_page-home.scss
+++ b/docs-overrides/assets/stylesheets/pages/_page-home.scss
@@ -32,7 +32,7 @@ body:has(.page-home) {
 
 // Section Hero
 .section-hero {
-  background: linear-gradient(182.44deg, #9FD2F4 -17.31%, #F3F3F3 97.95%);
+  background: var(--hero-bg);
   padding-top: 50px;
   overflow: hidden;
 
@@ -66,7 +66,7 @@ body:has(.page-home) {
       line-height: 1.25;
       text-align: center;
       letter-spacing: -0.02em;
-      color: #1A191C;
+      color: var(--text-primary);
       margin: 0;
     }
   }
@@ -79,7 +79,7 @@ body:has(.page-home) {
     line-height: 1.5;
     text-align: center;
     letter-spacing: -0.015em;
-    color: #1C1C1C;
+    color: var(--text-primary);
     max-width: 450px;
     margin-left: auto;
     margin-right: auto;
@@ -417,7 +417,7 @@ body:has(.page-home) {
 .section-deploy {
   padding-top: clamp-property(48, 100);
   padding-bottom: clamp-property(48, 100);
-  background-color: var(--color-light-blue);
+  background-color: var(--section-bg-light);
 
   .section-title {
     text-align: center;
@@ -432,7 +432,7 @@ body:has(.page-home) {
     font-size: clamp-property(26, 36);
     line-height: 1.4;
     letter-spacing: -0.02em;
-    color: var(--color-dark);
+    color: var(--text-primary);
   }
 
   .section-description {
@@ -518,7 +518,7 @@ body:has(.page-home) {
         font-weight: 400;
         font-size: 16px;
         line-height: 1.5;
-        color: rgba(28, 28, 28, 0.8);
+        color: var(--text-secondary);
       }
 
       &__cta {
@@ -540,7 +540,7 @@ body:has(.page-home) {
 .section-industries-tabs {
   padding-top: clamp-property(48, 100);
   padding-bottom: clamp-property(48, 100);
-  background-color: var(--color-light-blue);
+  background-color: var(--section-bg-light);
 
   .content-box {
     background-color: var(--color-white);
@@ -562,7 +562,7 @@ body:has(.page-home) {
     font-size: clamp-property(26, 36);
     line-height: 1.4;
     letter-spacing: -0.02em;
-    color: var(--color-dark);
+    color: var(--text-primary);
     max-width: 640px;
     margin-left: auto;
     margin-right: auto;
@@ -720,7 +720,7 @@ body:has(.page-home) {
 .section-community {
   padding-top: clamp-property(48, 100);
   padding-bottom: clamp-property(48, 100);
-  background-color: var(--color-light-blue);
+  background-color: var(--section-bg-light);
 
   .section-title {
     text-align: center;
@@ -735,7 +735,7 @@ body:has(.page-home) {
     font-size: clamp-property(26, 36);
     line-height: 1.4;
     letter-spacing: -0.02em;
-    color: var(--color-dark);
+    color: var(--text-primary);
   }
 
   .section-description {
@@ -772,7 +772,7 @@ body:has(.page-home) {
       padding-bottom: 24px;
       padding-left: 28px;
       padding-right: 28px;
-      background: var(--color-white);
+      background: var(--card-bg);
       border-radius: 16px;
       max-width: calc(100% / 3 - 24px * 2 / 3);
 
@@ -796,7 +796,7 @@ body:has(.page-home) {
             font-weight: 500;
             font-size: 16px;
             line-height: 1.5;
-            color: var(--color-dark);
+            color: var(--text-primary);
           }
 
           .author-tag {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -178,8 +178,31 @@ theme:
   name: 'material'
   custom_dir: docs-overrides
   palette:
-    primary: 'deep orange'
-    accent: 'green'
+    # Palette toggle for automatic mode
+    - media: '(prefers-color-scheme)'
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+      primary: 'deep orange'
+      accent: 'green'
+
+    # Palette toggle for light mode
+    - media: '(prefers-color-scheme: light)'
+      scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+      primary: 'deep orange'
+      accent: 'green'
+
+    # Palette toggle for dark mode
+    - media: '(prefers-color-scheme: dark)'
+      scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to system preference
+      primary: 'deep orange'
+      accent: 'green'
   favicon: image/sedona_logo_symbol.png
   logo: image/logo.svg
   icon:


### PR DESCRIPTION
Implements Material theme palette toggle with three modes:

Automatic mode (follows system preference)
Light mode (default scheme)
Dark mode (slate scheme)
Users can now toggle between themes using the icon in the header. All modes preserve the existing deep orange primary and green accent colors.

Closes #2444