### PR TITLE
[SEDONA-641] Add optimized non-broadcast left outer spatial join

### DIFF
--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/JoinQueryDetector.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/JoinQueryDetector.scala
@@ -184,9 +184,9 @@ class JoinQueryDetector(sparkSession: SparkSession) extends SparkStrategy {
 
       /*
        * If either side is small we can automatically broadcast just like Spark does.
-       * This only applies to inner joins as there are no optimized fallback plan for other join types.
-       * It's better that users are explicit about broadcasting for other join types than seeing wildly different behavior
-       * depending on data size.
+       * For inner joins, either side can be broadcast.
+       * For left outer joins, only the right side can be broadcast (the left side must be preserved).
+       * For other join types, users must be explicit about broadcasting.
        */
       if (!broadcastLeft && !broadcastRight && joinType == Inner) {
         val canAutoBroadCastLeft = canAutoBroadcastBySize(left)
@@ -199,6 +199,10 @@ class JoinQueryDetector(sparkSession: SparkSession) extends SparkStrategy {
           broadcastLeft = canAutoBroadCastLeft
           broadcastRight = canAutoBroadCastRight
         }
+      }
+
+      if (!broadcastLeft && !broadcastRight && joinType == LeftOuter) {
+        broadcastRight = canAutoBroadcastBySize(right)
       }
 
       // Check if the filters in the plans are supported
@@ -530,7 +534,7 @@ class JoinQueryDetector(sparkSession: SparkSession) extends SparkStrategy {
       spatialPredicate: SpatialPredicate,
       extraCondition: Option[Expression] = None): Seq[SparkPlan] = {
 
-    if (joinType != Inner) {
+    if (joinType != Inner && joinType != LeftOuter) {
       return Nil
     }
 
@@ -542,24 +546,44 @@ class JoinQueryDetector(sparkSession: SparkSession) extends SparkStrategy {
     matchExpressionsToPlans(a, b, left, right) match {
       case Some((_, _, false)) =>
         logInfo(s"Planning spatial join for $relationship relationship")
-        RangeJoinExec(
-          planLater(left),
-          planLater(right),
-          a,
-          b,
-          spatialPredicate,
-          extraCondition) :: Nil
+        if (joinType == LeftOuter) {
+          RangeLeftOuterJoinExec(
+            planLater(left),
+            planLater(right),
+            a,
+            b,
+            spatialPredicate,
+            extraCondition) :: Nil
+        } else {
+          RangeJoinExec(
+            planLater(left),
+            planLater(right),
+            a,
+            b,
+            spatialPredicate,
+            extraCondition) :: Nil
+        }
       case Some((_, _, true)) =>
         logInfo(
           s"Planning spatial join for $relationship relationship with swapped left and right shapes")
         val invSpatialPredicate = SpatialPredicate.inverse(spatialPredicate)
-        RangeJoinExec(
-          planLater(left),
-          planLater(right),
-          b,
-          a,
-          invSpatialPredicate,
-          extraCondition) :: Nil
+        if (joinType == LeftOuter) {
+          RangeLeftOuterJoinExec(
+            planLater(left),
+            planLater(right),
+            b,
+            a,
+            invSpatialPredicate,
+            extraCondition) :: Nil
+        } else {
+          RangeJoinExec(
+            planLater(left),
+            planLater(right),
+            b,
+            a,
+            invSpatialPredicate,
+            extraCondition) :: Nil
+        }
       case None =>
         logInfo(
           s"Spatial join for $relationship with arguments not aligned " +

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/RangeLeftOuterJoinExec.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/RangeLeftOuterJoinExec.scala
@@ -1,0 +1,219 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.spark.sql.sedona_sql.strategy.join
+
+import org.apache.sedona.core.enums.JoinSpartitionDominantSide
+import org.apache.sedona.core.spatialOperator.{JoinQuery, SpatialPredicate}
+import org.apache.sedona.core.spatialOperator.JoinQuery.JoinParams
+import org.apache.sedona.core.spatialRDD.SpatialRDD
+import org.apache.sedona.core.utils.SedonaConf
+import org.apache.sedona.sql.utils.GeometrySerializer
+import org.apache.spark.internal.Logging
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, BindReferences, Expression, GenericInternalRow, Predicate, UnsafeProjection, UnsafeRow}
+import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeRowJoiner
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.sedona_sql.execution.SedonaBinaryExecNode
+import org.locationtech.jts.geom.Geometry
+
+/**
+ * Non-broadcast left outer spatial join for range predicates (ST_Contains, ST_Intersects, etc.).
+ *
+ * Executes an optimized partitioned inner spatial join, then finds unmatched left rows via an
+ * equi-join on row IDs and appends them with null-padded right columns.
+ *
+ * @param left
+ *   left side of the join (all rows preserved)
+ * @param right
+ *   right side of the join (null-padded when no match)
+ * @param leftShape
+ *   expression for the first argument of spatialPredicate
+ * @param rightShape
+ *   expression for the second argument of spatialPredicate
+ * @param spatialPredicate
+ *   spatial predicate as join condition
+ * @param extraCondition
+ *   extra join condition other than spatialPredicate
+ */
+case class RangeLeftOuterJoinExec(
+    left: SparkPlan,
+    right: SparkPlan,
+    leftShape: Expression,
+    rightShape: Expression,
+    spatialPredicate: SpatialPredicate,
+    extraCondition: Option[Expression] = None)
+    extends SedonaBinaryExecNode
+    with TraitJoinQueryExec
+    with Logging {
+
+  override def output: Seq[Attribute] =
+    left.output ++ right.output.map(_.withNullability(true))
+
+  override protected def doExecute(): RDD[InternalRow] = {
+    val boundLeftShape = BindReferences.bindReference(leftShape, left.output)
+    val boundRightShape = BindReferences.bindReference(rightShape, right.output)
+
+    val leftResultsRaw = left.execute().asInstanceOf[RDD[UnsafeRow]]
+    val rightResultsRaw = right.execute().asInstanceOf[RDD[UnsafeRow]]
+
+    val sedonaConf = SedonaConf.fromActiveSession
+
+    // Step 1: Assign unique Long IDs to left rows (narrow transformation, no shuffle).
+    // Cached because it's consumed twice: once for the spatial join, once for subtractByKey.
+    val leftWithId: RDD[(UnsafeRow, Long)] = leftResultsRaw.zipWithUniqueId().cache()
+
+    // Step 2: Convert to SpatialRDDs
+    val leftShapes = toSpatialRDDWithId(leftWithId, boundLeftShape)
+    val rightShapes = toSpatialRDD(rightResultsRaw, boundRightShape)
+
+    // Step 3: Spatial partitioning (reuse logic from TraitJoinQueryExec)
+    if (sedonaConf.getJoinApproximateTotalCount == -1) {
+      if (sedonaConf.getJoinSpartitionDominantSide == JoinSpartitionDominantSide.LEFT) {
+        leftShapes.analyze()
+      } else {
+        rightShapes.analyze()
+      }
+    }
+    log.info("[SedonaSQL] Number of partitions on the left: " + leftResultsRaw.partitions.size)
+    log.info("[SedonaSQL] Number of partitions on the right: " + rightResultsRaw.partitions.size)
+
+    var numPartitions = -1
+    try {
+      if (sedonaConf.getJoinSpartitionDominantSide == JoinSpartitionDominantSide.LEFT) {
+        if (sedonaConf.getFallbackPartitionNum != -1) {
+          numPartitions = sedonaConf.getFallbackPartitionNum
+        } else {
+          numPartitions = joinPartitionNumOptimizer(
+            leftShapes.rawSpatialRDD.partitions.size(),
+            rightShapes.rawSpatialRDD.partitions.size(),
+            leftShapes.approximateTotalCount)
+        }
+        doSpatialPartitioning(leftShapes, rightShapes, numPartitions, sedonaConf)
+      } else {
+        if (sedonaConf.getFallbackPartitionNum != -1) {
+          numPartitions = sedonaConf.getFallbackPartitionNum
+        } else {
+          numPartitions = joinPartitionNumOptimizer(
+            rightShapes.rawSpatialRDD.partitions.size(),
+            leftShapes.rawSpatialRDD.partitions.size(),
+            rightShapes.approximateTotalCount)
+        }
+        doSpatialPartitioning(rightShapes, leftShapes, numPartitions, sedonaConf)
+      }
+    } catch {
+      case e: IllegalArgumentException =>
+        print(e.getMessage)
+        if (sedonaConf.getJoinSpartitionDominantSide == JoinSpartitionDominantSide.LEFT) {
+          numPartitions = sedonaConf.getFallbackPartitionNum
+          doSpatialPartitioning(leftShapes, rightShapes, numPartitions, sedonaConf)
+        } else {
+          numPartitions = sedonaConf.getFallbackPartitionNum
+          doSpatialPartitioning(rightShapes, leftShapes, numPartitions, sedonaConf)
+        }
+    }
+
+    // Step 4: Execute inner spatial join with dedup
+    val joinParams = new JoinParams(
+      sedonaConf.getUseIndex,
+      spatialPredicate,
+      sedonaConf.getIndexType,
+      sedonaConf.getJoinBuildSide)
+
+    val matchesRDD: RDD[(Geometry, Geometry)] =
+      (leftShapes.spatialPartitionedRDD, rightShapes.spatialPartitionedRDD) match {
+        case (null, null) =>
+          sparkContext.parallelize(Seq[(Geometry, Geometry)]())
+        case _ => JoinQuery.spatialJoin(leftShapes, rightShapes, joinParams).rdd
+      }
+
+    // Step 5: Extract matched pairs as (leftId, (leftRow, rightRow))
+    val leftSchema = left.schema
+    val rightSchema = right.schema
+    val matchedWithId: RDD[(Long, (UnsafeRow, UnsafeRow))] = matchesRDD.map {
+      case (leftGeom, rightGeom) =>
+        val (leftId, leftRow) = leftGeom.getUserData.asInstanceOf[(Long, UnsafeRow)]
+        val rightRow = rightGeom.getUserData.asInstanceOf[UnsafeRow]
+        (leftId, (leftRow, rightRow))
+    }
+
+    // Step 6: Apply extra condition filter on matched pairs
+    // This must happen before computing unmatched set (SQL outer join semantics:
+    // a left row that matches spatially but fails the extra condition appears with nulls)
+    val filteredMatches: RDD[(Long, (UnsafeRow, UnsafeRow))] = extraCondition match {
+      case Some(condition) =>
+        matchedWithId.mapPartitions { iter =>
+          val joiner = GenerateUnsafeRowJoiner.create(leftSchema, rightSchema)
+          val boundCondition = Predicate.create(condition, output)
+          iter.filter { case (_, (leftRow, rightRow)) =>
+            boundCondition.eval(joiner.join(leftRow, rightRow))
+          }
+        }
+      case None => matchedWithId
+    }
+
+    // Step 7: Build matched output rows, preserving matched left IDs for step 8.
+    // Cached because it's consumed twice: once for matched output, once for matchedIds.
+    val matchedWithJoinedRow: RDD[(Long, UnsafeRow)] = filteredMatches
+      .mapPartitions { iter =>
+        val joiner = GenerateUnsafeRowJoiner.create(leftSchema, rightSchema)
+        iter.map { case (id, (leftRow, rightRow)) => (id, joiner.join(leftRow, rightRow)) }
+      }
+      .cache()
+
+    // Step 8: Find unmatched left rows via subtractByKey (one shuffle on Long keys)
+    val matchedIds: RDD[(Long, Null)] =
+      matchedWithJoinedRow.map { case (id, _) => (id, null) }
+    val allLeftById: RDD[(Long, UnsafeRow)] = leftWithId.map { case (row, id) => (id, row) }
+    val unmatchedLeft: RDD[(Long, UnsafeRow)] = allLeftById.subtractByKey(matchedIds)
+
+    // Step 9: Build unmatched output rows with null-padded right columns
+    val rightOutputLength = right.output.length
+    val unmatchedOutput: RDD[InternalRow] = unmatchedLeft.mapPartitions { iter =>
+      val joiner = GenerateUnsafeRowJoiner.create(leftSchema, rightSchema)
+      val nullRow = new GenericInternalRow(rightOutputLength)
+      val nullUnsafeRow = UnsafeProjection.create(rightSchema).apply(nullRow)
+      iter.map { case (_, leftRow) => joiner.join(leftRow, nullUnsafeRow) }
+    }
+
+    // Step 10: Union matched and unmatched
+    val matchedOutput: RDD[InternalRow] = matchedWithJoinedRow.map(_._2)
+    matchedOutput.union(unmatchedOutput)
+  }
+
+  private def toSpatialRDDWithId(
+      rdd: RDD[(UnsafeRow, Long)],
+      shapeExpression: Expression): SpatialRDD[Geometry] = {
+    val spatialRdd = new SpatialRDD[Geometry]
+    spatialRdd.setRawSpatialRDD(
+      rdd
+        .map { case (row, id) =>
+          val shape =
+            GeometrySerializer.deserialize(shapeExpression.eval(row).asInstanceOf[Array[Byte]])
+          shape.setUserData((id, row.copy()))
+          shape
+        }
+        .toJavaRDD())
+    spatialRdd
+  }
+
+  protected def withNewChildrenInternal(newLeft: SparkPlan, newRight: SparkPlan): SparkPlan = {
+    copy(left = newLeft, right = newRight)
+  }
+}

--- a/spark/common/src/test/scala/org/apache/sedona/sql/SpatialJoinSuite.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/SpatialJoinSuite.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.{Column, DataFrame, Row}
 import org.apache.spark.sql.functions.{col, expr}
 import org.apache.spark.sql.sedona_sql.UDT.GeometryUDT
 import org.apache.spark.sql.sedona_sql.expressions.st_constructors.ST_GeomFromText
-import org.apache.spark.sql.sedona_sql.strategy.join.{BroadcastIndexJoinExec, DistanceJoinExec, RangeJoinExec}
+import org.apache.spark.sql.sedona_sql.strategy.join.{BroadcastIndexJoinExec, DistanceJoinExec, RangeJoinExec, RangeLeftOuterJoinExec}
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 import org.locationtech.jts.geom.Geometry
 import org.locationtech.jts.io.WKTReader
@@ -280,6 +280,172 @@ class SpatialJoinSuite extends TestBaseScala with TableDrivenPropertyChecks {
         "SELECT * FROM df2 WHERE ST_Distance(df2.geom, ST_GeomFromText('POINT EMPTY')) < 1")
       assert(result2.count() == 0)
     }
+  }
+
+  describe("Non-broadcast Left Outer Spatial Join") {
+    val noBroadcastConf = Map(
+      "spark.sql.autoBroadcastJoinThreshold" -> "-1",
+      "sedona.join.autoBroadcastJoinThreshold" -> "-1",
+      spatialJoinPartitionSideConfKey -> "left")
+
+    val leftOuterJoinConditions = Table(
+      "join condition",
+      "ST_Contains(df1.geom, df2.geom)",
+      "ST_Intersects(df1.geom, df2.geom)",
+      "ST_Within(df1.geom, df2.geom)",
+      "ST_Covers(df1.geom, df2.geom)",
+      "ST_CoveredBy(df1.geom, df2.geom)",
+      "ST_Touches(df1.geom, df2.geom)",
+      "ST_Crosses(df1.geom, df2.geom)",
+      "ST_Overlaps(df1.geom, df2.geom)",
+      "ST_Equals(df1.geom, df2.geom)")
+
+    forAll(leftOuterJoinConditions) { joinCondition =>
+      it(s"should left outer join two dataframes with $joinCondition") {
+        withConf(noBroadcastConf) {
+          val result = sparkSession.sql(
+            s"SELECT df1.id, df2.id FROM df1 LEFT OUTER JOIN df2 ON $joinCondition")
+          assertUsesRangeLeftOuterJoinExec(result)
+          val expected = buildExpectedLeftOuterResult(joinCondition)
+          verifyLeftOuterResult(expected, result)
+        }
+      }
+
+      it(
+        s"should left outer join two dataframes with $joinCondition, right side as dominant side") {
+        withConf(noBroadcastConf ++ Map(spatialJoinPartitionSideConfKey -> "right")) {
+          val result = sparkSession.sql(
+            s"SELECT df1.id, df2.id FROM df1 LEFT OUTER JOIN df2 ON $joinCondition")
+          assertUsesRangeLeftOuterJoinExec(result)
+          val expected = buildExpectedLeftOuterResult(joinCondition)
+          verifyLeftOuterResult(expected, result)
+        }
+      }
+    }
+
+    it("should produce correct results with SELECT *") {
+      withConf(noBroadcastConf) {
+        val resultAll = sparkSession
+          .sql("SELECT * FROM df1 LEFT OUTER JOIN df2 ON ST_Intersects(df1.geom, df2.geom)")
+          .collect()
+        val expected = buildExpectedLeftOuterResult("ST_Intersects(df1.geom, df2.geom)")
+        // Matched rows should have non-null df2.id (column index 3)
+        val matched =
+          resultAll.filter(_.get(3) != null).map(row => (row.getInt(0), row.getInt(3)))
+        val unmatched = resultAll.filter(_.get(3) == null).map(row => row.getInt(0))
+        val expectedMatched = expected.collect { case (id1, Some(id2)) => (id1, id2) }
+        val expectedUnmatched = expected.collect { case (id1, None) => id1 }
+        assert(matched.sorted === expectedMatched.sorted)
+        assert(unmatched.sorted === expectedUnmatched.sorted)
+      }
+    }
+
+    it("should produce correct result count with SELECT COUNT(*)") {
+      withConf(noBroadcastConf) {
+        val result = sparkSession
+          .sql(
+            "SELECT COUNT(*) FROM df1 LEFT OUTER JOIN df2 ON ST_Intersects(df1.geom, df2.geom)")
+          .collect()
+          .head
+          .getLong(0)
+        val expected = buildExpectedLeftOuterResult("ST_Intersects(df1.geom, df2.geom)")
+        assert(result === expected.length)
+      }
+    }
+
+    it("should handle extra conditions correctly") {
+      withConf(noBroadcastConf) {
+        val result = sparkSession.sql("""SELECT df1.id, df2.id FROM df1 LEFT OUTER JOIN df2
+            |ON ST_Intersects(df1.geom, df2.geom) AND df1.id > df2.id""".stripMargin)
+        assertUsesRangeLeftOuterJoinExec(result)
+        // Build expected: inner join with spatial + extra condition, then add unmatched left rows
+        val innerExpected = buildExpectedResult("ST_Intersects(df1.geom, df2.geom)")
+          .filter { case (id1, id2) => id1 > id2 }
+        val matchedLeftIds = innerExpected.map(_._1).toSet
+        val allLeftIds = loadTestData(spatialJoinLeftInputLocation).map(_._1)
+        val expected: Seq[(Int, Option[Int])] =
+          innerExpected.map { case (id1, id2) => (id1, Some(id2)) } ++
+            allLeftIds.filterNot(matchedLeftIds.contains).map(id => (id, None))
+        verifyLeftOuterResult(expected, result)
+      }
+    }
+
+    it("should return all left rows with nulls when no matches exist") {
+      withConf(noBroadcastConf) {
+        // Create a right table with geometries far from the left table
+        sparkSession
+          .range(0, 5)
+          .toDF("id")
+          .withColumn("geom", expr("ST_Point(id + 9999, id + 9999)"))
+          .createOrReplaceTempView("dfFarAway")
+
+        val result = sparkSession.sql(
+          "SELECT df1.id, dfFarAway.id FROM df1 LEFT OUTER JOIN dfFarAway ON ST_Intersects(df1.geom, dfFarAway.geom)")
+        val rows = result.collect()
+        val allLeftIds = loadTestData(spatialJoinLeftInputLocation).map(_._1)
+        assert(rows.length === allLeftIds.length)
+        assert(rows.forall(_.isNullAt(1)))
+      }
+    }
+
+    it("should match inner join result when all left rows have matches") {
+      withConf(noBroadcastConf) {
+        val leftOuterResult = sparkSession
+          .sql("SELECT df1.id, df2.id FROM df1 LEFT OUTER JOIN df2 ON ST_Intersects(df1.geom, df2.geom)")
+          .collect()
+          .filter(!_.isNullAt(1))
+          .map(row => (row.getInt(0), row.getInt(1)))
+          .sorted
+
+        val innerResult = sparkSession
+          .sql("SELECT df1.id, df2.id FROM df1 JOIN df2 ON ST_Intersects(df1.geom, df2.geom)")
+          .collect()
+          .map(row => (row.getInt(0), row.getInt(1)))
+          .sorted
+
+        assert(leftOuterResult === innerResult)
+      }
+    }
+
+    it("should handle swapped predicate arguments") {
+      withConf(noBroadcastConf) {
+        val result = sparkSession.sql(
+          "SELECT df1.id, df2.id FROM df1 LEFT OUTER JOIN df2 ON ST_Intersects(df2.geom, df1.geom)")
+        assertUsesRangeLeftOuterJoinExec(result)
+        val expected = buildExpectedLeftOuterResult("ST_Intersects(df1.geom, df2.geom)")
+        verifyLeftOuterResult(expected, result)
+      }
+    }
+  }
+
+  private def buildExpectedLeftOuterResult(joinCondition: String): Seq[(Int, Option[Int])] = {
+    val innerResult = buildExpectedResult(joinCondition)
+    val matchedLeftIds = innerResult.map(_._1).toSet
+    val allLeftIds = loadTestData(spatialJoinLeftInputLocation).map(_._1)
+    val matched = innerResult.map { case (id1, id2) => (id1, Some(id2)) }
+    val unmatched = allLeftIds.filterNot(matchedLeftIds.contains).map(id => (id, None))
+    (matched ++ unmatched).sortBy(r => (r._1, r._2.getOrElse(Int.MaxValue)))
+  }
+
+  private def verifyLeftOuterResult(
+      expected: Seq[(Int, Option[Int])],
+      result: DataFrame): Unit = {
+    val actual = result
+      .collect()
+      .map { row =>
+        val id1 = row.getInt(0)
+        val id2 = if (row.isNullAt(1)) None else Some(row.getInt(1))
+        (id1, id2)
+      }
+      .sortBy(r => (r._1, r._2.getOrElse(Int.MaxValue)))
+    assert(actual === expected)
+  }
+
+  private def assertUsesRangeLeftOuterJoinExec(df: DataFrame): Unit = {
+    val usesOptimized = df.queryExecution.executedPlan.collect { case _: RangeLeftOuterJoinExec =>
+      true
+    }.nonEmpty
+    assert(usesOptimized, "Expected RangeLeftOuterJoinExec in execution plan but not found")
   }
 
   private def withOptimizationMode(mode: String)(body: => Unit): Unit = {


### PR DESCRIPTION
## JIRA
https://issues.apache.org/jira/browse/SEDONA-641

## Summary
- Adds `RangeLeftOuterJoinExec`, a new physical plan node for non-broadcast LEFT OUTER spatial joins using range predicates (ST_Intersects, ST_Contains, etc.)
- Reuses the existing partitioned inner spatial join infrastructure, then finds unmatched left rows via `subtractByKey` on unique row IDs and appends them with null-padded right columns
- Updates `JoinQueryDetector` to route LeftOuter joins to the new node and auto-broadcast the right side when eligible
- Previously, LEFT OUTER spatial joins without broadcast hints fell back to `BroadcastNestedLoopJoinExec` (cartesian product)

## Test plan
- [ ] All 9 spatial predicates tested with both left and right dominant partitioning
- [ ] Extra condition filtering (e.g., `ST_Intersects(...) AND df1.id > df2.id`)
- [ ] Edge case: no matches (all right columns null)
- [ ] Inner join result comparison (matched rows of left outer == inner join)
- [ ] Swapped predicate arguments
- [ ] SELECT * and SELECT COUNT(*) verification
- [ ] Plan verification (`RangeLeftOuterJoinExec` appears in executed plan)
- [ ] Existing `SpatialJoinSuite` tests pass (no regressions)