### PR TITLE
[CI] Use pre-commit run `--color=always`

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -48,6 +48,6 @@ jobs:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Run pre-commit
-        run: pre-commit run --all-files
+        run: pre-commit run --color=always --all-files
       - name: Run manual pre-commit hooks
-        run: pre-commit run --all-files --hook-stage manual
+        run: pre-commit run --color=always --all-files --hook-stage manual


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

Marks up with color the `pass / fail / skipped` hook run statuses.

Makes it slightly easier to see what is happening with each hook similar to a local machine run.

## How was this patch tested?

With pre-commit locally. But this PR just targets GitHub Actions.

refs https://github.com/apache/cloudstack/pull/11977

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
