### PR TITLE
[GH-2787] Fix SedonaDB deadlink on homepage

### DIFF
--- a/docs-overrides/main.html
+++ b/docs-overrides/main.html
@@ -162,7 +162,7 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
                 Install SedonaDB, or run Sedona on distributed systems when you need additional scale.
               </div>
               <div class="bth-group">
-                <a href="sedonadb" class="btn btn-red">
+                <a href="/sedonadb" class="btn btn-red">
                      <span class="caption">
                    Install SedonaDB
                   </span>
@@ -190,7 +190,7 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
               <h3 class="info-item__title">SedonaDB</h3>
               <div class="info-item__description editor">Standalone runtime for local processing and development.</div>
               <div class="info-item__cta">
-                <a href="sedonadb" class="btn-link">
+                <a href="/sedonadb" class="btn-link">
                   <span class="caption">SedonaDB</span>
                   <span class="icon">
                         <svg width="19" height="19" viewBox="0 0 19 19" fill="none" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2787

## What changes were proposed in this PR?

The "Install SedonaDB" button and the SedonaDB link in the "Deploy" section on the homepage use relative `href="sedonadb"`, which resolves to `/latest/sedonadb` (a dead link) when viewed under versioned docs. Changed both to absolute `href="/sedonadb"` so they correctly point to `https://sedona.apache.org/sedonadb`.

## How was this patch tested?

Manual inspection of the link paths in `docs-overrides/main.html`.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.