### PR TITLE
[DOCS] Reorganize SedonaSpark install docs navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,23 +24,24 @@ nav:
   - SedonaSpark:
       - Home: sedonaspark.md
       - Install:
-          - Install Sedona Scala/Java: setup/install-scala.md
-          - Install Sedona Python: setup/install-python.md
-          - Install Sedona R: api/rdocs
-          - Sedona Python: api/pydocs
-          - Install Sedona-Zeppelin: setup/zeppelin.md
-          - Play Sedona in Docker: setup/docker.md
-          - Install on Wherobots: setup/wherobots.md
-          - Install on Databricks: setup/databricks.md
-          - Install on AWS EMR: setup/emr.md
-          - Install on AWS Glue: setup/glue.md
-          - Install on Microsoft Fabric: setup/fabric.md
-          - Set up Spark cluster manually: setup/cluster.md
-          - Install on Azure Synapse Analytics: setup/azure-synapse-analytics.md
           - Overview: setup/overview.md
           - Modules: setup/modules.md
           - Language wrappers: setup/platform.md
           - Maven Central coordinate: setup/maven-coordinates.md
+          - Use Sedona in Docker: setup/docker.md
+          - Install Sedona in your local Spark cluster:
+              - Install Sedona Scala/Java: setup/install-scala.md
+              - Install Sedona Python: setup/install-python.md
+              - Install Sedona R: api/rdocs
+              - Install Sedona-Zeppelin: setup/zeppelin.md
+              - Set up Spark cluster manually: setup/cluster.md
+          - Cloud platforms:
+              - Install on Wherobots: setup/wherobots.md
+              - Install on Databricks: setup/databricks.md
+              - Install on AWS EMR: setup/emr.md
+              - Install on AWS Glue: setup/glue.md
+              - Install on Microsoft Fabric: setup/fabric.md
+              - Install on Azure Synapse Analytics: setup/azure-synapse-analytics.md
       - Programming Guide:
           - Spatial DataFrame / SQL app: tutorial/sql.md
           - Raster DataFrame / SQL app: tutorial/raster.md


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2699

## What changes were proposed in this PR?

Reorganize the SedonaSpark Install navigation bar to reduce clutter and improve discoverability:

- Moved general reference items (Overview, Modules, Language wrappers, Maven Central coordinate) to the top of the Install section
- Grouped local installation guides (Scala/Java, Python, R, Zeppelin, manual cluster setup) under "Install Sedona in your local Spark cluster"
- Grouped cloud platform guides (Wherobots, Databricks, EMR, Glue, Fabric, Azure Synapse) under "Cloud platforms"
- Renamed "Play Sedona in Docker" to "Use Sedona in Docker"
- Removed duplicate "Sedona Python: api/pydocs" entry from the Install section

## How was this patch tested?

Verified locally with `mkdocs serve` that the navigation renders correctly.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.