### PR TITLE
[CI] Pin astral-sh/setup-uv to ASF-allowed SHA

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
       - name: Sync doc environment
         run: uv sync --group docs
       - run: sudo apt update

--- a/.github/workflows/pyflink.yml
+++ b/.github/workflows/pyflink.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
       - run: mvn package -pl "org.apache.sedona:sedona-flink-shaded_2.12" -am -DskipTests
       - name: Install python package + flink extra
         run: |

--- a/.github/workflows/python-extension.yml
+++ b/.github/workflows/python-extension.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: '0.9.22'
       - name: Install dependencies (dev)

--- a/.github/workflows/python-wheel.yml
+++ b/.github/workflows/python-wheel.yml
@@ -94,7 +94,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Build sdist
         run: cd python && uv build --sdist

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -90,7 +90,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
       - name: Cache Maven packages
         uses: actions/cache@v5
         with:

--- a/.prettierignore
+++ b/.prettierignore
@@ -23,3 +23,5 @@ site/
 target/
 binder/Pipfile.lock
 docs-overrides/main.html
+.claude/
+python/.venv-test/


### PR DESCRIPTION
## Summary
- Pin `astral-sh/setup-uv` to commit `37802adc` (v7.6.0) across all 5 Python-related workflows to comply with ASF infrastructure action allow list
- Add `.claude/` and `python/.venv-test/` to `.prettierignore` to fix pre-commit hook scanning vendored/generated files

Resolves the CI failures on `master` caused by the ASF infra permission issue tracked in [INFRA-27760](https://issues.apache.org/jira/browse/INFRA-27760).

## Test plan
- Verify CI workflows pass on this PR
- Confirm `astral-sh/setup-uv` SHA matches ASF allow list entry for v7.6.0