### PR TITLE
[GH-2678] Add SVG visuals for geometry constructor functions (Phase 5)

### DIFF
--- a/docs/api/flink/Geometry-Constructors/ST_GeomCollFromText.md
+++ b/docs/api/flink/Geometry-Constructors/ST_GeomCollFromText.md
@@ -21,6 +21,8 @@
 
 Introduction: Constructs a GeometryCollection from the WKT with the given SRID. If SRID is not provided then it defaults to 0. It returns `null` if the WKT is not a `GEOMETRYCOLLECTION`.
 
+![ST_GeomCollFromText](../../../image/ST_GeomCollFromText/ST_GeomCollFromText.svg "ST_GeomCollFromText")
+
 Format:
 
 `ST_GeomCollFromText (Wkt: String)`

--- a/docs/api/flink/Geometry-Constructors/ST_GeomFromEWKB.md
+++ b/docs/api/flink/Geometry-Constructors/ST_GeomFromEWKB.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Geometry from EWKB string or Binary. This function is an alias of [ST_GeomFromWKB](ST_GeomFromWKB.md).
 
+![ST_GeomFromEWKB](../../../image/ST_GeomFromEWKB/ST_GeomFromEWKB.svg "ST_GeomFromEWKB")
+
 Format:
 
 `ST_GeomFromEWKB (Wkb: String)`

--- a/docs/api/flink/Geometry-Constructors/ST_GeomFromEWKT.md
+++ b/docs/api/flink/Geometry-Constructors/ST_GeomFromEWKT.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Geometry from OGC Extended WKT
 
+![ST_GeomFromEWKT](../../../image/ST_GeomFromEWKT/ST_GeomFromEWKT.svg "ST_GeomFromEWKT")
+
 Format:
 `ST_GeomFromEWKT (EWkt: String)`
 

--- a/docs/api/flink/Geometry-Constructors/ST_GeomFromGML.md
+++ b/docs/api/flink/Geometry-Constructors/ST_GeomFromGML.md
@@ -24,6 +24,8 @@ Introduction: Construct a Geometry from GML.
 !!!note
     This function only supports GML1 and GML2. GML3 is not supported.
 
+![ST_GeomFromGML](../../../image/ST_GeomFromGML/ST_GeomFromGML.svg "ST_GeomFromGML")
+
 Format:
 `ST_GeomFromGML (gml: String)`
 

--- a/docs/api/flink/Geometry-Constructors/ST_GeomFromGeoHash.md
+++ b/docs/api/flink/Geometry-Constructors/ST_GeomFromGeoHash.md
@@ -21,6 +21,8 @@
 
 Introduction: Create Geometry from geohash string and optional precision
 
+![ST_GeomFromGeoHash](../../../image/ST_GeomFromGeoHash/ST_GeomFromGeoHash.svg "ST_GeomFromGeoHash")
+
 Format: `ST_GeomFromGeoHash(geohash: String, precision: Integer)`
 
 Return type: `Geometry`

--- a/docs/api/flink/Geometry-Constructors/ST_GeomFromGeoJSON.md
+++ b/docs/api/flink/Geometry-Constructors/ST_GeomFromGeoJSON.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Geometry from GeoJson
 
+![ST_GeomFromGeoJSON](../../../image/ST_GeomFromGeoJSON/ST_GeomFromGeoJSON.svg "ST_GeomFromGeoJSON")
+
 Format: `ST_GeomFromGeoJSON (GeoJson: String)`
 
 Return type: `Geometry`

--- a/docs/api/flink/Geometry-Constructors/ST_GeomFromKML.md
+++ b/docs/api/flink/Geometry-Constructors/ST_GeomFromKML.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Geometry from KML.
 
+![ST_GeomFromKML](../../../image/ST_GeomFromKML/ST_GeomFromKML.svg "ST_GeomFromKML")
+
 Format:
 `ST_GeomFromKML (kml: String)`
 

--- a/docs/api/flink/Geometry-Constructors/ST_GeomFromText.md
+++ b/docs/api/flink/Geometry-Constructors/ST_GeomFromText.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Geometry from WKT. Alias of  [ST_GeomFromWKT](ST_GeomFromWKT.md)
 
+![ST_GeomFromText](../../../image/ST_GeomFromText/ST_GeomFromText.svg "ST_GeomFromText")
+
 Format:
 `ST_GeomFromText (Wkt: String)`
 

--- a/docs/api/flink/Geometry-Constructors/ST_GeomFromWKB.md
+++ b/docs/api/flink/Geometry-Constructors/ST_GeomFromWKB.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Geometry from WKB string or Binary. This function also supports EWKB format.
 
+![ST_GeomFromWKB](../../../image/ST_GeomFromWKB/ST_GeomFromWKB.svg "ST_GeomFromWKB")
+
 Format:
 
 `ST_GeomFromWKB (Wkb: String)`

--- a/docs/api/flink/Geometry-Constructors/ST_GeomFromWKT.md
+++ b/docs/api/flink/Geometry-Constructors/ST_GeomFromWKT.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Geometry from WKT
 
+![ST_GeomFromWKT](../../../image/ST_GeomFromWKT/ST_GeomFromWKT.svg "ST_GeomFromWKT")
+
 Format:
 `ST_GeomFromWKT (Wkt: String)`
 

--- a/docs/api/flink/Geometry-Constructors/ST_GeometryFromText.md
+++ b/docs/api/flink/Geometry-Constructors/ST_GeometryFromText.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Geometry from WKT. If SRID is not set, it defaults to 0 (unknown). Alias of [ST_GeomFromWKT](ST_GeomFromWKT.md)
 
+![ST_GeometryFromText](../../../image/ST_GeometryFromText/ST_GeometryFromText.svg "ST_GeometryFromText")
+
 Format:
 
 `ST_GeometryFromText (Wkt: String)`

--- a/docs/api/flink/Geometry-Constructors/ST_LineFromText.md
+++ b/docs/api/flink/Geometry-Constructors/ST_LineFromText.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a LineString from Text
 
+![ST_LineFromText](../../../image/ST_LineFromText/ST_LineFromText.svg "ST_LineFromText")
+
 Format: `ST_LineFromText (Text: String)`
 
 Return type: `Geometry`

--- a/docs/api/flink/Geometry-Constructors/ST_LineFromWKB.md
+++ b/docs/api/flink/Geometry-Constructors/ST_LineFromWKB.md
@@ -24,6 +24,8 @@ Introduction: Construct a LineString geometry from WKB string or Binary and an o
 !!!note
     Returns null if geometry is not of type LineString.
 
+![ST_LineFromWKB](../../../image/ST_LineFromWKB/ST_LineFromWKB.svg "ST_LineFromWKB")
+
 Format:
 
 `ST_LineFromWKB (Wkb: String)`

--- a/docs/api/flink/Geometry-Constructors/ST_LineStringFromText.md
+++ b/docs/api/flink/Geometry-Constructors/ST_LineStringFromText.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a LineString from Text, delimited by Delimiter (Optional). Alias of  [ST_LineFromText](ST_LineFromText.md)
 
+![ST_LineStringFromText](../../../image/ST_LineStringFromText/ST_LineStringFromText.svg "ST_LineStringFromText")
+
 Format: `ST_LineStringFromText (Text: String, Delimiter: Char)`
 
 Return type: `Geometry`

--- a/docs/api/flink/Geometry-Constructors/ST_LinestringFromWKB.md
+++ b/docs/api/flink/Geometry-Constructors/ST_LinestringFromWKB.md
@@ -24,6 +24,8 @@ Introduction: Construct a LineString geometry from WKB string or Binary and an o
 !!!Note
     Returns null if geometry is not of type LineString.
 
+![ST_LinestringFromWKB](../../../image/ST_LinestringFromWKB/ST_LinestringFromWKB.svg "ST_LinestringFromWKB")
+
 Format:
 
 `ST_LinestringFromWKB (Wkb: String)`

--- a/docs/api/flink/Geometry-Constructors/ST_MLineFromText.md
+++ b/docs/api/flink/Geometry-Constructors/ST_MLineFromText.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a MultiLineString from Text and Optional SRID
 
+![ST_MLineFromText](../../../image/ST_MLineFromText/ST_MLineFromText.svg "ST_MLineFromText")
+
 Format:
 
 `ST_MLineFromText (Wkt: String)`

--- a/docs/api/flink/Geometry-Constructors/ST_MPointFromText.md
+++ b/docs/api/flink/Geometry-Constructors/ST_MPointFromText.md
@@ -21,6 +21,8 @@
 
 Introduction: Constructs a MultiPoint from the WKT with the given SRID. If SRID is not provided then it defaults to 0. It returns `null` if the WKT is not a `MULTIPOINT`.
 
+![ST_MPointFromText](../../../image/ST_MPointFromText/ST_MPointFromText.svg "ST_MPointFromText")
+
 Format:
 
 `ST_MPointFromText (Wkt: String)`

--- a/docs/api/flink/Geometry-Constructors/ST_MPolyFromText.md
+++ b/docs/api/flink/Geometry-Constructors/ST_MPolyFromText.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a MultiPolygon from Text and Optional SRID
 
+![ST_MPolyFromText](../../../image/ST_MPolyFromText/ST_MPolyFromText.svg "ST_MPolyFromText")
+
 Format:
 
 `ST_MPolyFromText (Wkt: String)`

--- a/docs/api/flink/Geometry-Constructors/ST_MakeEnvelope.md
+++ b/docs/api/flink/Geometry-Constructors/ST_MakeEnvelope.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Polygon from MinX, MinY, MaxX, MaxY, and an optional SRID.
 
+![ST_MakeEnvelope](../../../image/ST_MakeEnvelope/ST_MakeEnvelope.svg "ST_MakeEnvelope")
+
 Format:
 
 ```

--- a/docs/api/flink/Geometry-Constructors/ST_MakePoint.md
+++ b/docs/api/flink/Geometry-Constructors/ST_MakePoint.md
@@ -21,6 +21,8 @@
 
 Introduction: Creates a 2D, 3D Z or 4D ZM Point geometry. Use [ST_MakePointM](ST_MakePointM.md) to make points with XYM coordinates. Z and M values are optional.
 
+![ST_MakePoint](../../../image/ST_MakePoint/ST_MakePoint.svg "ST_MakePoint")
+
 Format: `ST_MakePoint (X: Double, Y: Double, Z: Double, M: Double)`
 
 Return type: `Geometry`

--- a/docs/api/flink/Geometry-Constructors/ST_MakePointM.md
+++ b/docs/api/flink/Geometry-Constructors/ST_MakePointM.md
@@ -21,6 +21,8 @@
 
 Introduction: Creates a point with X, Y, and M coordinate. Use [ST_MakePoint](ST_MakePoint.md) to make points with XY, XYZ, or XYZM coordinates.
 
+![ST_MakePointM](../../../image/ST_MakePointM/ST_MakePointM.svg "ST_MakePointM")
+
 Format: `ST_MakePointM(x: Double, y: Double, m: Double)`
 
 Return type: `Geometry`

--- a/docs/api/flink/Geometry-Constructors/ST_Point.md
+++ b/docs/api/flink/Geometry-Constructors/ST_Point.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Point from X and Y
 
+![ST_Point](../../../image/ST_Point/ST_Point.svg "ST_Point")
+
 Format: `ST_Point (X: Double, Y: Double)`
 
 Return type: `Geometry`

--- a/docs/api/flink/Geometry-Constructors/ST_PointFromGeoHash.md
+++ b/docs/api/flink/Geometry-Constructors/ST_PointFromGeoHash.md
@@ -21,6 +21,8 @@
 
 Introduction: Generates a Point geometry representing the center of the GeoHash cell defined by the input string. If `precision` is not specified, the full GeoHash precision is used. Providing a `precision` value limits the GeoHash characters used to determine the Point coordinates.
 
+![ST_PointFromGeoHash](../../../image/ST_PointFromGeoHash/ST_PointFromGeoHash.svg "ST_PointFromGeoHash")
+
 Format: `ST_PointFromGeoHash(geoHash: String, precision: Integer)`
 
 Return type: `Geometry`

--- a/docs/api/flink/Geometry-Constructors/ST_PointFromText.md
+++ b/docs/api/flink/Geometry-Constructors/ST_PointFromText.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Point from Text, delimited by Delimiter
 
+![ST_PointFromText](../../../image/ST_PointFromText/ST_PointFromText.svg "ST_PointFromText")
+
 Format: `ST_PointFromText (Text: String, Delimiter: Char)`
 
 Return type: `Geometry`

--- a/docs/api/flink/Geometry-Constructors/ST_PointFromWKB.md
+++ b/docs/api/flink/Geometry-Constructors/ST_PointFromWKB.md
@@ -24,6 +24,8 @@ Introduction: Construct a Point geometry from WKB string or Binary and an option
 !!!note
     Returns null if geometry is not of type Point.
 
+![ST_PointFromWKB](../../../image/ST_PointFromWKB/ST_PointFromWKB.svg "ST_PointFromWKB")
+
 Format:
 
 `ST_PointFromWKB (Wkb: String)`

--- a/docs/api/flink/Geometry-Constructors/ST_PointM.md
+++ b/docs/api/flink/Geometry-Constructors/ST_PointM.md
@@ -22,6 +22,8 @@
 Introduction: Construct a Point from X, Y and M and an optional srid. If srid is not set, it defaults to 0 (unknown).
 Must use ST_AsEWKT function to print the Z and M coordinates.
 
+![ST_PointM](../../../image/ST_PointM/ST_PointM.svg "ST_PointM")
+
 Format:
 
 `ST_PointM (X: Double, Y: Double, M: Double)`

--- a/docs/api/flink/Geometry-Constructors/ST_PointZ.md
+++ b/docs/api/flink/Geometry-Constructors/ST_PointZ.md
@@ -22,6 +22,8 @@
 Introduction: Construct a Point from X, Y and Z and an optional srid. If srid is not set, it defaults to 0 (unknown).
 Must use ST_AsEWKT function to print the Z coordinate.
 
+![ST_PointZ](../../../image/ST_PointZ/ST_PointZ.svg "ST_PointZ")
+
 Format:
 
 `ST_PointZ (X: Double, Y: Double, Z: Double)`

--- a/docs/api/flink/Geometry-Constructors/ST_PointZM.md
+++ b/docs/api/flink/Geometry-Constructors/ST_PointZM.md
@@ -22,6 +22,8 @@
 Introduction: Construct a Point from X, Y, Z, M and an optional srid. If srid is not set, it defaults to 0 (unknown).
 Must use ST_AsEWKT function to print the Z and M coordinates.
 
+![ST_PointZM](../../../image/ST_PointZM/ST_PointZM.svg "ST_PointZM")
+
 Format:
 
 `ST_PointZM (X: Double, Y: Double, Z: Double, M: Double)`

--- a/docs/api/flink/Geometry-Constructors/ST_PolygonFromEnvelope.md
+++ b/docs/api/flink/Geometry-Constructors/ST_PolygonFromEnvelope.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Polygon from MinX, MinY, MaxX, MaxY.
 
+![ST_PolygonFromEnvelope](../../../image/ST_PolygonFromEnvelope/ST_PolygonFromEnvelope.svg "ST_PolygonFromEnvelope")
+
 Format:
 
 `ST_PolygonFromEnvelope (MinX: Double, MinY: Double, MaxX: Double, MaxY: Double)`

--- a/docs/api/flink/Geometry-Constructors/ST_PolygonFromText.md
+++ b/docs/api/flink/Geometry-Constructors/ST_PolygonFromText.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Polygon from Text, delimited by Delimiter. Path must be closed
 
+![ST_PolygonFromText](../../../image/ST_PolygonFromText/ST_PolygonFromText.svg "ST_PolygonFromText")
+
 Format: `ST_PolygonFromText (Text: String, Delimiter: Char)`
 
 Return type: `Geometry`

--- a/docs/api/snowflake/vector-data/Geometry-Constructors/ST_GeomCollFromText.md
+++ b/docs/api/snowflake/vector-data/Geometry-Constructors/ST_GeomCollFromText.md
@@ -21,6 +21,8 @@
 
 Introduction: Constructs a GeometryCollection from the WKT with the given SRID. If SRID is not provided then it defaults to 0. It returns `null` if the WKT is not a `GEOMETRYCOLLECTION`.
 
+![ST_GeomCollFromText](../../../../image/ST_GeomCollFromText/ST_GeomCollFromText.svg "ST_GeomCollFromText")
+
 Format:
 
 `ST_GeomCollFromText (Wkt: String)`

--- a/docs/api/snowflake/vector-data/Geometry-Constructors/ST_GeomFromEWKB.md
+++ b/docs/api/snowflake/vector-data/Geometry-Constructors/ST_GeomFromEWKB.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Geometry from EWKB string or Binary. This function is an alias of [ST_GeomFromWKB](ST_GeomFromWKB.md).
 
+![ST_GeomFromEWKB](../../../../image/ST_GeomFromEWKB/ST_GeomFromEWKB.svg "ST_GeomFromEWKB")
+
 Format:
 
 `ST_GeomFromEWKB (Wkb: String)`

--- a/docs/api/snowflake/vector-data/Geometry-Constructors/ST_GeomFromEWKT.md
+++ b/docs/api/snowflake/vector-data/Geometry-Constructors/ST_GeomFromEWKT.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Geometry from OGC Extended WKT
 
+![ST_GeomFromEWKT](../../../../image/ST_GeomFromEWKT/ST_GeomFromEWKT.svg "ST_GeomFromEWKT")
+
 Format:
 `ST_GeomFromEWKT (EWkt:string)`
 

--- a/docs/api/snowflake/vector-data/Geometry-Constructors/ST_GeomFromGML.md
+++ b/docs/api/snowflake/vector-data/Geometry-Constructors/ST_GeomFromGML.md
@@ -24,6 +24,8 @@ Introduction: Construct a Geometry from GML.
 !!!note
     This function only supports GML1 and GML2. GML3 is not supported.
 
+![ST_GeomFromGML](../../../../image/ST_GeomFromGML/ST_GeomFromGML.svg "ST_GeomFromGML")
+
 Format:
 `ST_GeomFromGML (gml:string)`
 

--- a/docs/api/snowflake/vector-data/Geometry-Constructors/ST_GeomFromGeoHash.md
+++ b/docs/api/snowflake/vector-data/Geometry-Constructors/ST_GeomFromGeoHash.md
@@ -21,6 +21,8 @@
 
 Introduction: Create Geometry from geohash string and optional precision
 
+![ST_GeomFromGeoHash](../../../../image/ST_GeomFromGeoHash/ST_GeomFromGeoHash.svg "ST_GeomFromGeoHash")
+
 Format: `ST_GeomFromGeoHash(geohash: string, precision: int)`
 
 Return type: `Geometry`

--- a/docs/api/snowflake/vector-data/Geometry-Constructors/ST_GeomFromGeoJSON.md
+++ b/docs/api/snowflake/vector-data/Geometry-Constructors/ST_GeomFromGeoJSON.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Geometry from GeoJson
 
+![ST_GeomFromGeoJSON](../../../../image/ST_GeomFromGeoJSON/ST_GeomFromGeoJSON.svg "ST_GeomFromGeoJSON")
+
 Format: `ST_GeomFromGeoJSON (GeoJson:string)`
 
 Return type: `Geometry`

--- a/docs/api/snowflake/vector-data/Geometry-Constructors/ST_GeomFromKML.md
+++ b/docs/api/snowflake/vector-data/Geometry-Constructors/ST_GeomFromKML.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Geometry from KML.
 
+![ST_GeomFromKML](../../../../image/ST_GeomFromKML/ST_GeomFromKML.svg "ST_GeomFromKML")
+
 Format:
 `ST_GeomFromKML (kml:string)`
 

--- a/docs/api/snowflake/vector-data/Geometry-Constructors/ST_GeomFromText.md
+++ b/docs/api/snowflake/vector-data/Geometry-Constructors/ST_GeomFromText.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Geometry from WKT. If SRID is not set, it defaults to 0 (unknown). Alias of [ST_GeomFromWKT](ST_GeomFromWKT.md)
 
+![ST_GeomFromText](../../../../image/ST_GeomFromText/ST_GeomFromText.svg "ST_GeomFromText")
+
 Format:
 `ST_GeomFromText (Wkt:string)`
 `ST_GeomFromText (Wkt:string, srid:integer)`

--- a/docs/api/snowflake/vector-data/Geometry-Constructors/ST_GeomFromWKB.md
+++ b/docs/api/snowflake/vector-data/Geometry-Constructors/ST_GeomFromWKB.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Geometry from WKB string or Binary. This function also supports EWKB format.
 
+![ST_GeomFromWKB](../../../../image/ST_GeomFromWKB/ST_GeomFromWKB.svg "ST_GeomFromWKB")
+
 Format:
 `ST_GeomFromWKB (Wkb:string)`
 `ST_GeomFromWKB (Wkb:binary)`

--- a/docs/api/snowflake/vector-data/Geometry-Constructors/ST_GeomFromWKT.md
+++ b/docs/api/snowflake/vector-data/Geometry-Constructors/ST_GeomFromWKT.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Geometry from WKT. If SRID is not set, it defaults to 0 (unknown).
 
+![ST_GeomFromWKT](../../../../image/ST_GeomFromWKT/ST_GeomFromWKT.svg "ST_GeomFromWKT")
+
 Format:
 `ST_GeomFromWKT (Wkt:string)`
 `ST_GeomFromWKT (Wkt:string, srid:integer)`

--- a/docs/api/snowflake/vector-data/Geometry-Constructors/ST_GeometryFromText.md
+++ b/docs/api/snowflake/vector-data/Geometry-Constructors/ST_GeometryFromText.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Geometry from WKT. If SRID is not set, it defaults to 0 (unknown). Alias of [ST_GeomFromWKT](ST_GeomFromWKT.md)
 
+![ST_GeometryFromText](../../../../image/ST_GeometryFromText/ST_GeometryFromText.svg "ST_GeometryFromText")
+
 Format:
 
 `ST_GeometryFromText (Wkt: String)`

--- a/docs/api/snowflake/vector-data/Geometry-Constructors/ST_LineFromText.md
+++ b/docs/api/snowflake/vector-data/Geometry-Constructors/ST_LineFromText.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Line from Wkt text
 
+![ST_LineFromText](../../../../image/ST_LineFromText/ST_LineFromText.svg "ST_LineFromText")
+
 Format:
 `ST_LineFromText (Wkt:string)`
 

--- a/docs/api/snowflake/vector-data/Geometry-Constructors/ST_LineFromWKB.md
+++ b/docs/api/snowflake/vector-data/Geometry-Constructors/ST_LineFromWKB.md
@@ -24,6 +24,8 @@ Introduction: Construct a LineString geometry from WKB string or Binary and an o
 !!!note
     Returns null if geometry is not of type LineString.
 
+![ST_LineFromWKB](../../../../image/ST_LineFromWKB/ST_LineFromWKB.svg "ST_LineFromWKB")
+
 Format:
 
 `ST_LineFromWKB (Wkb: String)`

--- a/docs/api/snowflake/vector-data/Geometry-Constructors/ST_LineStringFromText.md
+++ b/docs/api/snowflake/vector-data/Geometry-Constructors/ST_LineStringFromText.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a LineString from Text, delimited by Delimiter
 
+![ST_LineStringFromText](../../../../image/ST_LineStringFromText/ST_LineStringFromText.svg "ST_LineStringFromText")
+
 Format: `ST_LineStringFromText (Text:string, Delimiter:char)`
 
 Return type: `Geometry`

--- a/docs/api/snowflake/vector-data/Geometry-Constructors/ST_LinestringFromWKB.md
+++ b/docs/api/snowflake/vector-data/Geometry-Constructors/ST_LinestringFromWKB.md
@@ -24,6 +24,8 @@ Introduction: Construct a LineString geometry from WKB string or Binary and an o
 !!!Note
     Returns null if geometry is not of type LineString.
 
+![ST_LinestringFromWKB](../../../../image/ST_LinestringFromWKB/ST_LinestringFromWKB.svg "ST_LinestringFromWKB")
+
 Format:
 
 `ST_LinestringFromWKB (Wkb: String)`

--- a/docs/api/snowflake/vector-data/Geometry-Constructors/ST_MLineFromText.md
+++ b/docs/api/snowflake/vector-data/Geometry-Constructors/ST_MLineFromText.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a MultiLineString from Wkt. If srid is not set, it defaults to 0 (unknown).
 
+![ST_MLineFromText](../../../../image/ST_MLineFromText/ST_MLineFromText.svg "ST_MLineFromText")
+
 Format:
 `ST_MLineFromText (Wkt:string)`
 `ST_MLineFromText (Wkt:string, srid:integer)`

--- a/docs/api/snowflake/vector-data/Geometry-Constructors/ST_MPointFromText.md
+++ b/docs/api/snowflake/vector-data/Geometry-Constructors/ST_MPointFromText.md
@@ -21,6 +21,8 @@
 
 Introduction: Constructs a MultiPoint from the WKT with the given SRID. If SRID is not provided then it defaults to 0. It returns `null` if the WKT is not a `MULTIPOINT`.
 
+![ST_MPointFromText](../../../../image/ST_MPointFromText/ST_MPointFromText.svg "ST_MPointFromText")
+
 Format:
 
 `ST_MPointFromText (Wkt: String)`

--- a/docs/api/snowflake/vector-data/Geometry-Constructors/ST_MPolyFromText.md
+++ b/docs/api/snowflake/vector-data/Geometry-Constructors/ST_MPolyFromText.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a MultiPolygon from Wkt. If srid is not set, it defaults to 0 (unknown).
 
+![ST_MPolyFromText](../../../../image/ST_MPolyFromText/ST_MPolyFromText.svg "ST_MPolyFromText")
+
 Format:
 `ST_MPolyFromText (Wkt:string)`
 `ST_MPolyFromText (Wkt:string, srid:integer)`

--- a/docs/api/snowflake/vector-data/Geometry-Constructors/ST_MakeEnvelope.md
+++ b/docs/api/snowflake/vector-data/Geometry-Constructors/ST_MakeEnvelope.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Polygon from MinX, MinY, MaxX, MaxY, and an optional SRID.
 
+![ST_MakeEnvelope](../../../../image/ST_MakeEnvelope/ST_MakeEnvelope.svg "ST_MakeEnvelope")
+
 Format:
 
 ```

--- a/docs/api/snowflake/vector-data/Geometry-Constructors/ST_MakePoint.md
+++ b/docs/api/snowflake/vector-data/Geometry-Constructors/ST_MakePoint.md
@@ -21,6 +21,8 @@
 
 Introduction: Creates a 2D, 3D Z or 4D ZM Point geometry. Use ST_MakePointM to make points with XYM coordinates. Z and M values are optional.
 
+![ST_MakePoint](../../../../image/ST_MakePoint/ST_MakePoint.svg "ST_MakePoint")
+
 Format: `ST_MakePoint (X:decimal, Y:decimal, Z:decimal, M:decimal)`
 
 Return type: `Geometry`

--- a/docs/api/snowflake/vector-data/Geometry-Constructors/ST_Point.md
+++ b/docs/api/snowflake/vector-data/Geometry-Constructors/ST_Point.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Point from X and Y
 
+![ST_Point](../../../../image/ST_Point/ST_Point.svg "ST_Point")
+
 Format: `ST_Point (X:decimal, Y:decimal)`
 
 Return type: `Geometry`

--- a/docs/api/snowflake/vector-data/Geometry-Constructors/ST_PointFromGeoHash.md
+++ b/docs/api/snowflake/vector-data/Geometry-Constructors/ST_PointFromGeoHash.md
@@ -21,6 +21,8 @@
 
 Introduction: Generates a Point geometry representing the center of the GeoHash cell defined by the input string. If `precision` is not specified, the full GeoHash precision is used. Providing a `precision` value limits the GeoHash characters used to determine the Point coordinates.
 
+![ST_PointFromGeoHash](../../../../image/ST_PointFromGeoHash/ST_PointFromGeoHash.svg "ST_PointFromGeoHash")
+
 Format: `ST_PointFromGeoHash(geoHash: String, precision: Integer)`
 
 Return type: `Geometry`

--- a/docs/api/snowflake/vector-data/Geometry-Constructors/ST_PointFromText.md
+++ b/docs/api/snowflake/vector-data/Geometry-Constructors/ST_PointFromText.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Point from Text, delimited by Delimiter
 
+![ST_PointFromText](../../../../image/ST_PointFromText/ST_PointFromText.svg "ST_PointFromText")
+
 Format: `ST_PointFromText (Text:string, Delimiter:char)`
 
 Return type: `Geometry`

--- a/docs/api/snowflake/vector-data/Geometry-Constructors/ST_PointFromWKB.md
+++ b/docs/api/snowflake/vector-data/Geometry-Constructors/ST_PointFromWKB.md
@@ -24,6 +24,8 @@ Introduction: Construct a Point geometry from WKB string or Binary and an option
 !!!note
     Returns null if geometry is not of type Point.
 
+![ST_PointFromWKB](../../../../image/ST_PointFromWKB/ST_PointFromWKB.svg "ST_PointFromWKB")
+
 Format:
 
 `ST_PointFromWKB (Wkb: String)`

--- a/docs/api/snowflake/vector-data/Geometry-Constructors/ST_PointZ.md
+++ b/docs/api/snowflake/vector-data/Geometry-Constructors/ST_PointZ.md
@@ -22,6 +22,8 @@
 Introduction: Construct a Point from X, Y and Z and an optional srid. If srid is not set, it defaults to 0 (unknown).
 Must use ST_AsEWKT function to print the Z coordinate.
 
+![ST_PointZ](../../../../image/ST_PointZ/ST_PointZ.svg "ST_PointZ")
+
 Format: `ST_PointZ (X:decimal, Y:decimal, Z:decimal)`
 
 Format: `ST_PointZ (X:decimal, Y:decimal, Z:decimal, srid:integer)`

--- a/docs/api/snowflake/vector-data/Geometry-Constructors/ST_PolygonFromEnvelope.md
+++ b/docs/api/snowflake/vector-data/Geometry-Constructors/ST_PolygonFromEnvelope.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Polygon from MinX, MinY, MaxX, MaxY.
 
+![ST_PolygonFromEnvelope](../../../../image/ST_PolygonFromEnvelope/ST_PolygonFromEnvelope.svg "ST_PolygonFromEnvelope")
+
 Format: `ST_PolygonFromEnvelope (MinX:decimal, MinY:decimal, MaxX:decimal, MaxY:decimal)`
 
 Return type: `Geometry`

--- a/docs/api/snowflake/vector-data/Geometry-Constructors/ST_PolygonFromText.md
+++ b/docs/api/snowflake/vector-data/Geometry-Constructors/ST_PolygonFromText.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Polygon from Text, delimited by Delimiter. Path must be closed
 
+![ST_PolygonFromText](../../../../image/ST_PolygonFromText/ST_PolygonFromText.svg "ST_PolygonFromText")
+
 Format: `ST_PolygonFromText (Text:string, Delimiter:char)`
 
 Return type: `Geometry`

--- a/docs/api/sql/Geometry-Constructors/ST_GeomCollFromText.md
+++ b/docs/api/sql/Geometry-Constructors/ST_GeomCollFromText.md
@@ -21,6 +21,8 @@
 
 Introduction: Constructs a GeometryCollection from the WKT with the given SRID. If SRID is not provided then it defaults to 0. It returns `null` if the WKT is not a `GEOMETRYCOLLECTION`.
 
+![ST_GeomCollFromText](../../../image/ST_GeomCollFromText/ST_GeomCollFromText.svg "ST_GeomCollFromText")
+
 Format:
 
 `ST_GeomCollFromText (Wkt: String)`

--- a/docs/api/sql/Geometry-Constructors/ST_GeomFromEWKB.md
+++ b/docs/api/sql/Geometry-Constructors/ST_GeomFromEWKB.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Geometry from EWKB string or Binary. This function is an alias of [ST_GeomFromWKB](ST_GeomFromWKB.md).
 
+![ST_GeomFromEWKB](../../../image/ST_GeomFromEWKB/ST_GeomFromEWKB.svg "ST_GeomFromEWKB")
+
 Format:
 
 `ST_GeomFromEWKB (Wkb: String)`

--- a/docs/api/sql/Geometry-Constructors/ST_GeomFromEWKT.md
+++ b/docs/api/sql/Geometry-Constructors/ST_GeomFromEWKT.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Geometry from OGC Extended WKT
 
+![ST_GeomFromEWKT](../../../image/ST_GeomFromEWKT/ST_GeomFromEWKT.svg "ST_GeomFromEWKT")
+
 Format:
 `ST_GeomFromEWKT (EWkt: String)`
 

--- a/docs/api/sql/Geometry-Constructors/ST_GeomFromGML.md
+++ b/docs/api/sql/Geometry-Constructors/ST_GeomFromGML.md
@@ -24,6 +24,8 @@ Introduction: Construct a Geometry from GML.
 !!!note
     This function only supports GML 1 and GML 2. GML 3 is not supported.
 
+![ST_GeomFromGML](../../../image/ST_GeomFromGML/ST_GeomFromGML.svg "ST_GeomFromGML")
+
 Format:
 `ST_GeomFromGML (gml: String)`
 

--- a/docs/api/sql/Geometry-Constructors/ST_GeomFromGeoHash.md
+++ b/docs/api/sql/Geometry-Constructors/ST_GeomFromGeoHash.md
@@ -21,6 +21,8 @@
 
 Introduction: Create Geometry from geohash string and optional precision
 
+![ST_GeomFromGeoHash](../../../image/ST_GeomFromGeoHash/ST_GeomFromGeoHash.svg "ST_GeomFromGeoHash")
+
 Format: `ST_GeomFromGeoHash(geohash: String, precision: Integer)`
 
 Return type: `Geometry`

--- a/docs/api/sql/Geometry-Constructors/ST_GeomFromGeoJSON.md
+++ b/docs/api/sql/Geometry-Constructors/ST_GeomFromGeoJSON.md
@@ -24,6 +24,8 @@
 
 Introduction: Construct a Geometry from GeoJson
 
+![ST_GeomFromGeoJSON](../../../image/ST_GeomFromGeoJSON/ST_GeomFromGeoJSON.svg "ST_GeomFromGeoJSON")
+
 Format: `ST_GeomFromGeoJSON (GeoJson: String)`
 
 Return type: `Geometry`

--- a/docs/api/sql/Geometry-Constructors/ST_GeomFromKML.md
+++ b/docs/api/sql/Geometry-Constructors/ST_GeomFromKML.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Geometry from KML.
 
+![ST_GeomFromKML](../../../image/ST_GeomFromKML/ST_GeomFromKML.svg "ST_GeomFromKML")
+
 Format:
 `ST_GeomFromKML (kml: String)`
 

--- a/docs/api/sql/Geometry-Constructors/ST_GeomFromMySQL.md
+++ b/docs/api/sql/Geometry-Constructors/ST_GeomFromMySQL.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Geometry from MySQL Geometry binary.
 
+![ST_GeomFromMySQL](../../../image/ST_GeomFromMySQL/ST_GeomFromMySQL.svg "ST_GeomFromMySQL")
+
 Format: `ST_GeomFromMySQL (binary: Binary)`
 
 Return type: `Geometry`

--- a/docs/api/sql/Geometry-Constructors/ST_GeomFromText.md
+++ b/docs/api/sql/Geometry-Constructors/ST_GeomFromText.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Geometry from WKT. If SRID is not set, it defaults to 0 (unknown). Alias of [ST_GeomFromWKT](ST_GeomFromWKT.md)
 
+![ST_GeomFromText](../../../image/ST_GeomFromText/ST_GeomFromText.svg "ST_GeomFromText")
+
 Format:
 
 `ST_GeomFromText (Wkt: String)`

--- a/docs/api/sql/Geometry-Constructors/ST_GeomFromWKB.md
+++ b/docs/api/sql/Geometry-Constructors/ST_GeomFromWKB.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Geometry from WKB string or Binary. This function also supports EWKB format.
 
+![ST_GeomFromWKB](../../../image/ST_GeomFromWKB/ST_GeomFromWKB.svg "ST_GeomFromWKB")
+
 Format:
 
 `ST_GeomFromWKB (Wkb: String)`

--- a/docs/api/sql/Geometry-Constructors/ST_GeomFromWKT.md
+++ b/docs/api/sql/Geometry-Constructors/ST_GeomFromWKT.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Geometry from WKT. If SRID is not set, it defaults to 0 (unknown).
 
+![ST_GeomFromWKT](../../../image/ST_GeomFromWKT/ST_GeomFromWKT.svg "ST_GeomFromWKT")
+
 Format:
 
 `ST_GeomFromWKT (Wkt: String)`

--- a/docs/api/sql/Geometry-Constructors/ST_GeometryFromText.md
+++ b/docs/api/sql/Geometry-Constructors/ST_GeometryFromText.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Geometry from WKT. If SRID is not set, it defaults to 0 (unknown). Alias of [ST_GeomFromWKT](ST_GeomFromWKT.md)
 
+![ST_GeometryFromText](../../../image/ST_GeometryFromText/ST_GeometryFromText.svg "ST_GeometryFromText")
+
 Format:
 
 `ST_GeometryFromText (Wkt: String)`

--- a/docs/api/sql/Geometry-Constructors/ST_LineFromText.md
+++ b/docs/api/sql/Geometry-Constructors/ST_LineFromText.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Line from Wkt text
 
+![ST_LineFromText](../../../image/ST_LineFromText/ST_LineFromText.svg "ST_LineFromText")
+
 Format:
 `ST_LineFromText (Wkt: String)`
 

--- a/docs/api/sql/Geometry-Constructors/ST_LineFromWKB.md
+++ b/docs/api/sql/Geometry-Constructors/ST_LineFromWKB.md
@@ -24,6 +24,8 @@ Introduction: Construct a LineString geometry from WKB string or Binary and an o
 !!!note
 	Returns null if geometry is not of type LineString.
 
+![ST_LineFromWKB](../../../image/ST_LineFromWKB/ST_LineFromWKB.svg "ST_LineFromWKB")
+
 Format:
 
 `ST_LineFromWKB (Wkb: String)`

--- a/docs/api/sql/Geometry-Constructors/ST_LineStringFromText.md
+++ b/docs/api/sql/Geometry-Constructors/ST_LineStringFromText.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a LineString from Text, delimited by Delimiter
 
+![ST_LineStringFromText](../../../image/ST_LineStringFromText/ST_LineStringFromText.svg "ST_LineStringFromText")
+
 Format: `ST_LineStringFromText (Text: String, Delimiter: Char)`
 
 Return type: `Geometry`

--- a/docs/api/sql/Geometry-Constructors/ST_LinestringFromWKB.md
+++ b/docs/api/sql/Geometry-Constructors/ST_LinestringFromWKB.md
@@ -24,6 +24,8 @@ Introduction: Construct a LineString geometry from WKB string or Binary and an o
 !!!Note
 	Returns null if geometry is not of type LineString.
 
+![ST_LinestringFromWKB](../../../image/ST_LinestringFromWKB/ST_LinestringFromWKB.svg "ST_LinestringFromWKB")
+
 Format:
 
 `ST_LinestringFromWKB (Wkb: String)`

--- a/docs/api/sql/Geometry-Constructors/ST_MLineFromText.md
+++ b/docs/api/sql/Geometry-Constructors/ST_MLineFromText.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a MultiLineString from Wkt. If srid is not set, it defaults to 0 (unknown).
 
+![ST_MLineFromText](../../../image/ST_MLineFromText/ST_MLineFromText.svg "ST_MLineFromText")
+
 Format:
 
 `ST_MLineFromText (Wkt: String)`

--- a/docs/api/sql/Geometry-Constructors/ST_MPointFromText.md
+++ b/docs/api/sql/Geometry-Constructors/ST_MPointFromText.md
@@ -21,6 +21,8 @@
 
 Introduction: Constructs a MultiPoint from the WKT with the given SRID. If SRID is not provided then it defaults to 0. It returns `null` if the WKT is not a `MULTIPOINT`.
 
+![ST_MPointFromText](../../../image/ST_MPointFromText/ST_MPointFromText.svg "ST_MPointFromText")
+
 Format:
 
 `ST_MPointFromText (Wkt: String)`

--- a/docs/api/sql/Geometry-Constructors/ST_MPolyFromText.md
+++ b/docs/api/sql/Geometry-Constructors/ST_MPolyFromText.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a MultiPolygon from Wkt. If srid is not set, it defaults to 0 (unknown).
 
+![ST_MPolyFromText](../../../image/ST_MPolyFromText/ST_MPolyFromText.svg "ST_MPolyFromText")
+
 Format:
 
 `ST_MPolyFromText (Wkt: String)`

--- a/docs/api/sql/Geometry-Constructors/ST_MakeEnvelope.md
+++ b/docs/api/sql/Geometry-Constructors/ST_MakeEnvelope.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Polygon from MinX, MinY, MaxX, MaxY, and an optional SRID.
 
+![ST_MakeEnvelope](../../../image/ST_MakeEnvelope/ST_MakeEnvelope.svg "ST_MakeEnvelope")
+
 Format:
 
 ```

--- a/docs/api/sql/Geometry-Constructors/ST_MakePoint.md
+++ b/docs/api/sql/Geometry-Constructors/ST_MakePoint.md
@@ -21,6 +21,8 @@
 
 Introduction: Creates a 2D, 3D Z or 4D ZM Point geometry. Use [ST_MakePointM](ST_MakePointM.md) to make points with XYM coordinates. Z and M values are optional.
 
+![ST_MakePoint](../../../image/ST_MakePoint/ST_MakePoint.svg "ST_MakePoint")
+
 Format: `ST_MakePoint (X: Double, Y: Double, Z: Double, M: Double)`
 
 Return type: `Geometry`

--- a/docs/api/sql/Geometry-Constructors/ST_MakePointM.md
+++ b/docs/api/sql/Geometry-Constructors/ST_MakePointM.md
@@ -21,6 +21,8 @@
 
 Introduction: Creates a point with X, Y, and M coordinate. Use [ST_MakePoint](ST_MakePoint.md) to make points with XY, XYZ, or XYZM coordinates.
 
+![ST_MakePointM](../../../image/ST_MakePointM/ST_MakePointM.svg "ST_MakePointM")
+
 Format: `ST_MakePointM(x: Double, y: Double, m: Double)`
 
 Return type: `Geometry`

--- a/docs/api/sql/Geometry-Constructors/ST_Point.md
+++ b/docs/api/sql/Geometry-Constructors/ST_Point.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Point from X and Y
 
+![ST_Point](../../../image/ST_Point/ST_Point.svg "ST_Point")
+
 Format: `ST_Point (X: Double, Y: Double)`
 
 Return type: `Geometry`

--- a/docs/api/sql/Geometry-Constructors/ST_PointFromGeoHash.md
+++ b/docs/api/sql/Geometry-Constructors/ST_PointFromGeoHash.md
@@ -21,6 +21,8 @@
 
 Introduction: Generates a Point geometry representing the center of the GeoHash cell defined by the input string. If `precision` is not specified, the full GeoHash precision is used. Providing a `precision` value limits the GeoHash characters used to determine the Point coordinates.
 
+![ST_PointFromGeoHash](../../../image/ST_PointFromGeoHash/ST_PointFromGeoHash.svg "ST_PointFromGeoHash")
+
 Format: `ST_PointFromGeoHash(geoHash: String, precision: Integer)`
 
 Return type: `Geometry`

--- a/docs/api/sql/Geometry-Constructors/ST_PointFromText.md
+++ b/docs/api/sql/Geometry-Constructors/ST_PointFromText.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Point from Text, delimited by Delimiter
 
+![ST_PointFromText](../../../image/ST_PointFromText/ST_PointFromText.svg "ST_PointFromText")
+
 Format: `ST_PointFromText (Text: String, Delimiter: Char)`
 
 Return type: `Geometry`

--- a/docs/api/sql/Geometry-Constructors/ST_PointFromWKB.md
+++ b/docs/api/sql/Geometry-Constructors/ST_PointFromWKB.md
@@ -24,6 +24,8 @@ Introduction: Construct a Point geometry from WKB string or Binary and an option
 !!!note
 	Returns null if geometry is not of type Point.
 
+![ST_PointFromWKB](../../../image/ST_PointFromWKB/ST_PointFromWKB.svg "ST_PointFromWKB")
+
 Format:
 
 `ST_PointFromWKB (Wkb: String)`

--- a/docs/api/sql/Geometry-Constructors/ST_PointM.md
+++ b/docs/api/sql/Geometry-Constructors/ST_PointM.md
@@ -22,6 +22,8 @@
 Introduction: Construct a Point from X, Y and M and an optional srid. If srid is not set, it defaults to 0 (unknown).
 Must use ST_AsEWKT function to print the Z and M coordinates.
 
+![ST_PointM](../../../image/ST_PointM/ST_PointM.svg "ST_PointM")
+
 Format:
 
 `ST_PointM (X: Double, Y: Double, M: Double)`

--- a/docs/api/sql/Geometry-Constructors/ST_PointZ.md
+++ b/docs/api/sql/Geometry-Constructors/ST_PointZ.md
@@ -22,6 +22,8 @@
 Introduction: Construct a Point from X, Y and Z and an optional srid. If srid is not set, it defaults to 0 (unknown).
 Must use ST_AsEWKT function to print the Z coordinate.
 
+![ST_PointZ](../../../image/ST_PointZ/ST_PointZ.svg "ST_PointZ")
+
 Format:
 
 `ST_PointZ (X: Double, Y: Double, Z: Double)`

--- a/docs/api/sql/Geometry-Constructors/ST_PointZM.md
+++ b/docs/api/sql/Geometry-Constructors/ST_PointZM.md
@@ -22,6 +22,8 @@
 Introduction: Construct a Point from X, Y, Z, M and an optional srid. If srid is not set, it defaults to 0 (unknown).
 Must use ST_AsEWKT function to print the Z and M coordinates.
 
+![ST_PointZM](../../../image/ST_PointZM/ST_PointZM.svg "ST_PointZM")
+
 Format:
 
 `ST_PointZM (X: Double, Y: Double, Z: Double, M: Double)`

--- a/docs/api/sql/Geometry-Constructors/ST_PolygonFromEnvelope.md
+++ b/docs/api/sql/Geometry-Constructors/ST_PolygonFromEnvelope.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Polygon from MinX, MinY, MaxX, MaxY.
 
+![ST_PolygonFromEnvelope](../../../image/ST_PolygonFromEnvelope/ST_PolygonFromEnvelope.svg "ST_PolygonFromEnvelope")
+
 Format:
 
 `ST_PolygonFromEnvelope (MinX: Double, MinY: Double, MaxX: Double, MaxY: Double)`

--- a/docs/api/sql/Geometry-Constructors/ST_PolygonFromText.md
+++ b/docs/api/sql/Geometry-Constructors/ST_PolygonFromText.md
@@ -21,6 +21,8 @@
 
 Introduction: Construct a Polygon from Text, delimited by Delimiter. Path must be closed
 
+![ST_PolygonFromText](../../../image/ST_PolygonFromText/ST_PolygonFromText.svg "ST_PolygonFromText")
+
 Format: `ST_PolygonFromText (Text: String, Delimiter: Char)`
 
 Return type: `Geometry`

--- a/docs/image/ST_GeomCollFromText/ST_GeomCollFromText.svg
+++ b/docs/image/ST_GeomCollFromText/ST_GeomCollFromText.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_GeomCollFromText</text>
+  <rect x="50" y="38" width="40" height="24" rx="4" fill="#8e44ad" opacity="0.12" stroke="#8e44ad" stroke-width="1.2" />
+  <text x="70" y="55" text-anchor="middle" font-size="13" font-weight="bold" fill="#8e44ad">WKT</text>
+  <line x1="70" y1="62" x2="157.7" y2="135.1" stroke="#2ecc71" stroke-width="2" />
+  <polygon points="160,137.1 154.9,127.6 149.8,133.7" fill="#2ecc71" />
+  <circle cx="121.28" cy="91.49" r="6" fill="#2ecc71" stroke="white" stroke-width="1.5" />
+  <polyline points="168.09,208.51 261.7,138.3" fill="none" stroke="#2ecc71" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="168.09" cy="208.51" r="3.5" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="261.7" cy="138.3" r="3.5" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <path d="M 285.11 185.11 L 378.72 185.11 L 378.72 91.49 L 285.11 91.49 L 285.11 185.11 Z" fill="rgba(46,204,113,0.18)" stroke="#2ecc71" stroke-width="2.5" fill-rule="evenodd" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Constructs a GeometryCollection from WKT</text>
+  <rect x="112" y="255" width="12" height="12" rx="2" fill="#8e44ad" stroke="#8e44ad" stroke-width="1" />
+  <text x="128" y="266" font-size="13" fill="#333333">Input Format</text>
+  <rect x="238" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="254" y="266" font-size="13" fill="#333333">Result Geometry</text>
+</svg>

--- a/docs/image/ST_GeomFromEWKB/ST_GeomFromEWKB.svg
+++ b/docs/image/ST_GeomFromEWKB/ST_GeomFromEWKB.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_GeomFromEWKB</text>
+  <rect x="46" y="38" width="48" height="24" rx="4" fill="#8e44ad" opacity="0.12" stroke="#8e44ad" stroke-width="1.2" />
+  <text x="70" y="55" text-anchor="middle" font-size="13" font-weight="bold" fill="#8e44ad">EWKB</text>
+  <line x1="70" y1="62" x2="177.7" y2="151.8" stroke="#2ecc71" stroke-width="2" />
+  <polygon points="180,153.8 174.9,144.3 169.8,150.4" fill="#2ecc71" />
+  <path d="M 146.88 218.75 L 353.12 218.75 L 353.12 81.25 L 146.88 81.25 L 146.88 218.75 Z" fill="rgba(46,204,113,0.18)" stroke="#2ecc71" stroke-width="2.5" fill-rule="evenodd" />
+  <circle cx="146.88" cy="218.75" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="353.12" cy="218.75" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="353.12" cy="81.25" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="146.88" cy="81.25" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="146.88" cy="218.75" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Constructs a Geometry from Extended WKB binary</text>
+  <rect x="112" y="255" width="12" height="12" rx="2" fill="#8e44ad" stroke="#8e44ad" stroke-width="1" />
+  <text x="128" y="266" font-size="13" fill="#333333">Input Format</text>
+  <rect x="238" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="254" y="266" font-size="13" fill="#333333">Result Geometry</text>
+</svg>

--- a/docs/image/ST_GeomFromEWKT/ST_GeomFromEWKT.svg
+++ b/docs/image/ST_GeomFromEWKT/ST_GeomFromEWKT.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_GeomFromEWKT</text>
+  <rect x="46" y="38" width="48" height="24" rx="4" fill="#8e44ad" opacity="0.12" stroke="#8e44ad" stroke-width="1.2" />
+  <text x="70" y="55" text-anchor="middle" font-size="13" font-weight="bold" fill="#8e44ad">EWKT</text>
+  <line x1="70" y1="62" x2="177.8" y2="158.0" stroke="#2ecc71" stroke-width="2" />
+  <polygon points="180,160.0 175.2,150.4 169.9,156.3" fill="#2ecc71" />
+  <path d="M 162.5 225.0 L 337.5 225.0 L 287.5 100.0 L 187.5 75.0 L 162.5 225.0 Z" fill="rgba(46,204,113,0.18)" stroke="#2ecc71" stroke-width="2.5" fill-rule="evenodd" />
+  <circle cx="162.5" cy="225.0" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="337.5" cy="225.0" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="287.5" cy="100.0" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="187.5" cy="75.0" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="162.5" cy="225.0" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Constructs a Geometry from Extended WKT</text>
+  <rect x="112" y="255" width="12" height="12" rx="2" fill="#8e44ad" stroke="#8e44ad" stroke-width="1" />
+  <text x="128" y="266" font-size="13" fill="#333333">Input Format</text>
+  <rect x="238" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="254" y="266" font-size="13" fill="#333333">Result Geometry</text>
+</svg>

--- a/docs/image/ST_GeomFromGML/ST_GeomFromGML.svg
+++ b/docs/image/ST_GeomFromGML/ST_GeomFromGML.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_GeomFromGML</text>
+  <rect x="50" y="38" width="40" height="24" rx="4" fill="#8e44ad" opacity="0.12" stroke="#8e44ad" stroke-width="1.2" />
+  <text x="70" y="55" text-anchor="middle" font-size="13" font-weight="bold" fill="#8e44ad">GML</text>
+  <line x1="70" y1="62" x2="177.7" y2="152.2" stroke="#2ecc71" stroke-width="2" />
+  <polygon points="180,154.1 174.9,144.6 169.8,150.7" fill="#2ecc71" />
+  <path d="M 151.28 220.51 L 348.72 220.51 L 348.72 79.49 L 151.28 79.49 L 151.28 220.51 Z" fill="rgba(46,204,113,0.18)" stroke="#2ecc71" stroke-width="2.5" fill-rule="evenodd" />
+  <circle cx="151.28" cy="220.51" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="348.72" cy="220.51" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="348.72" cy="79.49" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="151.28" cy="79.49" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="151.28" cy="220.51" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Constructs a Geometry from GML</text>
+  <rect x="112" y="255" width="12" height="12" rx="2" fill="#8e44ad" stroke="#8e44ad" stroke-width="1" />
+  <text x="128" y="266" font-size="13" fill="#333333">Input Format</text>
+  <rect x="238" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="254" y="266" font-size="13" fill="#333333">Result Geometry</text>
+</svg>

--- a/docs/image/ST_GeomFromGeoHash/ST_GeomFromGeoHash.svg
+++ b/docs/image/ST_GeomFromGeoHash/ST_GeomFromGeoHash.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_GeomFromGeoHash</text>
+  <rect x="34" y="38" width="72" height="24" rx="4" fill="#8e44ad" opacity="0.12" stroke="#8e44ad" stroke-width="1.2" />
+  <text x="70" y="55" text-anchor="middle" font-size="13" font-weight="bold" fill="#8e44ad">GeoHash</text>
+  <line x1="70" y1="62" x2="177.7" y2="151.8" stroke="#2ecc71" stroke-width="2" />
+  <polygon points="180,153.8 174.9,144.3 169.8,150.4" fill="#2ecc71" />
+  <path d="M 146.88 218.75 L 353.12 218.75 L 353.12 81.25 L 146.88 81.25 L 146.88 218.75 Z" fill="rgba(46,204,113,0.18)" stroke="#2ecc71" stroke-width="2.5" fill-rule="evenodd" />
+  <circle cx="146.88" cy="218.75" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="353.12" cy="218.75" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="353.12" cy="81.25" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="146.88" cy="81.25" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="146.88" cy="218.75" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Creates a Geometry from a GeoHash string</text>
+  <rect x="112" y="255" width="12" height="12" rx="2" fill="#8e44ad" stroke="#8e44ad" stroke-width="1" />
+  <text x="128" y="266" font-size="13" fill="#333333">Input Format</text>
+  <rect x="238" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="254" y="266" font-size="13" fill="#333333">Result Geometry</text>
+</svg>

--- a/docs/image/ST_GeomFromGeoJSON/ST_GeomFromGeoJSON.svg
+++ b/docs/image/ST_GeomFromGeoJSON/ST_GeomFromGeoJSON.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_GeomFromGeoJSON</text>
+  <rect x="34" y="38" width="72" height="24" rx="4" fill="#8e44ad" opacity="0.12" stroke="#8e44ad" stroke-width="1.2" />
+  <text x="70" y="55" text-anchor="middle" font-size="13" font-weight="bold" fill="#8e44ad">GeoJSON</text>
+  <line x1="70" y1="62" x2="177.8" y2="158.8" stroke="#2ecc71" stroke-width="2" />
+  <polygon points="180,160.8 175.2,151.2 169.9,157.1" fill="#2ecc71" />
+  <path d="M 160.81 224.32 L 339.19 224.32 L 339.19 105.41 L 220.27 75.68 L 160.81 224.32 Z" fill="rgba(46,204,113,0.18)" stroke="#2ecc71" stroke-width="2.5" fill-rule="evenodd" />
+  <circle cx="160.81" cy="224.32" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="339.19" cy="224.32" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="339.19" cy="105.41" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="220.27" cy="75.68" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="160.81" cy="224.32" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Constructs a Geometry from GeoJSON</text>
+  <rect x="112" y="255" width="12" height="12" rx="2" fill="#8e44ad" stroke="#8e44ad" stroke-width="1" />
+  <text x="128" y="266" font-size="13" fill="#333333">Input Format</text>
+  <rect x="238" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="254" y="266" font-size="13" fill="#333333">Result Geometry</text>
+</svg>

--- a/docs/image/ST_GeomFromKML/ST_GeomFromKML.svg
+++ b/docs/image/ST_GeomFromKML/ST_GeomFromKML.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_GeomFromKML</text>
+  <rect x="50" y="38" width="40" height="24" rx="4" fill="#8e44ad" opacity="0.12" stroke="#8e44ad" stroke-width="1.2" />
+  <text x="70" y="55" text-anchor="middle" font-size="13" font-weight="bold" fill="#8e44ad">KML</text>
+  <line x1="70" y1="62" x2="177.7" y2="153.1" stroke="#2ecc71" stroke-width="2" />
+  <polygon points="180,155.0 174.9,145.5 169.8,151.6" fill="#2ecc71" />
+  <path d="M 162.5 225.0 L 337.5 225.0 L 337.5 75.0 L 162.5 75.0 L 162.5 225.0 Z" fill="rgba(46,204,113,0.18)" stroke="#2ecc71" stroke-width="2.5" fill-rule="evenodd" />
+  <circle cx="162.5" cy="225.0" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="337.5" cy="225.0" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="337.5" cy="75.0" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="162.5" cy="75.0" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="162.5" cy="225.0" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Constructs a Geometry from KML</text>
+  <rect x="112" y="255" width="12" height="12" rx="2" fill="#8e44ad" stroke="#8e44ad" stroke-width="1" />
+  <text x="128" y="266" font-size="13" fill="#333333">Input Format</text>
+  <rect x="238" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="254" y="266" font-size="13" fill="#333333">Result Geometry</text>
+</svg>

--- a/docs/image/ST_GeomFromMySQL/ST_GeomFromMySQL.svg
+++ b/docs/image/ST_GeomFromMySQL/ST_GeomFromMySQL.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_GeomFromMySQL</text>
+  <rect x="42" y="38" width="56" height="24" rx="4" fill="#8e44ad" opacity="0.12" stroke="#8e44ad" stroke-width="1.2" />
+  <text x="70" y="55" text-anchor="middle" font-size="13" font-weight="bold" fill="#8e44ad">MySQL</text>
+  <line x1="70" y1="62" x2="177.7" y2="152.2" stroke="#2ecc71" stroke-width="2" />
+  <polygon points="180,154.1 174.9,144.6 169.8,150.7" fill="#2ecc71" />
+  <path d="M 151.28 220.51 L 348.72 220.51 L 348.72 79.49 L 151.28 79.49 L 151.28 220.51 Z" fill="rgba(46,204,113,0.18)" stroke="#2ecc71" stroke-width="2.5" fill-rule="evenodd" />
+  <circle cx="151.28" cy="220.51" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="348.72" cy="220.51" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="348.72" cy="79.49" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="151.28" cy="79.49" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="151.28" cy="220.51" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Constructs a Geometry from MySQL Geometry binary</text>
+  <rect x="112" y="255" width="12" height="12" rx="2" fill="#8e44ad" stroke="#8e44ad" stroke-width="1" />
+  <text x="128" y="266" font-size="13" fill="#333333">Input Format</text>
+  <rect x="238" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="254" y="266" font-size="13" fill="#333333">Result Geometry</text>
+</svg>

--- a/docs/image/ST_GeomFromText/ST_GeomFromText.svg
+++ b/docs/image/ST_GeomFromText/ST_GeomFromText.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_GeomFromText</text>
+  <rect x="50" y="38" width="40" height="24" rx="4" fill="#8e44ad" opacity="0.12" stroke="#8e44ad" stroke-width="1.2" />
+  <text x="70" y="55" text-anchor="middle" font-size="13" font-weight="bold" fill="#8e44ad">WKT</text>
+  <line x1="70" y1="62" x2="177.7" y2="152.7" stroke="#2ecc71" stroke-width="2" />
+  <polygon points="180,154.7 174.9,145.2 169.8,151.3" fill="#2ecc71" />
+  <path d="M 158.33 223.33 L 341.67 223.33 L 341.67 76.67 L 158.33 76.67 L 158.33 223.33 Z" fill="rgba(46,204,113,0.18)" stroke="#2ecc71" stroke-width="2.5" fill-rule="evenodd" />
+  <circle cx="158.33" cy="223.33" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="341.67" cy="223.33" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="341.67" cy="76.67" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="158.33" cy="76.67" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="158.33" cy="223.33" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Constructs a Geometry from WKT (alias of ST_GeomFromWKT)</text>
+  <rect x="112" y="255" width="12" height="12" rx="2" fill="#8e44ad" stroke="#8e44ad" stroke-width="1" />
+  <text x="128" y="266" font-size="13" fill="#333333">Input Format</text>
+  <rect x="238" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="254" y="266" font-size="13" fill="#333333">Result Geometry</text>
+</svg>

--- a/docs/image/ST_GeomFromWKB/ST_GeomFromWKB.svg
+++ b/docs/image/ST_GeomFromWKB/ST_GeomFromWKB.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_GeomFromWKB</text>
+  <rect x="50" y="38" width="40" height="24" rx="4" fill="#8e44ad" opacity="0.12" stroke="#8e44ad" stroke-width="1.2" />
+  <text x="70" y="55" text-anchor="middle" font-size="13" font-weight="bold" fill="#8e44ad">WKB</text>
+  <line x1="70" y1="62" x2="177.7" y2="152.2" stroke="#2ecc71" stroke-width="2" />
+  <polygon points="180,154.1 174.9,144.6 169.8,150.7" fill="#2ecc71" />
+  <path d="M 151.28 220.51 L 348.72 220.51 L 348.72 79.49 L 151.28 79.49 L 151.28 220.51 Z" fill="rgba(46,204,113,0.18)" stroke="#2ecc71" stroke-width="2.5" fill-rule="evenodd" />
+  <circle cx="151.28" cy="220.51" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="348.72" cy="220.51" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="348.72" cy="79.49" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="151.28" cy="79.49" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="151.28" cy="220.51" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Constructs a Geometry from WKB binary</text>
+  <rect x="112" y="255" width="12" height="12" rx="2" fill="#8e44ad" stroke="#8e44ad" stroke-width="1" />
+  <text x="128" y="266" font-size="13" fill="#333333">Input Format</text>
+  <rect x="238" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="254" y="266" font-size="13" fill="#333333">Result Geometry</text>
+</svg>

--- a/docs/image/ST_GeomFromWKT/ST_GeomFromWKT.svg
+++ b/docs/image/ST_GeomFromWKT/ST_GeomFromWKT.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_GeomFromWKT</text>
+  <rect x="50" y="38" width="40" height="24" rx="4" fill="#8e44ad" opacity="0.12" stroke="#8e44ad" stroke-width="1.2" />
+  <text x="70" y="55" text-anchor="middle" font-size="13" font-weight="bold" fill="#8e44ad">WKT</text>
+  <line x1="70" y1="62" x2="177.7" y2="152.2" stroke="#2ecc71" stroke-width="2" />
+  <polygon points="180,154.1 174.9,144.6 169.8,150.7" fill="#2ecc71" />
+  <path d="M 151.28 220.51 L 348.72 220.51 L 348.72 79.49 L 151.28 79.49 L 151.28 220.51 Z" fill="rgba(46,204,113,0.18)" stroke="#2ecc71" stroke-width="2.5" fill-rule="evenodd" />
+  <circle cx="151.28" cy="220.51" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="348.72" cy="220.51" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="348.72" cy="79.49" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="151.28" cy="79.49" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="151.28" cy="220.51" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Constructs a Geometry from WKT</text>
+  <rect x="112" y="255" width="12" height="12" rx="2" fill="#8e44ad" stroke="#8e44ad" stroke-width="1" />
+  <text x="128" y="266" font-size="13" fill="#333333">Input Format</text>
+  <rect x="238" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="254" y="266" font-size="13" fill="#333333">Result Geometry</text>
+</svg>

--- a/docs/image/ST_GeometryFromText/ST_GeometryFromText.svg
+++ b/docs/image/ST_GeometryFromText/ST_GeometryFromText.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_GeometryFromText</text>
+  <rect x="50" y="38" width="40" height="24" rx="4" fill="#8e44ad" opacity="0.12" stroke="#8e44ad" stroke-width="1.2" />
+  <text x="70" y="55" text-anchor="middle" font-size="13" font-weight="bold" fill="#8e44ad">WKT</text>
+  <line x1="70" y1="62" x2="177.7" y2="152.4" stroke="#2ecc71" stroke-width="2" />
+  <polygon points="180,154.3 174.9,144.9 169.8,151.0" fill="#2ecc71" />
+  <path d="M 154.35 221.74 L 345.65 221.74 L 345.65 78.26 L 154.35 78.26 L 154.35 221.74 Z" fill="rgba(46,204,113,0.18)" stroke="#2ecc71" stroke-width="2.5" fill-rule="evenodd" />
+  <circle cx="154.35" cy="221.74" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="345.65" cy="221.74" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="345.65" cy="78.26" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="154.35" cy="78.26" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="154.35" cy="221.74" r="3" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Constructs a Geometry from WKT (alias of ST_GeomFromWKT)</text>
+  <rect x="112" y="255" width="12" height="12" rx="2" fill="#8e44ad" stroke="#8e44ad" stroke-width="1" />
+  <text x="128" y="266" font-size="13" fill="#333333">Input Format</text>
+  <rect x="238" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="254" y="266" font-size="13" fill="#333333">Result Geometry</text>
+</svg>

--- a/docs/image/ST_LineFromText/ST_LineFromText.svg
+++ b/docs/image/ST_LineFromText/ST_LineFromText.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_LineFromText</text>
+  <rect x="50" y="38" width="40" height="24" rx="4" fill="#8e44ad" opacity="0.12" stroke="#8e44ad" stroke-width="1.2" />
+  <text x="70" y="55" text-anchor="middle" font-size="13" font-weight="bold" fill="#8e44ad">WKT</text>
+  <line x1="70" y1="62" x2="296.1" y2="153.1" stroke="#2ecc71" stroke-width="2" />
+  <polygon points="298.9,154.2 291.1,146.8 288.1,154.2" fill="#2ecc71" />
+  <polyline points="127.78,211.11 201.11,113.33 298.89,162.22 372.22,88.89" fill="none" stroke="#2ecc71" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="127.78" cy="211.11" r="3.5" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="201.11" cy="113.33" r="3.5" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="298.89" cy="162.22" r="3.5" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="372.22" cy="88.89" r="3.5" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Constructs a LineString from WKT text</text>
+  <rect x="112" y="255" width="12" height="12" rx="2" fill="#8e44ad" stroke="#8e44ad" stroke-width="1" />
+  <text x="128" y="266" font-size="13" fill="#333333">Input Format</text>
+  <rect x="238" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="254" y="266" font-size="13" fill="#333333">Result Geometry</text>
+</svg>

--- a/docs/image/ST_LineFromWKB/ST_LineFromWKB.svg
+++ b/docs/image/ST_LineFromWKB/ST_LineFromWKB.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_LineFromWKB</text>
+  <rect x="50" y="38" width="40" height="24" rx="4" fill="#8e44ad" opacity="0.12" stroke="#8e44ad" stroke-width="1.2" />
+  <text x="70" y="55" text-anchor="middle" font-size="13" font-weight="bold" fill="#8e44ad">WKB</text>
+  <line x1="70" y1="62" x2="296.1" y2="153.1" stroke="#2ecc71" stroke-width="2" />
+  <polygon points="298.9,154.2 291.1,146.8 288.1,154.2" fill="#2ecc71" />
+  <polyline points="127.78,211.11 201.11,113.33 298.89,162.22 372.22,88.89" fill="none" stroke="#2ecc71" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="127.78" cy="211.11" r="3.5" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="201.11" cy="113.33" r="3.5" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="298.89" cy="162.22" r="3.5" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="372.22" cy="88.89" r="3.5" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Constructs a LineString from WKB binary</text>
+  <rect x="112" y="255" width="12" height="12" rx="2" fill="#8e44ad" stroke="#8e44ad" stroke-width="1" />
+  <text x="128" y="266" font-size="13" fill="#333333">Input Format</text>
+  <rect x="238" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="254" y="266" font-size="13" fill="#333333">Result Geometry</text>
+</svg>

--- a/docs/image/ST_LineStringFromText/ST_LineStringFromText.svg
+++ b/docs/image/ST_LineStringFromText/ST_LineStringFromText.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_LineStringFromText</text>
+  <rect x="46" y="38" width="48" height="24" rx="4" fill="#8e44ad" opacity="0.12" stroke="#8e44ad" stroke-width="1.2" />
+  <text x="70" y="55" text-anchor="middle" font-size="13" font-weight="bold" fill="#8e44ad">Text</text>
+  <line x1="70" y1="62" x2="292.2" y2="174.3" stroke="#2ecc71" stroke-width="2" />
+  <polygon points="294.9,175.7 287.8,167.6 284.2,174.7" fill="#2ecc71" />
+  <polyline points="115.31,206.12 205.1,138.78 294.9,183.67 384.69,93.88" fill="none" stroke="#2ecc71" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="115.31" cy="206.12" r="3.5" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="205.1" cy="138.78" r="3.5" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="294.9" cy="183.67" r="3.5" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="384.69" cy="93.88" r="3.5" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Constructs a LineString from delimited text</text>
+  <rect x="112" y="255" width="12" height="12" rx="2" fill="#8e44ad" stroke="#8e44ad" stroke-width="1" />
+  <text x="128" y="266" font-size="13" fill="#333333">Input Format</text>
+  <rect x="238" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="254" y="266" font-size="13" fill="#333333">Result Geometry</text>
+</svg>

--- a/docs/image/ST_LinestringFromWKB/ST_LinestringFromWKB.svg
+++ b/docs/image/ST_LinestringFromWKB/ST_LinestringFromWKB.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_LinestringFromWKB</text>
+  <rect x="50" y="38" width="40" height="24" rx="4" fill="#8e44ad" opacity="0.12" stroke="#8e44ad" stroke-width="1.2" />
+  <text x="70" y="55" text-anchor="middle" font-size="13" font-weight="bold" fill="#8e44ad">WKB</text>
+  <line x1="70" y1="62" x2="296.1" y2="153.1" stroke="#2ecc71" stroke-width="2" />
+  <polygon points="298.9,154.2 291.1,146.8 288.1,154.2" fill="#2ecc71" />
+  <polyline points="127.78,211.11 201.11,113.33 298.89,162.22 372.22,88.89" fill="none" stroke="#2ecc71" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="127.78" cy="211.11" r="3.5" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="201.11" cy="113.33" r="3.5" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="298.89" cy="162.22" r="3.5" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="372.22" cy="88.89" r="3.5" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Constructs a LineString from WKB binary</text>
+  <rect x="112" y="255" width="12" height="12" rx="2" fill="#8e44ad" stroke="#8e44ad" stroke-width="1" />
+  <text x="128" y="266" font-size="13" fill="#333333">Input Format</text>
+  <rect x="238" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="254" y="266" font-size="13" fill="#333333">Result Geometry</text>
+</svg>

--- a/docs/image/ST_MLineFromText/ST_MLineFromText.svg
+++ b/docs/image/ST_MLineFromText/ST_MLineFromText.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_MLineFromText</text>
+  <rect x="50" y="38" width="40" height="24" rx="4" fill="#8e44ad" opacity="0.12" stroke="#8e44ad" stroke-width="1.2" />
+  <text x="70" y="55" text-anchor="middle" font-size="13" font-weight="bold" fill="#8e44ad">WKT</text>
+  <line x1="70" y1="62" x2="157.7" y2="134.8" stroke="#2ecc71" stroke-width="2" />
+  <polygon points="160,136.7 154.9,127.3 149.8,133.4" fill="#2ecc71" />
+  <polyline points="122.32,208.93 181.25,130.36 240.18,169.64" fill="none" stroke="#2ecc71" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="122.32" cy="208.93" r="3.5" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="181.25" cy="130.36" r="3.5" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="240.18" cy="169.64" r="3.5" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <polyline points="259.82,150.0 318.75,91.07 377.68,130.36" fill="none" stroke="#2ecc71" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="259.82" cy="150.0" r="3.5" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="318.75" cy="91.07" r="3.5" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="377.68" cy="130.36" r="3.5" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Constructs a MultiLineString from WKT</text>
+  <rect x="112" y="255" width="12" height="12" rx="2" fill="#8e44ad" stroke="#8e44ad" stroke-width="1" />
+  <text x="128" y="266" font-size="13" fill="#333333">Input Format</text>
+  <rect x="238" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="254" y="266" font-size="13" fill="#333333">Result Geometry</text>
+</svg>

--- a/docs/image/ST_MPointFromText/ST_MPointFromText.svg
+++ b/docs/image/ST_MPointFromText/ST_MPointFromText.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_MPointFromText</text>
+  <rect x="50" y="38" width="40" height="24" rx="4" fill="#8e44ad" opacity="0.12" stroke="#8e44ad" stroke-width="1.2" />
+  <text x="70" y="55" text-anchor="middle" font-size="13" font-weight="bold" fill="#8e44ad">WKT</text>
+  <line x1="70" y1="62" x2="157.7" y2="138.0" stroke="#2ecc71" stroke-width="2" />
+  <polygon points="160,140.0 155.1,130.4 149.8,136.5" fill="#2ecc71" />
+  <circle cx="151.28" cy="220.51" r="6" fill="#2ecc71" stroke="white" stroke-width="1.5" />
+  <circle cx="235.9" cy="107.69" r="6" fill="#2ecc71" stroke="white" stroke-width="1.5" />
+  <circle cx="348.72" cy="192.31" r="6" fill="#2ecc71" stroke="white" stroke-width="1.5" />
+  <circle cx="292.31" cy="79.49" r="6" fill="#2ecc71" stroke="white" stroke-width="1.5" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Constructs a MultiPoint from WKT</text>
+  <rect x="112" y="255" width="12" height="12" rx="2" fill="#8e44ad" stroke="#8e44ad" stroke-width="1" />
+  <text x="128" y="266" font-size="13" fill="#333333">Input Format</text>
+  <rect x="238" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="254" y="266" font-size="13" fill="#333333">Result Geometry</text>
+</svg>

--- a/docs/image/ST_MPolyFromText/ST_MPolyFromText.svg
+++ b/docs/image/ST_MPolyFromText/ST_MPolyFromText.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_MPolyFromText</text>
+  <rect x="50" y="38" width="40" height="24" rx="4" fill="#8e44ad" opacity="0.12" stroke="#8e44ad" stroke-width="1.2" />
+  <text x="70" y="55" text-anchor="middle" font-size="13" font-weight="bold" fill="#8e44ad">WKT</text>
+  <line x1="70" y1="62" x2="157.9" y2="147.7" stroke="#2ecc71" stroke-width="2" />
+  <polygon points="160,149.8 155.6,139.9 150.0,145.7" fill="#2ecc71" />
+  <path d="M 127.78 211.11 L 225.56 211.11 L 225.56 113.33 L 127.78 113.33 L 127.78 211.11 Z" fill="rgba(46,204,113,0.18)" stroke="#2ecc71" stroke-width="2.5" fill-rule="evenodd" />
+  <path d="M 274.44 186.67 L 372.22 186.67 L 372.22 88.89 L 274.44 88.89 L 274.44 186.67 Z" fill="rgba(46,204,113,0.18)" stroke="#2ecc71" stroke-width="2.5" fill-rule="evenodd" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Constructs a MultiPolygon from WKT</text>
+  <rect x="112" y="255" width="12" height="12" rx="2" fill="#8e44ad" stroke="#8e44ad" stroke-width="1" />
+  <text x="128" y="266" font-size="13" fill="#333333">Input Format</text>
+  <rect x="238" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="254" y="266" font-size="13" fill="#333333">Result Geometry</text>
+</svg>

--- a/docs/image/ST_MakeEnvelope/ST_MakeEnvelope.svg
+++ b/docs/image/ST_MakeEnvelope/ST_MakeEnvelope.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_MakeEnvelope</text>
+  <path d="M 136.76 214.71 L 363.24 214.71 L 363.24 85.29 L 136.76 85.29 L 136.76 214.71 Z" fill="rgba(46,204,113,0.18)" stroke="#2ecc71" stroke-width="2.5" fill-rule="evenodd" />
+  <text x="129" y="154" text-anchor="end" font-size="13" font-weight="bold" fill="#e67e22">minX=2</text>
+  <text x="371" y="154" text-anchor="start" font-size="13" font-weight="bold" fill="#e67e22">maxX=9</text>
+  <text x="250" y="233" text-anchor="middle" font-size="13" font-weight="bold" fill="#e67e22">minY=1</text>
+  <text x="250" y="77" text-anchor="middle" font-size="13" font-weight="bold" fill="#e67e22">maxY=5</text>
+  <circle cx="136.76" cy="214.71" r="4" fill="#2ecc71" stroke="white" stroke-width="1.5" />
+  <circle cx="363.24" cy="214.71" r="4" fill="#2ecc71" stroke="white" stroke-width="1.5" />
+  <circle cx="136.76" cy="85.29" r="4" fill="#2ecc71" stroke="white" stroke-width="1.5" />
+  <circle cx="363.24" cy="85.29" r="4" fill="#2ecc71" stroke="white" stroke-width="1.5" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Constructs a Polygon from MinX, MinY, MaxX, MaxY with optional SRID</text>
+  <rect x="140" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="156" y="266" font-size="13" fill="#333333">Result Polygon</text>
+  <rect x="282" y="255" width="12" height="12" rx="2" fill="#e67e22" stroke="#e67e22" stroke-width="1" />
+  <text x="298" y="266" font-size="13" fill="#333333">Bounds</text>
+</svg>

--- a/docs/image/ST_MakePoint/ST_MakePoint.svg
+++ b/docs/image/ST_MakePoint/ST_MakePoint.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_MakePoint</text>
+  <line x1="171.43" y1="228.57" x2="171.43" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="210.71" y1="228.57" x2="210.71" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="250.0" y1="228.57" x2="250.0" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="289.29" y1="228.57" x2="289.29" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="328.57" y1="228.57" x2="328.57" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="228.57" x2="328.57" y2="228.57" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="189.29" x2="328.57" y2="189.29" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="150.0" x2="328.57" y2="150.0" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="110.71" x2="328.57" y2="110.71" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="71.43" x2="328.57" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <circle cx="269.64" cy="150.0" r="10" fill="#2ecc71" stroke="white" stroke-width="1.5" />
+  <text x="284" y="138" text-anchor="start" font-size="13" fill="#e67e22" font-weight="bold">X=5, Y=4</text>
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Creates a 2D, 3DZ, or 4DZM Point geometry</text>
+  <rect x="128" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="144" y="266" font-size="13" fill="#333333">Result Point</text>
+  <rect x="254" y="255" width="12" height="12" rx="2" fill="#e67e22" stroke="#e67e22" stroke-width="1" />
+  <text x="270" y="266" font-size="13" fill="#333333">Coordinates</text>
+</svg>

--- a/docs/image/ST_MakePointM/ST_MakePointM.svg
+++ b/docs/image/ST_MakePointM/ST_MakePointM.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_MakePointM</text>
+  <line x1="171.43" y1="228.57" x2="171.43" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="210.71" y1="228.57" x2="210.71" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="250.0" y1="228.57" x2="250.0" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="289.29" y1="228.57" x2="289.29" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="328.57" y1="228.57" x2="328.57" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="228.57" x2="328.57" y2="228.57" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="189.29" x2="328.57" y2="189.29" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="150.0" x2="328.57" y2="150.0" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="110.71" x2="328.57" y2="110.71" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="71.43" x2="328.57" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <circle cx="269.64" cy="150.0" r="10" fill="#2ecc71" stroke="white" stroke-width="1.5" />
+  <text x="284" y="138" text-anchor="start" font-size="13" fill="#e67e22" font-weight="bold">X=5, Y=4, M=3</text>
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Creates a Point with X, Y, and M coordinate</text>
+  <rect x="128" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="144" y="266" font-size="13" fill="#333333">Result Point</text>
+  <rect x="254" y="255" width="12" height="12" rx="2" fill="#e67e22" stroke="#e67e22" stroke-width="1" />
+  <text x="270" y="266" font-size="13" fill="#333333">Coordinates</text>
+</svg>

--- a/docs/image/ST_Point/ST_Point.svg
+++ b/docs/image/ST_Point/ST_Point.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_Point</text>
+  <line x1="171.43" y1="228.57" x2="171.43" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="210.71" y1="228.57" x2="210.71" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="250.0" y1="228.57" x2="250.0" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="289.29" y1="228.57" x2="289.29" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="328.57" y1="228.57" x2="328.57" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="228.57" x2="328.57" y2="228.57" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="189.29" x2="328.57" y2="189.29" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="150.0" x2="328.57" y2="150.0" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="110.71" x2="328.57" y2="110.71" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="71.43" x2="328.57" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <circle cx="230.36" cy="130.36" r="10" fill="#2ecc71" stroke="white" stroke-width="1.5" />
+  <text x="244" y="118" text-anchor="start" font-size="13" fill="#e67e22" font-weight="bold">X=3, Y=5</text>
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Constructs a Point from X and Y coordinates</text>
+  <rect x="128" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="144" y="266" font-size="13" fill="#333333">Result Point</text>
+  <rect x="254" y="255" width="12" height="12" rx="2" fill="#e67e22" stroke="#e67e22" stroke-width="1" />
+  <text x="270" y="266" font-size="13" fill="#333333">Coordinates</text>
+</svg>

--- a/docs/image/ST_PointFromGeoHash/ST_PointFromGeoHash.svg
+++ b/docs/image/ST_PointFromGeoHash/ST_PointFromGeoHash.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_PointFromGeoHash</text>
+  <line x1="171.43" y1="228.57" x2="171.43" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="210.71" y1="228.57" x2="210.71" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="250.0" y1="228.57" x2="250.0" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="289.29" y1="228.57" x2="289.29" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="328.57" y1="228.57" x2="328.57" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="228.57" x2="328.57" y2="228.57" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="189.29" x2="328.57" y2="189.29" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="150.0" x2="328.57" y2="150.0" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="110.71" x2="328.57" y2="110.71" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="71.43" x2="328.57" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <rect x="64" y="138" width="72" height="24" rx="4" fill="#8e44ad" opacity="0.12" stroke="#8e44ad" stroke-width="1.2" />
+  <text x="100" y="155" text-anchor="middle" font-size="13" font-weight="bold" fill="#8e44ad">GeoHash</text>
+  <line x1="140" y1="150" x2="250.6" y2="150.0" stroke="#2ecc71" stroke-width="2" />
+  <polygon points="253.6,150.0 243.6,146.0 243.6,154.0" fill="#2ecc71" />
+  <circle cx="269.64" cy="150.0" r="10" fill="#2ecc71" stroke="white" stroke-width="1.5" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Creates a Point at the center of a GeoHash cell</text>
+  <rect x="112" y="255" width="12" height="12" rx="2" fill="#8e44ad" stroke="#8e44ad" stroke-width="1" />
+  <text x="128" y="266" font-size="13" fill="#333333">Input Format</text>
+  <rect x="238" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="254" y="266" font-size="13" fill="#333333">Result Geometry</text>
+</svg>

--- a/docs/image/ST_PointFromText/ST_PointFromText.svg
+++ b/docs/image/ST_PointFromText/ST_PointFromText.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_PointFromText</text>
+  <line x1="171.43" y1="228.57" x2="171.43" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="210.71" y1="228.57" x2="210.71" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="250.0" y1="228.57" x2="250.0" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="289.29" y1="228.57" x2="289.29" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="328.57" y1="228.57" x2="328.57" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="228.57" x2="328.57" y2="228.57" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="189.29" x2="328.57" y2="189.29" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="150.0" x2="328.57" y2="150.0" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="110.71" x2="328.57" y2="110.71" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="71.43" x2="328.57" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <rect x="76" y="138" width="48" height="24" rx="4" fill="#8e44ad" opacity="0.12" stroke="#8e44ad" stroke-width="1.2" />
+  <text x="100" y="155" text-anchor="middle" font-size="13" font-weight="bold" fill="#8e44ad">Text</text>
+  <line x1="140" y1="150" x2="231.1" y2="131.0" stroke="#2ecc71" stroke-width="2" />
+  <polygon points="234.0,130.4 223.4,128.5 225.0,136.3" fill="#2ecc71" />
+  <circle cx="250.0" cy="130.36" r="10" fill="#2ecc71" stroke="white" stroke-width="1.5" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Constructs a Point from delimited text</text>
+  <rect x="112" y="255" width="12" height="12" rx="2" fill="#8e44ad" stroke="#8e44ad" stroke-width="1" />
+  <text x="128" y="266" font-size="13" fill="#333333">Input Format</text>
+  <rect x="238" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="254" y="266" font-size="13" fill="#333333">Result Geometry</text>
+</svg>

--- a/docs/image/ST_PointFromWKB/ST_PointFromWKB.svg
+++ b/docs/image/ST_PointFromWKB/ST_PointFromWKB.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_PointFromWKB</text>
+  <line x1="171.43" y1="228.57" x2="171.43" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="210.71" y1="228.57" x2="210.71" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="250.0" y1="228.57" x2="250.0" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="289.29" y1="228.57" x2="289.29" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="328.57" y1="228.57" x2="328.57" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="228.57" x2="328.57" y2="228.57" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="189.29" x2="328.57" y2="189.29" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="150.0" x2="328.57" y2="150.0" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="110.71" x2="328.57" y2="110.71" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="71.43" x2="328.57" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <rect x="80" y="138" width="40" height="24" rx="4" fill="#8e44ad" opacity="0.12" stroke="#8e44ad" stroke-width="1.2" />
+  <text x="100" y="155" text-anchor="middle" font-size="13" font-weight="bold" fill="#8e44ad">WKB</text>
+  <line x1="140" y1="150" x2="231.1" y2="131.0" stroke="#2ecc71" stroke-width="2" />
+  <polygon points="234.0,130.4 223.4,128.5 225.0,136.3" fill="#2ecc71" />
+  <circle cx="250.0" cy="130.36" r="10" fill="#2ecc71" stroke="white" stroke-width="1.5" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Constructs a Point from WKB binary</text>
+  <rect x="112" y="255" width="12" height="12" rx="2" fill="#8e44ad" stroke="#8e44ad" stroke-width="1" />
+  <text x="128" y="266" font-size="13" fill="#333333">Input Format</text>
+  <rect x="238" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="254" y="266" font-size="13" fill="#333333">Result Geometry</text>
+</svg>

--- a/docs/image/ST_PointM/ST_PointM.svg
+++ b/docs/image/ST_PointM/ST_PointM.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_PointM</text>
+  <line x1="171.43" y1="228.57" x2="171.43" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="210.71" y1="228.57" x2="210.71" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="250.0" y1="228.57" x2="250.0" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="289.29" y1="228.57" x2="289.29" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="328.57" y1="228.57" x2="328.57" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="228.57" x2="328.57" y2="228.57" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="189.29" x2="328.57" y2="189.29" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="150.0" x2="328.57" y2="150.0" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="110.71" x2="328.57" y2="110.71" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="71.43" x2="328.57" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <circle cx="230.36" cy="130.36" r="10" fill="#2ecc71" stroke="white" stroke-width="1.5" />
+  <text x="244" y="118" text-anchor="start" font-size="13" fill="#e67e22" font-weight="bold">X=3, Y=5, M=1</text>
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Constructs a Point from X, Y, and M coordinates</text>
+  <rect x="128" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="144" y="266" font-size="13" fill="#333333">Result Point</text>
+  <rect x="254" y="255" width="12" height="12" rx="2" fill="#e67e22" stroke="#e67e22" stroke-width="1" />
+  <text x="270" y="266" font-size="13" fill="#333333">Coordinates</text>
+</svg>

--- a/docs/image/ST_PointZ/ST_PointZ.svg
+++ b/docs/image/ST_PointZ/ST_PointZ.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_PointZ</text>
+  <line x1="171.43" y1="228.57" x2="171.43" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="210.71" y1="228.57" x2="210.71" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="250.0" y1="228.57" x2="250.0" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="289.29" y1="228.57" x2="289.29" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="328.57" y1="228.57" x2="328.57" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="228.57" x2="328.57" y2="228.57" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="189.29" x2="328.57" y2="189.29" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="150.0" x2="328.57" y2="150.0" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="110.71" x2="328.57" y2="110.71" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="71.43" x2="328.57" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <circle cx="230.36" cy="130.36" r="10" fill="#2ecc71" stroke="white" stroke-width="1.5" />
+  <text x="244" y="118" text-anchor="start" font-size="13" fill="#e67e22" font-weight="bold">X=3, Y=5, Z=2</text>
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Constructs a Point from X, Y, and Z coordinates</text>
+  <rect x="128" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="144" y="266" font-size="13" fill="#333333">Result Point</text>
+  <rect x="254" y="255" width="12" height="12" rx="2" fill="#e67e22" stroke="#e67e22" stroke-width="1" />
+  <text x="270" y="266" font-size="13" fill="#333333">Coordinates</text>
+</svg>

--- a/docs/image/ST_PointZM/ST_PointZM.svg
+++ b/docs/image/ST_PointZM/ST_PointZM.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_PointZM</text>
+  <line x1="171.43" y1="228.57" x2="171.43" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="210.71" y1="228.57" x2="210.71" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="250.0" y1="228.57" x2="250.0" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="289.29" y1="228.57" x2="289.29" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="328.57" y1="228.57" x2="328.57" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="228.57" x2="328.57" y2="228.57" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="189.29" x2="328.57" y2="189.29" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="150.0" x2="328.57" y2="150.0" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="110.71" x2="328.57" y2="110.71" stroke="#e8e8e8" stroke-width="1" />
+  <line x1="171.43" y1="71.43" x2="328.57" y2="71.43" stroke="#e8e8e8" stroke-width="1" />
+  <circle cx="230.36" cy="130.36" r="10" fill="#2ecc71" stroke="white" stroke-width="1.5" />
+  <text x="244" y="118" text-anchor="start" font-size="13" fill="#e67e22" font-weight="bold">X=3, Y=5, Z=2, M=1</text>
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Constructs a Point from X, Y, Z, and M coordinates</text>
+  <rect x="128" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="144" y="266" font-size="13" fill="#333333">Result Point</text>
+  <rect x="254" y="255" width="12" height="12" rx="2" fill="#e67e22" stroke="#e67e22" stroke-width="1" />
+  <text x="270" y="266" font-size="13" fill="#333333">Coordinates</text>
+</svg>

--- a/docs/image/ST_PolygonFromEnvelope/ST_PolygonFromEnvelope.svg
+++ b/docs/image/ST_PolygonFromEnvelope/ST_PolygonFromEnvelope.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_PolygonFromEnvelope</text>
+  <path d="M 151.28 220.51 L 348.72 220.51 L 348.72 79.49 L 151.28 79.49 L 151.28 220.51 Z" fill="rgba(46,204,113,0.18)" stroke="#2ecc71" stroke-width="2.5" fill-rule="evenodd" />
+  <text x="143" y="154" text-anchor="end" font-size="13" font-weight="bold" fill="#e67e22">minX=1</text>
+  <text x="357" y="154" text-anchor="start" font-size="13" font-weight="bold" fill="#e67e22">maxX=8</text>
+  <text x="250" y="239" text-anchor="middle" font-size="13" font-weight="bold" fill="#e67e22">minY=1</text>
+  <text x="250" y="71" text-anchor="middle" font-size="13" font-weight="bold" fill="#e67e22">maxY=6</text>
+  <circle cx="151.28" cy="220.51" r="4" fill="#2ecc71" stroke="white" stroke-width="1.5" />
+  <circle cx="348.72" cy="220.51" r="4" fill="#2ecc71" stroke="white" stroke-width="1.5" />
+  <circle cx="151.28" cy="79.49" r="4" fill="#2ecc71" stroke="white" stroke-width="1.5" />
+  <circle cx="348.72" cy="79.49" r="4" fill="#2ecc71" stroke="white" stroke-width="1.5" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Constructs a Polygon from MinX, MinY, MaxX, MaxY</text>
+  <rect x="140" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="156" y="266" font-size="13" fill="#333333">Result Polygon</text>
+  <rect x="282" y="255" width="12" height="12" rx="2" fill="#e67e22" stroke="#e67e22" stroke-width="1" />
+  <text x="298" y="266" font-size="13" fill="#333333">Bounds</text>
+</svg>

--- a/docs/image/ST_PolygonFromText/ST_PolygonFromText.svg
+++ b/docs/image/ST_PolygonFromText/ST_PolygonFromText.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+  </defs>
+  <text x="250" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">ST_PolygonFromText</text>
+  <rect x="46" y="38" width="48" height="24" rx="4" fill="#8e44ad" opacity="0.12" stroke="#8e44ad" stroke-width="1.2" />
+  <text x="70" y="55" text-anchor="middle" font-size="13" font-weight="bold" fill="#8e44ad">Text</text>
+  <line x1="70" y1="62" x2="210.2" y2="152.8" stroke="#2ecc71" stroke-width="2" />
+  <polygon points="212.8,154.4 206.5,145.6 202.2,152.3" fill="#2ecc71" />
+  <path d="M 163.73 225.49 L 336.27 225.49 L 293.14 96.08 L 206.86 74.51 L 163.73 225.49 Z" fill="rgba(46,204,113,0.18)" stroke="#2ecc71" stroke-width="2.5" fill-rule="evenodd" />
+  <circle cx="163.73" cy="225.49" r="3.5" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="336.27" cy="225.49" r="3.5" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="293.14" cy="96.08" r="3.5" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="206.86" cy="74.51" r="3.5" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <circle cx="163.73" cy="225.49" r="3.5" fill="#2ecc71" stroke="white" stroke-width="1" />
+  <text x="250" y="292" text-anchor="middle" font-size="13" fill="#333333" font-style="italic">Constructs a Polygon from delimited text</text>
+  <rect x="112" y="255" width="12" height="12" rx="2" fill="#8e44ad" stroke="#8e44ad" stroke-width="1" />
+  <text x="128" y="266" font-size="13" fill="#333333">Input Format</text>
+  <rect x="238" y="255" width="12" height="12" rx="2" fill="#2ecc71" stroke="#2ecc71" stroke-width="1" />
+  <text x="254" y="266" font-size="13" fill="#333333">Result Geometry</text>
+</svg>


### PR DESCRIPTION
## What is the purpose of this PR?

This PR is **Phase 5** of the work for issue #2678, adding SVG visual illustrations to all **Geometry Constructor** function documentation pages.

## What changes are included?

### New SVG Images (31 files)
Added visual illustrations for all 31 geometry constructor functions in `docs/image/ST_<Name>/ST_<Name>.svg`.

### Documentation Updates (88 files)
- **SQL** (`docs/api/sql/Geometry-Constructors/`): 31 files updated
- **Flink** (`docs/api/flink/Geometry-Constructors/`): 30 files updated (ST_GeomFromMySQL not available in Flink)
- **Snowflake** (`docs/api/snowflake/vector-data/Geometry-Constructors/`): 27 files updated (ST_GeomFromMySQL, ST_MakePointM, ST_PointM, ST_PointZM not available in Snowflake)

### Visual Categories

The 31 constructor functions are grouped into 7 visual categories:

1. **Point from Coordinates** (6): ST_Point, ST_PointZ, ST_PointM, ST_PointZM, ST_MakePoint, ST_MakePointM — Grid background with labeled coordinate values (X, Y, Z, M)
2. **Point from Format** (3): ST_PointFromText, ST_PointFromWKB, ST_PointFromGeoHash — Format badge with arrow pointing to constructed point
3. **Line from Format** (4): ST_LineFromText, ST_LineFromWKB, ST_LineStringFromText, ST_LinestringFromWKB — Format badge with linestring result
4. **Envelope** (2): ST_PolygonFromEnvelope, ST_MakeEnvelope — Axis-aligned rectangle with min/max coordinate labels on edges
5. **Polygon from Format** (1): ST_PolygonFromText — Format badge with polygon result
6. **Multi from Format** (4): ST_MPointFromText, ST_MLineFromText, ST_MPolyFromText, ST_GeomCollFromText — Format badge with multi-geometry results
7. **General from Format** (11): ST_GeomFromWKT, ST_GeomFromText, ST_GeometryFromText, ST_GeomFromWKB, ST_GeomFromEWKB, ST_GeomFromEWKT, ST_GeomFromGeoHash, ST_GeomFromGeoJSON, ST_GeomFromGML, ST_GeomFromKML, ST_GeomFromMySQL — Format badge with generic polygon result

## How was this patch tested?

Visual inspection of generated SVGs and verification of correct image placement in all documentation variants.
