### PR TITLE
[GH-2645] Fix GitHub Actions workflow policy violation in Pull Request Labeler

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -18,7 +18,7 @@
 # https://github.com/actions/labeler
 name: Pull Request Labeler
 on:
-  - pull_request_target # zizmor: ignore[dangerous-triggers]
+  - pull_request
 jobs:
   triage:
     permissions:


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2645

## What changes were proposed in this PR?

Replace `pull_request_target` trigger with `pull_request` in the Pull Request Labeler workflow (`.github/workflows/labeler.yml`).

ASF Infrastructure flagged this as a policy violation because `pull_request_target` runs with elevated permissions and can be exploited by malicious PRs from forks. The `pull_request` trigger is the safe alternative.

## How was this patch tested?

This is a CI configuration change. The labeler workflow will be tested automatically when a PR is opened.

## Did this PR include necessary documents?

- No, this PR does not affect any public API so no need to change the documentation.