### PR TITLE
[GH-2590] Upgrade campskeleton

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -380,7 +380,7 @@
             <dependency>
                 <groupId>org.datasyslab</groupId>
                 <artifactId>campskeleton</artifactId>
-                <version>0.0.2-20251014</version>
+                <version>0.0.2-20260118</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2590 

## What changes were proposed in this PR?

This pull request makes a minor update to the `pom.xml` file, upgrading the version of the `campskeleton` dependency to ensure compatibility with the latest release.

### Workaround for Sedona 1.8.1 Users

Override the campskeleton version to use the fixed release:

```
<dependencyManagement>
    <dependencies>
        <dependency>
            <groupId>org.datasyslab</groupId>
            <artifactId>campskeleton</artifactId>
            <version>0.0.2-20260118</version>
        </dependency>
    </dependencies>
</dependencyManagement>
```

## How was this patch tested?


## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
