### PR TITLE
[CI] Add two pre-commit hooks forbid and remove tabs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -298,6 +298,15 @@ repos:
           - --license-filepath
           - .github/workflows/license-templates/LICENSE.txt
           - --fuzzy-match-generates-todo
+      - id: forbid-tabs
+        name: run forbid-tabs
+        description: check the codebase for tabs
+        exclude: ^python/sedona/doc/make\.bat$|^python/sedona/doc/Makefile$|^spark/common/src/test/resources/.*$|^Makefile$|\.csv$|\.md$|\.tsv$
+      - id: remove-tabs
+        name: run remove-tabs
+        description: find and convert tabs to spaces
+        args: [--whitespaces-count, '2']
+        exclude: ^python/sedona/doc/make\.bat$|^python/sedona/doc/Makefile$|^spark/common/src/test/resources/.*$|^Makefile$|\.csv$|\.md$|\.tsv$
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.21.2
     hooks:

--- a/spark/common/src/test/java/org/apache/sedona/core/formatMapper/testSerNetCDF.java
+++ b/spark/common/src/test/java/org/apache/sedona/core/formatMapper/testSerNetCDF.java
@@ -37,7 +37,7 @@ public class testSerNetCDF {
 
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
-    //		filename = System.getProperty("user.dir")+"/src/test/resources/" +
+    // filename = System.getProperty("user.dir")+"/src/test/resources/" +
     // "MYD11_L2.A2017091.0155.006.2017094143610.hdf";
   }
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

Two more quick checks for our pre-commit framework

https://github.com/Lucas-C/pre-commit-hooks?tab=readme-ov-file#usage

We already use `chmod` and `insert-license`

## How was this patch tested?

With pre-commit

These checks found one Java file with a tab inside a comment

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
