### PR TITLE
[CI] Simplify forbid-tabs/remove-tabs Makefile excludes to match any Makefile

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -301,12 +301,12 @@ repos:
       - id: forbid-tabs
         name: run forbid-tabs
         description: check the codebase for tabs
-        exclude: ^python/sedona/doc/make\.bat$|^python/sedona/doc/Makefile$|^spark/common/src/test/resources/.*$|^Makefile$|\.csv$|\.md$|\.tsv$
+        exclude: ^python/sedona/doc/make\.bat$|^spark/common/src/test/resources/.*$|(^|/)Makefile$|\.csv$|\.md$|\.tsv$
       - id: remove-tabs
         name: run remove-tabs
         description: find and convert tabs to spaces
         args: [--whitespaces-count, '2']
-        exclude: ^python/sedona/doc/make\.bat$|^python/sedona/doc/Makefile$|^spark/common/src/test/resources/.*$|^Makefile$|\.csv$|\.md$|\.tsv$
+        exclude: ^python/sedona/doc/make\.bat$|^spark/common/src/test/resources/.*$|(^|/)Makefile$|\.csv$|\.md$|\.tsv$
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.21.2
     hooks:


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Guide](https://sedona.apache.org/latest/community/rule/).

## Is this PR related to a JIRA ticket?

No — trivial CI config cleanup.

## What changes were proposed in this PR?

The `forbid-tabs` and `remove-tabs` pre-commit hooks currently list specific Makefile paths in their `exclude` regex:

```
^Makefile$|^python/sedona/doc/Makefile$
```

This only exempts the repo-root Makefile and the one under `python/sedona/doc/`. Any new Makefile added elsewhere in the tree (e.g. in a sub-tester module) will:

1. Trip `forbid-tabs`, which fails CI because Makefiles must use tabs.
2. Get rewritten by `remove-tabs` (tabs → 2 spaces), which then trips `editorconfig-checker` because the `.editorconfig` for Makefiles requires tabs.

This PR replaces the two path-specific entries with a single `(^|/)Makefile$` pattern that excludes any Makefile anywhere in the tree. Behavior on the two existing Makefiles is unchanged; it just future-proofs the config.

## How was this patch tested?

Ran `pre-commit run forbid-tabs remove-tabs editorconfig-checker --all-files` locally — all pass.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API or user-facing behavior.