### PR TITLE
[DOCS] Fix typos in Markdown and Python files

### DIFF
--- a/docs/tutorial/snowflake/sql.md
+++ b/docs/tutorial/snowflake/sql.md
@@ -485,7 +485,7 @@ rights AS (
           )
       )
 ),
--- compute s2 cells covering the polyons for both tables
+-- compute s2 cells covering the polygons for both tables
 -- S2 discretizes the polygons, hence higher resolution yields more accurate queries, at the cost of increased computation
 -- both tables need to be discretized at the same level - in this case 10
 lefts_s2 AS (

--- a/python/sedona/spark/geoarrow/geoarrow.py
+++ b/python/sedona/spark/geoarrow/geoarrow.py
@@ -200,7 +200,7 @@ def unique_srid_from_ewkb(obj):
         return None
 
     # WKB Z high byte is 0x80
-    # WKB M high byte is is 0x40
+    # WKB M high byte is 0x40
     # EWKB SRID high byte is 0x20
     # High bytes where the SRID is set would be
     # [0x20, 0x20 | 0x40, 0x20 | 0x80, 0x20 | 0x40 | 0x80]

--- a/python/tests/sql/test_function.py
+++ b/python/tests/sql/test_function.py
@@ -2397,7 +2397,7 @@ class TestPredicateJoin(TestBase):
         actual = actualDf.selectExpr("ST_NRings(geom)").take(1)[0][0]
         assert expected == actual
 
-    def test_trangulatePolygon(self):
+    def test_triangulatePolygon(self):
         baseDf = self.spark.sql(
             "SELECT ST_GeomFromWKT('POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (5 5, 5 8, 8 8, 8 5, 5 5))') as poly"
         )


### PR DESCRIPTION
Minor docs fixes and also corrected one typo in a Python test file function name

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a documentation update. The PR name follows the format `[DOCS] my subject`

## What changes were proposed in this PR?

As described above

## How was this patch tested?


## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
