### PR TITLE
[CI] pre-commit auto add license header to CITATION file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -254,7 +254,8 @@ repos:
             \.github/linters/\.clang-format|
             \.github/CODEOWNERS|
             .*/\.gitignore|
-            tools/maven/scalafmt\.conf
+            tools/maven/scalafmt\.conf|
+            CITATION\.cff
           )$
         args:
           - --comment-style

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 type: software


### PR DESCRIPTION
The CITATION file is really a YAML file so we can add the standard YAML license header

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

Adds a missing license header

## How was this patch tested?

With pre-commit

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
