### PR TITLE
[GH-2678] Add SVG visuals for geometry output functions (Phase 7)

### DIFF
--- a/docs/api/flink/Geometry-Output/ST_AsBinary.md
+++ b/docs/api/flink/Geometry-Output/ST_AsBinary.md
@@ -21,6 +21,8 @@
 
 Introduction: Return the Well-Known Binary representation of a geometry
 
+![ST_AsBinary](../../../image/ST_AsBinary/ST_AsBinary.svg "ST_AsBinary")
+
 Format: `ST_AsBinary (A: Geometry)`
 
 Return type: `Binary`

--- a/docs/api/flink/Geometry-Output/ST_AsEWKB.md
+++ b/docs/api/flink/Geometry-Output/ST_AsEWKB.md
@@ -25,6 +25,8 @@ The format originated in PostGIS but is supported by many GIS tools.
 If the geometry is lacking SRID a WKB format is produced.
 It will ignore the M coordinate if present.
 
+![ST_AsEWKB](../../../image/ST_AsEWKB/ST_AsEWKB.svg "ST_AsEWKB")
+
 Format: `ST_AsEWKB (A: Geometry)`
 
 Return type: `Binary`

--- a/docs/api/flink/Geometry-Output/ST_AsEWKT.md
+++ b/docs/api/flink/Geometry-Output/ST_AsEWKT.md
@@ -26,6 +26,8 @@ If the geometry is lacking SRID a WKT format is produced.
 [See ST_SetSRID](../Spatial-Reference-System/ST_SetSRID.md)
 It will support M coordinate if present since v1.5.0.
 
+![ST_AsEWKT](../../../image/ST_AsEWKT/ST_AsEWKT.svg "ST_AsEWKT")
+
 Format: `ST_AsEWKT (A: Geometry)`
 
 Return type: `String`

--- a/docs/api/flink/Geometry-Output/ST_AsGML.md
+++ b/docs/api/flink/Geometry-Output/ST_AsGML.md
@@ -21,6 +21,8 @@
 
 Introduction: Return the [GML](https://www.ogc.org/standards/gml) string representation of a geometry
 
+![ST_AsGML](../../../image/ST_AsGML/ST_AsGML.svg "ST_AsGML")
+
 Format: `ST_AsGML (A: Geometry)`
 
 Return type: `String`

--- a/docs/api/flink/Geometry-Output/ST_AsGeoJSON.md
+++ b/docs/api/flink/Geometry-Output/ST_AsGeoJSON.md
@@ -27,6 +27,8 @@ The type parameter (Since: `v1.6.1`) takes the following options -
 - "Feature": Wraps the geometry in a GeoJSON Feature.
 - "FeatureCollection": Wraps the Feature in a GeoJSON FeatureCollection.
 
+![ST_AsGeoJSON](../../../image/ST_AsGeoJSON/ST_AsGeoJSON.svg "ST_AsGeoJSON")
+
 Format:
 
 `ST_AsGeoJSON (A: Geometry)`

--- a/docs/api/flink/Geometry-Output/ST_AsHEXEWKB.md
+++ b/docs/api/flink/Geometry-Output/ST_AsHEXEWKB.md
@@ -21,6 +21,8 @@
 
 Introduction: This function returns the input geometry encoded to a text representation in HEXEWKB format. The HEXEWKB encoding can use either little-endian (NDR) or big-endian (XDR) byte ordering. If no encoding is explicitly specified, the function defaults to using the little-endian (NDR) format.
 
+![ST_AsHEXEWKB](../../../image/ST_AsHEXEWKB/ST_AsHEXEWKB.svg "ST_AsHEXEWKB")
+
 Format: `ST_AsHEXEWKB(geom: Geometry, endian: String = NDR)`
 
 Return type: `String`

--- a/docs/api/flink/Geometry-Output/ST_AsKML.md
+++ b/docs/api/flink/Geometry-Output/ST_AsKML.md
@@ -21,6 +21,8 @@
 
 Introduction: Return the [KML](https://www.ogc.org/standards/kml) string representation of a geometry
 
+![ST_AsKML](../../../image/ST_AsKML/ST_AsKML.svg "ST_AsKML")
+
 Format: `ST_AsKML (A: Geometry)`
 
 Return type: `String`

--- a/docs/api/flink/Geometry-Output/ST_AsText.md
+++ b/docs/api/flink/Geometry-Output/ST_AsText.md
@@ -22,6 +22,8 @@
 Introduction: Return the Well-Known Text string representation of a geometry.
 It will support M coordinate if present since v1.5.0.
 
+![ST_AsText](../../../image/ST_AsText/ST_AsText.svg "ST_AsText")
+
 Format: `ST_AsText (A: Geometry)`
 
 Return type: `String`

--- a/docs/api/flink/Geometry-Output/ST_GeoHash.md
+++ b/docs/api/flink/Geometry-Output/ST_GeoHash.md
@@ -21,6 +21,8 @@
 
 Introduction: Returns GeoHash of the geometry with given precision
 
+![ST_GeoHash](../../../image/ST_GeoHash/ST_GeoHash.svg "ST_GeoHash")
+
 Format: `ST_GeoHash(geom: Geometry, precision: Integer)`
 
 Return type: `String`

--- a/docs/api/snowflake/vector-data/Geometry-Output/ST_AsBinary.md
+++ b/docs/api/snowflake/vector-data/Geometry-Output/ST_AsBinary.md
@@ -21,6 +21,8 @@
 
 Introduction: Return the Well-Known Binary representation of a geometry
 
+![ST_AsBinary](../../../../image/ST_AsBinary/ST_AsBinary.svg "ST_AsBinary")
+
 Format: `ST_AsBinary (A:geometry)`
 
 Return type: `Binary`

--- a/docs/api/snowflake/vector-data/Geometry-Output/ST_AsEWKB.md
+++ b/docs/api/snowflake/vector-data/Geometry-Output/ST_AsEWKB.md
@@ -25,6 +25,8 @@ The format originated in PostGIS but is supported by many GIS tools.
 If the geometry is lacking SRID a WKB format is produced.
 [See ST_SetSRID](../Spatial-Reference-System/ST_SetSRID.md)
 
+![ST_AsEWKB](../../../../image/ST_AsEWKB/ST_AsEWKB.svg "ST_AsEWKB")
+
 Format: `ST_AsEWKB (A:geometry)`
 
 Return type: `Binary`

--- a/docs/api/snowflake/vector-data/Geometry-Output/ST_AsEWKT.md
+++ b/docs/api/snowflake/vector-data/Geometry-Output/ST_AsEWKT.md
@@ -25,6 +25,8 @@ The format originated in PostGIS but is supported by many GIS tools.
 If the geometry is lacking SRID a WKT format is produced.
 [See ST_SetSRID](../Spatial-Reference-System/ST_SetSRID.md)
 
+![ST_AsEWKT](../../../../image/ST_AsEWKT/ST_AsEWKT.svg "ST_AsEWKT")
+
 Format: `ST_AsEWKT (A:geometry)`
 
 Return type: `String`

--- a/docs/api/snowflake/vector-data/Geometry-Output/ST_AsGML.md
+++ b/docs/api/snowflake/vector-data/Geometry-Output/ST_AsGML.md
@@ -21,6 +21,8 @@
 
 Introduction: Return the [GML](https://www.ogc.org/standards/gml) string representation of a geometry
 
+![ST_AsGML](../../../../image/ST_AsGML/ST_AsGML.svg "ST_AsGML")
+
 Format: `ST_AsGML (A:geometry)`
 
 Return type: `String`

--- a/docs/api/snowflake/vector-data/Geometry-Output/ST_AsGeoJSON.md
+++ b/docs/api/snowflake/vector-data/Geometry-Output/ST_AsGeoJSON.md
@@ -27,6 +27,8 @@ The type parameter takes the following options -
 - "Feature": Wraps the geometry in a GeoJSON Feature.
 - "FeatureCollection": Wraps the Feature in a GeoJSON FeatureCollection.
 
+![ST_AsGeoJSON](../../../../image/ST_AsGeoJSON/ST_AsGeoJSON.svg "ST_AsGeoJSON")
+
 Format:
 
 `ST_AsGeoJSON (A:geometry)`

--- a/docs/api/snowflake/vector-data/Geometry-Output/ST_AsHEXEWKB.md
+++ b/docs/api/snowflake/vector-data/Geometry-Output/ST_AsHEXEWKB.md
@@ -21,6 +21,8 @@
 
 Introduction: This function returns the input geometry encoded to a text representation in HEXEWKB format. The HEXEWKB encoding can use either little-endian (NDR) or big-endian (XDR) byte ordering. If no encoding is explicitly specified, the function defaults to using the little-endian (NDR) format.
 
+![ST_AsHEXEWKB](../../../../image/ST_AsHEXEWKB/ST_AsHEXEWKB.svg "ST_AsHEXEWKB")
+
 Format: `ST_AsHEXEWKB(geom: Geometry, endian: String = NDR)`
 
 Return type: `String`

--- a/docs/api/snowflake/vector-data/Geometry-Output/ST_AsKML.md
+++ b/docs/api/snowflake/vector-data/Geometry-Output/ST_AsKML.md
@@ -21,6 +21,8 @@
 
 Introduction: Return the [KML](https://www.ogc.org/standards/kml) string representation of a geometry
 
+![ST_AsKML](../../../../image/ST_AsKML/ST_AsKML.svg "ST_AsKML")
+
 Format: `ST_AsKML (A:geometry)`
 
 Return type: `String`

--- a/docs/api/snowflake/vector-data/Geometry-Output/ST_AsText.md
+++ b/docs/api/snowflake/vector-data/Geometry-Output/ST_AsText.md
@@ -21,6 +21,8 @@
 
 Introduction: Return the Well-Known Text string representation of a geometry
 
+![ST_AsText](../../../../image/ST_AsText/ST_AsText.svg "ST_AsText")
+
 Format: `ST_AsText (A:geometry)`
 
 Return type: `String`

--- a/docs/api/snowflake/vector-data/Geometry-Output/ST_GeoHash.md
+++ b/docs/api/snowflake/vector-data/Geometry-Output/ST_GeoHash.md
@@ -21,6 +21,8 @@
 
 Introduction: Returns GeoHash of the geometry with given precision
 
+![ST_GeoHash](../../../../image/ST_GeoHash/ST_GeoHash.svg "ST_GeoHash")
+
 Format: `ST_GeoHash(geom: geometry, precision: int)`
 
 Return type: `String`

--- a/docs/api/sql/Geometry-Output/ST_AsBinary.md
+++ b/docs/api/sql/Geometry-Output/ST_AsBinary.md
@@ -21,6 +21,8 @@
 
 Introduction: Return the Well-Known Binary representation of a geometry
 
+![ST_AsBinary](../../../image/ST_AsBinary/ST_AsBinary.svg "ST_AsBinary")
+
 Format: `ST_AsBinary (A: Geometry)`
 
 Return type: `Binary`

--- a/docs/api/sql/Geometry-Output/ST_AsEWKB.md
+++ b/docs/api/sql/Geometry-Output/ST_AsEWKB.md
@@ -26,6 +26,8 @@ If the geometry is lacking SRID a WKB format is produced.
 [See ST_SetSRID](../Spatial-Reference-System/ST_SetSRID.md)
 It will ignore the M coordinate if present.
 
+![ST_AsEWKB](../../../image/ST_AsEWKB/ST_AsEWKB.svg "ST_AsEWKB")
+
 Format: `ST_AsEWKB (A: Geometry)`
 
 Return type: `Binary`

--- a/docs/api/sql/Geometry-Output/ST_AsEWKT.md
+++ b/docs/api/sql/Geometry-Output/ST_AsEWKT.md
@@ -26,6 +26,8 @@ If the geometry is lacking SRID a WKT format is produced.
 [See ST_SetSRID](../Spatial-Reference-System/ST_SetSRID.md)
 It will support M coordinate if present since v1.5.0.
 
+![ST_AsEWKT](../../../image/ST_AsEWKT/ST_AsEWKT.svg "ST_AsEWKT")
+
 Format: `ST_AsEWKT (A: Geometry)`
 
 Return type: `String`

--- a/docs/api/sql/Geometry-Output/ST_AsGML.md
+++ b/docs/api/sql/Geometry-Output/ST_AsGML.md
@@ -21,6 +21,8 @@
 
 Introduction: Return the [GML](https://www.ogc.org/standards/gml) string representation of a geometry
 
+![ST_AsGML](../../../image/ST_AsGML/ST_AsGML.svg "ST_AsGML")
+
 Format: `ST_AsGML (A: Geometry)`
 
 Return type: `String`

--- a/docs/api/sql/Geometry-Output/ST_AsGeoJSON.md
+++ b/docs/api/sql/Geometry-Output/ST_AsGeoJSON.md
@@ -30,6 +30,8 @@ The type parameter (Since: `v1.6.1`) takes the following options -
 - "Feature": Wraps the geometry in a GeoJSON Feature.
 - "FeatureCollection": Wraps the Feature in a GeoJSON FeatureCollection.
 
+![ST_AsGeoJSON](../../../image/ST_AsGeoJSON/ST_AsGeoJSON.svg "ST_AsGeoJSON")
+
 Format:
 
 `ST_AsGeoJSON (A: Geometry)`

--- a/docs/api/sql/Geometry-Output/ST_AsHEXEWKB.md
+++ b/docs/api/sql/Geometry-Output/ST_AsHEXEWKB.md
@@ -21,6 +21,8 @@
 
 Introduction: This function returns the input geometry encoded to a text representation in HEXEWKB format. The HEXEWKB encoding can use either little-endian (NDR) or big-endian (XDR) byte ordering. If no encoding is explicitly specified, the function defaults to using the little-endian (NDR) format.
 
+![ST_AsHEXEWKB](../../../image/ST_AsHEXEWKB/ST_AsHEXEWKB.svg "ST_AsHEXEWKB")
+
 Format: `ST_AsHEXEWKB(geom: Geometry, endian: String = NDR)`
 
 Return type: `String`

--- a/docs/api/sql/Geometry-Output/ST_AsKML.md
+++ b/docs/api/sql/Geometry-Output/ST_AsKML.md
@@ -21,6 +21,8 @@
 
 Introduction: Return the [KML](https://www.ogc.org/standards/kml) string representation of a geometry
 
+![ST_AsKML](../../../image/ST_AsKML/ST_AsKML.svg "ST_AsKML")
+
 Format: `ST_AsKML (A: Geometry)`
 
 Return type: `String`

--- a/docs/api/sql/Geometry-Output/ST_AsText.md
+++ b/docs/api/sql/Geometry-Output/ST_AsText.md
@@ -22,6 +22,8 @@
 Introduction: Return the Well-Known Text string representation of a geometry.
 It will support M coordinate if present since v1.5.0.
 
+![ST_AsText](../../../image/ST_AsText/ST_AsText.svg "ST_AsText")
+
 Format: `ST_AsText (A: Geometry)`
 
 Return type: `String`

--- a/docs/api/sql/Geometry-Output/ST_GeoHash.md
+++ b/docs/api/sql/Geometry-Output/ST_GeoHash.md
@@ -21,6 +21,8 @@
 
 Introduction: Returns GeoHash of the geometry with given precision
 
+![ST_GeoHash](../../../image/ST_GeoHash/ST_GeoHash.svg "ST_GeoHash")
+
 Format: `ST_GeoHash(geom: Geometry, precision: Integer)`
 
 Return type: `String`

--- a/docs/image/ST_AsBinary/ST_AsBinary.svg
+++ b/docs/image/ST_AsBinary/ST_AsBinary.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="380" height="120" viewBox="0 0 380 120">
+  <rect width="380" height="120" fill="#f5f5f5" rx="5"/>
+  <defs><marker id="arrowhead" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#666"/></marker></defs>
+  <polygon points="35.0,80.0 35.0,20.0 95.0,20.0 95.0,80.0 35.0,80.0" stroke="#4A90D9" stroke-width="2" fill="rgba(74,144,217,0.15)"/>
+  <line x1="140.0" y1="60.0" x2="180.0" y2="60.0" stroke="#666" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <text x="160.0" y="50.0" font-family="monospace" font-size="9" fill="#666" text-anchor="middle">ST_AsBinary</text>
+  <rect x="190.0" y="49.0" width="180.0" height="22" rx="4" fill="#E8F5E9" stroke="#43A047" stroke-width="1"/>
+  <text x="280.0" y="64.0" font-family="monospace" font-size="9" fill="#333" text-anchor="middle">0x0001020000...</text>
+  <text x="280.0" y="84.0" font-family="monospace" font-size="9" fill="#999" text-anchor="middle">WKB (binary)</text>
+</svg>

--- a/docs/image/ST_AsEWKB/ST_AsEWKB.svg
+++ b/docs/image/ST_AsEWKB/ST_AsEWKB.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="380" height="120" viewBox="0 0 380 120">
+  <rect width="380" height="120" fill="#f5f5f5" rx="5"/>
+  <defs><marker id="arrowhead" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#666"/></marker></defs>
+  <polygon points="35.0,80.0 35.0,20.0 95.0,20.0 95.0,80.0 35.0,80.0" stroke="#4A90D9" stroke-width="2" fill="rgba(74,144,217,0.15)"/>
+  <line x1="140.0" y1="60.0" x2="180.0" y2="60.0" stroke="#666" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <text x="160.0" y="50.0" font-family="monospace" font-size="9" fill="#666" text-anchor="middle">ST_AsEWKB</text>
+  <rect x="190.0" y="49.0" width="180.0" height="22" rx="4" fill="#E8F5E9" stroke="#43A047" stroke-width="1"/>
+  <text x="280.0" y="64.0" font-family="monospace" font-size="9" fill="#333" text-anchor="middle">0x0103000020E6...</text>
+  <text x="280.0" y="84.0" font-family="monospace" font-size="9" fill="#999" text-anchor="middle">EWKB (binary+SRID)</text>
+</svg>

--- a/docs/image/ST_AsEWKT/ST_AsEWKT.svg
+++ b/docs/image/ST_AsEWKT/ST_AsEWKT.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="380" height="120" viewBox="0 0 380 120">
+  <rect width="380" height="120" fill="#f5f5f5" rx="5"/>
+  <defs><marker id="arrowhead" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#666"/></marker></defs>
+  <polygon points="35.0,80.0 35.0,20.0 95.0,20.0 95.0,80.0 35.0,80.0" stroke="#4A90D9" stroke-width="2" fill="rgba(74,144,217,0.15)"/>
+  <line x1="140.0" y1="60.0" x2="180.0" y2="60.0" stroke="#666" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <text x="160.0" y="50.0" font-family="monospace" font-size="9" fill="#666" text-anchor="middle">ST_AsEWKT</text>
+  <rect x="190.0" y="49.0" width="180.0" height="22" rx="4" fill="#E8F5E9" stroke="#43A047" stroke-width="1"/>
+  <text x="280.0" y="64.0" font-family="monospace" font-size="9" fill="#333" text-anchor="middle">SRID=4326;POLYGON((...))</text>
+  <text x="280.0" y="84.0" font-family="monospace" font-size="9" fill="#999" text-anchor="middle">EWKT</text>
+</svg>

--- a/docs/image/ST_AsGML/ST_AsGML.svg
+++ b/docs/image/ST_AsGML/ST_AsGML.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="380" height="120" viewBox="0 0 380 120">
+  <rect width="380" height="120" fill="#f5f5f5" rx="5"/>
+  <defs><marker id="arrowhead" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#666"/></marker></defs>
+  <polygon points="35.0,80.0 35.0,20.0 95.0,20.0 95.0,80.0 35.0,80.0" stroke="#4A90D9" stroke-width="2" fill="rgba(74,144,217,0.15)"/>
+  <line x1="140.0" y1="60.0" x2="180.0" y2="60.0" stroke="#666" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <text x="160.0" y="50.0" font-family="monospace" font-size="9" fill="#666" text-anchor="middle">ST_AsGML</text>
+  <rect x="190.0" y="49.0" width="180.0" height="22" rx="4" fill="#E8F5E9" stroke="#43A047" stroke-width="1"/>
+  <text x="280.0" y="64.0" font-family="monospace" font-size="9" fill="#333" text-anchor="middle">&lt;gml:Polygon&gt;...&lt;/gml:Polygon&gt;</text>
+  <text x="280.0" y="84.0" font-family="monospace" font-size="9" fill="#999" text-anchor="middle">GML</text>
+</svg>

--- a/docs/image/ST_AsGeoJSON/ST_AsGeoJSON.svg
+++ b/docs/image/ST_AsGeoJSON/ST_AsGeoJSON.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="380" height="120" viewBox="0 0 380 120">
+  <rect width="380" height="120" fill="#f5f5f5" rx="5"/>
+  <defs><marker id="arrowhead" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#666"/></marker></defs>
+  <polygon points="35.0,80.0 35.0,20.0 95.0,20.0 95.0,80.0 35.0,80.0" stroke="#4A90D9" stroke-width="2" fill="rgba(74,144,217,0.15)"/>
+  <line x1="140.0" y1="60.0" x2="180.0" y2="60.0" stroke="#666" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <text x="160.0" y="50.0" font-family="monospace" font-size="9" fill="#666" text-anchor="middle">ST_AsGeoJSON</text>
+  <rect x="190.0" y="49.0" width="180.0" height="22" rx="4" fill="#E8F5E9" stroke="#43A047" stroke-width="1"/>
+  <text x="280.0" y="64.0" font-family="monospace" font-size="9" fill="#333" text-anchor="middle">{&quot;type&quot;:&quot;Polygon&quot;,...}</text>
+  <text x="280.0" y="84.0" font-family="monospace" font-size="9" fill="#999" text-anchor="middle">GeoJSON</text>
+</svg>

--- a/docs/image/ST_AsHEXEWKB/ST_AsHEXEWKB.svg
+++ b/docs/image/ST_AsHEXEWKB/ST_AsHEXEWKB.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="380" height="120" viewBox="0 0 380 120">
+  <rect width="380" height="120" fill="#f5f5f5" rx="5"/>
+  <defs><marker id="arrowhead" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#666"/></marker></defs>
+  <polygon points="35.0,80.0 35.0,20.0 95.0,20.0 95.0,80.0 35.0,80.0" stroke="#4A90D9" stroke-width="2" fill="rgba(74,144,217,0.15)"/>
+  <line x1="140.0" y1="60.0" x2="180.0" y2="60.0" stroke="#666" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <text x="160.0" y="50.0" font-family="monospace" font-size="9" fill="#666" text-anchor="middle">ST_AsHEXEWKB</text>
+  <rect x="190.0" y="49.0" width="180.0" height="22" rx="4" fill="#E8F5E9" stroke="#43A047" stroke-width="1"/>
+  <text x="280.0" y="64.0" font-family="monospace" font-size="9" fill="#333" text-anchor="middle">0103000020E610...</text>
+  <text x="280.0" y="84.0" font-family="monospace" font-size="9" fill="#999" text-anchor="middle">HEXEWKB</text>
+</svg>

--- a/docs/image/ST_AsKML/ST_AsKML.svg
+++ b/docs/image/ST_AsKML/ST_AsKML.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="380" height="120" viewBox="0 0 380 120">
+  <rect width="380" height="120" fill="#f5f5f5" rx="5"/>
+  <defs><marker id="arrowhead" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#666"/></marker></defs>
+  <polygon points="35.0,80.0 35.0,20.0 95.0,20.0 95.0,80.0 35.0,80.0" stroke="#4A90D9" stroke-width="2" fill="rgba(74,144,217,0.15)"/>
+  <line x1="140.0" y1="60.0" x2="180.0" y2="60.0" stroke="#666" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <text x="160.0" y="50.0" font-family="monospace" font-size="9" fill="#666" text-anchor="middle">ST_AsKML</text>
+  <rect x="190.0" y="49.0" width="180.0" height="22" rx="4" fill="#E8F5E9" stroke="#43A047" stroke-width="1"/>
+  <text x="280.0" y="64.0" font-family="monospace" font-size="9" fill="#333" text-anchor="middle">&lt;Polygon&gt;...&lt;/Polygon&gt;</text>
+  <text x="280.0" y="84.0" font-family="monospace" font-size="9" fill="#999" text-anchor="middle">KML</text>
+</svg>

--- a/docs/image/ST_AsText/ST_AsText.svg
+++ b/docs/image/ST_AsText/ST_AsText.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="380" height="120" viewBox="0 0 380 120">
+  <rect width="380" height="120" fill="#f5f5f5" rx="5"/>
+  <defs><marker id="arrowhead" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#666"/></marker></defs>
+  <polygon points="35.0,80.0 35.0,20.0 95.0,20.0 95.0,80.0 35.0,80.0" stroke="#4A90D9" stroke-width="2" fill="rgba(74,144,217,0.15)"/>
+  <line x1="140.0" y1="60.0" x2="180.0" y2="60.0" stroke="#666" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <text x="160.0" y="50.0" font-family="monospace" font-size="9" fill="#666" text-anchor="middle">ST_AsText</text>
+  <rect x="190.0" y="49.0" width="180.0" height="22" rx="4" fill="#E8F5E9" stroke="#43A047" stroke-width="1"/>
+  <text x="280.0" y="64.0" font-family="monospace" font-size="9" fill="#333" text-anchor="middle">POLYGON((1 1,1 4,...))</text>
+  <text x="280.0" y="84.0" font-family="monospace" font-size="9" fill="#999" text-anchor="middle">WKT</text>
+</svg>

--- a/docs/image/ST_GeoHash/ST_GeoHash.svg
+++ b/docs/image/ST_GeoHash/ST_GeoHash.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="380" height="120" viewBox="0 0 380 120">
+  <rect width="380" height="120" fill="#f5f5f5" rx="5"/>
+  <defs><marker id="arrowhead" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#666"/></marker></defs>
+  <circle cx="35.0" cy="20.0" r="4" fill="#4A90D9" stroke="none"/>
+  <line x1="140.0" y1="60.0" x2="180.0" y2="60.0" stroke="#666" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <text x="160.0" y="50.0" font-family="monospace" font-size="9" fill="#666" text-anchor="middle">ST_GeoHash</text>
+  <rect x="190.0" y="49.0" width="180.0" height="22" rx="4" fill="#E8F5E9" stroke="#43A047" stroke-width="1"/>
+  <text x="280.0" y="64.0" font-family="monospace" font-size="9" fill="#333" text-anchor="middle">s00twy01mt</text>
+  <text x="280.0" y="84.0" font-family="monospace" font-size="9" fill="#999" text-anchor="middle">GeoHash</text>
+</svg>


### PR DESCRIPTION
## Description

Add SVG visual illustrations for 9 geometry output functions, continuing the work on #2678.

### Functions covered (9)

ST_AsBinary, ST_AsEWKB, ST_AsEWKT, ST_AsGeoJSON, ST_AsGML, ST_AsHEXEWKB, ST_AsKML, ST_AsText, ST_GeoHash

### Changes
- 9 new SVG images in docs/image/
- 27 doc files updated (9 SQL + 9 Flink + 9 Snowflake)

### Visual style
- Each SVG shows: input geometry (left) -> arrow with function name -> output format box (right)
- Output box displays a representative output string with format label below

Part of #2678 (Phase 7 - Geometry Output)
