### PR TITLE
[GH-2702] Fix ST_LineMerge returning empty collection for LineString input

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/Functions.java
+++ b/common/src/main/java/org/apache/sedona/common/Functions.java
@@ -1196,6 +1196,9 @@ public class Functions {
   }
 
   public static Geometry lineMerge(Geometry geometry) {
+    if (geometry instanceof LineString) {
+      return geometry;
+    }
     if (geometry instanceof MultiLineString) {
       MultiLineString multiLineString = (MultiLineString) geometry;
       int numLineStrings = multiLineString.getNumGeometries();

--- a/spark/common/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
@@ -2246,7 +2246,8 @@ class functionTestScala
       ("MULTILINESTRING ((-29 -27, -30 -29.7, -45 -33), (-45 -33, -46 -32))"),
       ("MULTILINESTRING ((-29 -27, -30 -29.7, -36 -31, -45 -33), (-45.2 -33.2, -46 -32))"),
       ("POLYGON ((8 25, 28 22, 15 11, 33 3, 56 30, 47 44, 35 36, 43 19, 24 39, 8 25))"),
-      ("MULTILINESTRING ((10 160, 60 120), (120 140, 60 120), (120 140, 180 120), (100 180, 120 140))"))
+      ("MULTILINESTRING ((10 160, 60 120), (120 140, 60 120), (120 140, 180 120), (100 180, 120 140))"),
+      ("LINESTRING (0 0, 1 1)"))
       .toDF("Geometry")
 
     When("Using ST_LineMerge")
@@ -2261,7 +2262,8 @@ class functionTestScala
         "LINESTRING (-29 -27, -30 -29.7, -45 -33, -46 -32)",
         "MULTILINESTRING ((-45.2 -33.2, -46 -32), (-29 -27, -30 -29.7, -36 -31, -45 -33))",
         "GEOMETRYCOLLECTION EMPTY",
-        "MULTILINESTRING ((10 160, 60 120, 120 140), (100 180, 120 140), (120 140, 180 120))")
+        "MULTILINESTRING ((10 160, 60 120, 120 140), (100 180, 120 140), (120 140, 180 120))",
+        "LINESTRING (0 0, 1 1)")
   }
 
   it("Should pass ST_LocateAlong") {


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2702

## What changes were proposed in this PR?

`ST_LineMerge` returns `GEOMETRYCOLLECTION EMPTY` for `LineString` input instead of passing it through unchanged. This is inconsistent with PostGIS/GEOS behavior, where a single `LineString` is already "merged" and should be returned as-is.

**Fix:** Added a `LineString` instanceof check in `Functions.lineMerge()` before the `MultiLineString` block, so that a single `LineString` is returned unchanged.

```java
if (geometry instanceof LineString) {
  return geometry;
}
```

**Behavior after fix:**

| Input type | Result |
|---|---|
| `LineString` | Returned unchanged (was: `GEOMETRYCOLLECTION EMPTY`) |
| `LineString` | Returned unchanch| `LineString` | Retur (Point, Polygon, | `LineString` | Returned unchanch| `LineString` | Retur (Point, Polygon, | `LineString` | Returned unchanch| `LineString` | Retur (Point, Polygon, | `LineString` | Returned unchan test case to the existing `ST_LineMerg| `LineString` | Returned unchanch| `LineString` | Retur (Point, Polygon, | G (| `LineString` | Returned unchanch| `LinN EMPTY`.

All 223 tests in `functionTestScala` pass locally. No regressions.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
