### PR TITLE
fix: Should we run lychee link checker on master branch ?

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -24,6 +24,9 @@ on:
   repository_dispatch:
   workflow_dispatch:
   pull_request:
+  push:
+    branches:
+      - master
   schedule:
     - cron: '00 18 * * *'
 


### PR DESCRIPTION
Fixes #2761

Adds `push` trigger on the `master` branch to `.github/workflows/links.yml` so the lychee link checker runs on every merge to master, not just on a schedule or pull requests. Previously, broken links merged into master would go undetected until the next scheduled run. The fix inserts a `push.branches: [master]` block in the `on:` section of `links.yml`, consistent with the existing trigger ordering. Verified by inspecting the workflow trigger configuration and confirming the new event appears alongside `pull_request` and `schedule`.