### PR TITLE
[CI] Add pre-commit ecosystem to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,3 +40,15 @@ updates:
           - '*'
     cooldown:
       default-days: 7
+
+  - package-ecosystem: pre-commit
+    directory: /
+    open-pull-requests-limit: 2
+    schedule:
+      interval: monthly
+    groups:
+      github-dependencies:
+        patterns:
+          - '*'
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
https://github.blog/changelog/2026-03-10-dependabot-now-supports-pre-commit-hooks/

https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#package-ecosystem-

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)


## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

As described above

## How was this patch tested?


## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
