### PR TITLE
[GH-1979] Fix ST_Envelope and ST_Envelope_Aggr empty geometry handling

### DIFF
--- a/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
@@ -809,6 +809,25 @@ public class FunctionsTest extends TestBase {
   }
 
   @Test
+  public void envelopeEmptyGeometry() throws ParseException {
+    // ST_Envelope of EMPTY should return same-type EMPTY (matching PostGIS behavior)
+    Geometry emptyLineString = Constructors.geomFromWKT("LINESTRING EMPTY", 0);
+    Geometry result = Functions.envelope(emptyLineString);
+    assertTrue(result.isEmpty());
+    assertEquals("LineString", result.getGeometryType());
+
+    Geometry emptyPolygon = Constructors.geomFromWKT("POLYGON EMPTY", 0);
+    result = Functions.envelope(emptyPolygon);
+    assertTrue(result.isEmpty());
+    assertEquals("Polygon", result.getGeometryType());
+
+    Geometry emptyPoint = Constructors.geomFromWKT("POINT EMPTY", 0);
+    result = Functions.envelope(emptyPoint);
+    assertTrue(result.isEmpty());
+    assertEquals("Point", result.getGeometryType());
+  }
+
+  @Test
   public void envelopeAndCentroidSRID() throws ParseException {
     Geometry geom = Constructors.geomFromWKT("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))", 3857);
     Geometry envelope = Functions.envelope(geom);

--- a/docs/api/flink/Aggregator.md
+++ b/docs/api/flink/Aggregator.md
@@ -19,7 +19,7 @@
 
 ## ST_Envelope_Agg
 
-Introduction: Return the entire envelope boundary of all geometries in A
+Introduction: Return the entire envelope boundary of all geometries in A. Empty geometries and null values are skipped. If all inputs are empty or null, the result is null. This behavior is consistent with PostGIS's `ST_Extent`.
 
 Format: `ST_Envelope_Agg (A: geometryColumn)`
 

--- a/docs/api/snowflake/vector-data/AggregateFunction.md
+++ b/docs/api/snowflake/vector-data/AggregateFunction.md
@@ -22,7 +22,7 @@
 
 ## ST_Envelope_Agg
 
-Introduction: Return the entire envelope boundary of all geometries in A
+Introduction: Return the entire envelope boundary of all geometries in A. Empty geometries and null values are skipped. If all inputs are empty or null, the result is null. This behavior is consistent with PostGIS's `ST_Extent`.
 
 Format: `ST_Envelope_Agg (A:geometryColumn)`
 

--- a/docs/api/sql/AggregateFunction.md
+++ b/docs/api/sql/AggregateFunction.md
@@ -51,7 +51,7 @@ SELECT category, ST_Collect_Agg(geom) FROM geometries GROUP BY category
 
 ## ST_Envelope_Agg
 
-Introduction: Return the entire envelope boundary of all geometries in A
+Introduction: Return the entire envelope boundary of all geometries in A. Empty geometries and null values are skipped. If all inputs are empty or null, the result is null. This behavior is consistent with PostGIS's `ST_Extent`.
 
 Format: `ST_Envelope_Agg (A: geometryColumn)`
 

--- a/flink/src/main/java/org/apache/sedona/flink/expressions/Aggregators.java
+++ b/flink/src/main/java/org/apache/sedona/flink/expressions/Aggregators.java
@@ -56,6 +56,7 @@ public class Aggregators {
         rawSerializer = GeometryTypeSerializer.class,
         bridgedTo = Geometry.class)
     public Geometry getValue(Accumulators.Envelope acc) {
+      if (acc.minX > acc.maxX) return null;
       return createPolygon(acc.minX, acc.minY, acc.maxX, acc.maxY);
     }
 
@@ -66,7 +67,10 @@ public class Aggregators {
                 rawSerializer = GeometryTypeSerializer.class,
                 bridgedTo = Geometry.class)
             Object o) {
-      Envelope envelope = ((Geometry) o).getEnvelopeInternal();
+      if (o == null) return;
+      Geometry geometry = (Geometry) o;
+      if (geometry.isEmpty()) return;
+      Envelope envelope = geometry.getEnvelopeInternal();
       acc.minX = Math.min(acc.minX, envelope.getMinX());
       acc.minY = Math.min(acc.minY, envelope.getMinY());
       acc.maxX = Math.max(acc.maxX, envelope.getMaxX());

--- a/flink/src/test/java/org/apache/sedona/flink/AggregatorTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/AggregatorTest.java
@@ -20,6 +20,7 @@ package org.apache.sedona.flink;
 
 import static org.apache.flink.table.api.Expressions.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import org.apache.flink.table.api.*;
 import org.apache.flink.types.Row;
@@ -44,6 +45,18 @@ public class AggregatorTest extends TestBase {
             "POLYGON ((0 0, 0 %s, %s %s, %s 0, 0 0))",
             testDataSize - 1, testDataSize - 1, testDataSize - 1, testDataSize - 1),
         last.getField(0).toString());
+  }
+
+  @Test
+  public void testEnvelope_Aggr_EmptyGeometries() {
+    tableEnv.executeSql(
+        "CREATE OR REPLACE TEMPORARY VIEW empty_geom_view AS "
+            + "SELECT ST_GeomFromWKT(wkt) as geom FROM ("
+            + "VALUES ('POINT EMPTY'), ('LINESTRING EMPTY'), ('POLYGON EMPTY')"
+            + ") AS t(wkt)");
+    Table result = tableEnv.sqlQuery("SELECT ST_Envelope_Aggr(geom) FROM empty_geom_view");
+    Row last = last(result);
+    assertNull(last.getField(0));
   }
 
   @Test

--- a/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/udtfs/ST_Envelope_Agg.java
+++ b/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/udtfs/ST_Envelope_Agg.java
@@ -49,7 +49,13 @@ public class ST_Envelope_Agg {
   public ST_Envelope_Agg() {}
 
   public Stream<OutputRow> process(byte[] geom) throws ParseException {
+    if (geom == null) {
+      return Stream.empty();
+    }
     Geometry geometry = GeometrySerde.deserialize(geom);
+    if (geometry == null || geometry.isEmpty()) {
+      return Stream.empty();
+    }
     if (buffer == null) {
       buffer = geometry.getEnvelopeInternal();
     } else {
@@ -59,6 +65,9 @@ public class ST_Envelope_Agg {
   }
 
   public Stream<OutputRow> endPartition() {
+    if (buffer == null || buffer.isNull()) {
+      return Stream.of(new OutputRow(null));
+    }
     // Returns the value we initialized in the constructor.
     Polygon poly =
         geometryFactory.createPolygon(

--- a/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/udtfs/ST_Envelope_Aggr.java
+++ b/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/udtfs/ST_Envelope_Aggr.java
@@ -49,7 +49,13 @@ public class ST_Envelope_Aggr {
   public ST_Envelope_Aggr() {}
 
   public Stream<OutputRow> process(byte[] geom) throws ParseException {
+    if (geom == null) {
+      return Stream.empty();
+    }
     Geometry geometry = GeometrySerde.deserialize(geom);
+    if (geometry == null || geometry.isEmpty()) {
+      return Stream.empty();
+    }
     if (buffer == null) {
       buffer = geometry.getEnvelopeInternal();
     } else {
@@ -59,6 +65,9 @@ public class ST_Envelope_Aggr {
   }
 
   public Stream<OutputRow> endPartition() {
+    if (buffer == null || buffer.isNull()) {
+      return Stream.of(new OutputRow(null));
+    }
     // Returns the value we initialized in the constructor.
     Polygon poly =
         geometryFactory.createPolygon(

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/AggregateFunctions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/AggregateFunctions.scala
@@ -130,7 +130,7 @@ private[apache] class ST_Envelope_Aggr
   val serde = ExpressionEncoder[Geometry]()
 
   def reduce(buffer: Option[EnvelopeBuffer], input: Geometry): Option[EnvelopeBuffer] = {
-    if (input == null) return buffer
+    if (input == null || input.isEmpty) return buffer
     val env = input.getEnvelopeInternal
     val envBuffer = EnvelopeBuffer(env.getMinX, env.getMaxX, env.getMinY, env.getMaxY)
     buffer match {


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #1979

## What changes were proposed in this PR?

ST_Envelope (scalar): Already correctly returns same-type EMPTY geometry for empty inputs (matching PostGIS). Added test to verify this behavior.

ST_Envelope_Aggr (aggregate): Skip empty geometries during accumulation and return null when all inputs are empty, matching PostGIS ST_Extent behavior. Fixed in Spark (AggregateFunctions.scala), Flink (Aggregators.java), and Snowflake (ST_Envelope_Aggr.java, ST_Envelope_Agg.java).

PostGIS behavior: ST_Extent is a standard SQL aggregate. Like all SQL aggregates (SUM, AVG, etc.), it skips NULL values. If all values are NULL, it returns NULL. For empty geometries, PostGIS treats them as valid non-null geometries whose envelope is empty — ST_Extent over only empty geometries returns NULL because empty geometries have no extent to contribute (their internal envelope is "null"/empty in JTS terms).

This is actually the standard behavior:

All NULL inputs → NULL (standard SQL aggregate behavior)
All empty geometry inputs → NULL (empty geometries have no spatial extent)
Mixed NULL + empty inputs → NULL (same reason — no geometry has a spatial extent)
Mixed empty + non-empty → envelope of the non-empty geometries only

## How was this patch tested?

Added tests in Spark (aggregateFunctionTestScala: all-empty returns null, mixed empty/non-empty preserves valid envelope), Flink (AggregatorTest: all-empty returns null), and common (FunctionsTest: scalar envelope with empty geometries).

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
