### PR TITLE
docs: Add doc example of specifying broadcast hint in SQL

### DIFF
--- a/docs/api/sql/Optimizer.md
+++ b/docs/api/sql/Optimizer.md
@@ -211,6 +211,17 @@ The supported join type - broadcast side combinations are:
 pointDf.alias("pointDf").join(broadcast(polygonDf).alias("polygonDf"), expr("ST_Contains(polygonDf.polygonshape, pointDf.pointshape)"))
 ```
 
+To specify a broadcast hint in SQL, use the following syntax:
+
+```sql
+SELECT /*+ BROADCAST(polygonDf) */
+  pointDf.*,
+  polygonDf.*
+FROM pointDf
+JOIN polygonDf
+  ON ST_Contains(polygonDf.polygonshape, pointDf.pointshape);
+```
+
 Spark SQL Physical plan:
 
 ```


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2571

## What changes were proposed in this PR?
The docs only included an example of using a broadcast hint through spark dataframe syntax, and it was missing an example for how to do the same in SQL. It doesn't seem there are *any* examples of using a hint in SQL, so I think it's worth adding.

## How was this patch tested?
N/A

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.
