### PR TITLE
[GH-2565] Fix NULL handling for various aggregation functions in SedonaSpark

### DIFF
--- a/spark/common/src/test/scala/org/apache/sedona/sql/aggregateFunctionTestScala.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/aggregateFunctionTestScala.scala
@@ -372,6 +372,28 @@ class aggregateFunctionTestScala extends TestBaseScala {
 
       assert(result == null)
     }
+
+    it(
+      "ST_Envelope_Aggr should return empty geometry if inputs are mixed with null and empty geometries") {
+      sparkSession
+        .sql("""
+          |SELECT explode(array(
+          |  NULL,
+          |  NULL,
+          |  ST_GeomFromWKT('POINT EMPTY'),
+          |  NULL,
+          |  ST_GeomFromWKT('POLYGON EMPTY')
+          |)) AS geom
+        """.stripMargin)
+        .createOrReplaceTempView("mixed_null_empty_envelope")
+
+      val envelopeDF =
+        sparkSession.sql("SELECT ST_Envelope_Aggr(geom) FROM mixed_null_empty_envelope")
+      val result = envelopeDF.take(1)(0).get(0)
+
+      assert(result != null)
+      assert(result.asInstanceOf[Geometry].isEmpty)
+    }
   }
 
   def generateRandomPolygon(index: Int): String = {


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-2565] my subject`. Closes #2565

## What changes were proposed in this PR?

This PR refactors several spatial aggregate functions to fix `NULL` handling. Impacted functions are

* **ST_Envelope_Aggr**: fixed null handling, simplified the implementation by switching to lightweight intermediate data structure
* **ST_Union_Aggr**: fixed null handling
* **ST_Intersection_Aggr**: fixed null handling
* **ST_Collect_Agg**: return null instead of empty geometry collection when all the inputs are null. This is theoretically a breaking change, but it is a niche case so hopefully it won't impact many users.

## How was this patch tested?

Added new tests and tested locally using a standalone cluster to make sure that we are not damaging the serde in distributed environment.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
