### PR TITLE
[DOCS] Standardize and indent XML files with spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -28,5 +28,8 @@ charset = utf-8
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.xml]
+indent_style = space
+
 [Makefile]
 indent_style = tab

--- a/examples/java-spark-sql/pom.xml
+++ b/examples/java-spark-sql/pom.xml
@@ -18,16 +18,16 @@
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-	<groupId>org.apache.sedona</groupId>
-	<artifactId>sedona-java-spark-example</artifactId>
-	<version>1.8.0</version>
-	<name>Sedona : Examples : Java Spark SQL</name>
-	<description>Example project for Apache Sedona with Java and Spark.</description>
+    <groupId>org.apache.sedona</groupId>
+    <artifactId>sedona-java-spark-example</artifactId>
+    <version>1.8.0</version>
+    <name>Sedona : Examples : Java Spark SQL</name>
+    <description>Example project for Apache Sedona with Java and Spark.</description>
 
-	<properties>
+    <properties>
         <!-- Set spark.scope to "compile" to be able to run locally with java -jar shaded.jar -->
         <spark.scope>provided</spark.scope>
         <javax.scope>test</javax.scope>
@@ -57,13 +57,13 @@
             --add-opens=java.base/sun.util.calendar=ALL-UNNAMED
             -Djdk.reflect.useDirectMethodHandle=false
         </extraJavaArgs>
-	</properties>
+    </properties>
 
-	<dependencies>
+    <dependencies>
         <dependency>
-	        <groupId>org.datasyslab</groupId>
-	        <artifactId>geotools-wrapper</artifactId>
-	        <version>${geotools.version}</version>
+            <groupId>org.datasyslab</groupId>
+            <artifactId>geotools-wrapper</artifactId>
+            <version>${geotools.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.sedona</groupId>
@@ -94,9 +94,9 @@
             <scope>test</scope>
         </dependency>
 
-	</dependencies>
-	<build>
-		<plugins>
+    </dependencies>
+    <build>
+        <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -179,6 +179,6 @@
                     </execution>
                 </executions>
             </plugin>
-		</plugins>
-	</build>
+        </plugins>
+    </build>
 </project>

--- a/spark/common/pom.xml
+++ b/spark/common/pom.xml
@@ -18,19 +18,19 @@
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.sedona</groupId>
         <artifactId>sedona-spark-parent-${spark.compat.version}_${scala.compat.version}</artifactId>
         <version>1.8.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-	<artifactId>sedona-spark-common-${spark.compat.version}_${scala.compat.version}</artifactId>
+    <artifactId>sedona-spark-common-${spark.compat.version}_${scala.compat.version}</artifactId>
 
-	<name>${project.groupId}:${project.artifactId}</name>
-	<description>A cluster computing system for processing large-scale spatial data: Common SQL API.</description>
+    <name>${project.groupId}:${project.artifactId}</name>
+    <description>A cluster computing system for processing large-scale spatial data: Common SQL API.</description>
     <url>http://sedona.apache.org/</url>
-	<packaging>jar</packaging>
+    <packaging>jar</packaging>
 
     <properties>
         <maven.deploy.skip>false</maven.deploy.skip>
@@ -293,7 +293,7 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-	<build>
+    <build>
         <sourceDirectory>src/main/java</sourceDirectory>
         <plugins>
             <plugin>
@@ -336,7 +336,7 @@
                 <artifactId>scalastyle-maven-plugin</artifactId>
             </plugin>
         </plugins>
-	</build>
+    </build>
     <profiles>
         <profile>
             <id>sedona-spark-4.0</id>

--- a/spark/common/src/test/resources/shapefiles/polygon/map.xml
+++ b/spark/common/src/test/resources/shapefiles/polygon/map.xml
@@ -1,5 +1,5 @@
 <test>
-	<testName>testReadToGeometryRDD</testName>
-	<fileName>map</fileName>
-	<desc>additional file</desc>
+    <testName>testReadToGeometryRDD</testName>
+    <fileName>map</fileName>
+    <desc>additional file</desc>
 </test>

--- a/spark/common/src/test/resources/shapefiles/polygon/map1.xml
+++ b/spark/common/src/test/resources/shapefiles/polygon/map1.xml
@@ -1,5 +1,5 @@
 <test>
-	<testName>testReadToGeometryRDD</testName>
-	<fileName>map1</fileName>
-	<desc>additional file</desc>
+    <testName>testReadToGeometryRDD</testName>
+    <fileName>map1</fileName>
+    <desc>additional file</desc>
 </test>

--- a/spark/spark-3.4/pom.xml
+++ b/spark/spark-3.4/pom.xml
@@ -18,19 +18,19 @@
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.sedona</groupId>
         <artifactId>sedona-spark-parent-${spark.compat.version}_${scala.compat.version}</artifactId>
         <version>1.8.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-	<artifactId>sedona-spark-3.4_${scala.compat.version}</artifactId>
+    <artifactId>sedona-spark-3.4_${scala.compat.version}</artifactId>
 
-	<name>${project.groupId}:${project.artifactId}</name>
-	<description>A cluster computing system for processing large-scale spatial data: SQL API for Spark 3.4.</description>
+    <name>${project.groupId}:${project.artifactId}</name>
+    <description>A cluster computing system for processing large-scale spatial data: SQL API for Spark 3.4.</description>
     <url>http://sedona.apache.org/</url>
-	<packaging>jar</packaging>
+    <packaging>jar</packaging>
 
     <properties>
         <maven.deploy.skip>false</maven.deploy.skip>
@@ -165,7 +165,7 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-	<build>
+    <build>
         <sourceDirectory>src/main/scala</sourceDirectory>
         <plugins>
             <plugin>
@@ -181,5 +181,5 @@
                 <artifactId>scalastyle-maven-plugin</artifactId>
             </plugin>
         </plugins>
-	</build>
+    </build>
 </project>

--- a/spark/spark-3.5/pom.xml
+++ b/spark/spark-3.5/pom.xml
@@ -18,19 +18,19 @@
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.sedona</groupId>
         <artifactId>sedona-spark-parent-${spark.compat.version}_${scala.compat.version}</artifactId>
         <version>1.8.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-	<artifactId>sedona-spark-3.5_${scala.compat.version}</artifactId>
+    <artifactId>sedona-spark-3.5_${scala.compat.version}</artifactId>
 
-	<name>${project.groupId}:${project.artifactId}</name>
-	<description>A cluster computing system for processing large-scale spatial data: SQL API for Spark 3.5.</description>
+    <name>${project.groupId}:${project.artifactId}</name>
+    <description>A cluster computing system for processing large-scale spatial data: SQL API for Spark 3.5.</description>
     <url>http://sedona.apache.org/</url>
-	<packaging>jar</packaging>
+    <packaging>jar</packaging>
 
     <properties>
         <maven.deploy.skip>false</maven.deploy.skip>
@@ -165,7 +165,7 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-	<build>
+    <build>
         <sourceDirectory>src/main/scala</sourceDirectory>
         <plugins>
             <plugin>
@@ -181,5 +181,5 @@
                 <artifactId>scalastyle-maven-plugin</artifactId>
             </plugin>
         </plugins>
-	</build>
+    </build>
 </project>

--- a/spark/spark-4.0/pom.xml
+++ b/spark/spark-4.0/pom.xml
@@ -18,19 +18,19 @@
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.sedona</groupId>
         <artifactId>sedona-spark-parent-${spark.compat.version}_${scala.compat.version}</artifactId>
         <version>1.8.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-	<artifactId>sedona-spark-4.0_${scala.compat.version}</artifactId>
+    <artifactId>sedona-spark-4.0_${scala.compat.version}</artifactId>
 
-	<name>${project.groupId}:${project.artifactId}</name>
-	<description>A cluster computing system for processing large-scale spatial data: SQL API for Spark 4.0.</description>
+    <name>${project.groupId}:${project.artifactId}</name>
+    <description>A cluster computing system for processing large-scale spatial data: SQL API for Spark 4.0.</description>
     <url>http://sedona.apache.org/</url>
-	<packaging>jar</packaging>
+    <packaging>jar</packaging>
 
     <properties>
         <maven.deploy.skip>false</maven.deploy.skip>
@@ -165,7 +165,7 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-	<build>
+    <build>
         <sourceDirectory>src/main/scala</sourceDirectory>
         <plugins>
             <plugin>
@@ -181,5 +181,5 @@
                 <artifactId>scalastyle-maven-plugin</artifactId>
             </plugin>
         </plugins>
-	</build>
+    </build>
 </project>


### PR DESCRIPTION
Add xml file type to the EditorConfig.

Clean up XML files converting tabs to spaces.

We should use one format for indents in XML.

There are less line changes when coverting the tabs to spaces

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No

## What changes were proposed in this PR?

As above

## How was this patch tested?


## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
