### PR TITLE
[GH-2408] RS_ZonalStats: fix incorrect 4-arg function signature

### DIFF
--- a/docs/api/sql/Raster-operators.md
+++ b/docs/api/sql/Raster-operators.md
@@ -1200,7 +1200,7 @@ RS_ZonalStats(raster: Raster, zone: Geometry, band: Integer, statType: String, a
 ```
 
 ```
-RS_ZonalStats(raster: Raster, zone: Geometry, statType: String, allTouched: Boolean)
+RS_ZonalStats(raster: Raster, zone: Geometry, band: Integer, statType: String)
 ```
 
 ```


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

Fixes #2408

## What changes were proposed in this PR?

The docs listed a non-existent signature:
  RS_ZonalStats(raster, zone, statType, allTouched)

The actual 4-arg signature (matching the Java code) is:
  RS_ZonalStats(raster, zone, band, statType)

## How was this patch tested?


## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.
