### PR TITLE
[GH-1998] Fix broken links in docs

### DIFF
--- a/docs/tutorial/files/stac-sedona-spark.md
+++ b/docs/tutorial/files/stac-sedona-spark.md
@@ -466,5 +466,3 @@ Returns:
 - STAC Specification: https://stacspec.org/
 
 - STAC Browser: https://github.com/radiantearth/stac-browser
-
-- STAC YouTube Video: https://www.youtube.com/watch?v=stac-video

--- a/docs/tutorial/viz.md
+++ b/docs/tutorial/viz.md
@@ -24,7 +24,7 @@ SedonaViz provides native support for general cartographic design by extending S
 SedonaViz offers Map Visualization SQL. This gives users a more flexible way to design beautiful map visualization effects including scatter plots and heat maps. SedonaViz RDD API is also available.
 
 !!!note
-	All SedonaViz SQL/DataFrame APIs are explained in [SedonaViz API](../api/viz/sql.md). Please see [Viz example project](https://github.com/apache/sedona/tree/master/examples/spark-viz)
+	All SedonaViz SQL/DataFrame APIs are explained in [SedonaViz API](../api/viz/sql.md).
 
 ## Why scalable map visualization?
 
@@ -34,7 +34,7 @@ SedonaViz encapsulates the main steps of map visualization process, e.g., pixeli
 
 ## Visualize SpatialRDD
 
-This tutorial mainly focuses on explaining SQL/DataFrame API. SedonaViz RDD example can be found in Please see [Viz example project](https://github.com/apache/sedona/tree/master/examples/viz)
+This tutorial mainly focuses on explaining SQL/DataFrame API.
 
 ## Set up dependencies
 

--- a/docs/usecases/contrib/VectorAnalisisApacheSedona.ipynb
+++ b/docs/usecases/contrib/VectorAnalisisApacheSedona.ipynb
@@ -158,7 +158,7 @@
     "import requests\n",
     "import json\n",
     "\n",
-    "overpass_url = \"http://overpass-api.de/api/interpreter\"\n",
+    "overpass_url = \"https://overpass-api.de/api/interpreter\"\n",
     "# overpass_query = \"\"\"\n",
     "# [out:json];\n",
     "# area[\"ISO3166-1\"=\"DE\"][admin_level=2];\n",


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #1998 

- No:
  - this is a documentation update. The PR name follows the format `[DOCS] my subject`
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

- Remove placeholder YouTube link (watch?v=stac-video) from STAC tutorial
- Remove broken viz example project links (examples/spark-viz, examples/viz directories no longer exist) from viz tutorial
- Fix overpass-api.de URL from http to https in VectorAnalisis notebook

## How was this patch tested?


## Did this PR include necessary documentation updates?


- Yes, I have updated the documentation.
