### PR TITLE
[GH-2640] Simplify warning messages of SedonaContext.create()

### DIFF
--- a/spark/common/src/main/scala/org/apache/sedona/sql/RasterRegistrator.scala
+++ b/spark/common/src/main/scala/org/apache/sedona/sql/RasterRegistrator.scala
@@ -31,9 +31,13 @@ object RasterRegistrator {
   def registerAll(sparkSession: SparkSession): Unit = {
     if (isGeoToolsAvailable) {
       RasterUdtRegistratorWrapper.registerAll(gridClassName)
-      sparkSession.udf.register(
-        RasterUdafCatalog.rasterAggregateExpression.getClass.getSimpleName,
-        functions.udaf(RasterUdafCatalog.rasterAggregateExpression))
+      val functionName = RasterUdafCatalog.rasterAggregateExpression.getClass.getSimpleName
+      val functionIdentifier = FunctionIdentifier(functionName)
+      if (!sparkSession.sessionState.functionRegistry.functionExists(functionIdentifier)) {
+        sparkSession.udf.register(
+          functionName,
+          functions.udaf(RasterUdafCatalog.rasterAggregateExpression))
+      }
     }
   }
 

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/UDT/RasterUdtRegistratorWrapper.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/UDT/RasterUdtRegistratorWrapper.scala
@@ -23,6 +23,8 @@ import org.apache.spark.sql.types.UDTRegistration
 object RasterUdtRegistratorWrapper {
 
   def registerAll(gridClassName: String): Unit = {
-    UDTRegistration.register(gridClassName, classOf[RasterUDT].getName)
+    if (!UDTRegistration.exists(gridClassName)) {
+      UDTRegistration.register(gridClassName, classOf[RasterUDT].getName)
+    }
   }
 }

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/UDT/UdtRegistratorWrapper.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/UDT/UdtRegistratorWrapper.scala
@@ -26,8 +26,14 @@ import org.locationtech.jts.index.SpatialIndex
 object UdtRegistratorWrapper {
 
   def registerAll(): Unit = {
-    UDTRegistration.register(classOf[Geometry].getName, classOf[GeometryUDT].getName)
-    UDTRegistration.register(classOf[Geography].getName, classOf[GeographyUDT].getName)
-    UDTRegistration.register(classOf[SpatialIndex].getName, classOf[IndexUDT].getName)
+    registerIfNotExists(classOf[Geometry].getName, classOf[GeometryUDT].getName)
+    registerIfNotExists(classOf[Geography].getName, classOf[GeographyUDT].getName)
+    registerIfNotExists(classOf[SpatialIndex].getName, classOf[IndexUDT].getName)
+  }
+
+  private def registerIfNotExists(userClass: String, udtClass: String): Unit = {
+    if (!UDTRegistration.exists(userClass)) {
+      UDTRegistration.register(userClass, udtClass)
+    }
   }
 }

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_viz/UDT/UdtRegistratorWrapper.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_viz/UDT/UdtRegistratorWrapper.scala
@@ -24,9 +24,13 @@ import org.apache.spark.sql.types.UDTRegistration
 
 object UdtRegistratorWrapper {
   def registerAll(): Unit = {
-    UDTRegistration.register(
-      classOf[ImageSerializableWrapper].getName,
-      classOf[ImageWrapperUDT].getName)
-    UDTRegistration.register(classOf[Pixel].getName, classOf[PixelUDT].getName)
+    if (!UDTRegistration.exists(classOf[ImageSerializableWrapper].getName)) {
+      UDTRegistration.register(
+        classOf[ImageSerializableWrapper].getName,
+        classOf[ImageWrapperUDT].getName)
+    }
+    if (!UDTRegistration.exists(classOf[Pixel].getName)) {
+      UDTRegistration.register(classOf[Pixel].getName, classOf[PixelUDT].getName)
+    }
   }
 }


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Developer Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2640

## What changes were proposed in this PR?

When `SedonaContext.create()` is called a second time, it prints warning messages about functions and UDTs being already registered. This was partially fixed for ST functions but RS functions and UDT registrations still produced warnings.

This PR adds existence checks before registering:

1. RS aggregate functions (RS_Union_Aggr): Check functionRegistry.functionExists() before calling sparkSession.udf.register() in RasterRegistrator
2. UDT types (Geometry, Geography, SpatialIndex, GridCoverage2D): Check UDTRegistration.exists() before calling UDTRegistration.register() in UdtRegistratorWrapper and RasterUdtRegistratorWrapper
3. Viz UDT types (ImageSerializableWrapper, Pixel): Same check in viz UdtRegistratorWrapper

## How was this patch tested?

Tested by calling SedonaContext.create() twice and verifying no warning messages are produced. Also ran all 166 raster algebra tests to ensure RS functions remain functional.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
