### PR TITLE
[CI] Add pre-commit hook checkmake to lint Makefiles

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -118,6 +118,16 @@ repos:
           - .github/workflows/license-templates/LICENSE.txt
           - --fuzzy-match-generates-todo
       - id: insert-license
+        name: add license for all ini files
+        description: automatically adds a licence header to all ini files that don't have a license header
+        files: \.ini$
+        args:
+          - --comment-style
+          - '|;|'
+          - --license-filepath
+          - .github/workflows/license-templates/LICENSE.txt
+          - --fuzzy-match-generates-todo
+      - id: insert-license
         name: add license for all Java files
         description: automatically adds a licence header to all Java files that don't have a license header
         files: \.java$
@@ -526,3 +536,16 @@ repos:
           - 'SC2102'
           - -ignore
           - 'SC2155'
+  - repo: https://github.com/checkmake/checkmake.git
+    rev: v0.3.2
+    hooks:
+      - id: checkmake
+        name: run checkmake (root)
+        description: checkmake is a linter for Makefiles
+        files: ^Makefile$
+        args: ['--config=checkmake.ini']
+      - id: checkmake
+        name: run checkmake (python/sedona/doc)
+        description: checkmake is a linter for Makefiles
+        files: ^python/sedona/doc/Makefile$
+        args: ['--config=python/sedona/doc/checkmake.ini']

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 PYTHON := $(shell command -v python || command -v python3 || echo python)
 PIP := $(PYTHON) -m pip
 
-.PHONY: check checkinstall checkupdate install docsinstall docsbuild clean test
+.PHONY: check checkinstall checkupdate install docsinstall docsbuild clean run-docs
 
 check:
 	@echo "Running pre-commit checks..."

--- a/checkmake.ini
+++ b/checkmake.ini
@@ -1,0 +1,22 @@
+; Licensed to the Apache Software Foundation (ASF) under one
+; or more contributor license agreements.  See the NOTICE file
+; distributed with this work for additional information
+; regarding copyright ownership.  The ASF licenses this file
+; to you under the Apache License, Version 2.0 (the
+; "License"); you may not use this file except in compliance
+; with the License.  You may obtain a copy of the License at
+;
+;   http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing,
+; software distributed under the License is distributed on an
+; "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+; KIND, either express or implied.  See the License for the
+; specific language governing permissions and limitations
+; under the License.
+
+[maxbodylength]
+maxBodyLength = 10
+
+[minphony]
+required = check,checkinstall,checkupdate,install,docsinstall,docsbuild,clean,run-docs

--- a/python/sedona/doc/checkmake.ini
+++ b/python/sedona/doc/checkmake.ini
@@ -1,0 +1,22 @@
+; Licensed to the Apache Software Foundation (ASF) under one
+; or more contributor license agreements.  See the NOTICE file
+; distributed with this work for additional information
+; regarding copyright ownership.  The ASF licenses this file
+; to you under the Apache License, Version 2.0 (the
+; "License"); you may not use this file except in compliance
+; with the License.  You may obtain a copy of the License at
+;
+;   http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing,
+; software distributed under the License is distributed on an
+; "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+; KIND, either express or implied.  See the License for the
+; specific language governing permissions and limitations
+; under the License.
+
+[maxbodylength]
+maxBodyLength = 2
+
+[minphony]
+required = help,livehtml


### PR DESCRIPTION
Added 3 hooks:

- checkmake (root): with custom checkmake.ini
- checkmake (python/sedona/doc): with custom checkmake.ini
- insert-license: to auto insert license headers for ini files

Slightly relaxed config for phony target body "lengths"

Cleaned up the root Makefile removing the missing "test" target and adding "run-docs" target to the phony list

https://github.com/checkmake/checkmake

https://github.com/checkmake/checkmake?tab=readme-ov-file#pre-commit-usage

https://en.wikipedia.org/wiki/INI_file#Comments

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

Added 3 more hooks to our pre-commit framework.

---

Using checkmake—a static analysis linter for Makefiles—provides several benefits centered on maintaining build script quality and reliability. 
The primary advantages of using this tool include:

* Early Issue Detection: It identifies potential problems like missing required targets (e.g., all or test) or missing .PHONY declarations before you ever run the build.
* Enforcement of Best Practices: The linter checks against a set of configurable rules to ensure your Makefile follows community-accepted standards for correctness and maintainability.
* Customisable Rules: Users can define their own validation logic via a configuration file (checkmake.ini), allowing teams to enforce specific internal coding styles.
* Flexible Output Formats: It supports both human-readable text and machine-readable JSON output, which is useful for integrating into various developer tools and automated pipelines.
* Lightweight and Portable: Being written in Go, it can be run as a single binary, via Docker containers, or as a pre-commit hook without requiring a heavy runtime environment. 

---

## How was this patch tested?

With pre-commit

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
