### PR TITLE
[GH-2844] Bump snowflake-tester parent version to 1.9.1-SNAPSHOT

### DIFF
--- a/snowflake-tester/pom.xml
+++ b/snowflake-tester/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.sedona</groupId>
         <artifactId>sedona-parent</artifactId>
-        <version>1.9.0-SNAPSHOT</version>
+        <version>1.9.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Apache Sedona Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Apache Sedona Coding Standards](https://sedona.apache.org/latest-snapshot/community/develop/) before opening a pull request.

## Is this PR related to a JIRA ticket?

- Closes #2844

## What changes were proposed in this PR?

Bumps the `snowflake-tester` module's parent version from `1.9.0-SNAPSHOT` to `1.9.1-SNAPSHOT` so it aligns with every other module on the current development line.

## Why are the changes needed?

The `snowflake-tester` module is declared inside the `snowflake` profile in the root `pom.xml`, which is not active by default. As a result, the `maven-release-plugin` skipped this module during the 1.9.0 release preparation. Every other module moved to `1.9.1-SNAPSHOT` in commit `59275889be` ("prepare for next development iteration"), but `snowflake-tester` was left behind at `1.9.0-SNAPSHOT`. This causes a version mismatch that breaks building the snowflake profile against the current `sedona-parent`.

## How was this patch tested?

Version-only change verified by diffing against sibling module POMs (`snowflake/pom.xml`, `common/pom.xml`, etc.), all of which are now on `1.9.1-SNAPSHOT`.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public APIs or documentation.