### PR TITLE
[GH-1893] Fix docs build 'Compile JavaDoc' step error message

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -638,7 +638,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.12.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
https://maven.apache.org/plugins/maven-javadoc-plugin/

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #1893 

## What changes were proposed in this PR?

Upgrading `maven-javadoc-plugin` is the suggested fix from Google search

## How was this patch tested?

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
