### PR TITLE
[CI] Create reusable pre-commit workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,6 +20,7 @@
 /.github/workflows/license-templates/LICENSE.txt    @jbampton @jiayuasu
 /.github/workflows/pre-commit.yml                   @jbampton @jiayuasu
 /.github/workflows/pre-commit-manual.yml            @jbampton @jiayuasu
+/.github/workflows/pre-commit-reusable.yml          @jbampton @jiayuasu
 /.github/dependabot.yml                             @jbampton @jiayuasu
 /python/sedona/doc/checkmake.ini                    @jbampton @jiayuasu
 /python/sedona/doc/Makefile                         @jbampton @jiayuasu

--- a/.github/workflows/pre-commit-manual.yml
+++ b/.github/workflows/pre-commit-manual.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Manual hooks
+name: pre-commit-manual
 
 on:
   push:
@@ -33,27 +33,9 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
-  pre-commit:
-    name: Run pre-commit # https://pre-commit.com/
-    runs-on: ubuntu-latest
-    steps:
-      - name: 'Checkout ${{ github.ref }} ( ${{ github.sha }} )'
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - uses: actions/setup-python@v6 # https://www.python.org/
-        with:
-          python-version: '3.11' # Version range or exact version of a Python version to use, using SemVer's version range syntax
-          architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
-      - name: Install dependencies # https://pip.pypa.io/en/stable/
-        run: |
-          python -m pip install --upgrade pip
-          pip install pre-commit
-      - name: set PY
-        run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
-      - uses: actions/cache@v5
-        with:
-          path: ~/.cache/pre-commit
-          key: pre-commit-manual|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
-      - name: Run manual pre-commit hooks
-        run: pre-commit run --color=always --all-files --hook-stage manual --show-diff-on-failure
+  run:
+    name: Run manual hooks
+    uses: ./.github/workflows/pre-commit-reusable.yml
+    with:
+      job_id: 'manual'
+      extra_args: '--hook-stage manual'

--- a/.github/workflows/pre-commit-reusable.yml
+++ b/.github/workflows/pre-commit-reusable.yml
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: _pre-commit-base
+
+on:
+  workflow_call:
+    inputs:
+      extra_args:
+        required: false
+        type: string
+        default: ''
+      job_id:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  run-hooks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout ${{ github.ref }} ( ${{ github.sha }} )'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.11'
+          architecture: 'x64'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
+      - name: set PY
+        run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> "$GITHUB_ENV"
+      - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit|${{ inputs.job_id }}|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Run pre-commit
+        run: pre-commit run --color=always --all-files --show-diff-on-failure ${{ inputs.extra_args }} # zizmor: ignore[template-injection]

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -34,26 +34,7 @@ concurrency:
 
 jobs:
   pre-commit:
-    name: Run pre-commit # https://pre-commit.com/
-    runs-on: ubuntu-latest
-    steps:
-      - name: 'Checkout ${{ github.ref }} ( ${{ github.sha }} )'
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - uses: actions/setup-python@v6 # https://www.python.org/
-        with:
-          python-version: '3.11' # Version range or exact version of a Python version to use, using SemVer's version range syntax
-          architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
-      - name: Install dependencies # https://pip.pypa.io/en/stable/
-        run: |
-          python -m pip install --upgrade pip
-          pip install pre-commit
-      - name: set PY
-        run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
-      - uses: actions/cache@v5
-        with:
-          path: ~/.cache/pre-commit
-          key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
-      - name: Run pre-commit
-        run: pre-commit run --color=always --all-files --show-diff-on-failure
+    name: Run pre-commit standard
+    uses: ./.github/workflows/pre-commit-reusable.yml
+    with:
+      job_id: 'standard'


### PR DESCRIPTION
Separates the jobs run commands and arguments by reuse.

Gives us two jobs on the PR page when a PR is opened.

Quickly shows us what is failing by separation.

More jobs can be easily added.

Need two separate workflow files for both standard and manual hooks to ensure the README status buttons work

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

As described

## How was this patch tested?


## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
