### PR TITLE
[GH-2608] Fix RasterUDT JSON schema serialization for Delta/Parquet write

### DIFF
--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/UDT/RasterUDT.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/UDT/RasterUDT.scala
@@ -21,6 +21,8 @@ package org.apache.spark.sql.sedona_sql.UDT
 import org.apache.sedona.common.raster.serde.Serde
 import org.apache.spark.sql.types.{BinaryType, DataType, UserDefinedType}
 import org.geotools.coverage.grid.GridCoverage2D
+import org.json4s.JsonDSL._
+import org.json4s.JsonAST.JValue
 
 class RasterUDT extends UserDefinedType[GridCoverage2D] {
   override def sqlType: DataType = BinaryType
@@ -40,6 +42,13 @@ class RasterUDT extends UserDefinedType[GridCoverage2D] {
   }
 
   override def userClass: Class[GridCoverage2D] = classOf[GridCoverage2D]
+
+  override private[sql] def jsonValue: JValue = {
+    super.jsonValue mapField {
+      case ("class", _) => "class" -> this.getClass.getName.stripSuffix("$")
+      case other: Any => other
+    }
+  }
 
   override def equals(other: Any): Boolean = other match {
     case _: UserDefinedType[_] => other.isInstanceOf[RasterUDT]

--- a/spark/common/src/test/scala/org/apache/sedona/sql/RasterUDTSuite.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/RasterUDTSuite.scala
@@ -46,8 +46,7 @@ class RasterUDTSuite extends TestBaseScala with BeforeAndAfter {
       // Delta and Parquet serialize the schema to JSON, then deserialize it.
       // Without a jsonValue override, the class name includes a '$' suffix
       // from the Scala case object, causing ClassNotFoundException on read.
-      val rasterDf = sparkSession.sql(
-        "SELECT RS_MakeEmptyRaster(1, 10, 10, 0, 0, 1) as raster")
+      val rasterDf = sparkSession.sql("SELECT RS_MakeEmptyRaster(1, 10, 10, 0, 0, 1) as raster")
       assert(
         DataType
           .fromJson(rasterDf.schema.json)
@@ -58,8 +57,7 @@ class RasterUDTSuite extends TestBaseScala with BeforeAndAfter {
     it("Should write and read raster DataFrame in Parquet format") {
       // Parquet also serializes schema as JSON, triggering the same bug as Delta.
       tempFolder.create()
-      val rasterDf = sparkSession.sql(
-        "SELECT RS_MakeEmptyRaster(1, 10, 10, 0, 0, 1) as raster")
+      val rasterDf = sparkSession.sql("SELECT RS_MakeEmptyRaster(1, 10, 10, 0, 0, 1) as raster")
 
       rasterDf.write.parquet(tempFolder.getRoot.getPath + "/raster_parquet")
 
@@ -76,8 +74,7 @@ class RasterUDTSuite extends TestBaseScala with BeforeAndAfter {
       // whereas InferredExpression-based functions use the case object singleton
       // whose getClass.getName includes '$'.
       tempFolder.create()
-      val rasterDf = sparkSession.sql(
-        """SELECT RS_Union_Aggr(raster) as raster FROM (
+      val rasterDf = sparkSession.sql("""SELECT RS_Union_Aggr(raster) as raster FROM (
           |  SELECT RS_MakeEmptyRaster(1, 10, 10, 0, 0, 1) as raster
           |)""".stripMargin)
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2608 Closes #2347

## What changes were proposed in this PR?

Add a `jsonValue` override to `RasterUDT` that strips the trailing `$` from the Scala case object class name, fixing Delta Lake and Parquet write failures.

`RasterUDT` is defined as a Scala `case object`, so `getClass.getName` returns `org.apache.spark.sql.sedona_sql.UDT.RasterUDT$` (with a trailing `$`). Spark's `UserDefinedType.jsonValue` stores this class name in the JSON schema. When Delta Lake or Parquet tries to reconstruct the UDT during deserialization via `Class.forName(...).getConstructor().newInstance()`, it fails with:

- `NoSuchMethodException: RasterUDT$.<init>()` (JSON schema round-trip)
- `UNSUPPORTED_DATATYPE` referencing `RasterUDT$` (Parquet/Delta write)

This is the same issue that was previously fixed in `GeometryUDT` and `GeographyUDT`.

Note: `RS_Union_Aggr` was not affected because it uses `ExpressionEncoder` resolved via `UDTRegistration`, which stores `classOf[RasterUDT].getName` (without the `$` suffix). Other raster functions (e.g., `RS_MakeEmptyRaster`) use `InferredExpression` which references the `case object` singleton directly.

## How was this patch tested?

Added 3 new tests to `RasterUDTSuite`:
1. **JSON schema round-trip** — serializes RasterUDT to JSON, parses it back via `DataType.fromJson`, and verifies round-trip equality
2. **Parquet write/read** — creates a raster DataFrame via `RS_MakeEmptyRaster`, writes to Parquet, reads it back, and verifies schema and row count
3. **RS_Union_Aggr Parquet write/read** — confirms that `RS_Union_Aggr` output can be written to and read from Parquet (this already worked before the fix, serving as a control test)

All tests pass after the fix. Tests 1 and 2 fail without the fix, reproducing the reported issue.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
