### PR TITLE
[GH-2830] Add Geography dual-dispatch to ST_AsText

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/geography/Functions.java
+++ b/common/src/main/java/org/apache/sedona/common/geography/Functions.java
@@ -85,6 +85,12 @@ public class Functions {
     return toJTS(g).getNumPoints();
   }
 
+  /** Return the WKT text representation of a geography. */
+  public static String asText(Geography g) {
+    if (g == null) return null;
+    return toJTS(g).toText();
+  }
+
   // ─── Level 2: JTS + S2 geodesic metrics ──────────────────────────────────
 
   /**

--- a/common/src/test/java/org/apache/sedona/common/Geography/FunctionTest.java
+++ b/common/src/test/java/org/apache/sedona/common/Geography/FunctionTest.java
@@ -144,6 +144,27 @@ public class FunctionTest {
     assertEquals(5, Functions.nPoints(g));
   }
 
+  @Test
+  public void asText_point() throws ParseException {
+    Geography g = Constructors.geogFromWKT("POINT (1 2)", 4326);
+    String wkt = Functions.asText(g);
+    assertNotNull(wkt);
+    assertTrue("Expected POINT, got: " + wkt, wkt.startsWith("POINT ("));
+  }
+
+  @Test
+  public void asText_polygon() throws ParseException {
+    Geography g = Constructors.geogFromWKT("POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))", 4326);
+    String wkt = Functions.asText(g);
+    assertNotNull(wkt);
+    assertTrue("Expected POLYGON, got: " + wkt, wkt.startsWith("POLYGON ("));
+  }
+
+  @Test
+  public void asText_nullHandling() {
+    assertNull(Functions.asText(null));
+  }
+
   // ─── Level 2: ST_Distance ────────────────────────────────────────────────
 
   @Test

--- a/common/src/test/java/org/apache/sedona/common/Geography/FunctionTest.java
+++ b/common/src/test/java/org/apache/sedona/common/Geography/FunctionTest.java
@@ -29,7 +29,11 @@ import org.apache.sedona.common.S2Geography.PolygonGeography;
 import org.apache.sedona.common.geography.Constructors;
 import org.apache.sedona.common.geography.Functions;
 import org.junit.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
 import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
 
 public class FunctionTest {
   private static final double EPS = 1e-9;
@@ -149,7 +153,10 @@ public class FunctionTest {
     Geography g = Constructors.geogFromWKT("POINT (1 2)", 4326);
     String wkt = Functions.asText(g);
     assertNotNull(wkt);
-    assertTrue("Expected POINT, got: " + wkt, wkt.startsWith("POINT ("));
+    Point p = (Point) new WKTReader().read(wkt);
+    // S2 round-trip may introduce sub-nanometer floating-point drift; use a loose tolerance.
+    assertEquals(1.0, p.getX(), 1e-9);
+    assertEquals(2.0, p.getY(), 1e-9);
   }
 
   @Test
@@ -157,7 +164,14 @@ public class FunctionTest {
     Geography g = Constructors.geogFromWKT("POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))", 4326);
     String wkt = Functions.asText(g);
     assertNotNull(wkt);
-    assertTrue("Expected POLYGON, got: " + wkt, wkt.startsWith("POLYGON ("));
+    Polygon poly = (Polygon) new WKTReader().read(wkt);
+    Coordinate[] ring = poly.getExteriorRing().getCoordinates();
+    assertEquals(5, ring.length);
+    double[][] expected = {{0, 0}, {1, 0}, {1, 1}, {0, 1}, {0, 0}};
+    for (int i = 0; i < expected.length; i++) {
+      assertEquals("ring[" + i + "].x", expected[i][0], ring[i].x, 1e-9);
+      assertEquals("ring[" + i + "].y", expected[i][1], ring[i].y, 1e-9);
+    }
   }
 
   @Test

--- a/docs/api/sql/geography/Geography-Functions.md
+++ b/docs/api/sql/geography/Geography-Functions.md
@@ -42,6 +42,7 @@ These functions operate on geography type objects.
 | Function | Return type | Description | Since |
 | :--- | :--- | :--- | :--- |
 | [ST_AsEWKT](Geography-Functions/ST_AsEWKT.md) | String | Return the Extended Well-Known Text representation of a geography. | v1.8.0 |
+| [ST_AsText](Geography-Functions/ST_AsText.md) | String | Return the Well-Known Text (WKT) representation of a geography. | v1.9.0 |
 | [ST_Envelope](Geography-Functions/ST_Envelope.md) | Geography | Return the bounding box (envelope) of a geography. Supports anti-meridian splitting. | v1.8.0 |
 | [ST_NPoints](Geography-Functions/ST_NPoints.md) | Integer | Return the number of points (vertices) in a geography. | v1.9.0 |
 | [ST_Distance](Geography-Functions/ST_Distance.md) | Double | Return the minimum geodesic distance between two geographies in meters. | v1.9.0 |

--- a/docs/api/sql/geography/Geography-Functions.md
+++ b/docs/api/sql/geography/Geography-Functions.md
@@ -42,7 +42,7 @@ These functions operate on geography type objects.
 | Function | Return type | Description | Since |
 | :--- | :--- | :--- | :--- |
 | [ST_AsEWKT](Geography-Functions/ST_AsEWKT.md) | String | Return the Extended Well-Known Text representation of a geography. | v1.8.0 |
-| [ST_AsText](Geography-Functions/ST_AsText.md) | String | Return the Well-Known Text (WKT) representation of a geography. | v1.9.0 |
+| [ST_AsText](Geography-Functions/ST_AsText.md) | String | Return the Well-Known Text (WKT) representation of a geography. | v1.9.1 |
 | [ST_Envelope](Geography-Functions/ST_Envelope.md) | Geography | Return the bounding box (envelope) of a geography. Supports anti-meridian splitting. | v1.8.0 |
 | [ST_NPoints](Geography-Functions/ST_NPoints.md) | Integer | Return the number of points (vertices) in a geography. | v1.9.0 |
 | [ST_Distance](Geography-Functions/ST_Distance.md) | Double | Return the minimum geodesic distance between two geographies in meters. | v1.9.0 |

--- a/docs/api/sql/geography/Geography-Functions/ST_AsText.md
+++ b/docs/api/sql/geography/Geography-Functions/ST_AsText.md
@@ -27,7 +27,7 @@ Format:
 
 Return type: `String`
 
-Since: `v1.9.0`
+Since: `v1.9.1`
 
 SQL Example
 

--- a/docs/api/sql/geography/Geography-Functions/ST_AsText.md
+++ b/docs/api/sql/geography/Geography-Functions/ST_AsText.md
@@ -1,0 +1,42 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_AsText
+
+Introduction: Returns the Well-Known Text (WKT) representation of a geography object.
+
+Format:
+
+`ST_AsText (A: Geography)`
+
+Return type: `String`
+
+Since: `v1.9.0`
+
+SQL Example
+
+```sql
+SELECT ST_AsText(ST_GeogFromWKT('POINT (1 2)'));
+```
+
+Output:
+
+```
+POINT (1 2)
+```

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
@@ -571,7 +571,9 @@ private[apache] case class ST_SimplifyPolygonHull(inputExpressions: Seq[Expressi
 }
 
 private[apache] case class ST_AsText(inputExpressions: Seq[Expression])
-    extends InferredExpression(Functions.asWKT _) {
+    extends InferredExpression(
+      inferrableFunction1(Functions.asWKT),
+      inferrableFunction1(org.apache.sedona.common.geography.Functions.asText)) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)

--- a/spark/common/src/test/scala/org/apache/sedona/sql/geography/GeographyFunctionTest.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/geography/GeographyFunctionTest.scala
@@ -23,7 +23,8 @@ import org.apache.sedona.sql.TestBaseScala
 import org.apache.spark.sql.functions.{col, lit}
 import org.apache.spark.sql.sedona_sql.expressions.{st_constructors, st_functions, st_predicates}
 import org.junit.Assert.{assertEquals, assertNotNull, assertTrue}
-import org.locationtech.jts.geom.Geometry
+import org.locationtech.jts.geom.{Geometry, Point}
+import org.locationtech.jts.io.WKTReader
 
 /**
  * Spark SQL integration tests for Geography ST functions. Tests one representative function per
@@ -93,8 +94,10 @@ class GeographyFunctionTest extends TestBaseScala {
         .sql("SELECT ST_AsText(ST_GeogFromWKT('POINT (1 2)', 4326)) AS wkt")
         .first()
       val wkt = row.getString(0)
-      // S2 round-trip may introduce sub-nanometer floating-point drift
-      assertTrue(s"Expected POINT near (1, 2), got: $wkt", wkt.startsWith("POINT ("))
+      val point = new WKTReader().read(wkt).asInstanceOf[Point]
+      // S2 round-trip may introduce sub-nanometer floating-point drift; use a loose tolerance.
+      assertEquals(1.0, point.getX, 1e-9)
+      assertEquals(2.0, point.getY, 1e-9)
     }
   }
 

--- a/spark/common/src/test/scala/org/apache/sedona/sql/geography/GeographyFunctionTest.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/geography/GeographyFunctionTest.scala
@@ -77,7 +77,7 @@ class GeographyFunctionTest extends TestBaseScala {
     }
   }
 
-  // ─── Level 1: ST_NPoints ───────────────────────────────────────────────
+  // ─── Level 1: ST_NPoints, ST_AsText ────────────────────────────────────
 
   describe("Level 1: Structural") {
 
@@ -86,6 +86,15 @@ class GeographyFunctionTest extends TestBaseScala {
         .sql("SELECT ST_NPoints(ST_GeogFromWKT('LINESTRING (0 0, 1 1, 2 2)', 4326)) AS n")
         .first()
       assertEquals(3, row.getInt(0))
+    }
+
+    it("ST_AsText") {
+      val row = sparkSession
+        .sql("SELECT ST_AsText(ST_GeogFromWKT('POINT (1 2)', 4326)) AS wkt")
+        .first()
+      val wkt = row.getString(0)
+      // S2 round-trip may introduce sub-nanometer floating-point drift
+      assertTrue(s"Expected POINT near (1, 2), got: $wkt", wkt.startsWith("POINT ("))
     }
   }
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #<issue_number>

## What changes were proposed in this PR?
  - Adds Geography dual-dispatch to ST_AsText — now returns WKT for both Geometry and Geography inputs.
  - Follow-up to #2831; L1 tier (Geography path delegates to JTS via getJTSGeometry().toText()).

## How was this patch tested?
  - mvn -pl common -am test -Dtest=FunctionTest
  - New Spark SQL case in GeographyFunctionTest

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.
