### PR TITLE
[DOCS] Update Maven coordinates to Sedona 1.9.0 / geotools-wrapper 1.9.0-33.5

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -200,8 +200,8 @@ extra:
     - icon: fontawesome/brands/discord
       link: 'https://discord.gg/9A3k5dEBsY'
   sedona:
-    current_version: 1.8.0
-    current_geotools: 1.8.0-33.1
+    current_version: 1.9.0
+    current_geotools: 1.9.0-33.5
   sedona_create_release:
     current_version: 1.9.0
     current_git_tag: sedona-1.9.0-rc1


### PR DESCRIPTION
## Summary
- The Maven Coordinates docs page renders `{{ sedona.current_version }}` and `{{ sedona.current_geotools }}` from `mkdocs.yml`. These two keys were not bumped when 1.9.0 shipped, so the published page still shows `1.8.0` / `1.8.0-33.1`.
- Bumps `sedona.current_version` to `1.9.0` and `sedona.current_geotools` to `1.9.0-33.5` so the page reflects the current release.

## Test plan
- [ ] Build the docs locally (`mkdocs serve`) and confirm the Maven Coordinates page renders the correct versions.