### PR TITLE
[CI] Add pre-commit hook npm-install to ensure Zeppelin can install

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,14 @@ repos:
         files: ^README\.md$
   - repo: local
     hooks:
+      - id: npm-install
+        name: Install Zeppelin Node dependencies
+        entry: bash -c "cd zeppelin && npm install"
+        language: system
+        pass_filenames: false
+        files: ^zeppelin/(package\.json|package-lock\.json)$
+        description: Ensures local node_modules match the lockfile
+        stages: [manual]
       - id: prettier
         name: run prettier
         description: format files with prettier

--- a/zeppelin/package-lock.json
+++ b/zeppelin/package-lock.json
@@ -1,0 +1,72 @@
+{
+  "name": "apache-sedona",
+  "version": "1.8.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "apache-sedona",
+      "version": "1.8.1",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "jsts": "^1.6.2",
+        "leaflet": "~1.4.0",
+        "zeppelin-tabledata": "*",
+        "zeppelin-vis": "*"
+      }
+    },
+    "node_modules/json3": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
+      "integrity": "sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==",
+      "license": "MIT"
+    },
+    "node_modules/jsts": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/jsts/-/jsts-1.6.2.tgz",
+      "integrity": "sha512-JNfDQk/fo5MeXx4xefvCyHZD22/DHowHr5K07FdgCJ81MEqn02HsDV5FQvYTz60ZIOv/+hhGbsVzXX5cuDWWlA==",
+      "license": "(EDL-1.0 OR EPL-1.0)",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/leaflet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.4.0.tgz",
+      "integrity": "sha512-x9j9tGY1+PDLN9pcWTx9/y6C5nezoTMB8BLK5jTakx+H7bPlnbCHfi9Hjg+Qt36sgDz/cb9lrSpNQXmk45Tvhw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/lodash": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz",
+      "integrity": "sha512-v5SKZhnCUujcTpFpHEIJZDVcBM2OYjROx732HyJ6kzKZtwStTb4LG6noqmK9etHqDNhf6X7itXx5s0hTpAXPpQ==",
+      "license": "MIT"
+    },
+    "node_modules/nvd3": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/nvd3/-/nvd3-1.7.1.tgz",
+      "integrity": "sha512-sA1Z+bLYphUo9z1IupsiaFWZmOv0hf2BZEzgRMR7DU22h6xV7pWdBjbpOQEw2Fp0Ba1Dpys6x9fZQy96diR1ow=="
+    },
+    "node_modules/zeppelin-tabledata": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/zeppelin-tabledata/-/zeppelin-tabledata-0.7.1.tgz",
+      "integrity": "sha512-cnP4HtaitVn2gcQnvWAj2b69n9XbCjbN8J4TaqqVo90xtHK0g0wh2k02dAUWGEJ9rQ+9L2JLdst8TetjzHVv1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json3": "~3.3.1",
+        "lodash": "~3.9.3"
+      }
+    },
+    "node_modules/zeppelin-vis": {
+      "version": "0.7.3-SNAPSHOT",
+      "resolved": "https://registry.npmjs.org/zeppelin-vis/-/zeppelin-vis-0.7.3-SNAPSHOT.tgz",
+      "integrity": "sha512-EEK+VM5eG/RgGr+zse3kH0Q+rnK721F40XlFFOWVyFoGUSsE6ZPUY6bHBN5vJHIazsPTpGgSc1Km0zuI/vp/DQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json3": "~3.3.1",
+        "lodash": "~3.9.3",
+        "nvd3": "~1.7.1"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Set as manual hook since it runs bash by default not available on Windows

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

Added another check / test to our pre-commit framework

## How was this patch tested?

With pre-commit

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
