### PR TITLE
[GH-2830] Adds ST_Buffer for the Geography type via dual-dispatch

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/geography/Functions.java
+++ b/common/src/main/java/org/apache/sedona/common/geography/Functions.java
@@ -147,6 +147,53 @@ public class Functions {
     return geography.toEWKT();
   }
 
+  // ─── Level 4: spherical buffer ───────────────────────────────────────────
+
+  /**
+   * Returns a Geography that represents the metric ε-buffer of {@code g} on the sphere, where
+   * {@code radiusMeters} is interpreted as meters along the spheroid. Implementation reuses the
+   * existing geometry-side spheroidal buffer (UTM project → JTS planar buffer → unproject), which
+   * gives accurate sub-UTM-zone results; for very large geographies the UTM round-trip's accuracy
+   * caveats apply (see ST_Buffer's docs).
+   */
+  public static Geography buffer(Geography g, double radiusMeters) {
+    return buffer(g, radiusMeters, "");
+  }
+
+  /**
+   * Geography is inherently spheroidal, so the {@code useSpheroid} flag (only meaningful for the
+   * planar Geometry version of ST_Buffer) is rejected for Geography inputs. This overload exists to
+   * give a clear, actionable error when callers try to pass it; without it the resolver would
+   * coerce the boolean to a string and fail later inside the buffer-parameters parser with a
+   * confusing message.
+   */
+  public static Geography buffer(Geography g, double radiusMeters, boolean useSpheroid) {
+    throw new IllegalArgumentException(
+        "ST_Buffer does not accept a useSpheroid argument for Geography inputs (Geography is "
+            + "always spheroidal). Use ST_Buffer(geog, distance) or "
+            + "ST_Buffer(geog, distance, parameters) instead.");
+  }
+
+  /**
+   * Same as {@link #buffer(Geography, double)} but allows a JTS-style buffer parameters string
+   * ({@code "quad_segs=8 endcap=round join=round mitre_limit=5.0 side=both"}). The string is parsed
+   * by the existing geometry-side parser.
+   */
+  public static Geography buffer(Geography g, double radiusMeters, String parameters) {
+    if (g == null) return null;
+    Geometry jts = toJTS(g);
+    if (jts == null) return null;
+    int srid = g.getSRID();
+    // Geography is always lon/lat; default to WGS84 when the source has no SRID set.
+    jts.setSRID(srid != 0 ? srid : 4326);
+    Geometry buffered =
+        org.apache.sedona.common.Functions.buffer(jts, radiusMeters, true, parameters);
+    if (buffered == null) return null;
+    Geography result = Constructors.geomToGeography(buffered);
+    result.setSRID(srid);
+    return result;
+  }
+
   // ─── Helpers ───────────────────────────────────────────────────────────────
 
   private static Geometry toJTS(Geography g) {

--- a/common/src/test/java/org/apache/sedona/common/Geography/FunctionTest.java
+++ b/common/src/test/java/org/apache/sedona/common/Geography/FunctionTest.java
@@ -251,4 +251,66 @@ public class FunctionTest {
     assertFalse(Functions.contains(g1, null));
     assertFalse(Functions.contains(null, g1));
   }
+
+  // ─── Level 4: ST_Buffer ──────────────────────────────────────────────────
+
+  @Test
+  public void buffer_nullInputReturnsNull() throws ParseException {
+    assertNull(Functions.buffer(null, 100.0));
+    assertNull(Functions.buffer(null, 100.0, "quad_segs=4"));
+  }
+
+  @Test
+  public void buffer_pointProducesEnclosingPolygon() throws ParseException {
+    Geography origin = Constructors.geogFromWKT("POINT (0 0)", 4326);
+    Geography buffered = Functions.buffer(origin, 1000.0); // 1 km on the sphere
+    assertNotNull(buffered);
+    assertEquals("ST_Polygon", Functions.geometryType(buffered));
+    // A point ~785 m NE of origin should fall inside the 1 km buffer.
+    Geography near = Constructors.geogFromWKT("POINT (0.005 0.005)", 4326);
+    assertTrue(Functions.contains(buffered, near));
+    // A point ~1.57 km NE should fall outside.
+    Geography far = Constructors.geogFromWKT("POINT (0.01 0.01)", 4326);
+    assertFalse(Functions.contains(buffered, far));
+  }
+
+  @Test
+  public void buffer_polygonContainsOriginalInterior() throws ParseException {
+    Geography poly =
+        Constructors.geogFromWKT("POLYGON ((0 0, 0.01 0, 0.01 0.01, 0 0.01, 0 0))", 4326);
+    Geography buffered = Functions.buffer(poly, 200.0);
+    assertNotNull(buffered);
+    Geography inside = Constructors.geogFromWKT("POINT (0.005 0.005)", 4326);
+    assertTrue("buffered polygon must contain its centroid", Functions.contains(buffered, inside));
+    // A point 500 m beyond the original polygon's edge but inside the 200 m band would still
+    // be outside; pick a point far enough that the buffer cannot reach it.
+    Geography farOutside = Constructors.geogFromWKT("POINT (1 1)", 4326);
+    assertFalse(Functions.contains(buffered, farOutside));
+  }
+
+  @Test
+  public void buffer_parametersStringHonored() throws ParseException {
+    // quad_segs=2 produces a low-fidelity buffer (octagon for a point); quad_segs=64
+    // produces a much smoother boundary. Vertex counts should differ accordingly.
+    Geography origin = Constructors.geogFromWKT("POINT (0 0)", 4326);
+    Geography coarse = Functions.buffer(origin, 1000.0, "quad_segs=2");
+    Geography fine = Functions.buffer(origin, 1000.0, "quad_segs=64");
+    assertNotNull(coarse);
+    assertNotNull(fine);
+    assertTrue(
+        "fine buffer should have more vertices than coarse",
+        Functions.nPoints(fine) > Functions.nPoints(coarse));
+  }
+
+  @Test
+  public void buffer_negativeRadiusShrinksPolygon() throws ParseException {
+    Geography poly =
+        Constructors.geogFromWKT("POLYGON ((0 0, 0.01 0, 0.01 0.01, 0 0.01, 0 0))", 4326);
+    Geography shrunk = Functions.buffer(poly, -100.0);
+    assertNotNull(shrunk);
+    // Shrunk polygon is either smaller or empty; the original boundary point should now
+    // be outside (or contains() returns false on an empty geometry, which is also acceptable).
+    Geography boundary = Constructors.geogFromWKT("POINT (0 0)", 4326);
+    assertFalse(Functions.contains(shrunk, boundary));
+  }
 }

--- a/docs/api/sql/geography/Geography-Functions.md
+++ b/docs/api/sql/geography/Geography-Functions.md
@@ -43,6 +43,7 @@ These functions operate on geography type objects.
 | :--- | :--- | :--- | :--- |
 | [ST_AsEWKT](Geography-Functions/ST_AsEWKT.md) | String | Return the Extended Well-Known Text representation of a geography. | v1.8.0 |
 | [ST_AsText](Geography-Functions/ST_AsText.md) | String | Return the Well-Known Text (WKT) representation of a geography. | v1.9.1 |
+| [ST_Buffer](Geography-Functions/ST_Buffer.md) | Geography | Return the metric ε-buffer of a geography. Distance is always interpreted as meters along the spheroid. | v1.9.1 |
 | [ST_Envelope](Geography-Functions/ST_Envelope.md) | Geography | Return the bounding box (envelope) of a geography. Supports anti-meridian splitting. | v1.8.0 |
 | [ST_GeometryType](Geography-Functions/ST_GeometryType.md) | String | Return the type of a geography as a string (e.g., "ST_Point", "ST_Polygon"). | v1.9.1 |
 | [ST_NPoints](Geography-Functions/ST_NPoints.md) | Integer | Return the number of points (vertices) in a geography. | v1.9.0 |

--- a/docs/api/sql/geography/Geography-Functions/ST_Buffer.md
+++ b/docs/api/sql/geography/Geography-Functions/ST_Buffer.md
@@ -1,0 +1,93 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_Buffer
+
+Introduction: Returns a `Geography` whose interior is the metric ε-buffer of the input on the sphere. The `distance` argument is always interpreted as **meters** along the spheroid — there is no `useSpheroid` flag because `Geography` is inherently spheroidal.
+
+![ST_Buffer of a Geography point on the sphere](../../../../image/ST_Buffer_geography/ST_Buffer_geography_point.svg "ST_Buffer of a Geography point on the sphere")
+![ST_Buffer of a Geography polygon on the sphere](../../../../image/ST_Buffer_geography/ST_Buffer_geography_polygon.svg "ST_Buffer of a Geography polygon on the sphere")
+
+Internally, Sedona projects the input to the most appropriate UTM zone (selected via `ST_BestSRID`), applies a planar buffer in that zone, and projects the result back to lon/lat. This produces accurate results for inputs that fit inside a single UTM zone (~6° wide). For larger inputs the same accuracy caveats apply as for `ST_Buffer` on `Geometry` with `useSpheroid = true`.
+
+Format:
+
+`ST_Buffer (geog: Geography, distanceMeters: Double)`
+
+`ST_Buffer (geog: Geography, distanceMeters: Double, parameters: String)`
+
+Return type: `Geography`
+
+Since: `v1.9.1`
+
+!!! note "`useSpheroid` is not accepted for Geography inputs"
+    The 3-argument form `ST_Buffer(geom, distance, useSpheroid: Boolean)` from the `Geometry`
+    overload is **rejected** when the first argument is a `Geography`. Geography is inherently
+    spheroidal, so the flag would be either redundant (`useSpheroid = true`) or contradictory
+    (`useSpheroid = false`). A call like
+
+    ```sql
+    SELECT ST_Buffer(ST_GeogFromWKT('POINT(0 0)', 4326), 1000.0, true);  -- ❌ throws
+    ```
+
+    raises:
+
+    ```
+    IllegalArgumentException: ST_Buffer does not accept a useSpheroid argument for
+    Geography inputs (Geography is always spheroidal). Use ST_Buffer(geog, distance) or
+    ST_Buffer(geog, distance, parameters) instead.
+    ```
+
+    Drop the `useSpheroid` argument, or — if you really want a planar buffer — convert to
+    Geometry first via `ST_GeogToGeometry` and use the `Geometry` overload of `ST_Buffer`.
+
+The optional `parameters` string accepts the same JTS-style key/value pairs used by `ST_Buffer` for `Geometry`:
+
+| Key | Default | Allowed values |
+| :--- | :--- | :--- |
+| `quad_segs` | `8` | positive integer — segments per quadrant in curved corners |
+| `endcap` | `round` | `round`, `flat`, `butt`, `square` |
+| `join` | `round` | `round`, `mitre` (or `miter`), `bevel` |
+| `mitre_limit` (or `miter_limit`) | `5.0` | positive decimal |
+| `side` | `both` | `both`, `left`, `right` (single-sided buffer for linestrings) |
+
+Notes:
+
+- A negative `distanceMeters` shrinks polygons (returning a smaller polygon, possibly `EMPTY` when the radius exceeds the polygon's narrowest dimension); for points and lines a negative buffer always produces an empty result.
+- The output `Geography` preserves the input's SRID. If the input has no SRID set, the result is normalised to WGS84 (EPSG:4326).
+
+SQL Example
+
+```sql
+-- 1 km buffer around a point
+SELECT ST_AsText(ST_Buffer(ST_GeogFromWKT('POINT(0 0)', 4326), 1000));
+
+-- 200 m buffer around a polygon, with low-fidelity corners
+SELECT ST_AsText(ST_Buffer(
+  ST_GeogFromWKT('POLYGON((0 0, 0.01 0, 0.01 0.01, 0 0.01, 0 0))', 4326),
+  200,
+  'quad_segs=4 endcap=square'
+));
+
+-- Use the buffer as a containment test
+SELECT ST_Contains(
+  ST_Buffer(ST_GeogFromWKT('POINT(0 0)', 4326), 1000),
+  ST_GeogFromWKT('POINT(0.005 0.005)', 4326)
+);
+```

--- a/docs/image/ST_Buffer_geography/ST_Buffer_geography_point.svg
+++ b/docs/image/ST_Buffer_geography/ST_Buffer_geography_point.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+    <radialGradient id="globePoint" cx="42%" cy="38%" r="65%">
+      <stop offset="0%"  stop-color="#ffffff" stop-opacity="0.95"/>
+      <stop offset="60%" stop-color="#e7e7f7" stop-opacity="0.85"/>
+      <stop offset="100%" stop-color="#c5c5eb" stop-opacity="0.95"/>
+    </radialGradient>
+  </defs>
+
+  <!-- Title -->
+  <text x="250" y="22" text-anchor="middle" font-size="14" font-weight="bold" fill="#333333">ST_Buffer(point, distance) on the sphere</text>
+  <text x="250" y="40" text-anchor="middle" font-size="11" fill="#666666">distance is measured in meters along the spheroid</text>
+
+  <!-- Globe (curvature suggested by gradient) -->
+  <circle cx="250" cy="160" r="88" fill="url(#globePoint)" stroke="#8e8ed0" stroke-width="1.6"/>
+  <!-- Latitude / longitude hints -->
+  <ellipse cx="250" cy="160" rx="88" ry="22" fill="none" stroke="#8e8ed0" stroke-width="0.6" stroke-opacity="0.7"/>
+  <ellipse cx="250" cy="160" rx="22" ry="88" fill="none" stroke="#8e8ed0" stroke-width="0.6" stroke-opacity="0.7"/>
+
+  <!-- Geodesic buffer (an octagonal approximation around the point) -->
+  <polygon points="250,118 280,128 294,158 280,188 250,202 220,188 206,158 220,128"
+           fill="rgba(46,204,113,0.22)" stroke="#2ecc71" stroke-width="1.8"/>
+
+  <!-- Original point -->
+  <circle cx="250" cy="158" r="4.5" fill="#1565C0" stroke="#ffffff" stroke-width="1.2"/>
+
+  <!-- Distance arrow from point to buffer edge -->
+  <line x1="250" y1="158" x2="294" y2="158" stroke="#E53935" stroke-width="1.5"/>
+  <line x1="250" y1="154" x2="250" y2="162" stroke="#E53935" stroke-width="1"/>
+  <line x1="294" y1="148" x2="294" y2="168" stroke="#E53935" stroke-width="1"/>
+  <text x="270" y="151" text-anchor="middle" font-size="11" fill="#E53935" font-weight="bold">d (m)</text>
+
+  <!-- Legend -->
+  <rect x="60" y="265" width="14" height="14" rx="2" fill="url(#globePoint)" stroke="#8e8ed0" stroke-width="1"/>
+  <text x="78" y="276" font-size="11" fill="#333333">Sphere (Earth)</text>
+
+  <circle cx="180" cy="272" r="5" fill="#1565C0" stroke="#ffffff" stroke-width="1"/>
+  <text x="190" y="276" font-size="11" fill="#1565C0">Input point</text>
+
+  <rect x="262" y="265" width="14" height="14" rx="2" fill="rgba(46,204,113,0.4)" stroke="#2ecc71" stroke-width="1"/>
+  <text x="280" y="276" font-size="11" fill="#2ecc71">Buffer (Geography polygon)</text>
+</svg>

--- a/docs/image/ST_Buffer_geography/ST_Buffer_geography_polygon.svg
+++ b/docs/image/ST_Buffer_geography/ST_Buffer_geography_polygon.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" style="background:#ffffff">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+    </style>
+    <radialGradient id="globePoly" cx="42%" cy="38%" r="65%">
+      <stop offset="0%"  stop-color="#ffffff" stop-opacity="0.95"/>
+      <stop offset="60%" stop-color="#e7e7f7" stop-opacity="0.85"/>
+      <stop offset="100%" stop-color="#c5c5eb" stop-opacity="0.95"/>
+    </radialGradient>
+  </defs>
+
+  <!-- Title -->
+  <text x="250" y="22" text-anchor="middle" font-size="14" font-weight="bold" fill="#333333">ST_Buffer(polygon, distance) on the sphere</text>
+  <text x="250" y="40" text-anchor="middle" font-size="11" fill="#666666">UTM-projected planar buffer; result is unprojected back to lon/lat</text>
+
+  <!-- Globe -->
+  <circle cx="250" cy="160" r="88" fill="url(#globePoly)" stroke="#8e8ed0" stroke-width="1.6"/>
+  <ellipse cx="250" cy="160" rx="88" ry="22" fill="none" stroke="#8e8ed0" stroke-width="0.6" stroke-opacity="0.7"/>
+  <ellipse cx="250" cy="160" rx="22" ry="88" fill="none" stroke="#8e8ed0" stroke-width="0.6" stroke-opacity="0.7"/>
+
+  <!-- Outer buffered polygon (offset outward by ~16px to suggest the buffer band) -->
+  <path d="M 218 121
+           Q 230 110, 248 110
+           L 282 110
+           Q 296 113, 300 130
+           L 305 162
+           Q 304 184, 286 192
+           L 234 200
+           Q 215 199, 210 184
+           L 206 152
+           Q 207 132, 218 121 Z"
+        fill="rgba(46,204,113,0.20)" stroke="#2ecc71" stroke-width="1.8"/>
+
+  <!-- Original polygon -->
+  <polygon points="244,140 280,138 290,162 270,182 244,184 224,160"
+           fill="rgba(74,144,217,0.30)" stroke="#1565C0" stroke-width="1.8"/>
+
+  <!-- Distance arrow from polygon edge to buffer edge -->
+  <line x1="290" y1="162" x2="305" y2="162" stroke="#E53935" stroke-width="1.5"/>
+  <line x1="290" y1="156" x2="290" y2="168" stroke="#E53935" stroke-width="1"/>
+  <line x1="305" y1="154" x2="305" y2="170" stroke="#E53935" stroke-width="1"/>
+  <text x="319" y="166" font-size="11" fill="#E53935" font-weight="bold">d (m)</text>
+
+  <!-- Legend -->
+  <rect x="60" y="265" width="14" height="14" rx="2" fill="url(#globePoly)" stroke="#8e8ed0" stroke-width="1"/>
+  <text x="78" y="276" font-size="11" fill="#333333">Sphere (Earth)</text>
+
+  <rect x="170" y="265" width="14" height="14" rx="2" fill="rgba(74,144,217,0.4)" stroke="#1565C0" stroke-width="1"/>
+  <text x="188" y="276" font-size="11" fill="#1565C0">Input polygon</text>
+
+  <rect x="290" y="265" width="14" height="14" rx="2" fill="rgba(46,204,113,0.4)" stroke="#2ecc71" stroke-width="1"/>
+  <text x="308" y="276" font-size="11" fill="#2ecc71">Buffered polygon</text>
+</svg>

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/FunctionResolver.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/FunctionResolver.scala
@@ -86,6 +86,12 @@ object FunctionResolver {
           // All arguments are NullType literals; every overload returns null, so the choice
           // between equally-good matches is semantically irrelevant. Prefer the first candidate.
           ambiguousMatches.head._1
+        } else if (expressions.headOption.exists(_.dataType == NullType)) {
+          // The first argument (the geometry/geography input) is a NullType literal. All
+          // ST_* overloads return null on null input, so the dispatch choice is again
+          // semantically irrelevant — prefer the first registered candidate. This keeps
+          // calls like `ST_Buffer(null, 0)` working after Geography overloads were added.
+          ambiguousMatches.head._1
         } else {
           val ambiguousTypesMsg = ambiguousMatches
             .map { case (function, _) =>

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
@@ -192,7 +192,17 @@ private[apache] case class ST_Buffer(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(Functions.buffer),
       inferrableFunction3(Functions.buffer),
-      inferrableFunction4(Functions.buffer)) {
+      inferrableFunction4(Functions.buffer),
+      inferrableFunction2(org.apache.sedona.common.geography.Functions.buffer),
+      // Explicit type ascription disambiguates the two 3-arg Geography buffer overloads
+      // (`(Geography, double, String)` for the JTS-style parameters string, and
+      // `(Geography, double, boolean)` which throws a clear error if `useSpheroid` is passed).
+      inferrableFunction3(
+        org.apache.sedona.common.geography.Functions
+          .buffer(_: org.apache.sedona.common.S2Geography.Geography, _: Double, _: String)),
+      inferrableFunction3(
+        org.apache.sedona.common.geography.Functions
+          .buffer(_: org.apache.sedona.common.S2Geography.Geography, _: Double, _: Boolean))) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)

--- a/spark/common/src/test/scala/org/apache/sedona/sql/geography/GeographyFunctionTest.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/geography/GeographyFunctionTest.scala
@@ -169,6 +169,91 @@ class GeographyFunctionTest extends TestBaseScala {
     }
   }
 
+  // ─── Level 4: ST_Buffer ────────────────────────────────────────────────
+
+  describe("Level 4: Spherical buffer") {
+
+    it("ST_Buffer of a point produces a polygon containing nearby points") {
+      val row = sparkSession
+        .sql("""
+          SELECT
+            ST_GeometryType(ST_Buffer(ST_GeogFromWKT('POINT(0 0)', 4326), 1000)) AS gtype,
+            ST_Contains(
+              ST_Buffer(ST_GeogFromWKT('POINT(0 0)', 4326), 1000),
+              ST_GeogFromWKT('POINT(0.005 0.005)', 4326)
+            ) AS hits
+        """)
+        .first()
+      assertEquals("ST_Polygon", row.getString(0))
+      assertTrue("buffer should contain a point ~785m away", row.getBoolean(1))
+    }
+
+    it("ST_Buffer of a polygon contains the original interior") {
+      val hits = sparkSession
+        .sql("""
+          SELECT ST_Contains(
+            ST_Buffer(
+              ST_GeogFromWKT('POLYGON((0 0, 0.01 0, 0.01 0.01, 0 0.01, 0 0))', 4326),
+              200
+            ),
+            ST_GeogFromWKT('POINT(0.005 0.005)', 4326)
+          ) AS r
+        """)
+        .first()
+        .getBoolean(0)
+      assertTrue(hits)
+    }
+
+    it("ST_Buffer with parameters string is honored") {
+      // quad_segs=2 produces an octagonal-ish buffer; quad_segs=64 is much smoother.
+      val row = sparkSession
+        .sql("""
+          SELECT
+            ST_NPoints(ST_Buffer(ST_GeogFromWKT('POINT(0 0)', 4326), 1000, 'quad_segs=2')) AS coarse,
+            ST_NPoints(ST_Buffer(ST_GeogFromWKT('POINT(0 0)', 4326), 1000, 'quad_segs=64')) AS fine
+        """)
+        .first()
+      assertTrue(
+        s"fine (${row.getInt(1)}) should have more vertices than coarse (${row.getInt(0)})",
+        row.getInt(1) > row.getInt(0))
+    }
+
+    it("ST_Buffer result survives the GeographyUDT round-trip") {
+      val df = sparkSession
+        .sql("SELECT ST_Buffer(ST_GeogFromWKT('POINT(0 0)', 4326), 500) AS buf")
+      val geog = df.first().get(0).asInstanceOf[Geography]
+      assertTrue(geog.isInstanceOf[WKBGeography])
+      assertEquals(4326, geog.getSRID)
+    }
+
+    it("ST_Buffer with useSpheroid is rejected for Geography inputs") {
+      val ex = intercept[Throwable] {
+        sparkSession
+          .sql("SELECT ST_Buffer(ST_GeogFromWKT('POINT(0 0)', 4326), 1000.0, true) AS b")
+          .first()
+      }
+      // The actual cause may sit one or two layers down inside InferredExpressionException.
+      val msg = Iterator
+        .iterate[Throwable](ex)(t => if (t == null) null else t.getCause)
+        .takeWhile(_ != null)
+        .map(_.getMessage)
+        .mkString(" | ")
+      assert(
+        msg.contains("useSpheroid") && msg.contains("Geography"),
+        s"expected useSpheroid/Geography in message; got: $msg")
+    }
+
+    it("ST_Buffer via DataFrame API") {
+      val df = sparkSession
+        .sql("SELECT 'POINT(0 0)' AS wkt")
+        .select(st_constructors.ST_GeogFromWKT(col("wkt"), lit(4326)).as("g"))
+        .select(st_functions.ST_Buffer(col("g"), lit(1000.0)).as("buf"))
+      val geog = df.first().get(0).asInstanceOf[Geography]
+      assertTrue(geog.isInstanceOf[WKBGeography])
+      assertTrue(geog.toString.startsWith("POLYGON"))
+    }
+  }
+
   // ─── DataFrame API ─────────────────────────────────────────────────────
 
   describe("DataFrame API") {


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #<issue_number>

## What changes were proposed in this PR?

Adds ST_Buffer for the Geography type via dual-dispatch on the existing Catalyst expression. Distance is always interpreted as meters along the spheroid (no useSpheroid flag — Geography is inherently spheroidal). Implementation reuses the proven UTM-projection path that powers Geometry's useSpheroid=true mode (Geography → JTS → FunctionsGeoTools.bufferSpheroid → JTS → Geography).

Also extends FunctionResolver's tie-breaking: when multiple Geometry/Geography overloads tie on coercion score and the first argument is NullType, the first registered candidate wins — keeps ST_Buffer(null, 0) working after dual-dispatch was added.

## How was this patch tested?
Geography common tests (incl. 5 new buffer cases)

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.
