### PR TITLE
gitignore both `uv.lock` and `.venv` in root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 /.project
 /.scala-build
 /.settings/
+/.venv/
 /.vscode/
 /bin/
 /conf/
@@ -51,3 +52,5 @@ target
 
 # Ignore node_modules in docs-overrides
 docs-overrides/node_modules/
+
+uv.lock


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No

## What changes were proposed in this PR?

Ignoring generated files for now

## How was this patch tested?

When you run `make docsinstall` for the first time it generates both the `.venv` directory and the `uv.lock` file in the repository root. 

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
