### PR TITLE
[CI] Add descriptive labels to the dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,7 @@ updates:
     schedule:
       interval: monthly
     groups:
-      github-dependencies:
+      github-actions-dependencies:
         patterns:
           - '*'
     cooldown:
@@ -35,7 +35,7 @@ updates:
     schedule:
       interval: monthly
     groups:
-      github-dependencies:
+      pip-dependencies:
         patterns:
           - '*'
     cooldown:
@@ -47,6 +47,6 @@ updates:
     schedule:
       interval: monthly
     groups:
-      github-dependencies:
+      pre-commit-hooks:
         patterns:
           - '*'


### PR DESCRIPTION
The group label is used in the PR title when dependabot creates PRs

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

See the generic PR title in #2716 this was really updating the pre-commit hooks.

This PR gives us more structure and clarity for dependabot updates 

## How was this patch tested?

Google Gemini told me about this feature today in:

https://github.com/mruby/mgem-list/pull/485

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
