### PR TITLE
[GH-2589] bump graphframes to 0.10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <spark.compat.version>3.4</spark.compat.version>
         <spark.major.version>3</spark.major.version>
         <log4j.version>2.25.3</log4j.version>
-        <graphframes.version>0.10.0</graphframes.version>
+        <graphframes.version>0.10.1</graphframes.version>
         <flink.version>1.19.0</flink.version>
         <slf4j.version>1.7.36</slf4j.version>
         <googles2.version>20250620-rc1</googles2.version>


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2589


## What changes were proposed in this PR?
Bump to graphframes version 0.10.1 to resolve performance issues with connected components

## How was this patch tested?
CI: unit tests/ builds

## Did this PR include necessary documentation updates?
- No, this PR does not affect any public API so no need to change the documentation.
