### PR TITLE
[CI] Run links checker cron at 01:07 on Sundays

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -25,7 +25,7 @@ on:
   workflow_dispatch:
   pull_request:
   schedule:
-    - cron: '00 18 * * *'
+    - cron: '7 1 * * 0' # At 01:07 on Sunday.
 
 jobs:
   check-links:


### PR DESCRIPTION
https://crontab.guru/#7_1_*_*_0

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

Too many issues are being opened by the links checker workflow too quickly.

Set the cron to run only once a week.

## How was this patch tested?


## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
