### PR TITLE
[GH-2390] GeometryType: add regression test for EMPTY geometries

### DIFF
--- a/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
@@ -3953,6 +3953,28 @@ public class FunctionsTest extends TestBase {
   }
 
   @Test
+  public void geometryTypeWithMeasuredEmpty() {
+    // Regression test for GH-2390: GeometryType fails on all EMPTY geometries
+    assertEquals("POINT", Functions.geometryTypeWithMeasured(GEOMETRY_FACTORY.createEmpty(0)));
+    assertEquals(
+        "LINESTRING", Functions.geometryTypeWithMeasured(GEOMETRY_FACTORY.createLineString()));
+    assertEquals(
+        "POLYGON",
+        Functions.geometryTypeWithMeasured(
+            GEOMETRY_FACTORY.createPolygon(GEOMETRY_FACTORY.createLinearRing())));
+    assertEquals(
+        "MULTIPOINT", Functions.geometryTypeWithMeasured(GEOMETRY_FACTORY.createMultiPoint()));
+    assertEquals(
+        "MULTILINESTRING",
+        Functions.geometryTypeWithMeasured(GEOMETRY_FACTORY.createMultiLineString()));
+    assertEquals(
+        "MULTIPOLYGON", Functions.geometryTypeWithMeasured(GEOMETRY_FACTORY.createMultiPolygon()));
+    assertEquals(
+        "GEOMETRYCOLLECTION",
+        Functions.geometryTypeWithMeasured(GEOMETRY_FACTORY.createGeometryCollection()));
+  }
+
+  @Test
   public void closestPoint() {
     Point point1 = GEOMETRY_FACTORY.createPoint(new Coordinate(1, 1));
     LineString lineString1 =


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2390

## What changes were proposed in this PR?

The NPE was already fixed incidentally in PR #2380 (null check in isMeasuredGeometry). This commit adds explicit test coverage for all seven empty geometry types to prevent regression.

## How was this patch tested?

Added new test cases

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
