### PR TITLE
[CI] Add license to `.clang-format`; enforce with pre-commit

### DIFF
--- a/.github/linters/.clang-format
+++ b/.github/linters/.clang-format
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 ---
 Language:        Cpp
 # BasedOnStyle:  Google

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -251,6 +251,7 @@ repos:
             \.prettierignore|
             \.prettierrc|
             \.shellcheckrc|
+            \.github/linters/\.clang-format|
             \.github/CODEOWNERS|
             .*/\.gitignore|
             tools/maven/scalafmt\.conf


### PR DESCRIPTION
Adds the missing license header.

The .clang-format file is essentially a YAML file

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

Auto adds the missing license header with pre-commit

## How was this patch tested?

Ran `pre-commit run --all-files` both before and after the license header was auto added.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
