### PR TITLE
[GH-2407] Auto-detect raster columns in SedonaUtils.display_image

### DIFF
--- a/docs/api/sql/Raster-loader.md
+++ b/docs/api/sql/Raster-loader.md
@@ -22,6 +22,9 @@
 
 The raster loader of Sedona leverages Spark built-in binary data source and works with several RS constructors to produce Raster type. Each raster is a row in the resulting DataFrame and stored in a `Raster` format.
 
+!!!tip
+    After loading rasters, you can quickly visualize them in a Jupyter notebook using `SedonaUtils.display_image(df)`. It automatically detects raster columns and renders them as images. See [Raster visualizer docs](Raster-visualizer.md#display-raster-in-jupyter) for details.
+
 By default, these functions uses lon/lat order since `v1.5.0`. Before, it used lat/lon order.
 
 ## Step 1: Load raster to a binary DataFrame

--- a/docs/api/sql/Raster-map-algebra.md
+++ b/docs/api/sql/Raster-map-algebra.md
@@ -21,6 +21,9 @@
 
 Map algebra is a way to perform raster calculations using mathematical expressions. The expression can be a simple arithmetic operation or a complex combination of multiple operations. The expression can be applied to a single raster band or multiple raster bands. The result of the expression is a new raster.
 
+!!!tip
+    To visually inspect the result of a map algebra operation in a Jupyter notebook, use `SedonaUtils.display_image(df)`. It automatically detects raster columns and renders them as images. See [Raster visualizer docs](Raster-visualizer.md#display-raster-in-jupyter) for details.
+
 Apache Sedona provides two ways to perform map algebra operations:
 
 1. Using the `RS_MapAlgebra` function.

--- a/docs/api/sql/Raster-operators.md
+++ b/docs/api/sql/Raster-operators.md
@@ -17,6 +17,9 @@
  under the License.
  -->
 
+!!!tip
+    To quickly visualize raster data in a Jupyter notebook, use `SedonaUtils.display_image(df)`. It automatically detects raster columns and renders them as images. See [Raster visualizer docs](Raster-visualizer.md#display-raster-in-jupyter) for details.
+
 ## Pixel Functions
 
 ### RS_PixelAsCentroid

--- a/docs/api/sql/Raster-visualizer.md
+++ b/docs/api/sql/Raster-visualizer.md
@@ -71,21 +71,30 @@ Output:
 "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAECAAAAABjWKqcAAAAIElEQVR42mPgPfGfkYUhhfcBNw+DT1KihS6DqLKztjcATWMFp9rkkJgAAAAASUVORK5CYII=\" width=\"200\" />";
 ```
 
-!!!Tip
-    RS_AsImage can be paired with SedonaUtils.display_image(df) wrapper inside a Jupyter notebook to directly print the raster as an image in the output, where the 'df' parameter is the dataframe containing the HTML data provided by RS_AsImage
+### Display raster in Jupyter
 
-Example:
+Introduction: `SedonaUtils.display_image(df)` is a Python wrapper that renders raster images directly in a Jupyter notebook. It automatically detects raster columns in the DataFrame and applies `RS_AsImage` under the hood, so you don't need to call `RS_AsImage` yourself. You can also pass a DataFrame with pre-applied `RS_AsImage` HTML.
+
+Since: `v1.7.0` (auto-detection of raster columns since `v1.9.0`)
+
+Example — direct raster display (recommended):
 
 ```python
 from sedona.spark import SedonaUtils
-
-# Or from sedona.spark import *
 
 df = (
     sedona.read.format("binaryFile")
     .load(DATA_DIR + "raster.tiff")
     .selectExpr("RS_FromGeoTiff(content) as raster")
 )
+
+# Pass the raw raster DataFrame directly — RS_AsImage is applied automatically
+SedonaUtils.display_image(df)
+```
+
+Example — with explicit RS_AsImage:
+
+```python
 htmlDF = df.selectExpr("RS_AsImage(raster, 500) as raster_image")
 SedonaUtils.display_image(htmlDF)
 ```

--- a/docs/tutorial/raster.md
+++ b/docs/tutorial/raster.md
@@ -472,6 +472,17 @@ The output looks like this:
 
 ![Output](../image/DisplayImage.png)
 
+!!!tip
+    In a Jupyter notebook, use `SedonaUtils.display_image` to render rasters directly — no need to call RS_AsImage manually:
+
+    ```python
+    from sedona.spark import SedonaUtils
+
+    SedonaUtils.display_image(rasterDf)
+    ```
+
+    See [Display raster in Jupyter](../api/sql/Raster-visualizer.md#display-raster-in-jupyter) for details.
+
 ### 2-D Matrix
 
 Sedona offers an API to visualize raster data that is not sufficient for the other APIs mentioned above.
@@ -530,6 +541,15 @@ Please refer to [Raster writer docs](../api/sql/Raster-writer.md) for more detai
 
 Sedona allows collecting Dataframes with raster columns and working with them locally in Python since `v1.6.0`.
 The raster objects are represented as `SedonaRaster` objects in Python, which can be used to perform raster operations.
+
+!!!tip
+    If you just want to quickly visualize a raster in Jupyter, use `SedonaUtils.display_image(df)` instead of collecting the DataFrame:
+
+    ```python
+    from sedona.spark import SedonaUtils
+
+    SedonaUtils.display_image(df_raster)
+    ```
 
 ```python
 df_raster = (

--- a/python/sedona/spark/raster_utils/SedonaUtils.py
+++ b/python/sedona/spark/raster_utils/SedonaUtils.py
@@ -21,7 +21,40 @@ from sedona.spark.maps.SedonaMapUtils import SedonaMapUtils
 class SedonaUtils:
     @classmethod
     def display_image(cls, df):
+        """Display raster images in a Jupyter notebook.
+
+        Accepts DataFrames with either:
+        - A raster column (GridCoverage2D) — auto-applies RS_AsImage
+        - An HTML image column from RS_AsImage() — renders directly
+
+        Falls back to the SedonaMapUtils HTML table path for other DataFrames.
+        """
         from IPython.display import HTML, display
+
+        schema = df.schema
+
+        # Detect raster UDT columns and auto-apply RS_AsImage.
+        # Without this, passing a raw raster DataFrame to the fallback path
+        # causes __convert_to_gdf_or_pdf__ to Arrow-serialize the full raster
+        # grid, which hangs for large rasters (e.g., 1400x800).
+        raster_cols = [
+            f.name
+            for f in schema.fields
+            if hasattr(f.dataType, "typeName") and f.dataType.typeName() == "rastertype"
+        ]
+        if raster_cols:
+            # Replace each raster column with its RS_AsImage() HTML representation,
+            # preserving all other columns in the DataFrame.
+            select_exprs = []
+            for f in schema.fields:
+                col_name_escaped = f.name.replace("`", "``")
+                if f.name in raster_cols:
+                    select_exprs.append(
+                        f"RS_AsImage(`{col_name_escaped}`) as `{col_name_escaped}`"
+                    )
+                else:
+                    select_exprs.append(f"`{col_name_escaped}`")
+            df = df.selectExpr(*select_exprs)
 
         pdf = SedonaMapUtils.__convert_to_gdf_or_pdf__(df, rename=False)
         display(HTML(pdf.to_html(escape=False)))


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2407

## What changes were proposed in this PR?

`SedonaUtils.display_image()` hangs when passed a raw raster DataFrame (e.g., 1400x800) because `__convert_to_gdf_or_pdf__` attempts to Arrow-serialize the full GridCoverage2D object.

This PR adds raster UDT detection to `display_image()`:
- Detects raster columns via `typeName() == "rastertype"`
- Auto-applies `RS_AsImage()` to each raster column before rendering
- Preserves all non-raster columns in the DataFrame
- Falls through to the existing `__convert_to_gdf_or_pdf__` + `to_html()` path after conversion

Users can now pass a raw raster DataUsers can now pass a raw raster DataUsers can now pass a raw raster DataUsers  this patch tested?

- Tested manually in Jupyter notebook inside the Sedona Docker container
- Verified with raw raster DataFrame (single and multi-column)
- Verified with pre-applied `RS_AsImage()` DataFrame (regression check)
- Existing test `test_sedonautils.py::test_display_image` continues to pass

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation. Updated `docs/api/sql/Raster-visualizer.md` to show both the new direct raster display (recommended) and the explicit `RS_AsImage` workflow.