### PR TITLE
[GH-2230] Implement GeoSeries.minimum_clearance

### DIFF
--- a/python/sedona/spark/geopandas/base.py
+++ b/python/sedona/spark/geopandas/base.py
@@ -1129,8 +1129,32 @@ class GeoFrame(metaclass=ABCMeta):
         """
         return _delegate_to_geometry_column("minimum_bounding_radius", self)
 
-    # def minimum_clearance(self):
-    #     raise NotImplementedError("This method is not implemented yet.")
+    def minimum_clearance(self) -> ps.Series:
+        """Return a ``Series`` containing the minimum clearance distance,
+        which is the smallest distance by which a vertex of the geometry
+        could be moved to produce an invalid geometry.
+
+        If no minimum clearance exists for a geometry (for example,
+        a single point, or an empty geometry), infinity is returned.
+
+        Examples
+        --------
+        >>> from sedona.spark.geopandas import GeoSeries
+        >>> from shapely.geometry import Polygon, LineString, Point
+        >>> s = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (1, 1), (0, 1), (0, 0)]),
+        ...         LineString([(0, 0), (1, 1), (3, 2)]),
+        ...         Point(0, 0),
+        ...     ]
+        ... )
+        >>> s.minimum_clearance()
+        0    0.707107
+        1    1.414214
+        2         inf
+        dtype: float64
+        """
+        return _delegate_to_geometry_column("minimum_clearance", self)
 
     def normalize(self):
         """Return a ``GeoSeries`` of normalized geometries.

--- a/python/sedona/spark/geopandas/geoseries.py
+++ b/python/sedona/spark/geopandas/geoseries.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import sys
 import typing
 from typing import Any, Union, Literal, List
 
@@ -1077,9 +1078,14 @@ class GeoSeries(GeoFrame, pspd.Series):
             returns_geom=False,
         )
 
-    def minimum_clearance(self):
-        # Implementation of the abstract method.
-        raise NotImplementedError("This method is not implemented yet.")
+    def minimum_clearance(self) -> pspd.Series:
+        spark_col = stf.ST_MinimumClearance(self.spark.column)
+        # JTS returns Double.MAX_VALUE for degenerate geometries (e.g. Point, empty);
+        # convert to float('inf') to match geopandas/shapely behaviour.
+        spark_expr = F.when(
+            spark_col >= sys.float_info.max, F.lit(float("inf"))
+        ).otherwise(spark_col)
+        return self._query_geometry_column(spark_expr, returns_geom=False)
 
     def normalize(self):
         spark_expr = stf.ST_Normalize(self.spark.column)

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -1614,7 +1614,20 @@ e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3
         self.check_pd_series_equal(df_result, expected)
 
     def test_minimum_clearance(self):
-        pass
+        s = GeoSeries(
+            [
+                Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]),
+                Polygon([(0, 0), (0.5, 0), (0.5, 0.5), (0, 0.5)]),
+                MultiPoint([(1, 1), (1, 1)]),
+            ]
+        )
+        expected = pd.Series([1.0, 0.5, float("inf")])
+        result = s.minimum_clearance()
+        self.check_pd_series_equal(result, expected)
+
+        gdf = s.to_geoframe()
+        df_result = gdf.minimum_clearance()
+        self.check_pd_series_equal(df_result, expected)
 
     def test_normalize(self):
         s = GeoSeries(

--- a/python/tests/geopandas/test_match_geopandas_series.py
+++ b/python/tests/geopandas/test_match_geopandas_series.py
@@ -851,7 +851,10 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
             self.check_pd_series_equal(sgpd_result, gpd_result)
 
     def test_minimum_clearance(self):
-        pass
+        for geom in self.geoms:
+            sgpd_result = GeoSeries(geom).minimum_clearance()
+            gpd_result = gpd.GeoSeries(geom).minimum_clearance()
+            self.check_pd_series_equal(sgpd_result, gpd_result)
 
     def test_normalize(self):
         for geom in self.geoms:


### PR DESCRIPTION
# [GH-2230] Implement GeoSeries.minimum_clearance

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Part of #2230

## What changes were proposed in this PR?

Implements `GeoSeries.minimum_clearance()` from the [GH-2230 EPIC](https://github.com/apache/sedona/issues/2230) to expand Sedona's geopandas-compatible API:

**`GeoSeries.minimum_clearance()` (method)**
- Returns the minimum clearance distance of each geometry as a `float64` Series — the smallest distance by which any vertex could be moved to produce an invalid geometry.
- Backed by `ST_MinimumClearance`.
- Handles the JTS/GEOS representation difference: JTS returns `Double.MAX_VALUE` for degenerate geometries (e.g. `Point`, empty); this is converted to `float('inf')` to match geopandas/shapely behaviour.

The method is implemented in `geoseries.py` (Spark SQL logic) and `base.py` (GeoDataFrame delegation + docstring with examples).

## How was this patch tested?

- `tests/geopandas/test_geoseries.py` — hardcoded expected-value tests including GeoDataFrame delegation:
  - `test_minimum_clearance`: unit square → `1.0`, half-unit square → `0.5`, degenerate `MultiPoint` → `inf`
- `tests/geopandas/test_match_geopandas_series.py` — comparison against geopandas:
  - `test_minimum_clearance`: iterates all geometry fixture types (`self.geoms`) and compares against geopandas results

All tests pass locally.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API documentation — it implements an existing stub method that was already part of the planned API surface (tracked in #2230). A docstring with examples is included inline.