### PR TITLE
[GH-2566] Temporarily set pyspark < 4.1.0

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -37,13 +37,13 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-spark = ["pyspark>=3.4.0"]
+spark = ["pyspark>=3.4.0,<4.1.0"]
 pydeck-map = ["geopandas", "pydeck==0.8.0"]
 kepler-map = ["geopandas", "keplergl==0.3.2"]
 flink = ["apache-flink>=1.19.0"]
 db = ["sedonadb[geopandas]; python_version >= '3.9'"]
 all = [
-  "pyspark>=3.4.0",
+  "pyspark>=3.4.0,<4.1.0",
   "geopandas",
   "pydeck==0.8.0",
   "keplergl==0.3.2",
@@ -70,7 +70,7 @@ dev = [
   # cannot set geopandas>=0.14.4 since it doesn't support python 3.8, so we pin fiona to <1.10.0
   "fiona<1.10.0",
   "pyarrow",
-  "pyspark>=3.4.0",
+  "pyspark>=3.4.0,<4.1.0",
   "keplergl==0.3.2",
   "pydeck==0.8.0",
   "pystac==1.5.0",


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-2566] my subject`. Closes #2566 

## What changes were proposed in this PR?

This pull request updates the version constraints for the `pyspark` dependency in the `python/pyproject.toml` file to prevent compatibility issues with future `pyspark` releases. The new constraint ensures that only versions from 3.4.0 up to, but not including, 4.1.0 are allowed.

## How was this patch tested?


## Did this PR include necessary documentation updates?

- Yes, I am adding a new API. I am using the [current SNAPSHOT version number](https://github.com/apache/sedona/blob/99239524f17389fc4ae9548ea88756f8ea538bb9/pom.xml#L29) in `vX.Y.Z` format.
- Yes, I have updated the documentation.
- No, this PR does not affect any public API so no need to change the documentation.
