### PR TITLE
[CI] Rename label so we can remove duplicate from GitHub

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -30,7 +30,7 @@ docs:
               - docs-overrides/**/*
               - README.md
 
-github-actions:
+github_actions:
   - any:
       - changed-files:
           - any-glob-to-any-file:


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

After this PR is merged we can delete the unneeded label from this page:

https://github.com/apache/sedona/labels

This PR closes #2473 

So now our pull request labeler bot will use the same label that dependabot uses. 

Minor improvement.

## How was this patch tested?

This is a CI update we will see what happens

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
