### PR TITLE
[GH-2815] Disable offline link detection in maven-javadoc-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -649,6 +649,7 @@
                 </executions>
                 <configuration>
                     <additionalparam>-Xdoclint:none</additionalparam>
+                    <detectOfflineLinks>false</detectOfflineLinks>
                     <excludePackageNames>org.apache.spark.sql.execution.datasources.geoparquet.internal</excludePackageNames>
                 </configuration>
             </plugin>


### PR DESCRIPTION
## Summary
- Set `detectOfflineLinks` to `false` in the `maven-javadoc-plugin` configuration to suppress `[ERROR] Error fetching link: .../target/apidocs/package-list` messages during multi-module builds.
- The error occurs because the plugin tries to resolve cross-module Javadoc links by fetching `package-list` files from sibling modules' build output, which may not exist.

## Test plan
- [ ] Run `mvn install` and verify the `Error fetching link` messages no longer appear