### PR TITLE
[DOCS] Clean up Sedona Python docs navigation list

### DIFF
--- a/python/sedona/doc/index.rst
+++ b/python/sedona/doc/index.rst
@@ -30,10 +30,5 @@ This documentation covers the Python API for Apache Sedona, providing comprehens
    :maxdepth: 2
    :caption: Contents:
 
-   modules
    sedona.flink
    sedona.spark
-   sedona.spark.geopandas
-   sedona.stac
-   sedona.stats
-   sedona.utils


### PR DESCRIPTION
## Summary
- Removes redundant top-level entries from the Python API docs navigation (`python/sedona/doc/index.rst`)
- Navigation now shows only `sedona.flink` and `sedona.spark` as top-level items
- Removed entries (`modules`, `sedona.spark.geopandas`, `sedona.stac`, `sedona.stats`, `sedona.utils`) are already accessible as subpackages under `sedona.spark`

Closes #2797

## Test plan
- [ ] Verify docs build succeeds in CI
- [ ] Check that the navigation at `/api/pydocs/index.html` shows only `sedona.flink` and `sedona.spark`
- [ ] Confirm `sedona.spark.geopandas`, `sedona.stac`, `sedona.stats`, `sedona.utils` are still accessible under `sedona.spark`