### PR TITLE
[CI] Add new pre-commit config file for docker based hooks

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -51,3 +51,5 @@ jobs:
         run: pre-commit run --color=always --all-files
       - name: Run manual pre-commit hooks
         run: pre-commit run --color=always --all-files --hook-stage manual
+      - name: Run Docker pre-commit hooks
+        run: pre-commit run --color=always --all-files --config .pre-commit-docker.yaml

--- a/.pre-commit-docker.yaml
+++ b/.pre-commit-docker.yaml
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+repos:
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.14.0
+    hooks:
+      - id: hadolint-docker
+        name: run hadolint-docker
+        description: Dockerfile linter, validate inline bash, written in Haskell


### PR DESCRIPTION
Add the hadolint-docker hook.

Run the docker pre-commit hooks with GitHub Actions

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?


## How was this patch tested?


## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
