### PR TITLE
[CI] Refactor validate-dependabot-yaml hook to use language node

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,9 +87,11 @@ repos:
         types: [file] # Ensure only regular files are passed, not directories
         stages: [manual]
       - id: validate-dependabot-yml
-        name: Validate dependabot.yml
-        entry: npx @bugron/validate-dependabot-yaml@0.3.3
-        language: system
+        name: validate dependabot.yml
+        description: ensures the dependabot config file is valid
+        entry: validate-dependabot-yaml
+        language: node
+        additional_dependencies: ['@bugron/validate-dependabot-yaml@0.3.3']
         files: ^\.github/dependabot\.yml$
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.6


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

Changed to used node similar to how we run the prettier pre-commit hook:

https://github.com/apache/sedona/blob/1d1bd336c434ce04ff265a3c573a125b648e3b5d/.pre-commit-config.yaml#L51

## How was this patch tested?

With pre-commit

refs https://github.com/apache/cloudstack/pull/12932#discussion_r3015867305

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
