### PR TITLE
[GH-2704] Disable TransformNestedUDTParquet on Spark 4.1+

### DIFF
--- a/spark/common/src/main/scala/org/apache/sedona/spark/SedonaContext.scala
+++ b/spark/common/src/main/scala/org/apache/sedona/spark/SedonaContext.scala
@@ -42,11 +42,25 @@ class InternalApi(
 
 object SedonaContext {
 
-  private def customOptimizationsWithSession(sparkSession: SparkSession) =
-    Seq(
-      new TransformNestedUDTParquet(sparkSession),
+  private def customOptimizationsWithSession(sparkSession: SparkSession) = {
+    val optimizations = Seq(
       new SpatialFilterPushDownForGeoParquet(sparkSession),
       new SpatialTemporalFilterPushDownForStacScan(sparkSession))
+
+    val versionParts =
+      sparkSession.version
+        .split('.')
+        .map(s => scala.util.Try(s.takeWhile(_.isDigit).toInt).getOrElse(0))
+    val major = versionParts.lift(0).getOrElse(0)
+    val minor = versionParts.lift(1).getOrElse(0)
+    if (major < 4 || (major == 4 && minor < 1)) {
+      // SPARK-48942: nested UDTs crash the vectorized Parquet reader on Spark < 4.1.
+      // SPARK-52651 fixes this in Spark 4.1+ by recursively stripping UDTs in ColumnVector.
+      new TransformNestedUDTParquet(sparkSession) +: optimizations
+    } else {
+      optimizations
+    }
+  }
 
   def create(sqlContext: SQLContext): SQLContext = {
     create(sqlContext.sparkSession)


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2704

## What changes were proposed in this PR?

Disable the `TransformNestedUDTParquet` optimizer rule on Spark 4.1+, where the root cause (SPARK-48942) has been fixed natively by SPARK-52651.

PR #2359 introduced `TransformNestedUDTParquet` to work around SPARK-48942, which caused the vectorized Parquet reader to crash on nested UDTs. [SPARK-52651](https://issues.apache.org/jira/browse/SPARK-52651) (merged in Spark 4.1) fixes this at the Spark level by recursively stripping UDTs in `ColumnVector`, making our workaround unnecessary on 4.1+.

This PR version-gates the workaround so it is only registered on Spark < 4.1. It uses defensive version parsing (`Try`/`getOrElse`, `.lift()`) to avoid exceptions on malformed version strings.

## How was this patch tested?

- Verified compilation with `mvn clean install -Dspark=3.5 -Dscala=2.12 -DskipTests`

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.