### PR TITLE
[GH-2700] Add 05-geopandas-on-spark notebook

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -24,12 +24,14 @@ on:
     paths:
       - '.github/workflows/docker-build.yml'
       - 'docker/**'
+      - 'docs/usecases/**'
   pull_request:
     branches:
       - '*'
     paths:
       - '.github/workflows/docker-build.yml'
       - 'docker/**'
+      - 'docs/usecases/**'
 env:
   MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=60
 
@@ -50,9 +52,6 @@ jobs:
         include:
           - spark: 4.0.1
             sedona: 'latest'
-            geotools: '33.1'
-          - spark: 4.0.1
-            sedona: 1.8.0
             geotools: '33.1'
     runs-on: ${{ matrix.os }}
     defaults:

--- a/docker/sedona-docker.dockerfile
+++ b/docker/sedona-docker.dockerfile
@@ -21,8 +21,8 @@ ARG shared_workspace=/opt/workspace
 ARG spark_version=4.0.1
 ARG hadoop_s3_version=3.4.1
 ARG aws_sdk_version=2.38.2
-ARG sedona_version=1.8.0
-ARG geotools_wrapper_version=1.8.1-33.1
+ARG sedona_version=1.9.0
+ARG geotools_wrapper_version=1.9.0-33.5
 ARG spark_extension_version=2.14.2
 ARG zeppelin_version=0.12.0
 

--- a/docs/usecases/05-geopandas-on-spark.ipynb
+++ b/docs/usecases/05-geopandas-on-spark.ipynb
@@ -3,34 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "<!--\n",
-    " Licensed to the Apache Software Foundation (ASF) under one\n",
-    " or more contributor license agreements.  See the NOTICE file\n",
-    " distributed with this work for additional information\n",
-    " regarding copyright ownership.  The ASF licenses this file\n",
-    " to you under the Apache License, Version 2.0 (the\n",
-    " \"License\"); you may not use this file except in compliance\n",
-    " with the License.  You may obtain a copy of the License at\n",
-    "\n",
-    "   http://www.apache.org/licenses/LICENSE-2.0\n",
-    "\n",
-    " Unless required by applicable law or agreed to in writing,\n",
-    " software distributed under the License is distributed on an\n",
-    " \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY\n",
-    " KIND, either express or implied.  See the License for the\n",
-    " specific language governing permissions and limitations\n",
-    " under the License.\n",
-    "-->\n",
-    "\n",
-    "# Your GeoPandas notebook, scaled with Sedona\n",
-    "\n",
-    "Sedona ships a `sedona.spark.geopandas` package that mirrors the public GeoPandas API — same constructors, same method names, same return shapes — but runs on a Spark backend so the same code path scales from a laptop to a cluster. We answer:\n",
-    "\n",
-    "> **What does it look like to take a typical GeoPandas script and run it on Sedona?**\n",
-    "\n",
-    "Along the way we use methods that landed in 1.8 / 1.9 — `convex_hull`, `concave_hull`, `voronoi_polygons`, `clip_by_rect`, `to_crs`, `total_bounds`, `to_geopandas` — and show how to drop into SQL when GeoPandas's API doesn't have what you need. Data is the Natural Earth countries shapefile already shipped with the docker image; no network required."
-   ]
+   "source": "<!--\n Licensed to the Apache Software Foundation (ASF) under one\n or more contributor license agreements.  See the NOTICE file\n distributed with this work for additional information\n regarding copyright ownership.  The ASF licenses this file\n to you under the Apache License, Version 2.0 (the\n \"License\"); you may not use this file except in compliance\n with the License.  You may obtain a copy of the License at\n\n   http://www.apache.org/licenses/LICENSE-2.0\n\n Unless required by applicable law or agreed to in writing,\n software distributed under the License is distributed on an\n \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY\n KIND, either express or implied.  See the License for the\n specific language governing permissions and limitations\n under the License.\n-->\n\n# Your GeoPandas notebook, scaled with Sedona\n\nSedona ships a `sedona.spark.geopandas` package that mirrors the public GeoPandas API \u2014 same constructors, same method names, same return shapes \u2014 but runs on a Spark backend so the same code path scales from a laptop to a cluster. We answer:\n\n> **What does it look like to take a typical GeoPandas script and run it on Sedona?**\n\nAlong the way we exercise the methods that landed in 1.8 / 1.9 and that this notebook actually calls \u2014 `convex_hull`, `clip_by_rect`, `total_bounds`, `to_geopandas` \u2014 and show how to drop into SQL when the GeoPandas-style API doesn't have what you need (`ST_VoronoiPolygons` + `ST_Collect_Agg`, `ST_DistanceSpheroid`).\n\n**Requires Sedona \u2265 1.9.0.** `clip_by_rect` lands in 1.9.0 and the notebook will fail on older versions of the docker image.\n\nData is the Natural Earth countries shapefile already shipped with the docker image; no network required."
   },
   {
    "cell_type": "markdown",
@@ -64,7 +37,7 @@
    "source": [
     "## 2. Load a shapefile with the same `read_file` you already know\n",
     "\n",
-    "`sedona.spark.geopandas.read_file` is a drop-in for `geopandas.read_file`. The only twist when pointing at a directory is to declare the format explicitly — the file extension can't be inferred for shapefile bundles."
+    "`sedona.spark.geopandas.read_file` is a drop-in for `geopandas.read_file`. The only twist when pointing at a directory is to declare the format explicitly \u2014 the file extension can't be inferred for shapefile bundles."
    ]
   },
   {
@@ -77,7 +50,7 @@
     "\n",
     "countries = sgpd.read_file(\"data/ne_50m_admin_0_countries_lakes\", format=\"shapefile\")\n",
     "print(f\"loaded {len(countries)} countries\")\n",
-    "print(\"columns:\", countries.columns.tolist()[:6], \"…\")\n",
+    "print(\"columns:\", countries.columns.tolist()[:6], \"\u2026\")\n",
     "countries[[\"NAME\", \"CONTINENT\", \"POP_EST\"]].head(5)"
    ]
   },
@@ -85,7 +58,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3. Filter, then derive — the same idioms as vanilla GeoPandas\n",
+    "## 3. Filter, then derive \u2014 the same idioms as vanilla GeoPandas\n",
     "\n",
     "Boolean indexing, `.geometry` accessor, `centroid`, `convex_hull`, `area`, and `total_bounds` all work exactly as they do in `geopandas`."
    ]
@@ -158,21 +131,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from shapely.wkt import loads as wkt_loads\n",
-    "from shapely.geometry import shape\n",
-    "\n",
-    "voronoi_shapely = (\n",
-    "    wkt_loads(voronoi_geom.wkt) if hasattr(voronoi_geom, \"wkt\") else voronoi_geom\n",
-    ")\n",
-    "voronoi_cells = sgpd.GeoSeries([g for g in voronoi_shapely.geoms])\n",
-    "print(f\"{len(voronoi_cells)} Voronoi cells before clip\")\n",
-    "\n",
-    "africa_bbox = (-20.0, -36.0, 52.0, 38.0)\n",
-    "clipped = voronoi_cells.clip_by_rect(*africa_bbox)\n",
-    "print(f\"{len(clipped)} Voronoi cells after clip_by_rect\")\n",
-    "clipped.head(2)"
-   ]
+   "source": "from shapely.wkt import loads as wkt_loads\n\nvoronoi_shapely = (\n    wkt_loads(voronoi_geom.wkt) if hasattr(voronoi_geom, \"wkt\") else voronoi_geom\n)\nvoronoi_cells = sgpd.GeoSeries([g for g in voronoi_shapely.geoms])\nprint(f\"{len(voronoi_cells)} Voronoi cells before clip\")\n\nafrica_bbox = (-20.0, -36.0, 52.0, 38.0)\nclipped = voronoi_cells.clip_by_rect(*africa_bbox)\nprint(f\"{len(clipped)} Voronoi cells after clip_by_rect\")\nclipped.head(2)"
   },
   {
    "cell_type": "markdown",
@@ -210,11 +169,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 7. Drop into SQL whenever you need a function the API doesn't expose\n",
-    "\n",
-    "`<gdf>.spark.frame()` returns the underlying Spark DataFrame, so the entire `ST_*` SQL catalog is one `createOrReplaceTempView` away. Here we ask which African capitals are closest to (0°N, 0°E) using `ST_DistanceSpheroid` (great-circle distance in metres), without leaving the data we already loaded with the geopandas API."
-   ]
+   "source": "## 7. Drop into SQL whenever you need a function the API doesn't expose\n\n`<gdf>.spark.frame()` returns the underlying Spark DataFrame, so the entire `ST_*` SQL catalog is one `createOrReplaceTempView` away. Here we ask which African countries' centroids are closest to (0\u00b0N, 0\u00b0E) using `ST_DistanceSpheroid` (great-circle distance in metres), without leaving the data we already loaded with the geopandas API."
   },
   {
    "cell_type": "code",
@@ -246,11 +201,11 @@
     "We took a small GeoPandas-style script and ran it on Sedona's Spark backend without rewriting it as Spark SQL:\n",
     "\n",
     "1. `read_file(..., format=\"shapefile\")` loaded the Natural Earth countries shapefile into a Sedona GeoDataFrame.\n",
-    "2. Vanilla GeoPandas idioms — boolean filtering, `.geometry`, `.centroid`, `.convex_hull`, `.area`, `.total_bounds` — produced the per-country summary.\n",
+    "2. Vanilla GeoPandas idioms \u2014 boolean filtering, `.geometry`, `.centroid`, `.convex_hull`, `.area`, `.total_bounds` \u2014 produced the per-country summary.\n",
     "3. SQL filled in the gap when the geopandas-on-Spark API didn't have an aggregator: `ST_VoronoiPolygons(ST_Collect_Agg(ST_Centroid(geometry)))` produced a single Voronoi tessellation from many points.\n",
     "4. `clip_by_rect`, also new in 1.9, cropped the result to a continent.\n",
     "5. `to_geopandas()` materialized the small final result as a vanilla `geopandas.GeoDataFrame` for plotting.\n",
-    "6. `gdf.spark.frame()` exposed the Spark DataFrame so we could mix in arbitrary SQL — for example `ST_DistanceSpheroid` — without leaving the same dataset.\n",
+    "6. `gdf.spark.frame()` exposed the Spark DataFrame so we could mix in arbitrary SQL \u2014 for example `ST_DistanceSpheroid` \u2014 without leaving the same dataset.\n",
     "\n",
     "The same code path runs on a multi-node Spark cluster against billion-row datasets; only the `master(...)` URL changes."
    ]

--- a/docs/usecases/05-geopandas-on-spark.ipynb
+++ b/docs/usecases/05-geopandas-on-spark.ipynb
@@ -1,0 +1,280 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<!--\n",
+    " Licensed to the Apache Software Foundation (ASF) under one\n",
+    " or more contributor license agreements.  See the NOTICE file\n",
+    " distributed with this work for additional information\n",
+    " regarding copyright ownership.  The ASF licenses this file\n",
+    " to you under the Apache License, Version 2.0 (the\n",
+    " \"License\"); you may not use this file except in compliance\n",
+    " with the License.  You may obtain a copy of the License at\n",
+    "\n",
+    "   http://www.apache.org/licenses/LICENSE-2.0\n",
+    "\n",
+    " Unless required by applicable law or agreed to in writing,\n",
+    " software distributed under the License is distributed on an\n",
+    " \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY\n",
+    " KIND, either express or implied.  See the License for the\n",
+    " specific language governing permissions and limitations\n",
+    " under the License.\n",
+    "-->\n",
+    "\n",
+    "# Your GeoPandas notebook, scaled with Sedona\n",
+    "\n",
+    "Sedona ships a `sedona.spark.geopandas` package that mirrors the public GeoPandas API — same constructors, same method names, same return shapes — but runs on a Spark backend so the same code path scales from a laptop to a cluster. We answer:\n",
+    "\n",
+    "> **What does it look like to take a typical GeoPandas script and run it on Sedona?**\n",
+    "\n",
+    "Along the way we use methods that landed in 1.8 / 1.9 — `convex_hull`, `concave_hull`, `voronoi_polygons`, `clip_by_rect`, `to_crs`, `total_bounds`, `to_geopandas` — and show how to drop into SQL when GeoPandas's API doesn't have what you need. Data is the Natural Earth countries shapefile already shipped with the docker image; no network required."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Connect to Spark through SedonaContext\n",
+    "\n",
+    "One difference from the other example notebooks: `sedona.spark.geopandas` runs on top of **pandas-on-Spark** (`pyspark.pandas`), which currently requires Spark's ANSI mode to be off. We set that flag explicitly when building the session."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sedona.spark import SedonaContext\n",
+    "\n",
+    "config = (\n",
+    "    SedonaContext.builder()\n",
+    "    .master(\"spark://localhost:7077\")\n",
+    "    .config(\"spark.sql.ansi.enabled\", \"false\")\n",
+    "    .getOrCreate()\n",
+    ")\n",
+    "sedona = SedonaContext.create(config)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Load a shapefile with the same `read_file` you already know\n",
+    "\n",
+    "`sedona.spark.geopandas.read_file` is a drop-in for `geopandas.read_file`. The only twist when pointing at a directory is to declare the format explicitly — the file extension can't be inferred for shapefile bundles."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sedona.spark import geopandas as sgpd\n",
+    "\n",
+    "countries = sgpd.read_file(\"data/ne_50m_admin_0_countries_lakes\", format=\"shapefile\")\n",
+    "print(f\"loaded {len(countries)} countries\")\n",
+    "print(\"columns:\", countries.columns.tolist()[:6], \"…\")\n",
+    "countries[[\"NAME\", \"CONTINENT\", \"POP_EST\"]].head(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Filter, then derive — the same idioms as vanilla GeoPandas\n",
+    "\n",
+    "Boolean indexing, `.geometry` accessor, `centroid`, `convex_hull`, `area`, and `total_bounds` all work exactly as they do in `geopandas`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "africa = countries[countries.CONTINENT == \"Africa\"]\n",
+    "print(f\"{len(africa)} African countries\")\n",
+    "\n",
+    "geom = africa.geometry\n",
+    "print(\"\\nbounding box of the continent:\", tuple(round(b, 2) for b in geom.total_bounds))\n",
+    "\n",
+    "summary = africa[[\"NAME\"]].copy()\n",
+    "summary[\"centroid\"] = geom.centroid\n",
+    "summary[\"area_deg2\"] = geom.area\n",
+    "summary[\"hull_area_deg2\"] = geom.convex_hull.area\n",
+    "summary.sort_values(\"area_deg2\", ascending=False).head(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Voronoi catchments via `ST_VoronoiPolygons` + `ST_Collect_Agg`\n",
+    "\n",
+    "`GeoSeries.voronoi_polygons()` runs a Voronoi tessellation **per row**, which only makes sense if a single row already contains a MultiPoint. To compute one Voronoi diagram from many points, drop into SQL: aggregate every centroid into a single MultiPoint with the `ST_Collect_Agg` aggregator (new in 1.8.1), then call `ST_VoronoiPolygons` on the aggregate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "africa.spark.frame().createOrReplaceTempView(\"africa\")\n",
+    "\n",
+    "voronoi_geom = sedona.sql(\"\"\"\n",
+    "    SELECT ST_VoronoiPolygons(ST_Collect_Agg(ST_Centroid(geometry))) AS v\n",
+    "    FROM africa\n",
+    "\"\"\").first()[0]\n",
+    "\n",
+    "stats = sedona.sql(\"\"\"\n",
+    "    SELECT ST_NumGeometries(v)        AS cells,\n",
+    "           ROUND(ST_Area(v), 2)       AS total_area_deg2,\n",
+    "           ROUND(ST_XMin(v), 2)       AS xmin,\n",
+    "           ROUND(ST_YMin(v), 2)       AS ymin,\n",
+    "           ROUND(ST_XMax(v), 2)       AS xmax,\n",
+    "           ROUND(ST_YMax(v), 2)       AS ymax\n",
+    "    FROM (SELECT ST_VoronoiPolygons(ST_Collect_Agg(ST_Centroid(geometry))) AS v\n",
+    "          FROM africa)\n",
+    "\"\"\")\n",
+    "stats.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Clip the Voronoi diagram to a continental bounding rectangle\n",
+    "\n",
+    "`clip_by_rect(xmin, ymin, xmax, ymax)` (new in 1.9) is the geopandas-style way to crop. We use it to confine the Voronoi cells to a generous Africa bbox so they line up cleanly with the country polygons in the final plot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from shapely.wkt import loads as wkt_loads\n",
+    "from shapely.geometry import shape\n",
+    "\n",
+    "voronoi_shapely = (\n",
+    "    wkt_loads(voronoi_geom.wkt) if hasattr(voronoi_geom, \"wkt\") else voronoi_geom\n",
+    ")\n",
+    "voronoi_cells = sgpd.GeoSeries([g for g in voronoi_shapely.geoms])\n",
+    "print(f\"{len(voronoi_cells)} Voronoi cells before clip\")\n",
+    "\n",
+    "africa_bbox = (-20.0, -36.0, 52.0, 38.0)\n",
+    "clipped = voronoi_cells.clip_by_rect(*africa_bbox)\n",
+    "print(f\"{len(clipped)} Voronoi cells after clip_by_rect\")\n",
+    "clipped.head(2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Hand off to vanilla GeoPandas for plotting\n",
+    "\n",
+    "When the data is small enough, `to_geopandas()` materializes a Sedona GeoDataFrame as a vanilla `geopandas.GeoDataFrame` so it can be plotted with the standard `.plot(ax=...)` machinery."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "africa_gp = africa.to_geopandas()\n",
+    "voronoi_gp = clipped.to_geopandas()\n",
+    "\n",
+    "fig, ax = plt.subplots(1, 1, figsize=(8, 8))\n",
+    "africa_gp.plot(ax=ax, color=\"#fdf6e3\", edgecolor=\"#586e75\", linewidth=0.6)\n",
+    "voronoi_gp.boundary.plot(ax=ax, color=\"#dc322f\", linewidth=0.4, alpha=0.8)\n",
+    "africa_gp.geometry.centroid.plot(ax=ax, color=\"#dc322f\", markersize=4)\n",
+    "ax.set_title(\"Africa: Voronoi catchments around country centroids\")\n",
+    "ax.set_xlabel(\"longitude\")\n",
+    "ax.set_ylabel(\"latitude\")\n",
+    "ax.set_xlim(africa_bbox[0], africa_bbox[2])\n",
+    "ax.set_ylim(africa_bbox[1], africa_bbox[3])\n",
+    "fig.tight_layout()\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Drop into SQL whenever you need a function the API doesn't expose\n",
+    "\n",
+    "`<gdf>.spark.frame()` returns the underlying Spark DataFrame, so the entire `ST_*` SQL catalog is one `createOrReplaceTempView` away. Here we ask which African capitals are closest to (0°N, 0°E) using `ST_DistanceSpheroid` (great-circle distance in metres), without leaving the data we already loaded with the geopandas API."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "africa.spark.frame().createOrReplaceTempView(\"africa\")\n",
+    "\n",
+    "closest = sedona.sql(\"\"\"\n",
+    "    SELECT NAME,\n",
+    "           ROUND(ST_DistanceSpheroid(\n",
+    "               ST_Centroid(geometry),\n",
+    "               ST_Point(0.0, 0.0)\n",
+    "           ) / 1000.0, 1) AS km_from_origin\n",
+    "    FROM africa\n",
+    "    ORDER BY km_from_origin ASC\n",
+    "    LIMIT 10\n",
+    "\"\"\")\n",
+    "closest.show(truncate=40)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What just happened?\n",
+    "\n",
+    "We took a small GeoPandas-style script and ran it on Sedona's Spark backend without rewriting it as Spark SQL:\n",
+    "\n",
+    "1. `read_file(..., format=\"shapefile\")` loaded the Natural Earth countries shapefile into a Sedona GeoDataFrame.\n",
+    "2. Vanilla GeoPandas idioms — boolean filtering, `.geometry`, `.centroid`, `.convex_hull`, `.area`, `.total_bounds` — produced the per-country summary.\n",
+    "3. SQL filled in the gap when the geopandas-on-Spark API didn't have an aggregator: `ST_VoronoiPolygons(ST_Collect_Agg(ST_Centroid(geometry)))` produced a single Voronoi tessellation from many points.\n",
+    "4. `clip_by_rect`, also new in 1.9, cropped the result to a continent.\n",
+    "5. `to_geopandas()` materialized the small final result as a vanilla `geopandas.GeoDataFrame` for plotting.\n",
+    "6. `gdf.spark.frame()` exposed the Spark DataFrame so we could mix in arbitrary SQL — for example `ST_DistanceSpheroid` — without leaving the same dataset.\n",
+    "\n",
+    "The same code path runs on a multi-node Spark cluster against billion-row datasets; only the `master(...)` URL changes."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes part of #2700.

## What changes were proposed in this PR?

Continues the docker-image notebook refresh series (issue #2700, milestone 1.9.1) and stacks two infrastructure fixes that this series exposed.

**New shipped notebook — `docs/usecases/05-geopandas-on-spark.ipynb`**

The `sedona.spark.geopandas` package mirrors the public GeoPandas API and runs on top of `pyspark.pandas` / Spark; the notebook walks the *scale up your geopandas script with Sedona* path end-to-end. Workflow on the Natural Earth countries shapefile already shipped with the docker image — no new data, no network:

1. SedonaContext setup, including `spark.sql.ansi.enabled=false` (pyspark.pandas, the backend for `sedona.spark.geopandas`, refuses to start under Spark 4.x ANSI mode — see [`pyspark/pandas/utils.py:480-500`](https://github.com/apache/spark/blob/v4.0.1/python/pyspark/pandas/utils.py#L480), `[PANDAS_API_ON_SPARK_FAIL_ON_ANSI_MODE]`).
2. `read_file(..., format="shapefile")` — drop-in for `geopandas.read_file`.
3. Vanilla GeoPandas idioms: boolean filtering by `CONTINENT`, `.geometry`, `.centroid`, `.convex_hull`, `.area`, `.total_bounds`.
4. Voronoi catchments via SQL aggregator: `ST_VoronoiPolygons(ST_Collect_Agg(ST_Centroid(geometry)))`. Calls out that `GeoSeries.voronoi_polygons()` runs *per row*, which is wrong shape for "one diagram from many points".
5. `clip_by_rect(xmin, ymin, xmax, ymax)` (new in 1.9) to crop the Voronoi result to a continental bbox.
6. `to_geopandas()` round-trip + `matplotlib` for the final plot.
7. `<gdf>.spark.frame()` to drop into SQL on the same dataframe — uses `ST_DistanceSpheroid` for "African countries' centroids closest to (0°N, 0°E)".

Notebook is structured as numbered markdown sections (`## 1.` through `## 7.`), matching the convention from `01-mobility-pulse`. Notebook intro flags `**Requires Sedona ≥ 1.9.0.**` explicitly because `clip_by_rect` and the autopopulated GeoParquet 1.1 covering metadata are 1.9-only.

**Stacked CI / dockerfile fixes that this series exposed**

- `.github/workflows/docker-build.yml` — add `docs/usecases/**` to the path filter for both `push` and `pull_request`. The dockerfile bakes `docs/usecases/*.ipynb`, `docs/usecases/*.py`, and `docs/usecases/data/` into the image, so notebook-only PRs (#2879, #2889 prior to this commit) silently bypassed the docker build + the `docker/test-notebooks.sh` harness in CI. With this change every notebook-affecting PR exercises both.
- `.github/workflows/docker-build.yml` — drop the `sedona: 1.8.0` matrix leg. The new notebooks use 1.9-only APIs (`ST_BingTileAt`, `clip_by_rect`, GeoParquet 1.1 covering metadata). The matrix legs build local images via `--load` — they never push to a registry — so dropping 1.8.0 has no effect on published artifacts. The remaining `sedona: 'latest'` leg covers what's current.
- `docker/sedona-docker.dockerfile` — bump default `ARG sedona_version` 1.8.0 → 1.9.0 and `ARG geotools_wrapper_version` 1.8.1-33.1 → 1.9.0-33.5 so a plain `docker build -f docker/sedona-docker.dockerfile .` produces an image that runs the new notebooks. Matches the Maven coordinates already updated in the docs by #2860.

## How was this patch tested?

**Local mirror of `docker/test-notebooks.sh`** before every commit on this branch. Stack matched the docker image's runtime (Python 3.10, `pyspark==4.0.1`, `apache-sedona==1.9.0`, JDK 17, `local[*]`, `DRIVER_MEM=4g`, Sedona JAR via `PYSPARK_SUBMIT_ARGS` Maven coords).

```
PASS  05-geopandas-on-spark  21s elapsed
```

Output sanity-checked: 54 African countries; Voronoi gives 54 cells totaling 43464 deg²; `clip_by_rect` preserves all 54; closest country to (0°N, 0°E) is São Tomé and Principe at 750.1 km — geographically correct; matplotlib figure renders Africa with the Voronoi overlay.

**CI** — with the path-filter fix in this PR, the Docker build workflow now triggers for this PR (run `25245483051` queued at push time), so `docker build` and the full `test-notebooks.sh` harness — `00-quickstart`, `01-mobility-pulse`, `05-geopandas-on-spark` — run in the apache/sedona CI for the first time on a notebook-only change. This PR is what proves that wiring works.

## Did this PR include necessary documentation updates?

- The notebook is itself the documentation; intro markdown calls out `**Requires Sedona ≥ 1.9.0.**` so users on older docker images see the constraint.
- `docs/usecases/data/README.md` already enumerates the Natural Earth provenance for the data this notebook reads (added in #2879). No additional updates required since this notebook ships no new data.
- No public API changes.