### PR TITLE
[CI] Fix the failed CI build extension

### DIFF
--- a/.github/workflows/python-extension.yml
+++ b/.github/workflows/python-extension.yml
@@ -66,6 +66,8 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          version: '0.9.22'
       - name: Install dependencies (dev)
         run: |
           uv sync

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -56,8 +56,6 @@ dev = [
   "pytest-cov",
   "notebook==6.4.12",
   "jupyter",
-  # pywinpty 2.0.14 dropped Python 3.8 wheels; pin to avoid build failures on Windows
-  "pywinpty<2.0.14; sys_platform == 'win32' and python_version < '3.9'",
   "mkdocs",
   "scikit-learn",
   "esda",


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

This pull request makes a minor update to the Python extension workflow by specifying the version of the `uv` tool to ensure consistent dependency management.

The uv version was changed from 0.9.22 to 0.9.26. The newer version of uv has stricter pyproject.toml validation and now fails on the invalid pyproject.toml in pywinpty==2.0.14.

## How was this patch tested?

Passed CI

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
