### PR TITLE
[GH-2671] Remove broken labeler badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@
 [![Docs build](https://github.com/apache/sedona/actions/workflows/docs.yml/badge.svg)](https://github.com/apache/sedona/actions/workflows/docs.yml)
 [![Example project build](https://github.com/apache/sedona/actions/workflows/example.yml/badge.svg)](https://github.com/apache/sedona/actions/workflows/example.yml)
 [![First Interaction Workflow Status](https://github.com/apache/sedona/actions/workflows/first-interaction.yml/badge.svg)](https://github.com/apache/sedona/actions/workflows/first-interaction.yml)
-[![Labeler Workflow Status](https://github.com/apache/sedona/actions/workflows/labeler.yml/badge.svg)](https://github.com/apache/sedona/actions/workflows/labeler.yml)
 [![Pre-commit Workflow Status](https://github.com/apache/sedona/actions/workflows/pre-commit.yml/badge.svg)](https://github.com/apache/sedona/actions/workflows/pre-commit.yml)
 [![Python build](https://github.com/apache/sedona/actions/workflows/python.yml/badge.svg)](https://github.com/apache/sedona/actions/workflows/python.yml)
 [![Python Extension build](https://github.com/apache/sedona/actions/workflows/python-extension.yml/badge.svg)](https://github.com/apache/sedona/actions/workflows/python-extension.yml)


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Developer Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2671

## What changes were proposed in this PR?

Remove the broken Labeler Workflow Status badge from README.md since the labeler action has been removed.

## How was this patch tested?

No tests needed — this only removes a badge link from the README.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
