### PR TITLE
[GH-2830] Adds Geography dual-dispatch to ST_GeometryType

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/geography/Functions.java
+++ b/common/src/main/java/org/apache/sedona/common/geography/Functions.java
@@ -85,6 +85,12 @@ public class Functions {
     return toJTS(g).getNumPoints();
   }
 
+  /** Return the geometry type string of a geography, prefixed with "ST_". */
+  public static String geometryType(Geography g) {
+    if (g == null) return null;
+    return "ST_" + toJTS(g).getGeometryType();
+  }
+
   // ─── Level 2: JTS + S2 geodesic metrics ──────────────────────────────────
 
   /**

--- a/common/src/test/java/org/apache/sedona/common/Geography/FunctionTest.java
+++ b/common/src/test/java/org/apache/sedona/common/Geography/FunctionTest.java
@@ -163,7 +163,7 @@ public class FunctionTest {
   }
 
   @Test
-  public void geometryType_multiPoint() throws ParseException {
+  public void geometryType_multipoint() throws ParseException {
     Geography g = Constructors.geogFromWKT("MULTIPOINT ((0 0), (1 1))", 4326);
     assertEquals("ST_MultiPoint", Functions.geometryType(g));
   }

--- a/common/src/test/java/org/apache/sedona/common/Geography/FunctionTest.java
+++ b/common/src/test/java/org/apache/sedona/common/Geography/FunctionTest.java
@@ -144,6 +144,35 @@ public class FunctionTest {
     assertEquals(5, Functions.nPoints(g));
   }
 
+  @Test
+  public void geometryType_point() throws ParseException {
+    Geography g = Constructors.geogFromWKT("POINT (1 2)", 4326);
+    assertEquals("ST_Point", Functions.geometryType(g));
+  }
+
+  @Test
+  public void geometryType_linestring() throws ParseException {
+    Geography g = Constructors.geogFromWKT("LINESTRING (0 0, 1 1, 2 2)", 4326);
+    assertEquals("ST_LineString", Functions.geometryType(g));
+  }
+
+  @Test
+  public void geometryType_polygon() throws ParseException {
+    Geography g = Constructors.geogFromWKT("POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))", 4326);
+    assertEquals("ST_Polygon", Functions.geometryType(g));
+  }
+
+  @Test
+  public void geometryType_multiPoint() throws ParseException {
+    Geography g = Constructors.geogFromWKT("MULTIPOINT ((0 0), (1 1))", 4326);
+    assertEquals("ST_MultiPoint", Functions.geometryType(g));
+  }
+
+  @Test
+  public void geometryType_nullHandling() {
+    assertNull(Functions.geometryType(null));
+  }
+
   // ─── Level 2: ST_Distance ────────────────────────────────────────────────
 
   @Test

--- a/docs/api/sql/geography/Geography-Functions.md
+++ b/docs/api/sql/geography/Geography-Functions.md
@@ -43,6 +43,7 @@ These functions operate on geography type objects.
 | :--- | :--- | :--- | :--- |
 | [ST_AsEWKT](Geography-Functions/ST_AsEWKT.md) | String | Return the Extended Well-Known Text representation of a geography. | v1.8.0 |
 | [ST_Envelope](Geography-Functions/ST_Envelope.md) | Geography | Return the bounding box (envelope) of a geography. Supports anti-meridian splitting. | v1.8.0 |
+| [ST_GeometryType](Geography-Functions/ST_GeometryType.md) | String | Return the type of a geography as a string (e.g., "ST_Point", "ST_Polygon"). | v1.9.1 |
 | [ST_NPoints](Geography-Functions/ST_NPoints.md) | Integer | Return the number of points (vertices) in a geography. | v1.9.0 |
 | [ST_Distance](Geography-Functions/ST_Distance.md) | Double | Return the minimum geodesic distance between two geographies in meters. | v1.9.0 |
 | [ST_Contains](Geography-Functions/ST_Contains.md) | Boolean | Test whether geography A fully contains geography B. | v1.9.0 |

--- a/docs/api/sql/geography/Geography-Functions/ST_GeometryType.md
+++ b/docs/api/sql/geography/Geography-Functions/ST_GeometryType.md
@@ -1,0 +1,42 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_GeometryType
+
+Introduction: Returns the type of the geography object as a string (e.g., "ST_Point", "ST_Polygon", "ST_LineString").
+
+Format:
+
+`ST_GeometryType (A: Geography)`
+
+Return type: `String`
+
+Since: `v1.9.1`
+
+SQL Example
+
+```sql
+SELECT ST_GeometryType(ST_GeogFromWKT('POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))'));
+```
+
+Output:
+
+```
+ST_Polygon
+```

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
@@ -631,7 +631,9 @@ private[apache] case class ST_SetSRID(inputExpressions: Seq[Expression])
 }
 
 private[apache] case class ST_GeometryType(inputExpressions: Seq[Expression])
-    extends InferredExpression(Functions.geometryType _) {
+    extends InferredExpression(
+      inferrableFunction1(Functions.geometryType),
+      inferrableFunction1(org.apache.sedona.common.geography.Functions.geometryType)) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)

--- a/spark/common/src/test/scala/org/apache/sedona/sql/geography/GeographyFunctionTest.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/geography/GeographyFunctionTest.scala
@@ -97,8 +97,7 @@ class GeographyFunctionTest extends TestBaseScala {
 
     it("ST_GeometryType polygon") {
       val row = sparkSession
-        .sql(
-          "SELECT ST_GeometryType(ST_GeogFromWKT('POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))', 4326)) AS t")
+        .sql("SELECT ST_GeometryType(ST_GeogFromWKT('POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))', 4326)) AS t")
         .first()
       assertEquals("ST_Polygon", row.getString(0))
     }

--- a/spark/common/src/test/scala/org/apache/sedona/sql/geography/GeographyFunctionTest.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/geography/GeographyFunctionTest.scala
@@ -77,7 +77,7 @@ class GeographyFunctionTest extends TestBaseScala {
     }
   }
 
-  // ─── Level 1: ST_NPoints ───────────────────────────────────────────────
+  // ─── Level 1: ST_NPoints, ST_GeometryType ──────────────────────────────
 
   describe("Level 1: Structural") {
 
@@ -86,6 +86,21 @@ class GeographyFunctionTest extends TestBaseScala {
         .sql("SELECT ST_NPoints(ST_GeogFromWKT('LINESTRING (0 0, 1 1, 2 2)', 4326)) AS n")
         .first()
       assertEquals(3, row.getInt(0))
+    }
+
+    it("ST_GeometryType point") {
+      val row = sparkSession
+        .sql("SELECT ST_GeometryType(ST_GeogFromWKT('POINT (1 2)', 4326)) AS t")
+        .first()
+      assertEquals("ST_Point", row.getString(0))
+    }
+
+    it("ST_GeometryType polygon") {
+      val row = sparkSession
+        .sql(
+          "SELECT ST_GeometryType(ST_GeogFromWKT('POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))', 4326)) AS t")
+        .first()
+      assertEquals("ST_Polygon", row.getString(0))
     }
   }
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #<issue_number>

## What changes were proposed in this PR?
  - Adds Geography dual-dispatch to ST_GeometryType — returns type strings like ST_Point, ST_Polygon for both Geometry and Geography inputs.
  - Follow-up to #2831; L1 tier (Geography path delegates to JTS via "ST_" + getJTSGeometry().getGeometryType()).

## How was this patch tested?
  - mvn -pl common -am test -Dtest=FunctionTest
  - New Spark SQL cases in GeographyFunctionTest

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.
