### PR TITLE
[CI] Run pre-commit on master branch

### DIFF
--- a/.github/workflows/pre-commit-manual.yml
+++ b/.github/workflows/pre-commit-manual.yml
@@ -17,7 +17,13 @@
 
 name: Manual hooks
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '*'
 
 permissions:
   contents: read

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,7 +17,13 @@
 
 name: pre-commit
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '*'
 
 permissions:
   contents: read


### PR DESCRIPTION
The other workflows are setup like this running on master

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

Standardize the two pre-commit workflows to be like the other workflows for the "on" key

## How was this patch tested?

With pre-commit.  

Since this is changes to GitHub actions I have not tested it.

But I do know you run and test your GitHub Actions locally with:

https://github.com/nektos/act

https://nektosact.com/

We could create an issue for setting up this if needed.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
