### PR TITLE
[CI] Add pre-commit hook actionlint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -515,4 +515,14 @@ repos:
         description: actionlint is a static checker for GitHub Actions workflow files
         args:
           - -ignore
+          - 'SC2015'
+          - -ignore
+          - 'SC2061'
+          - -ignore
+          - 'SC2072'
+          - -ignore
           - 'SC2086'
+          - -ignore
+          - 'SC2102'
+          - -ignore
+          - 'SC2155'


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

Adds another check / test to our pre-commit framework

https://github.com/rhysd/actionlint/blob/v1.7.11/docs/usage.md#pre-commit

## How was this patch tested?

Ran `pre-commit run --all-files`

refs #1900 

Seems the GitHub CI picks up some `shellcheck` errors in the workflows that are not reported locally when running pre-commit

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
