### PR TITLE
[CI] pre-commit clean up insert license for other files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 *                           @jiayuasu
 .editorconfig               @jbampton @jiayuasu
 .pre-commit-config.yaml     @jbampton @jiayuasu

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -222,7 +222,17 @@ repos:
       - id: insert-license
         name: add license for all other files
         description: automatically adds a licence header to all other files that don't have a license header
-        files: ^\.(editorconfig|gitattributes|prettierignore|prettierrc|shellcheckrc)$|^.*/\.gitignore$|^tools/maven/scalafmt\.conf$
+        files: |
+          (?x)^(
+            \.editorconfig|
+            \.gitattributes|
+            \.prettierignore|
+            \.prettierrc|
+            \.shellcheckrc|
+            \.github/CODEOWNERS|
+            .*/\.gitignore|
+            tools/maven/scalafmt\.conf
+          )$
         args:
           - --comment-style
           - '|#|'


### PR DESCRIPTION
Auto add missing license header to the CODEOWNERS file.

Example CODEOWNERS file:

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file

For a more readable approach use a multi-line regex with the (?x) flag and indentation.

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

As described above.

## How was this patch tested?

With pre-commit

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
