### PR TITLE
[GH-2586] Use persist-credentials true for docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true # zizmor: ignore[credential-persistence]
       - name: Set up Java
         uses: actions/setup-java@v5
         with:


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2586 

## What changes were proposed in this PR?

Docs build needs git credentials to publish

## How was this patch tested?

With zizmor and pre-commit.  Read the broken build log. 

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
