### PR TITLE
[CI] Add pre-commit hook `pip-audit`

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,9 +48,7 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
-
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+          build-mode: none
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -278,6 +278,7 @@ repos:
       - id: pip-audit
         name: run pip-audit
         description: audits Python environments, requirements files and dependency trees for known security vulnerabilities, and can automatically fix them
+        args: ['.']
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v21.1.7
     hooks:


### PR DESCRIPTION
https://github.com/pypa/pip-audit

"Audits Python environments, requirements files and dependency trees for known security vulnerabilities, and can automatically fix them"

https://github.com/pypa/pip-audit?tab=readme-ov-file#pre-commit-support

Also used on the Apache Trusted Tooling Release repo:

https://github.com/apache/tooling-trusted-releases/blob/23b3bc5adce730835e0b7d218e14d7e90db13e0e/.pre-commit-config.yaml#L100

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

As described above added another check / test to our pre-commit framework.

In the examples it says it works with `pyproject.toml` files:

https://github.com/pypa/pip-audit?tab=readme-ov-file#examples

## How was this patch tested?

With pre-commit

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
