### PR TITLE
[GH-2559] Add CITATION.cff file for proper software citation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 type: software
 title: "Apache Sedona"
-version: 1.8.1-SNAPSHOT
+version: 1.8.1
 url: "https://sedona.apache.org/"
 repository-code: "https://github.com/apache/sedona"
 license: Apache-2.0


### PR DESCRIPTION
Add CITATION.cff file to enable GitHub's 'Cite this repository' feature with proper software metadata and preferred citation to the Geoinformatica 2019 paper.

Fixes #2559

## Did you read the Contributor Guide?

- [x] Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- [x] Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2559

## What changes were proposed in this PR?

Added [CITATION.cff](cci:7://file:///Users/subhamsangwan/sedona/CITATION.cff:0:0-0:0) file with:
- Software metadata (v1.8.0, Apache 2.0 license, URLs, description)
- Preferred citation pointing to "Spatial Data Management in Apache Spark: The GeoSpark Perspective and Beyond" (DOI: 10.1007/s10707-018-0330-9)
- Key authors with ORCID identifiers
- Follows CFF v1.2.0 specification

This enables GitHub's automatic citation feature and provides standardized citation formats.

## How was this patch tested?

Validated against CFF v1.2.0 specification and verified metadata accuracy from [pom.xml](cci:7://file:///Users/subhamsangwan/sedona/pom.xml:0:0-0:0), [R/DESCRIPTION](cci:7://file:///Users/subhamsangwan/sedona/R/DESCRIPTION:0:0-0:0), and [docs/community/publication.md](cci:7://file:///Users/subhamsangwan/sedona/docs/community/publication.md:0:0-0:0).

## Did this PR include necessary documentation updates?

- [x] No, this PR does not affect any public API so no need to change the documentation.