### PR TITLE
[GH-2536] Remove workflow badge buttons from compile docs page

### DIFF
--- a/docs/setup/compile.md
+++ b/docs/setup/compile.md
@@ -19,8 +19,6 @@
 
 # Compile Sedona source code
 
-[![Scala and Java build](https://github.com/apache/sedona/actions/workflows/java.yml/badge.svg)](https://github.com/apache/sedona/actions/workflows/java.yml) [![Python build](https://github.com/apache/sedona/actions/workflows/python.yml/badge.svg)](https://github.com/apache/sedona/actions/workflows/python.yml) [![R build](https://github.com/apache/sedona/actions/workflows/r.yml/badge.svg)](https://github.com/apache/sedona/actions/workflows/r.yml) [![Example project build](https://github.com/apache/sedona/actions/workflows/example.yml/badge.svg)](https://github.com/apache/sedona/actions/workflows/example.yml) [![Docs build](https://github.com/apache/sedona/actions/workflows/docs.yml/badge.svg)](https://github.com/apache/sedona/actions/workflows/docs.yml)
-
 ## Compile Scala / Java source code
 
 Sedona Scala/Java code is a project with multiple modules. Each module is a Scala/Java mixed project which is managed by Apache Maven 3.


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2536

## What changes were proposed in this PR?

Remove the GitHub Actions workflow status badges from `docs/setup/compile.md`. These badges use images hosted on `github.com`, which are blocked by the ASF website's Content-Security-Policy `img-src` directive, causing them to not render on the published docs site.

## How was this patch tested?

Manual verification — confirmed the badges are no longer embedded in the page.

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.