### PR TITLE
[GH-2639] Add StructuredAdapter.repartitionBySpatialKey for simplified spatial partitioning

### DIFF
--- a/spark/common/src/test/scala/org/apache/sedona/sql/structuredAdapterTestScala.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/structuredAdapterTestScala.scala
@@ -126,5 +126,22 @@ class structuredAdapterTestScala extends TestBaseScala with GivenWhenThen {
       val dfPartitions: Long = partitionedDF.select(spark_partition_id).distinct().count()
       assert(dfPartitions == numSpatialPartitions)
     }
+
+    it("Should repartition by spatial key in one step") {
+      val seq = generateTestData()
+      val dfOrigin = sparkSession.createDataFrame(seq)
+      val partitionedDf =
+        StructuredAdapter.repartitionBySpatialKey(dfOrigin, "_3", GridType.KDBTREE, 4)
+      assertEquals(seq.size, partitionedDf.count())
+      assert(partitionedDf.rdd.getNumPartitions >= 4)
+    }
+
+    it("Should repartition by spatial key with auto-detected geometry column") {
+      val seq = generateTestData()
+      val dfOrigin = sparkSession.createDataFrame(seq)
+      val partitionedDf =
+        StructuredAdapter.repartitionBySpatialKey(dfOrigin, GridType.KDBTREE)
+      assertEquals(seq.size, partitionedDf.count())
+    }
   }
 }


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2639

## What changes were proposed in this PR?

Added `StructuredAdapter.repartitionBySpatialKey()` - a one-step API for spatially partitioning DataFrames using KDB-Tree (or other grid types). This simplifies the current 5-step workflow (DataFrame to SpatialRDD to analyze to spatialPartitioningWithoutDuplicates to back to DataFrame) into a single method call.

Changes:

- Scala: 3 overloads of `repartitionBySpatialKey` in `StructuredAdapter.scala` (full params, auto-detect geometry, auto-detect plus default partitions)
- Python: Matching `repartitionBySpatialKey` classmethod in `structured_adapter.py`
- Scala tests: 2 new tests in `structuredAdapterTestScala.scala`
- Python tests: 2 new tests in `test_structured_adapter.py`
- Docs: New Spatial Partitioning for GeoParquet section in GeoParquet tutorial with Python, Scala, Java examples

## How was this patch tested?

- Scala tests: all 10 tests pass in `structuredAdapterTestScala`
- Python tests added following existing patterns
- Spotless formatting verified
- Pre-commit hooks pass

## Did this PR include necessary documentation updates?

- Yes, I am adding a new API. I am using the [current SNAPSHOT version number](https://github.com/apache/sedona/blob/99239524f17389fc4ae9548ea88756f8ea538bb9/pom.xml#L29) in `v1.9.0` format.
- Yes, I have updated the documentation. Added a new Spatial Partitioning for GeoParquet section to the GeoParquet tutorial with tabbed Python, Scala, Java examples.
