### PR TITLE
[GH-2678] Add SVG visuals for overlay functions (Phase 2)

### DIFF
--- a/docs/api/flink/Overlay-Functions/ST_Difference.md
+++ b/docs/api/flink/Overlay-Functions/ST_Difference.md
@@ -21,6 +21,8 @@
 
 Introduction: Return the difference between geometry A and B (return part of geometry A that does not intersect geometry B)
 
+![ST_Difference](../../../image/ST_Difference/ST_Difference.svg "ST_Difference")
+
 Format: `ST_Difference (A: Geometry, B: Geometry)`
 
 Return type: `Geometry`

--- a/docs/api/flink/Overlay-Functions/ST_Intersection.md
+++ b/docs/api/flink/Overlay-Functions/ST_Intersection.md
@@ -21,6 +21,8 @@
 
 Introduction: Return the intersection geometry of A and B
 
+![ST_Intersection](../../../image/ST_Intersection/ST_Intersection.svg "ST_Intersection")
+
 Format: `ST_Intersection (A: Geometry, B: Geometry)`
 
 Return type: `Geometry`

--- a/docs/api/flink/Overlay-Functions/ST_SubDivide.md
+++ b/docs/api/flink/Overlay-Functions/ST_SubDivide.md
@@ -23,6 +23,8 @@ Introduction: Returns list of geometries divided based of given maximum number o
 
 A minimum of 5 vertices is required for maxVertices parameter to form a closed box.
 
+![ST_SubDivide](../../../image/ST_SubDivide/ST_SubDivide.svg "ST_SubDivide")
+
 Format: `ST_SubDivide(geom: Geometry, maxVertices: Integer)`
 
 Return type: `Array<Geometry>`

--- a/docs/api/flink/Overlay-Functions/ST_SymDifference.md
+++ b/docs/api/flink/Overlay-Functions/ST_SymDifference.md
@@ -21,6 +21,8 @@
 
 Introduction: Return the symmetrical difference between geometry A and B (return parts of geometries which are in either of the sets, but not in their intersection)
 
+![ST_SymDifference](../../../image/ST_SymDifference/ST_SymDifference.svg "ST_SymDifference")
+
 Format: `ST_SymDifference (A: Geometry, B: Geometry)`
 
 Return type: `Geometry`

--- a/docs/api/flink/Overlay-Functions/ST_UnaryUnion.md
+++ b/docs/api/flink/Overlay-Functions/ST_UnaryUnion.md
@@ -21,6 +21,8 @@
 
 Introduction: This variant of [ST_Union](ST_Union.md) operates on a single geometry input. The input geometry can be a simple Geometry type, a MultiGeometry, or a GeometryCollection. The function calculates the geometric union across all components and elements within the provided geometry object.
 
+![ST_UnaryUnion](../../../image/ST_UnaryUnion/ST_UnaryUnion.svg "ST_UnaryUnion")
+
 Format: `ST_UnaryUnion(geometry: Geometry)`
 
 Return type: `Geometry`

--- a/docs/api/flink/Overlay-Functions/ST_Union.md
+++ b/docs/api/flink/Overlay-Functions/ST_Union.md
@@ -25,6 +25,8 @@ Variant 1: Return the union of geometry A and B.
 
 Variant 2: This function accepts an array of Geometry objects and returns the geometric union of all geometries in the input array. If the polygons within the input array do not share common boundaries, the ST_Union result will be a MultiPolygon geometry.
 
+![ST_Union](../../../image/ST_Union/ST_Union.svg "ST_Union")
+
 Format:
 
 `ST_Union (A: Geometry, B: Geometry)`

--- a/docs/api/snowflake/vector-data/Overlay-Functions/ST_Difference.md
+++ b/docs/api/snowflake/vector-data/Overlay-Functions/ST_Difference.md
@@ -21,6 +21,8 @@
 
 Introduction: Return the difference between geometry A and B (return part of geometry A that does not intersect geometry B)
 
+![ST_Difference](../../../../image/ST_Difference/ST_Difference.svg "ST_Difference")
+
 Format: `ST_Difference (A:geometry, B:geometry)`
 
 Return type: `Geometry`

--- a/docs/api/snowflake/vector-data/Overlay-Functions/ST_Intersection.md
+++ b/docs/api/snowflake/vector-data/Overlay-Functions/ST_Intersection.md
@@ -21,6 +21,8 @@
 
 Introduction: Return the intersection geometry of A and B
 
+![ST_Intersection](../../../../image/ST_Intersection/ST_Intersection.svg "ST_Intersection")
+
 Format: `ST_Intersection (A:geometry, B:geometry)`
 
 Return type: `Geometry`

--- a/docs/api/snowflake/vector-data/Overlay-Functions/ST_Split.md
+++ b/docs/api/snowflake/vector-data/Overlay-Functions/ST_Split.md
@@ -27,6 +27,8 @@ ST_Split will always return either a MultiLineString or MultiPolygon even if the
 Homogeneous GeometryCollections are treated as a multi-geometry of the type it contains.
 For example, if a GeometryCollection of only Point geometries is passed as a blade it is the same as passing a MultiPoint of the same geometries.
 
+![ST_Split](../../../../image/ST_Split/ST_Split.svg "ST_Split")
+
 Format: `ST_Split (input: geometry, blade: geometry)`
 
 Return type: `Geometry`

--- a/docs/api/snowflake/vector-data/Overlay-Functions/ST_SubDivide.md
+++ b/docs/api/snowflake/vector-data/Overlay-Functions/ST_SubDivide.md
@@ -23,6 +23,8 @@ Introduction: Returns a multi-geometry divided based of given maximum number of 
 
 A minimum of 5 vertices is required for maxVertices parameter to form a closed box.
 
+![ST_SubDivide](../../../../image/ST_SubDivide/ST_SubDivide.svg "ST_SubDivide")
+
 Format: `ST_SubDivide(geom: geometry, maxVertices: int)`
 
 Return type: `Array<Geometry>`

--- a/docs/api/snowflake/vector-data/Overlay-Functions/ST_SubDivideExplode.md
+++ b/docs/api/snowflake/vector-data/Overlay-Functions/ST_SubDivideExplode.md
@@ -23,6 +23,8 @@ Introduction: It works the same as ST_SubDivide but returns new rows with geomet
 
 A minimum of 5 vertices is required for maxVertices parameter to form a closed box.
 
+![ST_SubDivideExplode](../../../../image/ST_SubDivide/ST_SubDivide.svg "ST_SubDivideExplode")
+
 Format: `
 Return type: `Geometry`
 

--- a/docs/api/snowflake/vector-data/Overlay-Functions/ST_SymDifference.md
+++ b/docs/api/snowflake/vector-data/Overlay-Functions/ST_SymDifference.md
@@ -21,6 +21,8 @@
 
 Introduction: Return the symmetrical difference between geometry A and B (return parts of geometries which are in either of the sets, but not in their intersection)
 
+![ST_SymDifference](../../../../image/ST_SymDifference/ST_SymDifference.svg "ST_SymDifference")
+
 Format: `ST_SymDifference (A:geometry, B:geometry)`
 
 Return type: `Geometry`

--- a/docs/api/snowflake/vector-data/Overlay-Functions/ST_UnaryUnion.md
+++ b/docs/api/snowflake/vector-data/Overlay-Functions/ST_UnaryUnion.md
@@ -21,6 +21,8 @@
 
 Introduction: This variant of [ST_Union](ST_Union.md) operates on a single geometry input. The input geometry can be a simple Geometry type, a MultiGeometry, or a GeometryCollection. The function calculates the geometric union across all components and elements within the provided geometry object.
 
+![ST_UnaryUnion](../../../../image/ST_UnaryUnion/ST_UnaryUnion.svg "ST_UnaryUnion")
+
 Format: `ST_UnaryUnion(geometry: Geometry)`
 
 Return type: `Geometry`

--- a/docs/api/snowflake/vector-data/Overlay-Functions/ST_Union.md
+++ b/docs/api/snowflake/vector-data/Overlay-Functions/ST_Union.md
@@ -21,6 +21,8 @@
 
 Introduction: Return the union of geometry A and B
 
+![ST_Union](../../../../image/ST_Union/ST_Union.svg "ST_Union")
+
 Format: `ST_Union (A:geometry, B:geometry)`
 
 Return type: `Geometry`

--- a/docs/api/sql/Overlay-Functions/ST_Difference.md
+++ b/docs/api/sql/Overlay-Functions/ST_Difference.md
@@ -21,6 +21,8 @@
 
 Introduction: Return the difference between geometry A and B (return part of geometry A that does not intersect geometry B)
 
+![ST_Difference](../../../image/ST_Difference/ST_Difference.svg "ST_Difference")
+
 Format: `ST_Difference (A: Geometry, B: Geometry)`
 
 Return type: `Geometry`

--- a/docs/api/sql/Overlay-Functions/ST_Intersection.md
+++ b/docs/api/sql/Overlay-Functions/ST_Intersection.md
@@ -21,6 +21,8 @@
 
 Introduction: Return the intersection geometry of A and B
 
+![ST_Intersection](../../../image/ST_Intersection/ST_Intersection.svg "ST_Intersection")
+
 Format: `ST_Intersection (A: Geometry, B: Geometry)`
 
 Return type: `Geometry`

--- a/docs/api/sql/Overlay-Functions/ST_Split.md
+++ b/docs/api/sql/Overlay-Functions/ST_Split.md
@@ -27,6 +27,8 @@ ST_Split will always return either a MultiLineString or MultiPolygon even if the
 Homogeneous GeometryCollections are treated as a multi-geometry of the type it contains.
 For example, if a GeometryCollection of only Point geometries is passed as a blade it is the same as passing a MultiPoint of the same geometries.
 
+![ST_Split](../../../image/ST_Split/ST_Split.svg "ST_Split")
+
 Return type: `Geometry`
 
 Since: `v1.4.0`

--- a/docs/api/sql/Overlay-Functions/ST_SubDivide.md
+++ b/docs/api/sql/Overlay-Functions/ST_SubDivide.md
@@ -23,6 +23,8 @@ Introduction: Returns list of geometries divided based of given maximum number o
 
 A minimum of 5 vertices is required for maxVertices parameter to form a closed box.
 
+![ST_SubDivide](../../../image/ST_SubDivide/ST_SubDivide.svg "ST_SubDivide")
+
 Format: `ST_SubDivide(geom: Geometry, maxVertices: Integer)`
 
 Return type: `Array<Geometry>`

--- a/docs/api/sql/Overlay-Functions/ST_SubDivideExplode.md
+++ b/docs/api/sql/Overlay-Functions/ST_SubDivideExplode.md
@@ -23,6 +23,8 @@ Introduction: It works the same as ST_SubDivide but returns new rows with geomet
 
 A minimum of 5 vertices is required for maxVertices parameter to form a closed box.
 
+![ST_SubDivideExplode](../../../image/ST_SubDivide/ST_SubDivide.svg "ST_SubDivideExplode")
+
 Format: `ST_SubDivideExplode(geom: Geometry, maxVertices: Integer)`
 
 Return type: `Geometry`

--- a/docs/api/sql/Overlay-Functions/ST_SymDifference.md
+++ b/docs/api/sql/Overlay-Functions/ST_SymDifference.md
@@ -21,6 +21,8 @@
 
 Introduction: Return the symmetrical difference between geometry A and B (return parts of geometries which are in either of the sets, but not in their intersection)
 
+![ST_SymDifference](../../../image/ST_SymDifference/ST_SymDifference.svg "ST_SymDifference")
+
 Format: `ST_SymDifference (A: Geometry, B: Geometry)`
 
 Return type: `Geometry`

--- a/docs/api/sql/Overlay-Functions/ST_UnaryUnion.md
+++ b/docs/api/sql/Overlay-Functions/ST_UnaryUnion.md
@@ -21,6 +21,8 @@
 
 Introduction: This variant of [ST_Union](ST_Union.md) operates on a single geometry input. The input geometry can be a simple Geometry type, a MultiGeometry, or a GeometryCollection. The function calculates the geometric union across all components and elements within the provided geometry object.
 
+![ST_UnaryUnion](../../../image/ST_UnaryUnion/ST_UnaryUnion.svg "ST_UnaryUnion")
+
 Format: `ST_UnaryUnion(geometry: Geometry)`
 
 Return type: `Geometry`

--- a/docs/api/sql/Overlay-Functions/ST_Union.md
+++ b/docs/api/sql/Overlay-Functions/ST_Union.md
@@ -25,6 +25,8 @@ Variant 1: Return the union of geometry A and B.
 
 Variant 2 : As of version `1.6.0`, this function accepts an array of Geometry objects and returns the geometric union of all geometries in the input array. If the polygons within the input array do not share common boundaries, the ST_Union result will be a MultiPolygon geometry.
 
+![ST_Union](../../../image/ST_Union/ST_Union.svg "ST_Union")
+
 Format:
 
 `ST_Union (A: Geometry, B: Geometry)`

--- a/docs/image/ST_Difference/ST_Difference.svg
+++ b/docs/image/ST_Difference/ST_Difference.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_Difference(A, B)</text>
+  <path d="M 121.43 221.43 L 292.86 221.43 L 292.86 107.14 L 121.43 107.14 L 121.43 221.43 Z" fill="rgba(74,144,217,0.15)" stroke="#4a90d9" stroke-width="2" fill-rule="evenodd" stroke-dasharray="6,3" />
+  <text x="190.0" y="175.71" text-anchor="middle" font-size="15" font-weight="bold" fill="#4a90d9">A</text>
+  <path d="M 207.14 192.86 L 378.57 192.86 L 378.57 78.57 L 207.14 78.57 L 207.14 192.86 Z" fill="rgba(217,74,74,0.15)" stroke="#d94a4a" stroke-width="2" fill-rule="evenodd" stroke-dasharray="6,3" />
+  <text x="275.71" y="147.14" text-anchor="middle" font-size="15" font-weight="bold" fill="#d94a4a">B</text>
+  <path d="M 121.43 221.43 L 292.86 221.43 L 292.86 192.86 L 207.14 192.86 L 207.14 107.14 L 121.43 107.14 L 121.43 221.43 Z" fill="rgba(46,204,113,0.35)" stroke="#2ecc71" stroke-width="3" fill-rule="evenodd" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Returns the part of A that does not intersect B</text>
+  <rect x="101" y="255" width="12" height="12" rx="2" fill="#4a90d9" stroke="#4a90d9" stroke-width="1" />
+  <text x="117" y="266" font-size="13" fill="#333333">Geometry A</text>
+  <rect x="211" y="255" width="12" height="12" rx="2" fill="#d94a4a" stroke="#d94a4a" stroke-width="1" />
+  <text x="227" y="266" font-size="13" fill="#333333">Geometry B</text>
+  <rect x="321" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="337" y="266" font-size="13" fill="#333333">Result</text>
+</svg>

--- a/docs/image/ST_Intersection/ST_Intersection.svg
+++ b/docs/image/ST_Intersection/ST_Intersection.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_Intersection(A, B)</text>
+  <path d="M 121.43 221.43 L 292.86 221.43 L 292.86 107.14 L 121.43 107.14 L 121.43 221.43 Z" fill="rgba(74,144,217,0.15)" stroke="#4a90d9" stroke-width="2" fill-rule="evenodd" stroke-dasharray="6,3" />
+  <text x="190.0" y="175.71" text-anchor="middle" font-size="15" font-weight="bold" fill="#4a90d9">A</text>
+  <path d="M 207.14 192.86 L 378.57 192.86 L 378.57 78.57 L 207.14 78.57 L 207.14 192.86 Z" fill="rgba(217,74,74,0.15)" stroke="#d94a4a" stroke-width="2" fill-rule="evenodd" stroke-dasharray="6,3" />
+  <text x="275.71" y="147.14" text-anchor="middle" font-size="15" font-weight="bold" fill="#d94a4a">B</text>
+  <path d="M 207.14 192.86 L 292.86 192.86 L 292.86 107.14 L 207.14 107.14 L 207.14 192.86 Z" fill="rgba(46,204,113,0.35)" stroke="#2ecc71" stroke-width="3" fill-rule="evenodd" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Returns the shared portion of A and B</text>
+  <rect x="101" y="255" width="12" height="12" rx="2" fill="#4a90d9" stroke="#4a90d9" stroke-width="1" />
+  <text x="117" y="266" font-size="13" fill="#333333">Geometry A</text>
+  <rect x="211" y="255" width="12" height="12" rx="2" fill="#d94a4a" stroke="#d94a4a" stroke-width="1" />
+  <text x="227" y="266" font-size="13" fill="#333333">Geometry B</text>
+  <rect x="321" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="337" y="266" font-size="13" fill="#333333">Result</text>
+</svg>

--- a/docs/image/ST_Split/ST_Split.svg
+++ b/docs/image/ST_Split/ST_Split.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_Split(A, blade)</text>
+  <path d="M 165.38 213.46 L 334.62 213.46 L 334.62 86.54 L 165.38 86.54 L 165.38 213.46 Z" fill="rgba(74,144,217,0.15)" stroke="#4a90d9" stroke-width="2" fill-rule="evenodd" stroke-dasharray="6,3" />
+  <text x="233.08" y="162.69" text-anchor="middle" font-size="15" font-weight="bold" fill="#4a90d9">A</text>
+  <polyline points="250.0,234.62 250.0,65.38" fill="none" stroke="#d94a4a" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,3" />
+  <circle cx="250.0" cy="234.62" r="3" fill="#d94a4a" />
+  <circle cx="250.0" cy="65.38" r="3" fill="#d94a4a" />
+  <text x="256.0" y="57.379999999999995" font-size="15" font-weight="bold" fill="#d94a4a">blade</text>
+  <path d="M 165.38 213.46 L 250.0 213.46 L 250.0 86.54 L 165.38 86.54 L 165.38 213.46 Z" fill="rgba(46,204,113,0.35)" stroke="#2ecc71" stroke-width="3" fill-rule="evenodd" />
+  <path d="M 250.0 213.46 L 334.62 213.46 L 334.62 86.54 L 250.0 86.54 L 250.0 213.46 Z" fill="rgba(46,204,113,0.35)" stroke="#2ecc71" stroke-width="3" fill-rule="evenodd" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Splits geometry A using a blade geometry</text>
+  <rect x="85" y="255" width="12" height="12" rx="2" fill="#4a90d9" stroke="#4a90d9" stroke-width="1" />
+  <text x="101" y="266" font-size="13" fill="#333333">Geometry A</text>
+  <rect x="195" y="255" width="12" height="12" rx="2" fill="#d94a4a" stroke="#d94a4a" stroke-width="1" />
+  <text x="211" y="266" font-size="13" fill="#333333">Geometry blade</text>
+  <rect x="337" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="353" y="266" font-size="13" fill="#333333">Result</text>
+</svg>

--- a/docs/image/ST_SubDivide/ST_SubDivide.svg
+++ b/docs/image/ST_SubDivide/ST_SubDivide.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_SubDivide(A, maxVertices)</text>
+  <path d="M 165.38 234.62 L 334.62 234.62 L 334.62 65.38 L 165.38 65.38 L 165.38 234.62 Z" fill="rgba(74,144,217,0.15)" stroke="#4a90d9" stroke-width="2" fill-rule="evenodd" stroke-dasharray="6,3" />
+  <text x="233.08" y="166.92" text-anchor="middle" font-size="15" font-weight="bold" fill="#4a90d9">A</text>
+  <path d="M 165.38 234.62 L 250.0 234.62 L 250.0 150.0 L 165.38 150.0 L 165.38 234.62 Z" fill="rgba(46,204,113,0.35)" stroke="#2ecc71" stroke-width="3" fill-rule="evenodd" />
+  <path d="M 250.0 234.62 L 334.62 234.62 L 334.62 150.0 L 250.0 150.0 L 250.0 234.62 Z" fill="rgba(46,204,113,0.35)" stroke="#2ecc71" stroke-width="3" fill-rule="evenodd" />
+  <path d="M 165.38 150.0 L 250.0 150.0 L 250.0 65.38 L 165.38 65.38 L 165.38 150.0 Z" fill="rgba(46,204,113,0.35)" stroke="#2ecc71" stroke-width="3" fill-rule="evenodd" />
+  <path d="M 250.0 150.0 L 334.62 150.0 L 334.62 65.38 L 250.0 65.38 L 250.0 150.0 Z" fill="rgba(46,204,113,0.35)" stroke="#2ecc71" stroke-width="3" fill-rule="evenodd" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Divides geometry into parts with at most maxVertices vertices</text>
+  <rect x="156" y="255" width="12" height="12" rx="2" fill="#4a90d9" stroke="#4a90d9" stroke-width="1" />
+  <text x="172" y="266" font-size="13" fill="#333333">Geometry A</text>
+  <rect x="266" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="282" y="266" font-size="13" fill="#333333">Result</text>
+</svg>

--- a/docs/image/ST_SymDifference/ST_SymDifference.svg
+++ b/docs/image/ST_SymDifference/ST_SymDifference.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_SymDifference(A, B)</text>
+  <path d="M 121.43 221.43 L 292.86 221.43 L 292.86 107.14 L 121.43 107.14 L 121.43 221.43 Z" fill="rgba(74,144,217,0.15)" stroke="#4a90d9" stroke-width="2" fill-rule="evenodd" stroke-dasharray="6,3" />
+  <text x="190.0" y="175.71" text-anchor="middle" font-size="15" font-weight="bold" fill="#4a90d9">A</text>
+  <path d="M 207.14 192.86 L 378.57 192.86 L 378.57 78.57 L 207.14 78.57 L 207.14 192.86 Z" fill="rgba(217,74,74,0.15)" stroke="#d94a4a" stroke-width="2" fill-rule="evenodd" stroke-dasharray="6,3" />
+  <text x="275.71" y="147.14" text-anchor="middle" font-size="15" font-weight="bold" fill="#d94a4a">B</text>
+  <path d="M 121.43 221.43 L 292.86 221.43 L 292.86 192.86 L 207.14 192.86 L 207.14 107.14 L 121.43 107.14 L 121.43 221.43 Z" fill="rgba(46,204,113,0.35)" stroke="#2ecc71" stroke-width="3" fill-rule="evenodd" />
+  <path d="M 292.86 192.86 L 378.57 192.86 L 378.57 78.57 L 207.14 78.57 L 207.14 107.14 L 292.86 107.14 L 292.86 192.86 Z" fill="rgba(46,204,113,0.35)" stroke="#2ecc71" stroke-width="3" fill-rule="evenodd" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Returns parts of A and B that do not intersect each other</text>
+  <rect x="101" y="255" width="12" height="12" rx="2" fill="#4a90d9" stroke="#4a90d9" stroke-width="1" />
+  <text x="117" y="266" font-size="13" fill="#333333">Geometry A</text>
+  <rect x="211" y="255" width="12" height="12" rx="2" fill="#d94a4a" stroke="#d94a4a" stroke-width="1" />
+  <text x="227" y="266" font-size="13" fill="#333333">Geometry B</text>
+  <rect x="321" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="337" y="266" font-size="13" fill="#333333">Result</text>
+</svg>

--- a/docs/image/ST_UnaryUnion/ST_UnaryUnion.svg
+++ b/docs/image/ST_UnaryUnion/ST_UnaryUnion.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_UnaryUnion(A)</text>
+  <path d="M 145.24 228.57 L 276.19 228.57 L 276.19 123.81 L 145.24 123.81 L 145.24 228.57 Z" fill="rgba(74,144,217,0.15)" stroke="#4a90d9" stroke-width="2" fill-rule="evenodd" stroke-dasharray="6,3" />
+  <text x="197.62" y="186.67" text-anchor="middle" font-size="15" font-weight="bold" fill="#4a90d9">A</text>
+  <path d="M 223.81 176.19 L 354.76 176.19 L 354.76 71.43 L 223.81 71.43 L 223.81 176.19 Z" fill="rgba(74,144,217,0.15)" stroke="#4a90d9" stroke-width="2" fill-rule="evenodd" stroke-dasharray="6,3" />
+  <path d="M 145.24 228.57 L 276.19 228.57 L 276.19 176.19 L 354.76 176.19 L 354.76 71.43 L 223.81 71.43 L 223.81 123.81 L 145.24 123.81 L 145.24 228.57 Z" fill="rgba(46,204,113,0.35)" stroke="#2ecc71" stroke-width="3" fill-rule="evenodd" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Returns the union of all components of a multi-geometry</text>
+  <rect x="156" y="255" width="12" height="12" rx="2" fill="#4a90d9" stroke="#4a90d9" stroke-width="1" />
+  <text x="172" y="266" font-size="13" fill="#333333">Geometry A</text>
+  <rect x="266" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="282" y="266" font-size="13" fill="#333333">Result</text>
+</svg>

--- a/docs/image/ST_Union/ST_Union.svg
+++ b/docs/image/ST_Union/ST_Union.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_Union(A, B)</text>
+  <path d="M 121.43 221.43 L 292.86 221.43 L 292.86 107.14 L 121.43 107.14 L 121.43 221.43 Z" fill="rgba(74,144,217,0.15)" stroke="#4a90d9" stroke-width="2" fill-rule="evenodd" stroke-dasharray="6,3" />
+  <text x="190.0" y="175.71" text-anchor="middle" font-size="15" font-weight="bold" fill="#4a90d9">A</text>
+  <path d="M 207.14 192.86 L 378.57 192.86 L 378.57 78.57 L 207.14 78.57 L 207.14 192.86 Z" fill="rgba(217,74,74,0.15)" stroke="#d94a4a" stroke-width="2" fill-rule="evenodd" stroke-dasharray="6,3" />
+  <text x="275.71" y="147.14" text-anchor="middle" font-size="15" font-weight="bold" fill="#d94a4a">B</text>
+  <path d="M 121.43 221.43 L 292.86 221.43 L 292.86 192.86 L 378.57 192.86 L 378.57 78.57 L 207.14 78.57 L 207.14 107.14 L 121.43 107.14 L 121.43 221.43 Z" fill="rgba(46,204,113,0.35)" stroke="#2ecc71" stroke-width="3" fill-rule="evenodd" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Returns the combined area of A and B</text>
+  <rect x="101" y="255" width="12" height="12" rx="2" fill="#4a90d9" stroke="#4a90d9" stroke-width="1" />
+  <text x="117" y="266" font-size="13" fill="#333333">Geometry A</text>
+  <rect x="211" y="255" width="12" height="12" rx="2" fill="#d94a4a" stroke="#d94a4a" stroke-width="1" />
+  <text x="227" y="266" font-size="13" fill="#333333">Geometry B</text>
+  <rect x="321" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="337" y="266" font-size="13" fill="#333333">Result</text>
+</svg>


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2678

## What changes were proposed in this PR?

Added SVG visual illustrations for 7 overlay functions (Phase 2 of #2678):

- ST_Intersection, ST_Union, ST_Difference, ST_SymDifference
- ST_Split, ST_SubDivide (also used by ST_SubDivideExplode), ST_UnaryUnion

Each overlay function gets one SVG showing input geometries (A and B in dashed outline) with the result region highlighted in green. For single-geometry functions (ST_SubDivide, ST_UnaryUnion), only geometry A is shown.

SVG files stored in docs/image/ST_Name/. Images embedded in 22 markdown files across:

- docs/api/sql/Overlay-Functions/
- docs/api/flink/Overlay-Functions/
- docs/api/snowflake/vector-data/Overlay-Functions/

## How was this patch tested?

- Verified all 7 SVG files exist and render correctly
- Verified all image references in 22 markdown files resolve to existing files (no broken links)
- Visual inspection of SVG output

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.
