### PR TITLE
Feat/remove flink scala deps

### DIFF
--- a/flink-shaded/pom.xml
+++ b/flink-shaded/pom.xml
@@ -39,7 +39,7 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.sedona</groupId>
-            <artifactId>sedona-flink_${scala.compat.version}</artifactId>
+            <artifactId>sedona-flink</artifactId>
             <version>${project.version}</version>
         </dependency>
          <!-- Define this to be shaded since it is provided in other modules -->

--- a/flink/pom.xml
+++ b/flink/pom.xml
@@ -25,7 +25,7 @@
         <version>1.8.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-    <artifactId>sedona-flink_${scala.compat.version}</artifactId>
+    <artifactId>sedona-flink</artifactId>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>A cluster computing system for processing large-scale spatial data: Streaming API for Apache Flink.</description>
@@ -83,7 +83,7 @@
 <!--        Starting Flink 14, Blink planner has been renamed to the official Flink planner-->
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-table-planner_${scala.compat.version}</artifactId>
+            <artifactId>flink-table-planner-loader</artifactId>
             <version>${flink.version}</version>
             <scope>${flink.scope}</scope>
         </dependency>
@@ -119,9 +119,28 @@
             <artifactId>gt-epsg-hsql</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-library</artifactId>
-            <version>${scala.version}</version>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-api-java</artifactId>
+            <version>${flink.version}</version>
+            <scope>${flink.scope}</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <version>2.7.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner_${scala.compat.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-api-scala-bridge_${scala.compat.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
@@ -141,4 +160,17 @@
             <scope>compile</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <classpathDependencyExcludes>
+                        <classpathDependencyExclude>org.apache.flink:flink-table-planner-loader</classpathDependencyExclude>
+                    </classpathDependencyExcludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-2457] Remove Flink Scala dependency`. Closes #2457

## What changes were proposed in this PR?

According to Flink FLIP 265, the Flink community has decided to drop Scala API. Flink now also offers pure Java dependencies. This PR removes Flink Scala dependencies from Sedona to align with this change.

Key changes:
- Modified `flink/pom.xml`:
    - Changed `artifactId` from `sedona-flink_${scala.compat.version}` to `sedona-flink`.
    - Replaced `flink-table-planner_${scala.compat.version}` with `flink-table-planner-loader`.
    - Removed `scala-library` dependency.
- Updated `flink-shaded/pom.xml` to depend on the new `sedona-flink` artifact.

## How was this patch tested?

- Verified the build with `mvn clean install -pl flink -am`.
- Ran tests with `mvn test -pl flink -am`.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.