### PR TITLE
[CI] Dependabot: add a cooldown period for new releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,8 @@ updates:
       github-dependencies:
         patterns:
           - '*'
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: pip
     directory: /docker
@@ -36,3 +38,5 @@ updates:
       github-dependencies:
         patterns:
           - '*'
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Enforces security best practices by requiring a minimum age for new dependency releases before they are automatically updated by Dependabot. 

This practice, known as a "cooldown period," helps mitigate supply chain attacks by allowing time for frequently published malicious packages to be identified.

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

Described above

## How was this patch tested?


## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
