### PR TITLE
[CI] Add basic tests action workflow with one job

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Basic Tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '*'
+
+permissions:
+  contents: read
+
+jobs:
+  test-git-clone-on-windows:
+    timeout-minutes: 5
+    name: 'Test git clone on Windows'
+    runs-on: ['windows-latest']
+    steps:
+      - name: 'Checkout ${{ github.ref }} ( ${{ github.sha }} )'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+          persist-credentials: false


### PR DESCRIPTION
Apache Airflow uses this same basic check:

https://github.com/apache/airflow/blob/a9a9c5a57fbaaa11499967b39bac11adedea857e/.github/workflows/basic-tests.yml#L270

We don't have much test coverage running on Windows.

Should be quick to run on the GitHub CI

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

Minor improvement one more check.

Maybe we can add more basic test jobs in future ?

## How was this patch tested?

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
