### PR TITLE
[GH-2403] SetSRID handle empty geometry types

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/Functions.java
+++ b/common/src/main/java/org/apache/sedona/common/Functions.java
@@ -923,7 +923,12 @@ public class Functions {
             geometry.getPrecisionModel(),
             srid,
             geometry.getFactory().getCoordinateSequenceFactory());
-    return factory.createGeometry(geometry);
+    Geometry newGeom = factory.createGeometry(geometry);
+    // Workaround for JTS bug: GeometryEditor.editPolygon returns the original
+    // empty polygon without copying it to the new factory, so the SRID is not
+    // updated for POLYGON EMPTY (and similar empty geometry types).
+    newGeom.setSRID(srid);
+    return newGeom;
   }
 
   public static int getSRID(Geometry geometry) {

--- a/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
@@ -4015,6 +4015,26 @@ public class FunctionsTest extends TestBase {
   }
 
   @Test
+  public void setSRIDEmptyGeometries() throws ParseException {
+    // Regression test for GH-2403: SetSRID doesn't work on POLYGON EMPTY
+    String[] emptyWkts = {
+      "POINT EMPTY",
+      "LINESTRING EMPTY",
+      "POLYGON EMPTY",
+      "MULTIPOINT EMPTY",
+      "MULTILINESTRING EMPTY",
+      "MULTIPOLYGON EMPTY",
+      "GEOMETRYCOLLECTION EMPTY"
+    };
+    for (String wkt : emptyWkts) {
+      Geometry geom = Constructors.geomFromWKT(wkt, 0);
+      Geometry result = Functions.setSRID(geom, 4236);
+      assertEquals("SRID should be set for " + wkt, 4236, result.getSRID());
+      assertTrue("Result should be empty for " + wkt, result.isEmpty());
+    }
+  }
+
+  @Test
   public void closestPoint() {
     Point point1 = GEOMETRY_FACTORY.createPoint(new Coordinate(1, 1));
     LineString lineString1 =


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2403

## What changes were proposed in this PR?

JTS 1.20.0 GeometryEditor.editPolygon() returns the original empty polygon without copying it to the new GeometryFactory, so the SRID is not updated. Work around this by explicitly calling setSRID() after createGeometry().

## How was this patch tested?

Added one more test case to cover

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
