### PR TITLE
[CI] Configure EditorConfig for Java files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -28,6 +28,10 @@ charset = utf-8
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.java]
+indent_size = 2
+indent_style = space
+
 [*.xml]
 indent_style = space
 

--- a/spark/common/src/main/java/org/apache/sedona/viz/core/VisualizationOperator.java
+++ b/spark/common/src/main/java/org/apache/sedona/viz/core/VisualizationOperator.java
@@ -686,9 +686,9 @@ public abstract class VisualizationOperator implements Serializable {
       List<Tuple2<Pixel,Integer>> colorMatrix = this.distributedRasterColorMatrix.collect();
       for(Tuple2<Pixel,Integer> pixelColor:colorMatrix)
       {
-      	int pixelX = pixelColor._1().getX();
-      	int pixelY = pixelColor._1().getY();
-      	renderedImage.setRGB(pixelX, (this.resolutionY-1)-pixelY, pixelColor._2);
+        int pixelX = pixelColor._1().getX();
+        int pixelY = pixelColor._1().getY();
+        renderedImage.setRGB(pixelX, (this.resolutionY-1)-pixelY, pixelColor._2);
       }
       this.rasterImage = renderedImage;
       */
@@ -886,19 +886,19 @@ public abstract class VisualizationOperator implements Serializable {
     /*
           spatialRDDwithPixelId = spatialRDDwithPixelId.reduceByKey(new Function2<Double,Double,Double>()
     {
-    	@Override
-    	public Double call(Double count1, Double count2) throws Exception {
-    		if(colorizeOption==ColorizeOption.SPATIALAGGREGATION)
-    		{
-    			return count1+count2;
-    		}
-    		else
-    		{
-    			//TODO, colorizeOption for uniform color and z-axis color follow the same aggregate strategy
-    			// which takes the large value. We need to find a better strategy to distinguish them.
-    			return count1>count2?count1:count2;
-    		}
-    	}
+      @Override
+      public Double call(Double count1, Double count2) throws Exception {
+        if(colorizeOption==ColorizeOption.SPATIALAGGREGATION)
+        {
+          return count1+count2;
+        }
+        else
+        {
+          //TODO, colorizeOption for uniform color and z-axis color follow the same aggregate strategy
+          // which takes the large value. We need to find a better strategy to distinguish them.
+          return count1>count2?count1:count2;
+        }
+      }
     });
     */
     this.distributedRasterCountMatrix = spatialRDDwithPixelId;
@@ -956,16 +956,16 @@ public abstract class VisualizationOperator implements Serializable {
     /*
     spatialRDDwithPixelId = spatialRDDwithPixelId.reduceByKey(new Function2<Double,Double,Double>()
     {
-    	@Override
-    	public Double call(Double count1, Double count2) throws Exception {
-    		if(colorizeOption==ColorizeOption.SPATIALAGGREGATION)
-    		{
-    			return count1+count2;
-    		}
-    		else {
-    			return count1>count2?count1:count2;
-    		}
-    	}
+      @Override
+      public Double call(Double count1, Double count2) throws Exception {
+        if(colorizeOption==ColorizeOption.SPATIALAGGREGATION)
+        {
+          return count1+count2;
+        }
+        else {
+          return count1>count2?count1:count2;
+        }
+      }
     });
     */
 

--- a/spark/common/src/main/java/org/apache/sedona/viz/core/VisualizationPartitioner.java
+++ b/spark/common/src/main/java/org/apache/sedona/viz/core/VisualizationPartitioner.java
@@ -199,29 +199,29 @@ public class VisualizationPartitioner extends Partitioner implements Serializabl
 
     if(pixelCoordinateInPartition._1()<=0+photoFilterRadius || pixelCoordinateInPartition._1()>=partitionIntervalX-photoFilterRadius||pixelCoordinateInPartition._2()<=0+photoFilterRadius || pixelCoordinateInPartition._2()>=partitionIntervalY-photoFilterRadius)
     {
-    	// Second, calculate the partitions that the pixel duplicates should go to
-    	for (int x = -photoFilterRadius; x <= photoFilterRadius; x++) {
-    		for (int y = -photoFilterRadius; y <= photoFilterRadius; y++) {
-    			int neighborPixelX = pixelCoordinateInPartition._1()+x;
-    			int neighborPixelY = pixelCoordinateInPartition._2()+y;
-    			try {
-    				partitionId = RasterizationUtils.CalculatePartitionId(this.resolutionX,this.resolutionY,this.partitionX, this.partitionY, neighborPixelX, neighborPixelY);
-    				// This partition id is out of the image boundary
-    				if(partitionId<0) continue;
-    				if(!existingPartitionIds.contains(partitionId))
-    				{
-    					Pixel newPixelDuplicate = pixelDoubleTuple2._1();
-    					newPixelDuplicate.setCurrentPartitionId(partitionId);
-    					newPixelDuplicate.setDuplicate(true);
-    					existingPartitionIds.add(partitionId);
-    					duplicatePixelList.add(new Tuple2<Pixel, Double>(newPixelDuplicate, pixelDoubleTuple2._2()));
-    				}
-    			} catch (Exception e) {
-    				e.printStackTrace();
-    			}
+      // Second, calculate the partitions that the pixel duplicates should go to
+      for (int x = -photoFilterRadius; x <= photoFilterRadius; x++) {
+        for (int y = -photoFilterRadius; y <= photoFilterRadius; y++) {
+          int neighborPixelX = pixelCoordinateInPartition._1()+x;
+          int neighborPixelY = pixelCoordinateInPartition._2()+y;
+          try {
+            partitionId = RasterizationUtils.CalculatePartitionId(this.resolutionX,this.resolutionY,this.partitionX, this.partitionY, neighborPixelX, neighborPixelY);
+            // This partition id is out of the image boundary
+            if(partitionId<0) continue;
+            if(!existingPartitionIds.contains(partitionId))
+            {
+              Pixel newPixelDuplicate = pixelDoubleTuple2._1();
+              newPixelDuplicate.setCurrentPartitionId(partitionId);
+              newPixelDuplicate.setDuplicate(true);
+              existingPartitionIds.add(partitionId);
+              duplicatePixelList.add(new Tuple2<Pixel, Double>(newPixelDuplicate, pixelDoubleTuple2._2()));
+            }
+          } catch (Exception e) {
+            e.printStackTrace();
+          }
 
-    		}
-    	}
+        }
+      }
 
     }*/
 

--- a/spark/common/src/main/java/org/apache/sedona/viz/extension/visualizationEffect/ChoroplethMap.java
+++ b/spark/common/src/main/java/org/apache/sedona/viz/extension/visualizationEffect/ChoroplethMap.java
@@ -159,31 +159,31 @@ public class ChoroplethMap extends VisualizationOperator {
   @Override
   protected JavaPairRDD<Integer, Color> GenerateColorMatrix()
   {
-  	//This Color Matrix version controls some too high pixel weights by dividing the max weight to 1/4.
-  	logger.debug("[VisualizationOperator][GenerateColorMatrix][Start]");
-  	final long maxWeight = this.distributedCountMatrix.max(new PixelCountComparator())._2;
-  	final long minWeight = 0;
-  	System.out.println("Max weight "+maxWeight);
-  	JavaPairRDD<Integer, Long> normalizedPixelWeights = this.distributedCountMatrix.mapToPair(new PairFunction<Tuple2<Integer,Long>, Integer, Long>(){
-  		@Override
-  		public Tuple2<Integer, Long> call(Tuple2<Integer, Long> pixelWeight) throws Exception {
-  			if(pixelWeight._2>maxWeight/20)
-  			{
-  				return new Tuple2<Integer, Long>(pixelWeight._1,new Long(255));
-  			}
-  			return new Tuple2<Integer, Long>(pixelWeight._1,(pixelWeight._2-minWeight)*255/(maxWeight/20-minWeight));
-  		}});
-  	this.distributedColorMatrix = normalizedPixelWeights.mapToPair(new PairFunction<Tuple2<Integer,Long>,Integer,Color>()
-  	{
+    //This Color Matrix version controls some too high pixel weights by dividing the max weight to 1/4.
+    logger.debug("[VisualizationOperator][GenerateColorMatrix][Start]");
+    final long maxWeight = this.distributedCountMatrix.max(new PixelCountComparator())._2;
+    final long minWeight = 0;
+    System.out.println("Max weight "+maxWeight);
+    JavaPairRDD<Integer, Long> normalizedPixelWeights = this.distributedCountMatrix.mapToPair(new PairFunction<Tuple2<Integer,Long>, Integer, Long>(){
+      @Override
+      public Tuple2<Integer, Long> call(Tuple2<Integer, Long> pixelWeight) throws Exception {
+        if(pixelWeight._2>maxWeight/20)
+        {
+          return new Tuple2<Integer, Long>(pixelWeight._1,new Long(255));
+        }
+        return new Tuple2<Integer, Long>(pixelWeight._1,(pixelWeight._2-minWeight)*255/(maxWeight/20-minWeight));
+      }});
+    this.distributedColorMatrix = normalizedPixelWeights.mapToPair(new PairFunction<Tuple2<Integer,Long>,Integer,Color>()
+    {
 
-  		@Override
-  		public Tuple2<Integer, Color> call(Tuple2<Integer, Long> pixelCount) throws Exception {
-  			Color pixelColor = EncodeColor(pixelCount._2.intValue());
-  			return new Tuple2<Integer,Color>(pixelCount._1,pixelColor);
-  		}
-  	});
-  	logger.debug("[VisualizationOperator][GenerateColorMatrix][Stop]");
-  	return this.distributedColorMatrix;
+      @Override
+      public Tuple2<Integer, Color> call(Tuple2<Integer, Long> pixelCount) throws Exception {
+        Color pixelColor = EncodeColor(pixelCount._2.intValue());
+        return new Tuple2<Integer,Color>(pixelCount._1,pixelColor);
+      }
+    });
+    logger.debug("[VisualizationOperator][GenerateColorMatrix][Stop]");
+    return this.distributedColorMatrix;
   }
   */
 

--- a/spark/common/src/main/java/org/apache/sedona/viz/utils/RasterizationUtils.java
+++ b/spark/common/src/main/java/org/apache/sedona/viz/utils/RasterizationUtils.java
@@ -70,13 +70,13 @@ public class RasterizationUtils implements Serializable {
       datasetBoundary = datasetBoundaryOriginal;
     }
     /*
-     if(spatialCoordinate.x < datasetBoundary.getMinX() || spatialCoordinate.x > datasetBoundary.getMaxX())
+    if(spatialCoordinate.x < datasetBoundary.getMinX() || spatialCoordinate.x > datasetBoundary.getMaxX())
     {
-    	throw new Exception("[RasterizationUtils][FindOnePixelCoordinate] This spatial coordinate is out of the given boundary. Should be ignored.");
+      throw new Exception("[RasterizationUtils][FindOnePixelCoordinate] This spatial coordinate is out of the given boundary. Should be ignored.");
     }
     if(spatialCoordinate.y < datasetBoundaryOriginal.getMinY() || spatialCoordinate.y > datasetBoundaryOriginal.getMaxY())
     {
-    	throw new Exception("[RasterizationUtils][FindOnePixelCoordinate] This spatial coordinate is out of the given boundary. Should be ignored.");
+      throw new Exception("[RasterizationUtils][FindOnePixelCoordinate] This spatial coordinate is out of the given boundary. Should be ignored.");
     }*/
 
     Double pixelXDouble =
@@ -221,7 +221,7 @@ public class RasterizationUtils implements Serializable {
     /*
     if((twoDimensionIdX+twoDimensionIdY*resolutionX)<0 ||(twoDimensionIdX+twoDimensionIdY*resolutionX)>(resolutionX*resolutionY-1))
     {
-    	throw new Exception("[RasterizationUtils][Encode2DTo1DId] This given 2 dimension coordinate is "+twoDimensionIdX+" "+twoDimensionIdY+". This coordinate is out of the given boundary and will be dropped.");
+      throw new Exception("[RasterizationUtils][Encode2DTo1DId] This given 2 dimension coordinate is "+twoDimensionIdX+" "+twoDimensionIdY+". This coordinate is out of the given boundary and will be dropped.");
     }
     */
     return twoDimensionIdX + twoDimensionIdY * resolutionX;

--- a/spark/common/src/test/java/org/apache/sedona/core/spatialRDD/LineStringRDDTest.java
+++ b/spark/common/src/test/java/org/apache/sedona/core/spatialRDD/LineStringRDDTest.java
@@ -126,8 +126,8 @@ public class LineStringRDDTest extends SpatialRDDTestBase {
   @Test
   public void testPolygonUnion()
   {
-  	LineStringRDD lineStringRDD = new LineStringRDD(sc, InputLocation, offset, splitter, numPartitions);
-  	assert lineStringRDD.PolygonUnion() instanceof Polygon;
+    LineStringRDD lineStringRDD = new LineStringRDD(sc, InputLocation, offset, splitter, numPartitions);
+    assert lineStringRDD.PolygonUnion() instanceof Polygon;
   }
   */
 

--- a/spark/common/src/test/java/org/apache/sedona/core/spatialRDD/PolygonRDDTest.java
+++ b/spark/common/src/test/java/org/apache/sedona/core/spatialRDD/PolygonRDDTest.java
@@ -211,8 +211,8 @@ public class PolygonRDDTest extends SpatialRDDTestBase {
   @Test
   public void testPolygonUnion()
   {
-  	PolygonRDD polygonRDD = new PolygonRDD(sc, InputLocation, offset, splitter, numPartitions);
-  	assert polygonRDD.PolygonUnion() instanceof Polygon;
+    PolygonRDD polygonRDD = new PolygonRDD(sc, InputLocation, offset, splitter, numPartitions);
+    assert polygonRDD.PolygonUnion() instanceof Polygon;
   }
   */
 


### PR DESCRIPTION
We run our editorconfig checker with pre-commit and it found some Java files that had some tabs in the indentation.

Cleaned up the tabs converting to spaces.

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

Enforcing standards with EditorConfig

## How was this patch tested?

With pre-commit

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
