### PR TITLE
[CI] prettier: `set pass_filenames: false` to avoid multiple passes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,7 @@ repos:
         files: \.(js|ya?ml)$
         language: node
         additional_dependencies: ['prettier@3.7.4']
+        pass_filenames: false
       - id: maven-spotless-apply
         name: maven spotless apply
         description: automatically formats Java and Scala code using mvn spotless:apply.


### PR DESCRIPTION
This PR speeds up the prettier hook and avoids multiple passes through the targetted files.

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?


## How was this patch tested?

With pre-commit and manually edited some files.

From Google:

### When to use pass_filenames: false

Directory-based linters/tools: Some tools, especially in languages like Go or Terraform, perform analysis based on the entire directory context. Passing individual files can lead to false positives (e.g., "unused symbol" errors).

Tools that manage their own file discovery: If your hook's entry command (e.g., a Makefile target or a specific CLI tool) already finds the required files to check, you should set pass_filenames: false to avoid passing extra command-line arguments that the tool might not handle correctly.

Performance: For large codebases, running a tool on the whole project (pass_filenames: false) might be slow. The default pass_filenames: true behavior is often recommended for faster local checks, as it only runs on the changed files.

Hooks that use always_run: true: When a hook is set to run regardless of which files have changed, you often also set pass_filenames: false so that the command runs once on the entire project as intended."

---

So the prettier hook uses an entry command that finds its own files:

https://github.com/apache/sedona/blob/6ed356368432abb0c65e8d8e683cd32390c5580c/.pre-commit-config.yaml#L46

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
