### PR TITLE
[CI] Expand and reorder the CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,12 +16,17 @@
 # under the License.
 
 *                                                   @jiayuasu
+/.github/linters/                                   @jbampton @jiayuasu
+/.github/workflows/license-templates/LICENSE.txt    @jbampton @jiayuasu
+/.github/workflows/pre-commit.yml                   @jbampton @jiayuasu
+/.github/workflows/pre-commit-manual.yml            @jbampton @jiayuasu
+/.github/dependabot.yml                             @jbampton @jiayuasu
+/python/sedona/doc/checkmake.ini                    @jbampton @jiayuasu
+/python/sedona/doc/Makefile                         @jbampton @jiayuasu
+/scripts/                                           @jbampton @jiayuasu
 .editorconfig                                       @jbampton @jiayuasu
 .pre-commit-config.yaml                             @jbampton @jiayuasu
 .prettierignore                                     @jbampton @jiayuasu
 .prettierrc                                         @jbampton @jiayuasu
+checkmake.ini                                       @jbampton @jiayuasu
 Makefile                                            @jbampton @jiayuasu
-/.github/linters/                                   @jbampton @jiayuasu
-/.github/workflows/license-templates/LICENSE.txt    @jbampton @jiayuasu
-/.github/dependabot.yml                             @jbampton @jiayuasu
-/scripts/                                           @jbampton @jiayuasu


### PR DESCRIPTION
Five entries added and the whole file reordered in the same order it appears in the repo

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

refs #2746 

## How was this patch tested?

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

With pre-commit.

Seeing here in the pull request create page this image:

<img width="1402" height="1482" alt="Screenshot from 2026-03-16 16-40-33" src="https://github.com/user-attachments/assets/596384fc-0f38-4adb-9d73-fc610e485f99" />

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
