### PR TITLE
[GH-2714] Remove cooldown from dependabot pre-commit ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,5 +50,3 @@ updates:
       github-dependencies:
         patterns:
           - '*'
-    cooldown:
-      default-days: 7


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2714 

## What changes were proposed in this PR?

As described

## How was this patch tested?

With pre-commit.

Saw the dependabot updates trigger on Apache Shiro here:

refs https://github.com/apache/shiro/pull/2621

This was after I added the pre-commit ecosystem to Shiro dependabot today.

So this made me check the Sedona dependabot workflow and I saw the error message in the issue

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
