### PR TITLE
[CI] Run pre-commit with `--show-diff-on-failure`

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -50,6 +50,6 @@ jobs:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Run pre-commit
-        run: pre-commit run --color=always --all-files
+        run: pre-commit run --color=always --all-files --show-diff-on-failure
       - name: Run manual pre-commit hooks
-        run: pre-commit run --color=always --all-files --hook-stage manual
+        run: pre-commit run --color=always --all-files --hook-stage manual --show-diff-on-failure


### PR DESCRIPTION
What it specifically changes:

- Standard Behavior: The hook fails, and you see a message like: Files were modified by this hook.
- With `--show-diff-on-failure`: If a hook fails, pre-commit will automatically print the git diff directly to your terminal output.

Why use it?

It is a massive time-saver, especially in CI/CD pipelines. Since you can't easily "log in" to a GitHub Action to run git diff manually, having the diff printed in the build logs allows you to see exactly which line caused the failure without re-running the test locally.

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

As described above

## How was this patch tested?

With pre-commit locally

refs https://github.com/apache/shiro/pull/2487

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
