### PR TITLE
[GH-2549] Upgrade Testcontainers to 2.0.2

### DIFF
--- a/spark/common/pom.xml
+++ b/spark/common/pom.xml
@@ -250,14 +250,14 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>minio</artifactId>
-            <version>1.20.0</version>
+            <artifactId>testcontainers-minio</artifactId>
+            <version>2.0.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>mysql</artifactId>
-            <version>1.20.0</version>
+            <artifactId>testcontainers-mysql</artifactId>
+            <version>2.0.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/spark/spark-3.4/pom.xml
+++ b/spark/spark-3.4/pom.xml
@@ -135,13 +135,13 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.20.1</version>
+            <version>2.0.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>minio</artifactId>
-            <version>1.20.0</version>
+            <artifactId>testcontainers-minio</artifactId>
+            <version>2.0.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/spark/spark-3.5/pom.xml
+++ b/spark/spark-3.5/pom.xml
@@ -135,13 +135,13 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.20.1</version>
+            <version>2.0.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>minio</artifactId>
-            <version>1.20.0</version>
+            <artifactId>testcontainers-minio</artifactId>
+            <version>2.0.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/spark/spark-4.0/pom.xml
+++ b/spark/spark-4.0/pom.xml
@@ -135,13 +135,13 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.20.1</version>
+            <version>2.0.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>minio</artifactId>
-            <version>1.20.0</version>
+            <artifactId>testcontainers-minio</artifactId>
+            <version>2.0.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)


## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2549 


## What changes were proposed in this PR?

This PR upgrades Testcontainers to 2.0.2 so that the tests using Testcontainers work with the recent version of Docker (29.0.0+).


## How was this patch tested?

I ran the following commands and ensured that all of them succeeded.

```
$ mvn clean install  -Dspark=3.4 -Dscala=2.12 -DskipTests
$ mvn scalatest:test -Dspark=3.4 -Dscala=2.12 -pl spark/common/pom.xml -Dsuites=org.apache.sedona.sql.OsmReaderTest,org.apache.sedona.sql.constructorTestScala
$ mvn scalatest:test -Dspark=3.4 -Dscala=2.12 -pl spark/spark-3.4/pom.xml -Dsuites=org.apache.sedona.sql.GeoPackageReaderTest
```

```
$ mvn clean install  -Dspark=3.5 -Dscala=2.13 -DskipTests
$ mvn scalatest:test -Dspark=3.5 -Dscala=2.13 -pl spark/common/pom.xml -Dsuites=org.apache.sedona.sql.OsmReaderTest,org.apache.sedona.sql.constructorTestScala
$ mvn scalatest:test -Dspark=3.5 -Dscala=2.13 -pl spark/spark-3.5/pom.xml -Dsuites=org.apache.sedona.sql.GeoPackageReaderTest
```

```
$ mvn clean install  -Dspark=4.0 -Dscala=2.13 -DskipTests
$ mvn scalatest:test -Dspark=4.0 -Dscala=2.13 -pl spark/common/pom.xml -Dsuites=org.apache.sedona.sql.OsmReaderTest,org.apache.sedona.sql.constructorTestScala
$ mvn scalatest:test -Dspark=4.0 -Dscala=2.13 -pl spark/spark-4.0/pom.xml -Dsuites=org.apache.sedona.sql.GeoPackageReaderTest
```

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
