### PR TITLE
[DOCS] Pin sphinx version to fix the doc build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,9 @@ docs = [
   "pymdown-extensions",
   "mike",
   "blacken-docs",
-  "sphinx",
-  "sphinx_rtd_theme",
+  # TODO: sphinx_rtd_theme only supports Sphinx < 9.0, consider migrating to a different theme or wait for sphinx_rtd_theme to support Sphinx 9+
+  # Using Sphinx 6.2.1 as it's the latest version supporting Python >= 3.8 (Sphinx 7+ requires Python >= 3.9, Sphinx 8+ requires Python >= 3.11)
+  "sphinx==6.2.1",
+  "sphinx_rtd_theme==3.0.2",
   "sphinx-autobuild",
 ]


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)


## Is this PR related to a ticket?


- No:
  - this is a documentation update. The PR name follows the format `[DOCS] my subject`

## What changes were proposed in this PR?

This pull request updates the documentation dependencies in `pyproject.toml` to address compatibility issues with Sphinx 9+. The main change is pinning both `sphinx` and `sphinx_rtd_theme` to specific versions that are compatible with each other, along with a TODO note about future migration.

## How was this patch tested?


## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
