### PR TITLE
[DOCS] Bump Python, R, and Zeppelin versions to 1.9.0

### DIFF
--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: apache.sedona
 Title: R Interface for Apache Sedona
-Version: 1.8.1
+Version: 1.9.0
 Authors@R:
     c(person(family = "Apache Sedona",
              role = c("aut", "cre"),

--- a/R/R/dependencies.R
+++ b/R/R/dependencies.R
@@ -25,7 +25,7 @@ spark_dependencies <- function(spark_version, scala_version, ...) {
   }
 
   packages <- c(
-    "org.datasyslab:geotools-wrapper:1.8.1-33.1"
+    "org.datasyslab:geotools-wrapper:1.9.0-33.5"
   )
   jars <- NULL
 
@@ -38,7 +38,7 @@ spark_dependencies <- function(spark_version, scala_version, ...) {
       paste0(
         "org.apache.sedona:sedona-",
         c("spark-shaded"),
-        sprintf("-%s_%s:1.8.1", spark_version, scala_version)
+        sprintf("-%s_%s:1.9.0", spark_version, scala_version)
       ),
       packages
     )

--- a/python/sedona/version.py
+++ b/python/sedona/version.py
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version = "1.8.1"
+version = "1.9.0"

--- a/zeppelin/package-lock.json
+++ b/zeppelin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "apache-sedona",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "apache-sedona",
-      "version": "1.8.1",
+      "version": "1.9.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "jsts": "^1.6.2",

--- a/zeppelin/package.json
+++ b/zeppelin/package.json
@@ -2,7 +2,7 @@
   "name": "apache-sedona",
   "description": "Zeppelin visualization support for Sedona",
   "author": "Apache Sedona, original authors are listed on https://github.com/myuwono/zeppelin-leaflet",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No: this is a release preparation update.

## What changes were proposed in this PR?

Bump Python, R, and Zeppelin versions to 1.9.0 for the upcoming Sedona 1.9.0 release.

- `python/sedona/version.py`: 1.8.1 -> 1.9.0
- `R/DESCRIPTION`: 1.8.1 -> 1.9.0
- `R/R/dependencies.R`: sedona 1.8.1 -> 1.9.0, geotools-wrapper 1.8.1-33.1 -> 1.9.0-33.5
- `zeppelin/package.json`: 1.8.1 -> 1.9.0

## How was this patch tested?

Version string changes only, no functional changes.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
Bump Python, R, and Zeppelin versions to 1.9.0 for the upcoming Sedona 1.9.0 release.

Changes:
- `python/sedona/version.py`: 1.8.1 -> 1.9.0
- `R/DESCRIPTION`: 1.8.1 -> 1.9.0
- `R/R/dependencies.R`: sedona 1.8.1 -> 1.9.0, geotools-wrapper 1.8.1-33.1 -> 1.9.0-33.5
- `zeppelin/package.json`: 1.8.1 -> 1.9.0
