### PR TITLE
[CI] Pin pypa/gh-action-pypi-publish to allowed commit hash

### DIFF
--- a/.github/linters/zizmor.yml
+++ b/.github/linters/zizmor.yml
@@ -21,7 +21,6 @@ rules:
       policies:
         actions/*: any
         github/*: any
-        pypa/gh-action-pypi-publish: any
         r-lib/actions/check-r-package: any
         r-lib/actions/setup-r: any
         r-lib/actions/setup-r-dependencies: any

--- a/.github/workflows/python-wheel.yml
+++ b/.github/workflows/python-wheel.yml
@@ -127,5 +127,5 @@ jobs:
           done
           echo "Content copied to dist."
       - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         # repository_url: https://test.pypi.org/legacy/ # to test


### PR DESCRIPTION
## Summary
- Pin `pypa/gh-action-pypi-publish` from `@release/v1` (branch ref) to `@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e` (`v1.13.0`), which is the latest version in [Apache's infrastructure-actions allowlist](https://github.com/apache/infrastructure-actions/blob/main/actions.yml).
- Remove the `pypa/gh-action-pypi-publish: any` exception from `.github/linters/zizmor.yml` since the action is now properly pinned to a commit hash.

Closes #2814