### PR TITLE
[GH-2678] Add SVG visuals for measurement functions (Phase 4)

### DIFF
--- a/docs/api/flink/Measurement-Functions/ST_3DDistance.md
+++ b/docs/api/flink/Measurement-Functions/ST_3DDistance.md
@@ -21,6 +21,8 @@
 
 Introduction: Return the 3-dimensional minimum cartesian distance between A and B
 
+![ST_3DDistance](../../../image/ST_3DDistance/ST_3DDistance.svg "ST_3DDistance")
+
 Format: `ST_3DDistance (A: Geometry, B: Geometry)`
 
 Return type: `Double`

--- a/docs/api/flink/Measurement-Functions/ST_Angle.md
+++ b/docs/api/flink/Measurement-Functions/ST_Angle.md
@@ -45,6 +45,8 @@ Computes the angle formed by vectors S1 - E1 and S2 - E2, where S and E denote s
 !!!Tip
     ST_Angle returns the angle in radian between 0 and 2\Pi. To convert the angle to degrees, use [ST_Degrees](ST_Degrees.md).
 
+![ST_Angle](../../../image/ST_Angle/ST_Angle.svg "ST_Angle")
+
 Format: `ST_Angle(p1, p2, p3, p4) | ST_Angle(p1, p2, p3) | ST_Angle(line1, line2)`
 
 Return type: `Double`

--- a/docs/api/flink/Measurement-Functions/ST_Area.md
+++ b/docs/api/flink/Measurement-Functions/ST_Area.md
@@ -21,6 +21,8 @@
 
 Introduction: Return the area of A
 
+![ST_Area](../../../image/ST_Area/ST_Area.svg "ST_Area")
+
 Format: `ST_Area (A: Geometry)`
 
 Return type: `Double`

--- a/docs/api/flink/Measurement-Functions/ST_AreaSpheroid.md
+++ b/docs/api/flink/Measurement-Functions/ST_AreaSpheroid.md
@@ -26,6 +26,8 @@ Geometry must be in EPSG:4326 (WGS84) projection and must be in ==lon/lat== orde
 !!!note
     By default, this function uses lon/lat order since `v1.5.0`. Before, it used lat/lon order.
 
+![ST_AreaSpheroid](../../../image/ST_AreaSpheroid/ST_AreaSpheroid.svg "ST_AreaSpheroid")
+
 Format: `ST_AreaSpheroid (A: Geometry)`
 
 Return type: `Double`

--- a/docs/api/flink/Measurement-Functions/ST_Azimuth.md
+++ b/docs/api/flink/Measurement-Functions/ST_Azimuth.md
@@ -21,6 +21,8 @@
 
 Introduction: Returns Azimuth for two given points in radians. Returns null if the two points are identical.
 
+![ST_Azimuth](../../../image/ST_Azimuth/ST_Azimuth.svg "ST_Azimuth")
+
 Format: `ST_Azimuth(pointA: Point, pointB: Point)`
 
 Return type: `Double`

--- a/docs/api/flink/Measurement-Functions/ST_ClosestPoint.md
+++ b/docs/api/flink/Measurement-Functions/ST_ClosestPoint.md
@@ -22,6 +22,8 @@
 Introduction: Returns the 2-dimensional point on geom1 that is closest to geom2. This is the first point of the shortest line between the geometries. If using 3D geometries, the Z coordinates will be ignored. If you have a 3D Geometry, you may prefer to use ST_3DClosestPoint.
 It will throw an exception indicates illegal argument if one of the params is an empty geometry.
 
+![ST_ClosestPoint](../../../image/ST_ClosestPoint/ST_ClosestPoint.svg "ST_ClosestPoint")
+
 Format: `ST_ClosestPoint(g1: Geometry, g2: Geometry)`
 
 Return type: `Geometry`

--- a/docs/api/flink/Measurement-Functions/ST_Degrees.md
+++ b/docs/api/flink/Measurement-Functions/ST_Degrees.md
@@ -21,6 +21,8 @@
 
 Introduction: Convert an angle in radian to degrees.
 
+![ST_Degrees](../../../image/ST_Degrees/ST_Degrees.svg "ST_Degrees")
+
 Format: `ST_Degrees(angleInRadian)`
 
 Return type: `Double`

--- a/docs/api/flink/Measurement-Functions/ST_Distance.md
+++ b/docs/api/flink/Measurement-Functions/ST_Distance.md
@@ -21,6 +21,8 @@
 
 Introduction: Return the Euclidean distance between A and B
 
+![ST_Distance](../../../image/ST_Distance/ST_Distance.svg "ST_Distance")
+
 Format: `ST_Distance (A: Geometry, B: Geometry)`
 
 Return type: `Double`

--- a/docs/api/flink/Measurement-Functions/ST_DistanceSphere.md
+++ b/docs/api/flink/Measurement-Functions/ST_DistanceSphere.md
@@ -26,6 +26,8 @@ Geometry must be in EPSG:4326 (WGS84) projection and must be in ==lon/lat== orde
 !!!note
     By default, this function uses lon/lat order since `v1.5.0`. Before, it used lat/lon order.
 
+![ST_DistanceSphere](../../../image/ST_DistanceSphere/ST_DistanceSphere.svg "ST_DistanceSphere")
+
 Format: `ST_DistanceSphere (A: Geometry)`
 
 Return type: `Double`

--- a/docs/api/flink/Measurement-Functions/ST_DistanceSpheroid.md
+++ b/docs/api/flink/Measurement-Functions/ST_DistanceSpheroid.md
@@ -26,6 +26,8 @@ Geometry must be in EPSG:4326 (WGS84) projection and must be in ==lon/lat== orde
 !!!note
     By default, this function uses lon/lat order since `v1.5.0`. Before, it used lat/lon order.
 
+![ST_DistanceSpheroid](../../../image/ST_DistanceSpheroid/ST_DistanceSpheroid.svg "ST_DistanceSpheroid")
+
 Format: `ST_DistanceSpheroid (A: Geometry)`
 
 Return type: `Double`

--- a/docs/api/flink/Measurement-Functions/ST_FrechetDistance.md
+++ b/docs/api/flink/Measurement-Functions/ST_FrechetDistance.md
@@ -24,6 +24,8 @@ based on [Computing Discrete Frechet Distance](http://www.kr.tuwien.ac.at/staff/
 
 If any of the geometries is empty, returns 0.0
 
+![ST_FrechetDistance](../../../image/ST_FrechetDistance/ST_FrechetDistance.svg "ST_FrechetDistance")
+
 Format: `ST_FrechetDistance(g1: Geometry, g2: Geometry)`
 
 Return type: `Double`

--- a/docs/api/flink/Measurement-Functions/ST_HausdorffDistance.md
+++ b/docs/api/flink/Measurement-Functions/ST_HausdorffDistance.md
@@ -33,6 +33,8 @@ If any of the geometry is empty, 0.0 is returned.
 !!!Note
     Even though the function accepts 3D geometry, the z ordinate is ignored and the computed hausdorff distance is equivalent to the geometries not having the z ordinate.
 
+![ST_HausdorffDistance](../../../image/ST_HausdorffDistance/ST_HausdorffDistance.svg "ST_HausdorffDistance")
+
 Format: `ST_HausdorffDistance(g1: Geometry, g2: Geometry, densityFrac: Double)`
 
 Return type: `Double`

--- a/docs/api/flink/Measurement-Functions/ST_Length.md
+++ b/docs/api/flink/Measurement-Functions/ST_Length.md
@@ -24,6 +24,8 @@ Introduction: Returns the perimeter of A.
 !!!Warning
     Since `v1.7.0`, this function only supports LineString, MultiLineString, and GeometryCollections containing linear geometries. Use [ST_Perimeter](ST_Perimeter.md) for polygons.
 
+![ST_Length](../../../image/ST_Length/ST_Length.svg "ST_Length")
+
 Format: `ST_Length (A: Geometry)`
 
 Return type: `Double`

--- a/docs/api/flink/Measurement-Functions/ST_Length2D.md
+++ b/docs/api/flink/Measurement-Functions/ST_Length2D.md
@@ -24,6 +24,8 @@ Introduction: Returns the perimeter of A. This function is an alias of [ST_Lengt
 !!!Warning
     Since `v1.7.0`, this function only supports LineString, MultiLineString, and GeometryCollections containing linear geometries. Use [ST_Perimeter](ST_Perimeter.md) for polygons.
 
+![ST_Length2D](../../../image/ST_Length2D/ST_Length2D.svg "ST_Length2D")
+
 Format: ST_Length2D (A:geometry)
 
 Return type: `Double`

--- a/docs/api/flink/Measurement-Functions/ST_LengthSpheroid.md
+++ b/docs/api/flink/Measurement-Functions/ST_LengthSpheroid.md
@@ -29,6 +29,8 @@ Geometry must be in EPSG:4326 (WGS84) projection and must be in ==lon/lat== orde
 !!!Warning
     Since `v1.7.0`, this function only supports LineString, MultiLineString, and GeometryCollections containing linear geometries. Use [ST_Perimeter](ST_Perimeter.md) for polygons.
 
+![ST_LengthSpheroid](../../../image/ST_LengthSpheroid/ST_LengthSpheroid.svg "ST_LengthSpheroid")
+
 Format: `ST_LengthSpheroid (A: Geometry)`
 
 Return type: `Double`

--- a/docs/api/flink/Measurement-Functions/ST_LongestLine.md
+++ b/docs/api/flink/Measurement-Functions/ST_LongestLine.md
@@ -21,6 +21,8 @@
 
 Introduction: Returns the LineString geometry representing the maximum distance between any two points from the input geometries.
 
+![ST_LongestLine](../../../image/ST_LongestLine/ST_LongestLine.svg "ST_LongestLine")
+
 Format: `ST_LongestLine(geom1: Geometry, geom2: Geometry)`
 
 Return type: `Geometry`

--- a/docs/api/flink/Measurement-Functions/ST_MaxDistance.md
+++ b/docs/api/flink/Measurement-Functions/ST_MaxDistance.md
@@ -21,6 +21,8 @@
 
 Introduction: Calculates and returns the length value representing the maximum distance between any two points across the input geometries. This function is an alias for `ST_LongestDistance`.
 
+![ST_MaxDistance](../../../image/ST_MaxDistance/ST_MaxDistance.svg "ST_MaxDistance")
+
 Format: `ST_MaxDistance(geom1: Geometry, geom2: Geometry)`
 
 Return type: `Double`

--- a/docs/api/flink/Measurement-Functions/ST_MinimumClearance.md
+++ b/docs/api/flink/Measurement-Functions/ST_MinimumClearance.md
@@ -28,6 +28,8 @@ For a geometry with a minimum clearance of `x`, the following conditions hold:
 
 For geometries with no definable minimum clearance, such as single Point geometries or MultiPoint geometries where all points occupy the same location, the function returns `Double.MAX_VALUE`.
 
+![ST_MinimumClearance](../../../image/ST_MinimumClearance/ST_MinimumClearance.svg "ST_MinimumClearance")
+
 Format: `ST_MinimumClearance(geometry: Geometry)`
 
 Return type: `Double`

--- a/docs/api/flink/Measurement-Functions/ST_MinimumClearanceLine.md
+++ b/docs/api/flink/Measurement-Functions/ST_MinimumClearanceLine.md
@@ -21,6 +21,8 @@
 
 Introduction: This function returns a two-point LineString geometry representing the minimum clearance distance of the input geometry. If the input geometry does not have a defined minimum clearance, such as for single Points or coincident MultiPoints, an empty LineString geometry is returned instead.
 
+![ST_MinimumClearanceLine](../../../image/ST_MinimumClearanceLine/ST_MinimumClearanceLine.svg "ST_MinimumClearanceLine")
+
 Format: `ST_MinimumClearanceLine(geometry: Geometry)`
 
 Return type: `Geometry`

--- a/docs/api/flink/Measurement-Functions/ST_Perimeter.md
+++ b/docs/api/flink/Measurement-Functions/ST_Perimeter.md
@@ -23,6 +23,8 @@ Introduction: This function calculates the 2D perimeter of a given geometry. It 
 
 To get the perimeter in meters, set `use_spheroid` to `true`. This calculates the geodesic perimeter using the WGS84 spheroid. When using `use_spheroid`, the `lenient` parameter defaults to true, assuming the geometry uses EPSG:4326. To throw an exception instead, set `lenient` to `false`.
 
+![ST_Perimeter](../../../image/ST_Perimeter/ST_Perimeter.svg "ST_Perimeter")
+
 Format:
 
 `ST_Perimeter(geom: Geometry)`

--- a/docs/api/flink/Measurement-Functions/ST_Perimeter2D.md
+++ b/docs/api/flink/Measurement-Functions/ST_Perimeter2D.md
@@ -26,6 +26,8 @@ To get the perimeter in meters, set `use_spheroid` to `true`. This calculates th
 !!!Info
     This function is an alias for [ST_Perimeter](ST_Perimeter.md).
 
+![ST_Perimeter2D](../../../image/ST_Perimeter2D/ST_Perimeter2D.svg "ST_Perimeter2D")
+
 Format:
 
 `ST_Perimeter2D(geom: Geometry)`

--- a/docs/api/snowflake/vector-data/Measurement-Functions/ST_3DDistance.md
+++ b/docs/api/snowflake/vector-data/Measurement-Functions/ST_3DDistance.md
@@ -21,6 +21,8 @@
 
 Introduction: Return the 3-dimensional minimum cartesian distance between A and B
 
+![ST_3DDistance](../../../../image/ST_3DDistance/ST_3DDistance.svg "ST_3DDistance")
+
 Format: `ST_3DDistance (A:geometry, B:geometry)`
 
 Return type: `Double`

--- a/docs/api/snowflake/vector-data/Measurement-Functions/ST_Angle.md
+++ b/docs/api/snowflake/vector-data/Measurement-Functions/ST_Angle.md
@@ -42,6 +42,8 @@ Additionally, if any of the provided geometry is empty, ST_Angle throws an Illeg
 !!!Tip
     ST_Angle returns the angle in radian between 0 and 2\Pi. To convert the angle to degrees, use [ST_Degrees](ST_Degrees.md).
 
+![ST_Angle](../../../../image/ST_Angle/ST_Angle.svg "ST_Angle")
+
 Format: `ST_Angle(p1, p2, p3, p4) | ST_Angle(p1, p2, p3) | ST_Angle(line1, line2)`
 
 Return type: `Double`

--- a/docs/api/snowflake/vector-data/Measurement-Functions/ST_Area.md
+++ b/docs/api/snowflake/vector-data/Measurement-Functions/ST_Area.md
@@ -21,6 +21,8 @@
 
 Introduction: Return the area of A
 
+![ST_Area](../../../../image/ST_Area/ST_Area.svg "ST_Area")
+
 Format: `ST_Area (A:geometry)`
 
 Return type: `Double`

--- a/docs/api/snowflake/vector-data/Measurement-Functions/ST_AreaSpheroid.md
+++ b/docs/api/snowflake/vector-data/Measurement-Functions/ST_AreaSpheroid.md
@@ -23,6 +23,8 @@ Introduction: Return the geodesic area of A using WGS84 spheroid. Unit is square
 
 Geometry must be in EPSG:4326 (WGS84) projection and must be in ==lat/lon== order. You can use ==ST_FlipCoordinates== to swap lat and lon.
 
+![ST_AreaSpheroid](../../../../image/ST_AreaSpheroid/ST_AreaSpheroid.svg "ST_AreaSpheroid")
+
 Format: `ST_AreaSpheroid (A:geometry)`
 
 Return type: `Double`

--- a/docs/api/snowflake/vector-data/Measurement-Functions/ST_Azimuth.md
+++ b/docs/api/snowflake/vector-data/Measurement-Functions/ST_Azimuth.md
@@ -21,6 +21,8 @@
 
 Introduction: Returns Azimuth for two given points in radians. Returns null if the two points are identical.
 
+![ST_Azimuth](../../../../image/ST_Azimuth/ST_Azimuth.svg "ST_Azimuth")
+
 Format: `ST_Azimuth(pointA: Point, pointB: Point)`
 
 Return type: `Double`

--- a/docs/api/snowflake/vector-data/Measurement-Functions/ST_ClosestPoint.md
+++ b/docs/api/snowflake/vector-data/Measurement-Functions/ST_ClosestPoint.md
@@ -22,6 +22,8 @@
 Introduction: Returns the 2-dimensional point on geom1 that is closest to geom2. This is the first point of the shortest line between the geometries. If using 3D geometries, the Z coordinates will be ignored. If you have a 3D Geometry, you may prefer to use ST_3DClosestPoint.
 It will throw an exception indicates illegal argument if one of the params is an empty geometry.
 
+![ST_ClosestPoint](../../../../image/ST_ClosestPoint/ST_ClosestPoint.svg "ST_ClosestPoint")
+
 Format: `ST_ClosestPoint(g1: Geometry, g2: Geometry)`
 
 Return type: `Geometry`

--- a/docs/api/snowflake/vector-data/Measurement-Functions/ST_Degrees.md
+++ b/docs/api/snowflake/vector-data/Measurement-Functions/ST_Degrees.md
@@ -21,6 +21,8 @@
 
 Introduction: Convert an angle in radian to degrees.
 
+![ST_Degrees](../../../../image/ST_Degrees/ST_Degrees.svg "ST_Degrees")
+
 Format: `ST_Degrees(angleInRadian)`
 
 Return type: `Double`

--- a/docs/api/snowflake/vector-data/Measurement-Functions/ST_Distance.md
+++ b/docs/api/snowflake/vector-data/Measurement-Functions/ST_Distance.md
@@ -21,6 +21,8 @@
 
 Introduction: Return the Euclidean distance between A and B
 
+![ST_Distance](../../../../image/ST_Distance/ST_Distance.svg "ST_Distance")
+
 Format: `ST_Distance (A:geometry, B:geometry)`
 
 Return type: `Double`

--- a/docs/api/snowflake/vector-data/Measurement-Functions/ST_DistanceSphere.md
+++ b/docs/api/snowflake/vector-data/Measurement-Functions/ST_DistanceSphere.md
@@ -23,6 +23,8 @@ Introduction: Return the haversine / great-circle distance of A using a given ea
 
 Geometry must be in EPSG:4326 (WGS84) projection and must be in ==lat/lon== order. You can use ==ST_FlipCoordinates== to swap lat and lon. For non-point data, we first take the centroids of both geometries and then compute the distance.
 
+![ST_DistanceSphere](../../../../image/ST_DistanceSphere/ST_DistanceSphere.svg "ST_DistanceSphere")
+
 Format: `ST_DistanceSphere (A:geometry)`
 
 Return type: `Double`

--- a/docs/api/snowflake/vector-data/Measurement-Functions/ST_DistanceSpheroid.md
+++ b/docs/api/snowflake/vector-data/Measurement-Functions/ST_DistanceSpheroid.md
@@ -23,6 +23,8 @@ Introduction: Return the geodesic distance of A using WGS84 spheroid. Unit is me
 
 Geometry must be in EPSG:4326 (WGS84) projection and must be in ==lat/lon== order. You can use ==ST_FlipCoordinates== to swap lat and lon. For non-point data, we first take the centroids of both geometries and then compute the distance.
 
+![ST_DistanceSpheroid](../../../../image/ST_DistanceSpheroid/ST_DistanceSpheroid.svg "ST_DistanceSpheroid")
+
 Format: `ST_DistanceSpheroid (A:geometry)`
 
 Return type: `Double`

--- a/docs/api/snowflake/vector-data/Measurement-Functions/ST_FrechetDistance.md
+++ b/docs/api/snowflake/vector-data/Measurement-Functions/ST_FrechetDistance.md
@@ -24,6 +24,8 @@ based on [Computing Discrete Frechet Distance](http://www.kr.tuwien.ac.at/staff/
 
 If any of the geometries is empty, returns 0.0
 
+![ST_FrechetDistance](../../../../image/ST_FrechetDistance/ST_FrechetDistance.svg "ST_FrechetDistance")
+
 Format: `ST_FrechetDistance(g1: Geometry, g2: Geometry)`
 
 Return type: `Double`

--- a/docs/api/snowflake/vector-data/Measurement-Functions/ST_HausdorffDistance.md
+++ b/docs/api/snowflake/vector-data/Measurement-Functions/ST_HausdorffDistance.md
@@ -33,6 +33,8 @@ If any of the geometry is empty, 0.0 is returned.
 !!!Note
     Even though the function accepts 3D geometry, the z ordinate is ignored and the computed hausdorff distance is equivalent to the geometries not having the z ordinate.
 
+![ST_HausdorffDistance](../../../../image/ST_HausdorffDistance/ST_HausdorffDistance.svg "ST_HausdorffDistance")
+
 Format: `ST_HausdorffDistance(g1: Geometry, g2: Geometry, densityFrac: Double)`
 
 Return type: `Double`

--- a/docs/api/snowflake/vector-data/Measurement-Functions/ST_Length.md
+++ b/docs/api/snowflake/vector-data/Measurement-Functions/ST_Length.md
@@ -24,6 +24,8 @@ Introduction: Returns the perimeter of A.
 !!!Warning
     This function only supports LineString, MultiLineString, and GeometryCollections containing linear geometries. Use [ST_Perimeter](ST_Perimeter.md) for polygons.
 
+![ST_Length](../../../../image/ST_Length/ST_Length.svg "ST_Length")
+
 Format: ST_Length (A:geometry)
 
 Return type: `Double`

--- a/docs/api/snowflake/vector-data/Measurement-Functions/ST_Length2D.md
+++ b/docs/api/snowflake/vector-data/Measurement-Functions/ST_Length2D.md
@@ -24,6 +24,8 @@ Introduction: Returns the perimeter of A. This function is an alias of [ST_Lengt
 !!!Warning
     This function only supports LineString, MultiLineString, and GeometryCollections containing linear geometries. Use [ST_Perimeter](ST_Perimeter.md) for polygons.
 
+![ST_Length2D](../../../../image/ST_Length2D/ST_Length2D.svg "ST_Length2D")
+
 Format: ST_Length2D (A:geometry)
 
 Return type: `Double`

--- a/docs/api/snowflake/vector-data/Measurement-Functions/ST_LengthSpheroid.md
+++ b/docs/api/snowflake/vector-data/Measurement-Functions/ST_LengthSpheroid.md
@@ -26,6 +26,8 @@ Geometry must be in EPSG:4326 (WGS84) projection and must be in ==lat/lon== orde
 !!!Warning
     This function only supports LineString, MultiLineString, and GeometryCollections containing linear geometries. Use [ST_Perimeter](ST_Perimeter.md) for polygons.
 
+![ST_LengthSpheroid](../../../../image/ST_LengthSpheroid/ST_LengthSpheroid.svg "ST_LengthSpheroid")
+
 Format: `ST_LengthSpheroid (A:geometry)`
 
 Return type: `Double`

--- a/docs/api/snowflake/vector-data/Measurement-Functions/ST_LongestLine.md
+++ b/docs/api/snowflake/vector-data/Measurement-Functions/ST_LongestLine.md
@@ -21,6 +21,8 @@
 
 Introduction: Returns the LineString geometry representing the maximum distance between any two points from the input geometries.
 
+![ST_LongestLine](../../../../image/ST_LongestLine/ST_LongestLine.svg "ST_LongestLine")
+
 Format: `ST_LongestLine(geom1: Geometry, geom2: Geometry)`
 
 Return type: `Geometry`

--- a/docs/api/snowflake/vector-data/Measurement-Functions/ST_MaxDistance.md
+++ b/docs/api/snowflake/vector-data/Measurement-Functions/ST_MaxDistance.md
@@ -21,6 +21,8 @@
 
 Introduction: Calculates and returns the length value representing the maximum distance between any two points across the input geometries. This function is an alias for `ST_LongestDistance`.
 
+![ST_MaxDistance](../../../../image/ST_MaxDistance/ST_MaxDistance.svg "ST_MaxDistance")
+
 Format: `ST_MaxDistance(geom1: Geometry, geom2: Geometry)`
 
 Return type: `Double`

--- a/docs/api/snowflake/vector-data/Measurement-Functions/ST_MinimumClearance.md
+++ b/docs/api/snowflake/vector-data/Measurement-Functions/ST_MinimumClearance.md
@@ -28,6 +28,8 @@ For a geometry with a minimum clearance of `x`, the following conditions hold:
 
 For geometries with no definable minimum clearance, such as single Point geometries or MultiPoint geometries where all points occupy the same location, the function returns `Double.MAX_VALUE`.
 
+![ST_MinimumClearance](../../../../image/ST_MinimumClearance/ST_MinimumClearance.svg "ST_MinimumClearance")
+
 Format: `ST_MinimumClearance(geometry: Geometry)`
 
 Return type: `Double`

--- a/docs/api/snowflake/vector-data/Measurement-Functions/ST_MinimumClearanceLine.md
+++ b/docs/api/snowflake/vector-data/Measurement-Functions/ST_MinimumClearanceLine.md
@@ -21,6 +21,8 @@
 
 Introduction: This function returns a two-point LineString geometry representing the minimum clearance distance of the input geometry. If the input geometry does not have a defined minimum clearance, such as for single Points or coincident MultiPoints, an empty LineString geometry is returned instead.
 
+![ST_MinimumClearanceLine](../../../../image/ST_MinimumClearanceLine/ST_MinimumClearanceLine.svg "ST_MinimumClearanceLine")
+
 Format: `ST_MinimumClearanceLine(geometry: Geometry)`
 
 Return type: `Geometry`

--- a/docs/api/snowflake/vector-data/Measurement-Functions/ST_Perimeter.md
+++ b/docs/api/snowflake/vector-data/Measurement-Functions/ST_Perimeter.md
@@ -23,6 +23,8 @@ Introduction: This function calculates the 2D perimeter of a given geometry. It 
 
 To get the perimeter in meters, set `use_spheroid` to `true`. This calculates the geodesic perimeter using the WGS84 spheroid. When using `use_spheroid`, the `lenient` parameter defaults to true, assuming the geometry uses EPSG:4326. To throw an exception instead, set `lenient` to `false`.
 
+![ST_Perimeter](../../../../image/ST_Perimeter/ST_Perimeter.svg "ST_Perimeter")
+
 Format:
 
 `ST_Perimeter(geom: Geometry)`

--- a/docs/api/snowflake/vector-data/Measurement-Functions/ST_Perimeter2D.md
+++ b/docs/api/snowflake/vector-data/Measurement-Functions/ST_Perimeter2D.md
@@ -26,6 +26,8 @@ To get the perimeter in meters, set `use_spheroid` to `true`. This calculates th
 !!!Info
     This function is an alias for [ST_Perimeter](ST_Perimeter.md).
 
+![ST_Perimeter2D](../../../../image/ST_Perimeter2D/ST_Perimeter2D.svg "ST_Perimeter2D")
+
 Format:
 
 `ST_Perimeter2D(geom: Geometry)`

--- a/docs/api/sql/Measurement-Functions/ST_3DDistance.md
+++ b/docs/api/sql/Measurement-Functions/ST_3DDistance.md
@@ -21,6 +21,8 @@
 
 Introduction: Return the 3-dimensional minimum cartesian distance between A and B
 
+![ST_3DDistance](../../../image/ST_3DDistance/ST_3DDistance.svg "ST_3DDistance")
+
 Format: `ST_3DDistance (A: Geometry, B: Geometry)`
 
 Return type: `Double`

--- a/docs/api/sql/Measurement-Functions/ST_Angle.md
+++ b/docs/api/sql/Measurement-Functions/ST_Angle.md
@@ -42,6 +42,8 @@ Computes the angle formed by vectors S1 - E1 and S2 - E2, where S and E denote s
 !!!Tip
     ST_Angle returns the angle in radian between 0 and 2\Pi. To convert the angle to degrees, use [ST_Degrees](ST_Degrees.md).
 
+![ST_Angle](../../../image/ST_Angle/ST_Angle.svg "ST_Angle")
+
 Format: `ST_Angle(p1, p2, p3, p4) | ST_Angle(p1, p2, p3) | ST_Angle(line1, line2)`
 
 Return type: `Double`

--- a/docs/api/sql/Measurement-Functions/ST_Area.md
+++ b/docs/api/sql/Measurement-Functions/ST_Area.md
@@ -21,6 +21,8 @@
 
 Introduction: Return the area of A
 
+![ST_Area](../../../image/ST_Area/ST_Area.svg "ST_Area")
+
 Format: `ST_Area (A: Geometry)`
 
 Return type: `Double`

--- a/docs/api/sql/Measurement-Functions/ST_AreaSpheroid.md
+++ b/docs/api/sql/Measurement-Functions/ST_AreaSpheroid.md
@@ -26,6 +26,8 @@ Geometry must be in EPSG:4326 (WGS84) projection and must be in ==lon/lat== orde
 !!!note
     By default, this function uses lon/lat order since `v1.5.0`. Before, it used lat/lon order.
 
+![ST_AreaSpheroid](../../../image/ST_AreaSpheroid/ST_AreaSpheroid.svg "ST_AreaSpheroid")
+
 Format: `ST_AreaSpheroid (A: Geometry)`
 
 Return type: `Double`

--- a/docs/api/sql/Measurement-Functions/ST_Azimuth.md
+++ b/docs/api/sql/Measurement-Functions/ST_Azimuth.md
@@ -21,6 +21,8 @@
 
 Introduction: Returns Azimuth for two given points in radians. Returns null if the two points are identical.
 
+![ST_Azimuth](../../../image/ST_Azimuth/ST_Azimuth.svg "ST_Azimuth")
+
 Format: `ST_Azimuth(pointA: Point, pointB: Point)`
 
 Return type: `Double`

--- a/docs/api/sql/Measurement-Functions/ST_ClosestPoint.md
+++ b/docs/api/sql/Measurement-Functions/ST_ClosestPoint.md
@@ -22,6 +22,8 @@
 Introduction: Returns the 2-dimensional point on geom1 that is closest to geom2. This is the first point of the shortest line between the geometries. If using 3D geometries, the Z coordinates will be ignored. If you have a 3D Geometry, you may prefer to use ST_3DClosestPoint.
 It will throw an exception indicates illegal argument if one of the params is an empty geometry.
 
+![ST_ClosestPoint](../../../image/ST_ClosestPoint/ST_ClosestPoint.svg "ST_ClosestPoint")
+
 Format: `ST_ClosestPoint(g1: Geometry, g2: Geometry)`
 
 Return type: `Geometry`

--- a/docs/api/sql/Measurement-Functions/ST_Degrees.md
+++ b/docs/api/sql/Measurement-Functions/ST_Degrees.md
@@ -21,6 +21,8 @@
 
 Introduction: Convert an angle in radian to degrees.
 
+![ST_Degrees](../../../image/ST_Degrees/ST_Degrees.svg "ST_Degrees")
+
 Format: `ST_Degrees(angleInRadian)`
 
 Return type: `Double`

--- a/docs/api/sql/Measurement-Functions/ST_Distance.md
+++ b/docs/api/sql/Measurement-Functions/ST_Distance.md
@@ -21,6 +21,8 @@
 
 Introduction: Return the Euclidean distance between A and B
 
+![ST_Distance](../../../image/ST_Distance/ST_Distance.svg "ST_Distance")
+
 Format: `ST_Distance (A: Geometry, B: Geometry)`
 
 Return type: `Double`

--- a/docs/api/sql/Measurement-Functions/ST_DistanceSphere.md
+++ b/docs/api/sql/Measurement-Functions/ST_DistanceSphere.md
@@ -26,6 +26,8 @@ Geometry must be in EPSG:4326 (WGS84) projection and must be in ==lon/lat== orde
 !!!note
     By default, this function uses lon/lat order since `v1.5.0`. Before, it used lat/lon order.
 
+![ST_DistanceSphere](../../../image/ST_DistanceSphere/ST_DistanceSphere.svg "ST_DistanceSphere")
+
 Format: `ST_DistanceSphere (A: Geometry)`
 
 Return type: `Double`

--- a/docs/api/sql/Measurement-Functions/ST_DistanceSpheroid.md
+++ b/docs/api/sql/Measurement-Functions/ST_DistanceSpheroid.md
@@ -26,6 +26,8 @@ Geometry must be in EPSG:4326 (WGS84) projection and must be in ==lon/lat== orde
 !!!note
     By default, this function uses lon/lat order since `v1.5.0`. Before, it used lat/lon order.
 
+![ST_DistanceSpheroid](../../../image/ST_DistanceSpheroid/ST_DistanceSpheroid.svg "ST_DistanceSpheroid")
+
 Format: `ST_DistanceSpheroid (A: Geometry)`
 
 Return type: `Double`

--- a/docs/api/sql/Measurement-Functions/ST_FrechetDistance.md
+++ b/docs/api/sql/Measurement-Functions/ST_FrechetDistance.md
@@ -24,6 +24,8 @@ based on [Computing Discrete Frechet Distance](http://www.kr.tuwien.ac.at/staff/
 
 If any of the geometries is empty, returns 0.0
 
+![ST_FrechetDistance](../../../image/ST_FrechetDistance/ST_FrechetDistance.svg "ST_FrechetDistance")
+
 Format: `ST_FrechetDistance(g1: Geometry, g2: Geometry)`
 
 Return type: `Double`

--- a/docs/api/sql/Measurement-Functions/ST_HausdorffDistance.md
+++ b/docs/api/sql/Measurement-Functions/ST_HausdorffDistance.md
@@ -33,6 +33,8 @@ If any of the geometry is empty, 0.0 is returned.
 !!!Note
     Even though the function accepts 3D geometry, the z ordinate is ignored and the computed hausdorff distance is equivalent to the geometries not having the z ordinate.
 
+![ST_HausdorffDistance](../../../image/ST_HausdorffDistance/ST_HausdorffDistance.svg "ST_HausdorffDistance")
+
 Format: `ST_HausdorffDistance(g1: Geometry, g2: Geometry, densityFrac: Double)`
 
 Return type: `Double`

--- a/docs/api/sql/Measurement-Functions/ST_Length.md
+++ b/docs/api/sql/Measurement-Functions/ST_Length.md
@@ -24,6 +24,8 @@ Introduction: Returns the perimeter of A.
 !!!Warning
     Since `v1.7.0`, this function only supports LineString, MultiLineString, and GeometryCollections containing linear geometries. Use [ST_Perimeter](ST_Perimeter.md) for polygons.
 
+![ST_Length](../../../image/ST_Length/ST_Length.svg "ST_Length")
+
 Format: `ST_Length (A: Geometry)`
 
 Return type: `Double`

--- a/docs/api/sql/Measurement-Functions/ST_Length2D.md
+++ b/docs/api/sql/Measurement-Functions/ST_Length2D.md
@@ -24,6 +24,8 @@ Introduction: Returns the perimeter of A. This function is an alias of [ST_Lengt
 !!!Warning
     Since `v1.7.0`, this function only supports LineString, MultiLineString, and GeometryCollections containing linear geometries. Use [ST_Perimeter](ST_Perimeter.md) for polygons.
 
+![ST_Length2D](../../../image/ST_Length2D/ST_Length2D.svg "ST_Length2D")
+
 Format: ST_Length2D (A:geometry)
 
 Return type: `Double`

--- a/docs/api/sql/Measurement-Functions/ST_LengthSpheroid.md
+++ b/docs/api/sql/Measurement-Functions/ST_LengthSpheroid.md
@@ -29,6 +29,8 @@ Geometry must be in EPSG:4326 (WGS84) projection and must be in ==lon/lat== orde
 !!!Warning
     Since `v1.7.0`, this function only supports LineString, MultiLineString, and GeometryCollections containing linear geometries. Use [ST_Perimeter](ST_Perimeter.md) for polygons.
 
+![ST_LengthSpheroid](../../../image/ST_LengthSpheroid/ST_LengthSpheroid.svg "ST_LengthSpheroid")
+
 Format: `ST_LengthSpheroid (A: Geometry)`
 
 Return type: `Double`

--- a/docs/api/sql/Measurement-Functions/ST_LongestLine.md
+++ b/docs/api/sql/Measurement-Functions/ST_LongestLine.md
@@ -21,6 +21,8 @@
 
 Introduction: Returns the LineString geometry representing the maximum distance between any two points from the input geometries.
 
+![ST_LongestLine](../../../image/ST_LongestLine/ST_LongestLine.svg "ST_LongestLine")
+
 Format: `ST_LongestLine(geom1: Geometry, geom2: Geometry)`
 
 Return type: `Geometry`

--- a/docs/api/sql/Measurement-Functions/ST_MaxDistance.md
+++ b/docs/api/sql/Measurement-Functions/ST_MaxDistance.md
@@ -21,6 +21,8 @@
 
 Introduction: Calculates and returns the length value representing the maximum distance between any two points across the input geometries. This function is an alias for `ST_LongestDistance`.
 
+![ST_MaxDistance](../../../image/ST_MaxDistance/ST_MaxDistance.svg "ST_MaxDistance")
+
 Format: `ST_MaxDistance(geom1: Geometry, geom2: Geometry)`
 
 Return type: `Double`

--- a/docs/api/sql/Measurement-Functions/ST_MinimumClearance.md
+++ b/docs/api/sql/Measurement-Functions/ST_MinimumClearance.md
@@ -28,6 +28,8 @@ For a geometry with a minimum clearance of `x`, the following conditions hold:
 
 For geometries with no definable minimum clearance, such as single Point geometries or MultiPoint geometries where all points occupy the same location, the function returns `Double.MAX_VALUE`.
 
+![ST_MinimumClearance](../../../image/ST_MinimumClearance/ST_MinimumClearance.svg "ST_MinimumClearance")
+
 Format: `ST_MinimumClearance(geometry: Geometry)`
 
 Return type: `Double`

--- a/docs/api/sql/Measurement-Functions/ST_MinimumClearanceLine.md
+++ b/docs/api/sql/Measurement-Functions/ST_MinimumClearanceLine.md
@@ -21,6 +21,8 @@
 
 Introduction: This function returns a two-point LineString geometry representing the minimum clearance distance of the input geometry. If the input geometry does not have a defined minimum clearance, such as for single Points or coincident MultiPoints, an empty LineString geometry is returned instead.
 
+![ST_MinimumClearanceLine](../../../image/ST_MinimumClearanceLine/ST_MinimumClearanceLine.svg "ST_MinimumClearanceLine")
+
 Format: `ST_MinimumClearanceLine(geometry: Geometry)`
 
 Return type: `Geometry`

--- a/docs/api/sql/Measurement-Functions/ST_Perimeter.md
+++ b/docs/api/sql/Measurement-Functions/ST_Perimeter.md
@@ -23,6 +23,8 @@ Introduction: This function calculates the 2D perimeter of a given geometry. It 
 
 To get the perimeter in meters, set `use_spheroid` to `true`. This calculates the geodesic perimeter using the WGS84 spheroid. When using `use_spheroid`, the `lenient` parameter defaults to true, assuming the geometry uses EPSG:4326. To throw an exception instead, set `lenient` to `false`.
 
+![ST_Perimeter](../../../image/ST_Perimeter/ST_Perimeter.svg "ST_Perimeter")
+
 Format:
 
 `ST_Perimeter(geom: Geometry)`

--- a/docs/api/sql/Measurement-Functions/ST_Perimeter2D.md
+++ b/docs/api/sql/Measurement-Functions/ST_Perimeter2D.md
@@ -26,6 +26,8 @@ To get the perimeter in meters, set `use_spheroid` to `true`. This calculates th
 !!!Info
     This function is an alias for [ST_Perimeter](ST_Perimeter.md).
 
+![ST_Perimeter2D](../../../image/ST_Perimeter2D/ST_Perimeter2D.svg "ST_Perimeter2D")
+
 Format:
 
 `ST_Perimeter2D(geom: Geometry)`

--- a/docs/image/ST_3DDistance/ST_3DDistance.svg
+++ b/docs/image/ST_3DDistance/ST_3DDistance.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+    <marker id="arrowG" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#2ecc71" />
+    </marker>
+    <marker id="arrowGrev" markerWidth="8" markerHeight="6" refX="0" refY="3" orient="auto">
+      <path d="M8,0 L0,3 L8,6" fill="#2ecc71" />
+    </marker>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_3DDistance</text>
+  <circle cx="112.5" cy="218.75" r="5" fill="#4a90d9" stroke="#4a90d9" stroke-width="1.5" />
+  <text x="121.5" y="211.75" font-size="15" font-weight="bold" fill="#4a90d9">A</text>
+  <circle cx="387.5" cy="81.25" r="5" fill="#d94a4a" stroke="#d94a4a" stroke-width="1.5" />
+  <text x="396.5" y="74.25" font-size="15" font-weight="bold" fill="#d94a4a">B</text>
+  <line x1="112.5" y1="218.75" x2="387.5" y2="81.25" stroke="#2ecc71" stroke-width="2" stroke-dasharray="6,3" marker-start="url(#arrowGrev)" marker-end="url(#arrowG)" />
+  <text x="258" y="144" font-size="15" font-weight="bold" fill="#2ecc71" font-style="italic">d₃D</text>
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Returns the 3D minimum cartesian distance between A and B</text>
+  <rect x="93" y="255" width="12" height="12" rx="2" fill="#4a90d9" stroke="#4a90d9" stroke-width="1" />
+  <text x="109" y="266" font-size="13" fill="#333333">Geometry A</text>
+  <rect x="203" y="255" width="12" height="12" rx="2" fill="#d94a4a" stroke="#d94a4a" stroke-width="1" />
+  <text x="219" y="266" font-size="13" fill="#333333">Geometry B</text>
+  <rect x="313" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="329" y="266" font-size="13" fill="#333333">Distance</text>
+</svg>

--- a/docs/image/ST_Angle/ST_Angle.svg
+++ b/docs/image/ST_Angle/ST_Angle.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+    <marker id="arrowG" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#2ecc71" />
+    </marker>
+    <marker id="arrowGrev" markerWidth="8" markerHeight="6" refX="0" refY="3" orient="auto">
+      <path d="M8,0 L0,3 L8,6" fill="#2ecc71" />
+    </marker>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_Angle</text>
+  <polyline points="121.43,78.57 264.29,221.43" fill="none" stroke="#4a90d9" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="121.43" cy="78.57" r="3" fill="#4a90d9" />
+  <circle cx="264.29" cy="221.43" r="3" fill="#4a90d9" />
+  <polyline points="264.29,221.43 378.57,107.14" fill="none" stroke="#d94a4a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="264.29" cy="221.43" r="3" fill="#d94a4a" />
+  <circle cx="378.57" cy="107.14" r="3" fill="#d94a4a" />
+  <text x="127" y="73" font-size="13" fill="#333333">P1</text>
+  <text x="270" y="215" font-size="13" fill="#333333">P2</text>
+  <text x="270" y="215" font-size="13" fill="#333333">P3</text>
+  <text x="385" y="101" font-size="13" fill="#333333">P4</text>
+  <path d="M 243.08 200.22 A 30 30 0 0 1 285.5 200.22" fill="none" stroke="#2ecc71" stroke-width="2" />
+  <text x="264" y="181" text-anchor="middle" font-size="15" font-weight="bold" fill="#2ecc71" font-style="italic">θ</text>
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Returns the angle between two vectors (in radians)</text>
+  <rect x="145" y="255" width="12" height="12" rx="2" fill="#4a90d9" stroke="#4a90d9" stroke-width="1" />
+  <text x="161" y="266" font-size="13" fill="#333333">Ray 1</text>
+  <rect x="215" y="255" width="12" height="12" rx="2" fill="#d94a4a" stroke="#d94a4a" stroke-width="1" />
+  <text x="231" y="266" font-size="13" fill="#333333">Ray 2</text>
+  <rect x="285" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="301" y="266" font-size="13" fill="#333333">Angle</text>
+</svg>

--- a/docs/image/ST_Area/ST_Area.svg
+++ b/docs/image/ST_Area/ST_Area.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+    <marker id="arrowG" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#2ecc71" />
+    </marker>
+    <marker id="arrowGrev" markerWidth="8" markerHeight="6" refX="0" refY="3" orient="auto">
+      <path d="M8,0 L0,3 L8,6" fill="#2ecc71" />
+    </marker>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_Area</text>
+  <path d="M 131.08 224.32 L 368.92 224.32 L 368.92 75.68 L 131.08 75.68 L 131.08 224.32 Z" fill="rgba(74,144,217,0.15)" stroke="#4a90d9" stroke-width="2" fill-rule="evenodd" />
+  <path d="M 131.08 224.32 L 368.92 224.32 L 368.92 75.68 L 131.08 75.68 L 131.08 224.32 Z" fill="rgba(46,204,113,0.35)" stroke="#2ecc71" stroke-width="0.5" fill-rule="evenodd" />
+  <text x="226.22" y="164.86" text-anchor="middle" font-size="20" font-weight="bold" fill="#2ecc71" font-style="italic">Area</text>
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Returns the area of the geometry</text>
+  <rect x="184" y="255" width="12" height="12" rx="2" fill="#4a90d9" stroke="#4a90d9" stroke-width="1" />
+  <text x="200" y="266" font-size="13" fill="#333333">Input</text>
+  <rect x="254" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="270" y="266" font-size="13" fill="#333333">Area</text>
+</svg>

--- a/docs/image/ST_AreaSpheroid/ST_AreaSpheroid.svg
+++ b/docs/image/ST_AreaSpheroid/ST_AreaSpheroid.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+    <marker id="arrowG" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#2ecc71" />
+    </marker>
+    <marker id="arrowGrev" markerWidth="8" markerHeight="6" refX="0" refY="3" orient="auto">
+      <path d="M8,0 L0,3 L8,6" fill="#2ecc71" />
+    </marker>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_AreaSpheroid</text>
+  <path d="M 131.08 224.32 L 368.92 224.32 L 368.92 75.68 L 131.08 75.68 L 131.08 224.32 Z" fill="rgba(74,144,217,0.15)" stroke="#4a90d9" stroke-width="2" fill-rule="evenodd" />
+  <path d="M 131.08 224.32 L 368.92 224.32 L 368.92 75.68 L 131.08 75.68 L 131.08 224.32 Z" fill="rgba(46,204,113,0.35)" stroke="#2ecc71" stroke-width="0.5" fill-rule="evenodd" />
+  <text x="226.22" y="164.86" text-anchor="middle" font-size="20" font-weight="bold" fill="#2ecc71" font-style="italic">Area</text>
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Returns the geodesic area (sq meters) on the WGS84 spheroid</text>
+  <rect x="184" y="255" width="12" height="12" rx="2" fill="#4a90d9" stroke="#4a90d9" stroke-width="1" />
+  <text x="200" y="266" font-size="13" fill="#333333">Input</text>
+  <rect x="254" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="270" y="266" font-size="13" fill="#333333">Area</text>
+</svg>

--- a/docs/image/ST_Azimuth/ST_Azimuth.svg
+++ b/docs/image/ST_Azimuth/ST_Azimuth.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+    <marker id="arrowG" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#2ecc71" />
+    </marker>
+    <marker id="arrowGrev" markerWidth="8" markerHeight="6" refX="0" refY="3" orient="auto">
+      <path d="M8,0 L0,3 L8,6" fill="#2ecc71" />
+    </marker>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_Azimuth</text>
+  <polyline points="182.31,234.62 182.31,65.38" fill="none" stroke="#999999" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="4,3" />
+  <circle cx="182.31" cy="234.62" r="3" fill="#999999" />
+  <circle cx="182.31" cy="65.38" r="3" fill="#999999" />
+  <text x="170" y="61" font-size="13" fill="#999999" font-weight="bold">N</text>
+  <polyline points="182.31,234.62 317.69,133.08" fill="none" stroke="#4a90d9" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="182.31" cy="234.62" r="3" fill="#4a90d9" />
+  <circle cx="317.69" cy="133.08" r="3" fill="#4a90d9" />
+  <circle cx="182.31" cy="234.62" r="5" fill="#4a90d9" stroke="#4a90d9" stroke-width="1.5" />
+  <text x="191.31" y="227.62" font-size="15" font-weight="bold" fill="#4a90d9">A</text>
+  <circle cx="317.69" cy="133.08" r="5" fill="#d94a4a" stroke="#d94a4a" stroke-width="1.5" />
+  <text x="326.69" y="126.08000000000001" font-size="15" font-weight="bold" fill="#d94a4a">B</text>
+  <path d="M 182.31 204.62 A 30 30 0 0 1 206.31 216.62" fill="none" stroke="#2ecc71" stroke-width="2" />
+  <text x="202" y="199" text-anchor="middle" font-size="15" font-weight="bold" fill="#2ecc71" font-style="italic">azimuth</text>
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Returns the azimuth angle from point A to point B (in radians)</text>
+  <rect x="121" y="255" width="12" height="12" rx="2" fill="#4a90d9" stroke="#4a90d9" stroke-width="1" />
+  <text x="137" y="266" font-size="13" fill="#333333">Point A</text>
+  <rect x="207" y="255" width="12" height="12" rx="2" fill="#d94a4a" stroke="#d94a4a" stroke-width="1" />
+  <text x="223" y="266" font-size="13" fill="#333333">Point B</text>
+  <rect x="293" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="309" y="266" font-size="13" fill="#333333">Azimuth</text>
+</svg>

--- a/docs/image/ST_ClosestPoint/ST_ClosestPoint.svg
+++ b/docs/image/ST_ClosestPoint/ST_ClosestPoint.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+    <marker id="arrowG" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#2ecc71" />
+    </marker>
+    <marker id="arrowGrev" markerWidth="8" markerHeight="6" refX="0" refY="3" orient="auto">
+      <path d="M8,0 L0,3 L8,6" fill="#2ecc71" />
+    </marker>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_ClosestPoint</text>
+  <path d="M 131.08 224.32 L 279.73 224.32 L 279.73 75.68 L 131.08 75.68 L 131.08 224.32 Z" fill="rgba(74,144,217,0.15)" stroke="#4a90d9" stroke-width="2.5" fill-rule="evenodd" />
+  <text x="190.54" y="164.86" text-anchor="middle" font-size="15" font-weight="bold" fill="#4a90d9">A</text>
+  <circle cx="368.92" cy="135.14" r="5" fill="#d94a4a" stroke="#d94a4a" stroke-width="1.5" />
+  <text x="377.92" y="128.14" font-size="15" font-weight="bold" fill="#d94a4a">B</text>
+  <circle cx="279.73" cy="135.14" r="8" fill="white" stroke="#2ecc71" stroke-width="2.5" />
+  <circle cx="279.73" cy="135.14" r="4" fill="#2ecc71" />
+  <line x1="279.73" y1="135.14" x2="368.92" y2="135.14" stroke="#2ecc71" stroke-width="2" stroke-dasharray="6,3" marker-start="url(#arrowGrev)" marker-end="url(#arrowG)" />
+  <text x="332" y="129" font-size="15" font-weight="bold" fill="#2ecc71" font-style="italic">d</text>
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Returns the point on A that is closest to B</text>
+  <rect x="73" y="255" width="12" height="12" rx="2" fill="#4a90d9" stroke="#4a90d9" stroke-width="1" />
+  <text x="89" y="266" font-size="13" fill="#333333">Geometry A</text>
+  <rect x="183" y="255" width="12" height="12" rx="2" fill="#d94a4a" stroke="#d94a4a" stroke-width="1" />
+  <text x="199" y="266" font-size="13" fill="#333333">Geometry B</text>
+  <rect x="293" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="309" y="266" font-size="13" fill="#333333">Closest point</text>
+</svg>

--- a/docs/image/ST_Degrees/ST_Degrees.svg
+++ b/docs/image/ST_Degrees/ST_Degrees.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+    <marker id="arrowG" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#2ecc71" />
+    </marker>
+    <marker id="arrowGrev" markerWidth="8" markerHeight="6" refX="0" refY="3" orient="auto">
+      <path d="M8,0 L0,3 L8,6" fill="#2ecc71" />
+    </marker>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_Degrees</text>
+  <circle cx="250" cy="160" r="80" fill="none" stroke="#cccccc" stroke-width="1" stroke-dasharray="4,3" />
+  <path d="M 330 160 A 80 80 0 0 0 290.0 90.72" fill="none" stroke="#2ecc71" stroke-width="3" />
+  <line x1="250" y1="160" x2="330" y2="160" stroke="#4a90d9" stroke-width="2" />
+  <line x1="250" y1="160" x2="290.0" y2="90.72" stroke="#4a90d9" stroke-width="2" />
+  <path d="M 280 160 A 30 30 0 0 0 265.0 134.02" fill="none" stroke="#2ecc71" stroke-width="2" />
+  <text x="290" y="141" text-anchor="middle" font-size="14" font-weight="bold" fill="#2ecc71">60°</text>
+  <text x="333" y="116" text-anchor="middle" font-size="14" fill="#4a90d9">π/3 rad</text>
+  <circle cx="250" cy="160" r="3" fill="#4a90d9" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Converts an angle from radians to degrees</text>
+  <rect x="180" y="255" width="12" height="12" rx="2" fill="#4a90d9" stroke="#4a90d9" stroke-width="1" />
+  <text x="196" y="266" font-size="13" fill="#333333">Radii</text>
+  <rect x="250" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="266" y="266" font-size="13" fill="#333333">Angle</text>
+</svg>

--- a/docs/image/ST_Distance/ST_Distance.svg
+++ b/docs/image/ST_Distance/ST_Distance.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+    <marker id="arrowG" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#2ecc71" />
+    </marker>
+    <marker id="arrowGrev" markerWidth="8" markerHeight="6" refX="0" refY="3" orient="auto">
+      <path d="M8,0 L0,3 L8,6" fill="#2ecc71" />
+    </marker>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_Distance</text>
+  <path d="M 119.89 220.97 L 214.52 220.97 L 214.52 126.34 L 119.89 126.34 L 119.89 220.97 Z" fill="rgba(74,144,217,0.15)" stroke="#4a90d9" stroke-width="2.5" fill-rule="evenodd" />
+  <text x="157.74" y="183.12" text-anchor="middle" font-size="15" font-weight="bold" fill="#4a90d9">A</text>
+  <path d="M 285.48 173.66 L 380.11 173.66 L 380.11 79.03 L 285.48 79.03 L 285.48 173.66 Z" fill="rgba(217,74,74,0.15)" stroke="#d94a4a" stroke-width="2.5" fill-rule="evenodd" />
+  <text x="323.33" y="135.81" text-anchor="middle" font-size="15" font-weight="bold" fill="#d94a4a">B</text>
+  <line x1="214.52" y1="150.0" x2="285.48" y2="150.0" stroke="#2ecc71" stroke-width="2" stroke-dasharray="6,3" marker-start="url(#arrowGrev)" marker-end="url(#arrowG)" />
+  <text x="258" y="144" font-size="15" font-weight="bold" fill="#2ecc71" font-style="italic">d</text>
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Returns the Euclidean distance between two geometries</text>
+  <rect x="93" y="255" width="12" height="12" rx="2" fill="#4a90d9" stroke="#4a90d9" stroke-width="1" />
+  <text x="109" y="266" font-size="13" fill="#333333">Geometry A</text>
+  <rect x="203" y="255" width="12" height="12" rx="2" fill="#d94a4a" stroke="#d94a4a" stroke-width="1" />
+  <text x="219" y="266" font-size="13" fill="#333333">Geometry B</text>
+  <rect x="313" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="329" y="266" font-size="13" fill="#333333">Distance</text>
+</svg>

--- a/docs/image/ST_DistanceSphere/ST_DistanceSphere.svg
+++ b/docs/image/ST_DistanceSphere/ST_DistanceSphere.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+    <marker id="arrowG" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#2ecc71" />
+    </marker>
+    <marker id="arrowGrev" markerWidth="8" markerHeight="6" refX="0" refY="3" orient="auto">
+      <path d="M8,0 L0,3 L8,6" fill="#2ecc71" />
+    </marker>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_DistanceSphere</text>
+  <circle cx="88.46" cy="210.58" r="5" fill="#4a90d9" stroke="#4a90d9" stroke-width="1.5" />
+  <text x="97.46" y="203.58" font-size="15" font-weight="bold" fill="#4a90d9">A</text>
+  <circle cx="411.54" cy="89.42" r="5" fill="#d94a4a" stroke="#d94a4a" stroke-width="1.5" />
+  <text x="420.54" y="82.42" font-size="15" font-weight="bold" fill="#d94a4a">B</text>
+  <line x1="88.46" y1="210.58" x2="411.54" y2="89.42" stroke="#2ecc71" stroke-width="2" stroke-dasharray="6,3" marker-start="url(#arrowGrev)" marker-end="url(#arrowG)" />
+  <text x="258" y="144" font-size="15" font-weight="bold" fill="#2ecc71" font-style="italic">d</text>
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Returns the great-circle distance (meters) on a sphere</text>
+  <rect x="93" y="255" width="12" height="12" rx="2" fill="#4a90d9" stroke="#4a90d9" stroke-width="1" />
+  <text x="109" y="266" font-size="13" fill="#333333">Geometry A</text>
+  <rect x="203" y="255" width="12" height="12" rx="2" fill="#d94a4a" stroke="#d94a4a" stroke-width="1" />
+  <text x="219" y="266" font-size="13" fill="#333333">Geometry B</text>
+  <rect x="313" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="329" y="266" font-size="13" fill="#333333">Distance</text>
+</svg>

--- a/docs/image/ST_DistanceSpheroid/ST_DistanceSpheroid.svg
+++ b/docs/image/ST_DistanceSpheroid/ST_DistanceSpheroid.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+    <marker id="arrowG" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#2ecc71" />
+    </marker>
+    <marker id="arrowGrev" markerWidth="8" markerHeight="6" refX="0" refY="3" orient="auto">
+      <path d="M8,0 L0,3 L8,6" fill="#2ecc71" />
+    </marker>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_DistanceSpheroid</text>
+  <circle cx="88.46" cy="210.58" r="5" fill="#4a90d9" stroke="#4a90d9" stroke-width="1.5" />
+  <text x="97.46" y="203.58" font-size="15" font-weight="bold" fill="#4a90d9">A</text>
+  <circle cx="411.54" cy="89.42" r="5" fill="#d94a4a" stroke="#d94a4a" stroke-width="1.5" />
+  <text x="420.54" y="82.42" font-size="15" font-weight="bold" fill="#d94a4a">B</text>
+  <line x1="88.46" y1="210.58" x2="411.54" y2="89.42" stroke="#2ecc71" stroke-width="2" stroke-dasharray="6,3" marker-start="url(#arrowGrev)" marker-end="url(#arrowG)" />
+  <text x="258" y="144" font-size="15" font-weight="bold" fill="#2ecc71" font-style="italic">d</text>
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Returns the geodesic distance (meters) on the WGS84 spheroid</text>
+  <rect x="93" y="255" width="12" height="12" rx="2" fill="#4a90d9" stroke="#4a90d9" stroke-width="1" />
+  <text x="109" y="266" font-size="13" fill="#333333">Geometry A</text>
+  <rect x="203" y="255" width="12" height="12" rx="2" fill="#d94a4a" stroke="#d94a4a" stroke-width="1" />
+  <text x="219" y="266" font-size="13" fill="#333333">Geometry B</text>
+  <rect x="313" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="329" y="266" font-size="13" fill="#333333">Distance</text>
+</svg>

--- a/docs/image/ST_FrechetDistance/ST_FrechetDistance.svg
+++ b/docs/image/ST_FrechetDistance/ST_FrechetDistance.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+    <marker id="arrowG" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#2ecc71" />
+    </marker>
+    <marker id="arrowGrev" markerWidth="8" markerHeight="6" refX="0" refY="3" orient="auto">
+      <path d="M8,0 L0,3 L8,6" fill="#2ecc71" />
+    </marker>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_FrechetDistance</text>
+  <polyline points="140.0,183.0 206.0,95.0 272.0,139.0 338.0,73.0" fill="none" stroke="#4a90d9" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="140.0" cy="183.0" r="3" fill="#4a90d9" />
+  <circle cx="206.0" cy="95.0" r="3" fill="#4a90d9" />
+  <circle cx="272.0" cy="139.0" r="3" fill="#4a90d9" />
+  <circle cx="338.0" cy="73.0" r="3" fill="#4a90d9" />
+  <text x="278.0" y="131.0" font-size="15" font-weight="bold" fill="#4a90d9">A</text>
+  <polyline points="140.0,227.0 206.0,139.0 272.0,183.0 360.0,117.0" fill="none" stroke="#d94a4a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="140.0" cy="227.0" r="3" fill="#d94a4a" />
+  <circle cx="206.0" cy="139.0" r="3" fill="#d94a4a" />
+  <circle cx="272.0" cy="183.0" r="3" fill="#d94a4a" />
+  <circle cx="360.0" cy="117.0" r="3" fill="#d94a4a" />
+  <text x="278.0" y="175.0" font-size="15" font-weight="bold" fill="#d94a4a">B</text>
+  <line x1="140.0" y1="183.0" x2="140.0" y2="227.0" stroke="#2ecc71" stroke-width="1.5" stroke-dasharray="4,3" opacity="0.6" />
+  <line x1="206.0" y1="95.0" x2="206.0" y2="139.0" stroke="#2ecc71" stroke-width="1.5" stroke-dasharray="4,3" opacity="0.6" />
+  <line x1="272.0" y1="139.0" x2="272.0" y2="183.0" stroke="#2ecc71" stroke-width="1.5" stroke-dasharray="4,3" opacity="0.6" />
+  <line x1="338.0" y1="73.0" x2="360.0" y2="117.0" stroke="#2ecc71" stroke-width="1.5" stroke-dasharray="4,3" opacity="0.6" />
+  <line x1="338.0" y1="73.0" x2="360.0" y2="117.0" stroke="#2ecc71" stroke-width="2" stroke-dasharray="6,3" marker-start="url(#arrowGrev)" marker-end="url(#arrowG)" />
+  <text x="357" y="89" font-size="15" font-weight="bold" fill="#2ecc71" font-style="italic">d_F</text>
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Returns the discrete Fréchet distance between two geometries</text>
+  <rect x="93" y="255" width="12" height="12" rx="2" fill="#4a90d9" stroke="#4a90d9" stroke-width="1" />
+  <text x="109" y="266" font-size="13" fill="#333333">Geometry A</text>
+  <rect x="203" y="255" width="12" height="12" rx="2" fill="#d94a4a" stroke="#d94a4a" stroke-width="1" />
+  <text x="219" y="266" font-size="13" fill="#333333">Geometry B</text>
+  <rect x="313" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="329" y="266" font-size="13" fill="#333333">Distance</text>
+</svg>

--- a/docs/image/ST_HausdorffDistance/ST_HausdorffDistance.svg
+++ b/docs/image/ST_HausdorffDistance/ST_HausdorffDistance.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+    <marker id="arrowG" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#2ecc71" />
+    </marker>
+    <marker id="arrowGrev" markerWidth="8" markerHeight="6" refX="0" refY="3" orient="auto">
+      <path d="M8,0 L0,3 L8,6" fill="#2ecc71" />
+    </marker>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_HausdorffDistance</text>
+  <polyline points="147.94,184.02 215.98,93.3 284.02,138.66 352.06,70.62" fill="none" stroke="#4a90d9" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="147.94" cy="184.02" r="3" fill="#4a90d9" />
+  <circle cx="215.98" cy="93.3" r="3" fill="#4a90d9" />
+  <circle cx="284.02" cy="138.66" r="3" fill="#4a90d9" />
+  <circle cx="352.06" cy="70.62" r="3" fill="#4a90d9" />
+  <text x="290.02" y="130.66" font-size="15" font-weight="bold" fill="#4a90d9">A</text>
+  <polyline points="147.94,229.38 238.66,161.34 329.38,206.7" fill="none" stroke="#d94a4a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="147.94" cy="229.38" r="3" fill="#d94a4a" />
+  <circle cx="238.66" cy="161.34" r="3" fill="#d94a4a" />
+  <circle cx="329.38" cy="206.7" r="3" fill="#d94a4a" />
+  <text x="244.66" y="153.34" font-size="15" font-weight="bold" fill="#d94a4a">B</text>
+  <line x1="352.06" y1="70.62" x2="329.38" y2="206.7" stroke="#2ecc71" stroke-width="2" stroke-dasharray="6,3" marker-start="url(#arrowGrev)" marker-end="url(#arrowG)" />
+  <text x="349" y="133" font-size="15" font-weight="bold" fill="#2ecc71" font-style="italic">d_H</text>
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Returns the Hausdorff distance between two geometries</text>
+  <rect x="93" y="255" width="12" height="12" rx="2" fill="#4a90d9" stroke="#4a90d9" stroke-width="1" />
+  <text x="109" y="266" font-size="13" fill="#333333">Geometry A</text>
+  <rect x="203" y="255" width="12" height="12" rx="2" fill="#d94a4a" stroke="#d94a4a" stroke-width="1" />
+  <text x="219" y="266" font-size="13" fill="#333333">Geometry B</text>
+  <rect x="313" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="329" y="266" font-size="13" fill="#333333">Distance</text>
+</svg>

--- a/docs/image/ST_Length/ST_Length.svg
+++ b/docs/image/ST_Length/ST_Length.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+    <marker id="arrowG" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#2ecc71" />
+    </marker>
+    <marker id="arrowGrev" markerWidth="8" markerHeight="6" refX="0" refY="3" orient="auto">
+      <path d="M8,0 L0,3 L8,6" fill="#2ecc71" />
+    </marker>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_Length</text>
+  <polyline points="88.46,203.85 196.15,123.08 303.85,176.92 411.54,96.15" fill="none" stroke="#2ecc71" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="88.46" cy="203.85" r="3" fill="#2ecc71" />
+  <circle cx="196.15" cy="123.08" r="3" fill="#2ecc71" />
+  <circle cx="303.85" cy="176.92" r="3" fill="#2ecc71" />
+  <circle cx="411.54" cy="96.15" r="3" fill="#2ecc71" />
+  <text x="304" y="165" text-anchor="middle" font-size="18" font-weight="bold" fill="#2ecc71" font-style="italic">Length</text>
+  <line x1="88.46" y1="203.85" x2="88.46" y2="203.85" stroke="#2ecc71" stroke-width="0" marker-start="url(#arrowGrev)" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Returns the length / perimeter of the geometry</text>
+  <rect x="211" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="227" y="266" font-size="13" fill="#333333">Length</text>
+</svg>

--- a/docs/image/ST_Length2D/ST_Length2D.svg
+++ b/docs/image/ST_Length2D/ST_Length2D.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+    <marker id="arrowG" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#2ecc71" />
+    </marker>
+    <marker id="arrowGrev" markerWidth="8" markerHeight="6" refX="0" refY="3" orient="auto">
+      <path d="M8,0 L0,3 L8,6" fill="#2ecc71" />
+    </marker>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_Length2D</text>
+  <polyline points="112.5,218.75 195.0,108.75 305.0,163.75 387.5,81.25" fill="none" stroke="#2ecc71" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="112.5" cy="218.75" r="3" fill="#2ecc71" />
+  <circle cx="195.0" cy="108.75" r="3" fill="#2ecc71" />
+  <circle cx="305.0" cy="163.75" r="3" fill="#2ecc71" />
+  <circle cx="387.5" cy="81.25" r="3" fill="#2ecc71" />
+  <text x="305" y="152" text-anchor="middle" font-size="18" font-weight="bold" fill="#2ecc71" font-style="italic">Length</text>
+  <line x1="112.5" y1="218.75" x2="112.5" y2="218.75" stroke="#2ecc71" stroke-width="0" marker-start="url(#arrowGrev)" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Returns the 2D length / perimeter of the geometry (alias of ST_Length)</text>
+  <rect x="211" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="227" y="266" font-size="13" fill="#333333">Length</text>
+</svg>

--- a/docs/image/ST_LengthSpheroid/ST_LengthSpheroid.svg
+++ b/docs/image/ST_LengthSpheroid/ST_LengthSpheroid.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+    <marker id="arrowG" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#2ecc71" />
+    </marker>
+    <marker id="arrowGrev" markerWidth="8" markerHeight="6" refX="0" refY="3" orient="auto">
+      <path d="M8,0 L0,3 L8,6" fill="#2ecc71" />
+    </marker>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_LengthSpheroid</text>
+  <polyline points="88.46,203.85 196.15,123.08 303.85,176.92 411.54,96.15" fill="none" stroke="#2ecc71" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="88.46" cy="203.85" r="3" fill="#2ecc71" />
+  <circle cx="196.15" cy="123.08" r="3" fill="#2ecc71" />
+  <circle cx="303.85" cy="176.92" r="3" fill="#2ecc71" />
+  <circle cx="411.54" cy="96.15" r="3" fill="#2ecc71" />
+  <text x="304" y="165" text-anchor="middle" font-size="18" font-weight="bold" fill="#2ecc71" font-style="italic">Length</text>
+  <line x1="88.46" y1="203.85" x2="88.46" y2="203.85" stroke="#2ecc71" stroke-width="0" marker-start="url(#arrowGrev)" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Returns the geodesic length (meters) on the WGS84 spheroid</text>
+  <rect x="211" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="227" y="266" font-size="13" fill="#333333">Length</text>
+</svg>

--- a/docs/image/ST_LongestLine/ST_LongestLine.svg
+++ b/docs/image/ST_LongestLine/ST_LongestLine.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+    <marker id="arrowG" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#2ecc71" />
+    </marker>
+    <marker id="arrowGrev" markerWidth="8" markerHeight="6" refX="0" refY="3" orient="auto">
+      <path d="M8,0 L0,3 L8,6" fill="#2ecc71" />
+    </marker>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_LongestLine</text>
+  <path d="M 132.52 224.76 L 217.96 224.76 L 217.96 139.32 L 132.52 139.32 L 132.52 224.76 Z" fill="rgba(74,144,217,0.15)" stroke="#4a90d9" stroke-width="2.5" fill-rule="evenodd" />
+  <text x="166.7" y="190.58" text-anchor="middle" font-size="15" font-weight="bold" fill="#4a90d9">A</text>
+  <path d="M 282.04 160.68 L 367.48 160.68 L 367.48 75.24 L 282.04 75.24 L 282.04 160.68 Z" fill="rgba(217,74,74,0.15)" stroke="#d94a4a" stroke-width="2.5" fill-rule="evenodd" />
+  <text x="316.21" y="126.5" text-anchor="middle" font-size="15" font-weight="bold" fill="#d94a4a">B</text>
+  <line x1="132.52" y1="224.76" x2="367.48" y2="75.24" stroke="#2ecc71" stroke-width="2.5" stroke-dasharray="6,3" marker-start="url(#arrowGrev)" marker-end="url(#arrowG)" />
+  <text x="258" y="144" font-size="15" font-weight="bold" fill="#2ecc71" font-style="italic">longest</text>
+  <circle cx="132.52" cy="224.76" r="4" fill="#2ecc71" />
+  <circle cx="367.48" cy="75.24" r="4" fill="#2ecc71" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Returns the longest line between any two points of A and B</text>
+  <rect x="77" y="255" width="12" height="12" rx="2" fill="#4a90d9" stroke="#4a90d9" stroke-width="1" />
+  <text x="93" y="266" font-size="13" fill="#333333">Geometry A</text>
+  <rect x="187" y="255" width="12" height="12" rx="2" fill="#d94a4a" stroke="#d94a4a" stroke-width="1" />
+  <text x="203" y="266" font-size="13" fill="#333333">Geometry B</text>
+  <rect x="297" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="313" y="266" font-size="13" fill="#333333">Longest line</text>
+</svg>

--- a/docs/image/ST_MaxDistance/ST_MaxDistance.svg
+++ b/docs/image/ST_MaxDistance/ST_MaxDistance.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+    <marker id="arrowG" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#2ecc71" />
+    </marker>
+    <marker id="arrowGrev" markerWidth="8" markerHeight="6" refX="0" refY="3" orient="auto">
+      <path d="M8,0 L0,3 L8,6" fill="#2ecc71" />
+    </marker>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_MaxDistance</text>
+  <path d="M 119.89 220.97 L 214.52 220.97 L 214.52 126.34 L 119.89 126.34 L 119.89 220.97 Z" fill="rgba(74,144,217,0.15)" stroke="#4a90d9" stroke-width="2.5" fill-rule="evenodd" />
+  <text x="157.74" y="183.12" text-anchor="middle" font-size="15" font-weight="bold" fill="#4a90d9">A</text>
+  <path d="M 285.48 173.66 L 380.11 173.66 L 380.11 79.03 L 285.48 79.03 L 285.48 173.66 Z" fill="rgba(217,74,74,0.15)" stroke="#d94a4a" stroke-width="2.5" fill-rule="evenodd" />
+  <text x="323.33" y="135.81" text-anchor="middle" font-size="15" font-weight="bold" fill="#d94a4a">B</text>
+  <line x1="119.89" y1="220.97" x2="380.11" y2="79.03" stroke="#2ecc71" stroke-width="2" stroke-dasharray="6,3" marker-start="url(#arrowGrev)" marker-end="url(#arrowG)" />
+  <text x="258" y="144" font-size="15" font-weight="bold" fill="#2ecc71" font-style="italic">d_max</text>
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Returns the maximum distance between any two points of A and B</text>
+  <rect x="93" y="255" width="12" height="12" rx="2" fill="#4a90d9" stroke="#4a90d9" stroke-width="1" />
+  <text x="109" y="266" font-size="13" fill="#333333">Geometry A</text>
+  <rect x="203" y="255" width="12" height="12" rx="2" fill="#d94a4a" stroke="#d94a4a" stroke-width="1" />
+  <text x="219" y="266" font-size="13" fill="#333333">Geometry B</text>
+  <rect x="313" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="329" y="266" font-size="13" fill="#333333">Distance</text>
+</svg>

--- a/docs/image/ST_MinimumClearance/ST_MinimumClearance.svg
+++ b/docs/image/ST_MinimumClearance/ST_MinimumClearance.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+    <marker id="arrowG" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#2ecc71" />
+    </marker>
+    <marker id="arrowGrev" markerWidth="8" markerHeight="6" refX="0" refY="3" orient="auto">
+      <path d="M8,0 L0,3 L8,6" fill="#2ecc71" />
+    </marker>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_MinimumClearance</text>
+  <path d="M 127.78 223.33 L 372.22 223.33 L 372.22 76.67 L 225.56 76.67 L 225.56 174.44 L 127.78 174.44 L 127.78 223.33 Z" fill="rgba(74,144,217,0.15)" stroke="#4a90d9" stroke-width="2.5" fill-rule="evenodd" />
+  <line x1="225.56" y1="174.44" x2="225.56" y2="76.67" stroke="#2ecc71" stroke-width="2" stroke-dasharray="6,3" marker-start="url(#arrowGrev)" marker-end="url(#arrowG)" />
+  <text x="234" y="120" font-size="15" font-weight="bold" fill="#2ecc71" font-style="italic">clearance</text>
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Returns the minimum clearance distance of the geometry</text>
+  <rect x="164" y="255" width="12" height="12" rx="2" fill="#4a90d9" stroke="#4a90d9" stroke-width="1" />
+  <text x="180" y="266" font-size="13" fill="#333333">Input</text>
+  <rect x="234" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="250" y="266" font-size="13" fill="#333333">Clearance</text>
+</svg>

--- a/docs/image/ST_MinimumClearanceLine/ST_MinimumClearanceLine.svg
+++ b/docs/image/ST_MinimumClearanceLine/ST_MinimumClearanceLine.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+    <marker id="arrowG" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#2ecc71" />
+    </marker>
+    <marker id="arrowGrev" markerWidth="8" markerHeight="6" refX="0" refY="3" orient="auto">
+      <path d="M8,0 L0,3 L8,6" fill="#2ecc71" />
+    </marker>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_MinimumClearanceLine</text>
+  <path d="M 127.78 223.33 L 372.22 223.33 L 372.22 76.67 L 225.56 76.67 L 225.56 174.44 L 127.78 174.44 L 127.78 223.33 Z" fill="rgba(74,144,217,0.15)" stroke="#4a90d9" stroke-width="2.5" fill-rule="evenodd" />
+  <line x1="225.56" y1="174.44" x2="225.56" y2="76.67" stroke="#2ecc71" stroke-width="3" />
+  <circle cx="225.56" cy="174.44" r="5" fill="#2ecc71" />
+  <circle cx="225.56" cy="76.67" r="5" fill="#2ecc71" />
+  <text x="236" y="126" font-size="15" font-weight="bold" fill="#2ecc71" font-style="italic">clearance line</text>
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Returns a LineString representing the minimum clearance of the geometry</text>
+  <rect x="164" y="255" width="12" height="12" rx="2" fill="#4a90d9" stroke="#4a90d9" stroke-width="1" />
+  <text x="180" y="266" font-size="13" fill="#333333">Input</text>
+  <rect x="234" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="250" y="266" font-size="13" fill="#333333">Clearance</text>
+</svg>

--- a/docs/image/ST_Perimeter/ST_Perimeter.svg
+++ b/docs/image/ST_Perimeter/ST_Perimeter.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+    <marker id="arrowG" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#2ecc71" />
+    </marker>
+    <marker id="arrowGrev" markerWidth="8" markerHeight="6" refX="0" refY="3" orient="auto">
+      <path d="M8,0 L0,3 L8,6" fill="#2ecc71" />
+    </marker>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_Perimeter</text>
+  <path d="M 131.08 224.32 L 368.92 224.32 L 368.92 75.68 L 131.08 75.68 L 131.08 224.32 Z" fill="rgba(74,144,217,0.15)" stroke="#4a90d9" stroke-width="1" fill-rule="evenodd" stroke-dasharray="6,3" />
+  <path d="M 131.08 224.32 L 368.92 224.32 L 368.92 75.68 L 131.08 75.68 L 131.08 224.32 Z" fill="none" stroke="#2ecc71" stroke-width="3" fill-rule="evenodd" />
+  <text x="226.22" y="164.86" text-anchor="middle" font-size="18" font-weight="bold" fill="#2ecc71" font-style="italic">Perimeter</text>
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Returns the 2D perimeter of the polygon</text>
+  <rect x="164" y="255" width="12" height="12" rx="2" fill="#4a90d9" stroke="#4a90d9" stroke-width="1" />
+  <text x="180" y="266" font-size="13" fill="#333333">Input</text>
+  <rect x="234" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="250" y="266" font-size="13" fill="#333333">Perimeter</text>
+</svg>

--- a/docs/image/ST_Perimeter2D/ST_Perimeter2D.svg
+++ b/docs/image/ST_Perimeter2D/ST_Perimeter2D.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+    <marker id="arrowG" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#2ecc71" />
+    </marker>
+    <marker id="arrowGrev" markerWidth="8" markerHeight="6" refX="0" refY="3" orient="auto">
+      <path d="M8,0 L0,3 L8,6" fill="#2ecc71" />
+    </marker>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_Perimeter2D</text>
+  <path d="M 131.08 224.32 L 368.92 224.32 L 368.92 75.68 L 131.08 75.68 L 131.08 224.32 Z" fill="rgba(74,144,217,0.15)" stroke="#4a90d9" stroke-width="1" fill-rule="evenodd" stroke-dasharray="6,3" />
+  <path d="M 131.08 224.32 L 368.92 224.32 L 368.92 75.68 L 131.08 75.68 L 131.08 224.32 Z" fill="none" stroke="#2ecc71" stroke-width="3" fill-rule="evenodd" />
+  <text x="226.22" y="164.86" text-anchor="middle" font-size="18" font-weight="bold" fill="#2ecc71" font-style="italic">Perimeter</text>
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Returns the 2D perimeter of the polygon (alias of ST_Perimeter)</text>
+  <rect x="164" y="255" width="12" height="12" rx="2" fill="#4a90d9" stroke="#4a90d9" stroke-width="1" />
+  <text x="180" y="266" font-size="13" fill="#333333">Input</text>
+  <rect x="234" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="250" y="266" font-size="13" fill="#333333">Perimeter</text>
+</svg>


### PR DESCRIPTION
## What is this PR about?

Phase 4 of [GH-2678](https://github.com/apache/sedona/issues/2678): Add SVG visual illustrations for all **21 measurement functions**.

### Changes

- **21 new SVG files** in `docs/image/ST_<Name>/ST_<Name>.svg`
- **63 updated doc files** (21 SQL + 21 Flink + 21 Snowflake) with image references

### Functions covered

| Category | Functions |
|----------|-----------|
| Distance | ST_Distance, ST_3DDistance, ST_DistanceSphere, ST_DistanceSpheroid, ST_FrechetDistance, ST_HausdorffDistance, ST_MaxDistance |
| Closest/Longest | ST_ClosestPoint, ST_LongestLine, ST_MinimumClearance, ST_MinimumClearanceLine |
| Area | ST_Area, ST_AreaSpheroid |
| Length | ST_Length, ST_Length2D, ST_LengthSpheroid |
| Perimeter | ST_Perimeter, ST_Perimeter2D |
| Angle | ST_Angle, ST_Azimuth, ST_Degrees |

### Visual style

- **Distance**: Two geometries (blue A, red B) with dashed green measurement line and arrows
- **Area**: Polygon with green highlighted fill and "- **Area**: Polygon with green highlighghlighted in green with "Leng- **Area**: Polygon with green highlighted fill and "- **Area**: Polygon with green highlighghlighted in green with "Leng- **Area**: istance line to - **Area**: Polygon with green highlighted fill and "arthest points
- **Angle**: Rays with green angle arc annotation
- **Fréchet/Hausdorff**: Coupling lines between corresponding vertices

### Image placement

Images are inserted after the complete Introduction section and before the Format line, consistent with Phases 1-3. Multi-line introductions (with notes, tips, warnings) are handled correctly — image is placed after the full intro block.

Closes #2678 (partial — Phase 4 of multi-phase effort)
