### PR TITLE
[CI] Fix python tests workflow by preventing Pandas 3.0 from being used

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -63,7 +63,7 @@ dev = [
   "matplotlib",  # implicit dependency of esda
   # prevent incompatibility with pysal 4.7.0, which is what is resolved to when shapely >2 is specified
   "scipy<=1.10.0",
-  "pandas>=2.0.0",
+  "pandas>=2.0.0,<3.0.0",
   "numpy<2",
   "geopandas",
   # https://stackoverflow.com/questions/78949093/how-to-resolve-attributeerror-module-fiona-has-no-attribute-path


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

Setting an upper limit for Pandas version to prevent Pandas 3.0 from being used, otherwise it will cause compatibility issue with PySpark. See https://github.com/apache/sedona/actions/runs/21231898899/job/61094414269

## How was this patch tested?

Passing tests

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
