### PR TITLE
Fix/javadoc package list error

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-site_name: Apache Sedona&trade;
+site_name: Apache Sedona
 site_url: https://sedona.apache.org
-site_description: Apache Sedona&trade; is a cluster computing system for processing large-scale spatial data. Sedona extends existing cluster computing systems, such as Apache Spark, Apache Flink, and Snowflake, with a set of out-of-the-box distributed Spatial Datasets and Spatial SQL that efficiently load, process, and analyze large-scale spatial data across machines.
+site_description: Apache Sedona is a cluster computing system for processing large-scale spatial data. Sedona extends existing cluster computing systems, such as Apache Spark, Apache Flink, and Snowflake, with a set of out-of-the-box distributed Spatial Datasets and Spatial SQL that efficiently load, process, and analyze large-scale spatial data across machines.
 nav:
   - Home: index.md
   - Setup:
@@ -36,6 +36,7 @@ nav:
           - Install Sedona Scala/Java: setup/install-scala.md
           - Install Sedona Python: setup/install-python.md
           - Install Sedona R: api/rdocs
+          - Sedona Python: api/pydocs
           - Install Sedona-Zeppelin: setup/zeppelin.md
           - Play Sedona in Docker: setup/docker.md
           - Install on Wherobots: setup/wherobots.md
@@ -51,13 +52,13 @@ nav:
       - Install with Snowflake:
           - Install Sedona SQL: setup/snowflake/install.md
       - Release notes: setup/release-notes.md
-      - Compile the code: setup/compile.md
   - Download: download.md
   - Programming Guides:
       - Sedona with Apache Spark:
-          - Spatial SQL app: tutorial/sql.md
-          - Raster SQL app: tutorial/raster.md
+          - Spatial DataFrame / SQL app: tutorial/sql.md
+          - Raster DataFrame / SQL app: tutorial/raster.md
           - Pure SQL environment: tutorial/sql-pure-sql.md
+          - GeoPandas API on Sedona: tutorial/geopandas-api.md
           - Spatial RDD app: tutorial/rdd.md
           - Sedona R: api/rdocs
           - Work with GeoPandas and Shapely: tutorial/geopandas-shapely.md
@@ -93,10 +94,16 @@ nav:
           - SQL:
               - Quick start: api/sql/Overview.md
               - Vector data:
-                  - Constructor: api/sql/Constructor.md
-                  - Function: api/sql/Function.md
-                  - Predicate: api/sql/Predicate.md
-                  - Aggregate function: api/sql/AggregateFunction.md
+                  - Geometry type:
+                      - Constructor: api/sql/Constructor.md
+                      - Function: api/sql/Function.md
+                      - Predicate: api/sql/Predicate.md
+                      - Aggregate function: api/sql/AggregateFunction.md
+                  - Geography type:
+                      - Constructor: api/sql/geography/Constructor.md
+                      - Function: api/sql/geography/Function.md
+                      - Predicate: api/sql/geography/Predicate.md
+                      - Aggregate function: api/sql/geography/AggregateFunction.md
                   - DataFrame Style functions: api/sql/DataFrameAPI.md
                   - Query optimization: api/sql/Optimizer.md
                   - Nearest-Neighbour searching: api/sql/NearestNeighbourSearching.md
@@ -122,6 +129,7 @@ nav:
               - DataFrame/SQL: api/viz/sql.md
               - RDD: api/viz/java-api.md
           - Sedona R: api/rdocs
+          - Sedona Python: api/pydocs
       - Sedona with Apache Flink:
           - SQL:
               - Overview (Flink): api/flink/Overview.md
@@ -136,12 +144,16 @@ nav:
               - Function (Snowflake): api/snowflake/vector-data/Function.md
               - Aggregate Function (Snowflake): api/snowflake/vector-data/AggregateFunction.md
               - Predicate (Snowflake): api/snowflake/vector-data/Predicate.md
+  - SedonaDB: 'https://sedona.apache.org/sedonadb/'
+  - SpatialBench: 'https://sedona.apache.org/spatialbench/'
   - Blog: blog/index.md
   - Community:
+      - Compile the code: setup/compile.md
       - Community: community/contact.md
       - Contributor Guide:
           - Rules: community/rule.md
           - Develop: community/develop.md
+          - Contribute to Geopandas API on Sedona: community/geopandas.md
       - Committer Guide:
           - Project Management Committee: community/contributor.md
           - Become a release manager: community/release-manager.md
@@ -169,11 +181,12 @@ theme:
     primary: 'deep orange'
     accent: 'green'
   favicon: image/sedona_logo_symbol.png
-  logo: image/sedona_logo_symbol_white.svg
+  logo: image/logo.svg
   icon:
     logo: fontawesome/solid/earth-americas
     repo: fontawesome/brands/github
   features:
+    - announce.dismiss
     - content.code.copy
     - content.action.edit
     - search.highlight
@@ -181,6 +194,7 @@ theme:
     - search.suggest
     - navigation.footer
     - navigation.instant
+    - navigation.instant.prefetch
     - navigation.tabs
     - navigation.tabs.sticky
     - navigation.top
@@ -190,21 +204,21 @@ extra:
     default:
       - latest
   social:
-    - icon: fontawesome/brands/github-alt
+    - icon: fontawesome/brands/github
       link: 'https://github.com/apache/sedona'
     - icon: fontawesome/brands/twitter
       link: 'https://twitter.com/ApacheSedona'
     - icon: fontawesome/brands/discord
       link: 'https://discord.gg/9A3k5dEBsY'
   sedona:
-    current_version: 1.7.2
-    current_geotools: 1.7.2-28.5
+    current_version: 1.8.0
+    current_geotools: 1.8.0-33.1
   sedona_create_release:
-    current_version: 1.7.1
-    current_git_tag: sedona-1.7.1-rc1
-    current_rc: 1.7.1-rc1
-    current_snapshot: 1.8.0-SNAPSHOT
-    next_version: 1.8.0
+    current_version: 1.8.0
+    current_git_tag: sedona-1.8.0-rc1
+    current_rc: 1.8.0-rc1
+    current_snapshot: 1.8.1-SNAPSHOT
+    next_version: 1.8.1
 copyright: Copyright © 2025 The Apache Software Foundation. Apache Sedona, Sedona, Apache, the Apache feather logo, and the Apache Sedona project logo are either registered trademarks or trademarks of The Apache Software Foundation in the United States and other countries. All other marks mentioned may be trademarks or registered trademarks of their respective owners. Please visit <a href="https://www.apache.org/">Apache Software Foundation</a> for more details.<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=f3e121f6-c909-4592-8be6-5bd345768cba" /><img referrerpolicy="no-referrer-when-downgrade" src="https://analytics.apache.org/matomo.php?idsite=74&rec=1" />
 
 markdown_extensions:
@@ -253,3 +267,7 @@ plugins:
       type: datetime
   - mike:
       canonical_version: 'latest'
+extra_css:
+  - assets/stylesheets/extra.min.css
+extra_javascript:
+  - assets/javascripts/main.min.js


### PR DESCRIPTION
Did you read the Contributor Guide?
Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)
No, I haven't read it.
Is this PR related to a ticket?
Yes, and the PR name follows the format [GH-1893] Fix JavaDoc package-list error in docs build workflow. Closes #1893
No:
this is a documentation update. The PR name follows the format [DOCS] my subject
this is a CI update. The PR name follows the format [CI] my subject
What changes were proposed in this PR?
This PR fixes the JavaDoc build error reported in issue #1893, where the build failed with Error fetching link: .../common/target/target/apidocs/package-list.

The issue was caused by the spark/common module trying to link to the common module's JavaDoc, but the common module's JavaDoc was not being copied to the documentation directory in the GitHub Actions workflow.

This patch updates the .github/workflows/docs.yml file to explicitly copy the common module's generated JavaDoc to docs/api/javadoc/common/. This ensures the package-list file exists at the expected location for linking.

How was this patch tested?
Verified the workflow syntax and path logic.
Ran mvn -q clean install -DskipTests locally to ensure the build process works.
The CI build for this PR will serve as the final verification.
Did this PR include necessary documentation updates?
Yes, I am adding a new API. I am using the [current SNAPSHOT version number](https://github.com/apache/sedona/blob/99239524f17389fc4ae9548ea88756f8ea538bb9/pom.xml#L29) in vX.Y.Z format.
Yes, I have updated the documentation.
No, this PR does not affect any public API so no need to change the documentation.