### PR TITLE
[GH-2881] Add ST_Box2D(geom) scalar function

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/Functions.java
+++ b/common/src/main/java/org/apache/sedona/common/Functions.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.sedona.common.S2Geography.Geography;
 import org.apache.sedona.common.approximate.StraightSkeleton;
+import org.apache.sedona.common.geometryObjects.Box2D;
 import org.apache.sedona.common.geometryObjects.Circle;
 import org.apache.sedona.common.jts2geojson.GeoJSONWriter;
 import org.apache.sedona.common.sphere.Spheroid;
@@ -597,6 +598,10 @@ public class Functions {
       return geometry;
     }
     return geometry.getEnvelope();
+  }
+
+  public static Box2D box2D(Geometry geometry) {
+    return Box2D.fromGeometry(geometry);
   }
 
   public static Double distance(Geometry left, Geometry right) {

--- a/spark/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
+++ b/spark/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
@@ -278,6 +278,7 @@ object Catalog extends AbstractCatalog with Logging {
   // Bounding-Box-Functions
   val boundingBoxExprs: Seq[FunctionDescription] = Seq(
     function[ST_BoundingDiagonal](),
+    function[ST_Box2D](),
     function[ST_Envelope](),
     function[ST_Expand](),
     function[ST_MMax](),

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
@@ -240,6 +240,19 @@ private[apache] case class ST_Envelope(inputExpressions: Seq[Expression])
   }
 }
 
+/**
+ * Return the planar bounding box (Box2D) of a Geometry. Returns NULL for null or empty input.
+ *
+ * @param inputExpressions
+ */
+private[apache] case class ST_Box2D(inputExpressions: Seq[Expression])
+    extends InferredExpression(Functions.box2D _) {
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
+}
+
 private[apache] case class ST_Expand(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction4(Functions.expand),

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/InferredExpression.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/InferredExpression.scala
@@ -269,12 +269,14 @@ object InferredTypes {
       } else {
         null
       }
-    } else if (t =:= typeOf[Box2D]) { output =>
-      if (output != null) {
-        Box2DUDT().serialize(output.asInstanceOf[Box2D])
-      } else {
-        null
-      }
+    } else if (t =:= typeOf[Box2D]) {
+      val udt = Box2DUDT
+      output =>
+        if (output != null) {
+          udt.serialize(output.asInstanceOf[Box2D])
+        } else {
+          null
+        }
     } else if (InferredRasterExpression.isRasterType(t)) {
       InferredRasterExpression.rasterSerializer
     } else if (t =:= typeOf[String]) { output =>

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/InferredExpression.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/InferredExpression.scala
@@ -20,11 +20,12 @@ package org.apache.spark.sql.sedona_sql.expressions
 
 import org.apache.commons.lang3.StringUtils
 import org.apache.sedona.common.S2Geography.Geography
+import org.apache.sedona.common.geometryObjects.Box2D
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
 import org.apache.spark.sql.catalyst.expressions.{Expression, ImplicitCastInputTypes}
 import org.apache.spark.sql.catalyst.util.ArrayData
-import org.apache.spark.sql.sedona_sql.UDT.{GeographyUDT, GeometryUDT}
+import org.apache.spark.sql.sedona_sql.UDT.{Box2DUDT, GeographyUDT, GeometryUDT}
 import org.apache.spark.sql.sedona_sql.expressions.implicits._
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
@@ -164,6 +165,8 @@ object InferrableType {
     new InferrableType[Geography] {}
   implicit val geographyArrayInstance: InferrableType[Array[Geography]] =
     new InferrableType[Array[Geography]] {}
+  implicit val box2DInstance: InferrableType[Box2D] =
+    new InferrableType[Box2D] {}
   implicit val javaDoubleInstance: InferrableType[java.lang.Double] =
     new InferrableType[java.lang.Double] {}
   implicit val javaIntegerInstance: InferrableType[java.lang.Integer] =
@@ -266,6 +269,12 @@ object InferredTypes {
       } else {
         null
       }
+    } else if (t =:= typeOf[Box2D]) { output =>
+      if (output != null) {
+        Box2DUDT().serialize(output.asInstanceOf[Box2D])
+      } else {
+        null
+      }
     } else if (InferredRasterExpression.isRasterType(t)) {
       InferredRasterExpression.rasterSerializer
     } else if (t =:= typeOf[String]) { output =>
@@ -332,6 +341,8 @@ object InferredTypes {
       GeographyUDT()
     } else if (t =:= typeOf[Array[Geography]] || t =:= typeOf[java.util.List[Geography]]) {
       DataTypes.createArrayType(GeographyUDT())
+    } else if (t =:= typeOf[Box2D]) {
+      Box2DUDT()
     } else if (InferredRasterExpression.isRasterType(t)) {
       InferredRasterExpression.rasterUDT
     } else if (InferredRasterExpression.isRasterArrayType(t)) {

--- a/spark/common/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
@@ -199,7 +199,7 @@ class functionTestScala
           SELECT
             ST_Box2D(ST_GeomFromText('POLYGON((1 2, 1 5, 4 5, 4 2, 1 2))')) AS bbox,
             ST_Box2D(ST_GeomFromText('POINT EMPTY')) AS bbox_empty,
-            ST_Box2D(CAST(NULL AS GEOMETRY)) AS bbox_null
+            ST_Box2D(ST_GeomFromText(NULL)) AS bbox_null
         """)
       val row = df.collect()(0)
       val bbox = row.getAs[Box2D]("bbox")

--- a/spark/common/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
@@ -21,6 +21,7 @@ package org.apache.sedona.sql
 import org.apache.commons.codec.binary.Hex
 import org.apache.commons.io.FileUtils
 import org.apache.sedona.common.FunctionsGeoTools
+import org.apache.sedona.common.geometryObjects.Box2D
 import org.apache.sedona.sql.implicits._
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.functions._
@@ -190,6 +191,24 @@ class functionTestScala
       val functionDf =
         sparkSession.sql("select ST_ShiftLongitude(polygondf.countyshape) from polygondf")
       assert(functionDf.count() > 0)
+    }
+
+    it("Passed ST_Box2D") {
+      val df = sparkSession
+        .sql("""
+          SELECT
+            ST_Box2D(ST_GeomFromText('POLYGON((1 2, 1 5, 4 5, 4 2, 1 2))')) AS bbox,
+            ST_Box2D(ST_GeomFromText('POINT EMPTY')) AS bbox_empty,
+            ST_Box2D(CAST(NULL AS GEOMETRY)) AS bbox_null
+        """)
+      val row = df.collect()(0)
+      val bbox = row.getAs[Box2D]("bbox")
+      assert(bbox.getXMin == 1.0)
+      assert(bbox.getYMin == 2.0)
+      assert(bbox.getXMax == 4.0)
+      assert(bbox.getYMax == 5.0)
+      assert(row.isNullAt(1))
+      assert(row.isNullAt(2))
     }
 
     it("Passed ST_Envelope") {


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2881

## What changes were proposed in this PR?

Adds the `ST_Box2D(geom) -> Box2D` scalar function. Returns the planar bounding box of the input geometry as a `Box2D`, or SQL NULL for null/empty input (PostGIS-compatible).

This is the first user-facing function on top of the `Box2D` type and UDT introduced in #2878.

- `common/.../Functions.java` — adds `box2D(Geometry)` static helper that delegates to `Box2D.fromGeometry` (already merged).
- `spark/common/.../expressions/InferredExpression.scala` — registers `Box2D` as an inferrable return type. Adds the `InferrableType[Box2D]` instance, the struct-row serializer (via `Box2DUDT.serialize`), and the Spark return-type mapping (`Box2D → Box2DUDT`). Future Box2D-returning functions plug in for free.
- `spark/common/.../expressions/Functions.scala` — `ST_Box2D` case class extending `InferredExpression(Functions.box2D _)`.
- `spark/common/.../UDF/Catalog.scala` — registers in the `boundingBoxExprs` group alongside `ST_Envelope`.

## How was this patch tested?

`functionTestScala` (added "Passed ST_Box2D"):
- Polygon input → expected xmin/ymin/xmax/ymax via `row.getAs[Box2D]("bbox")`.
- `POINT EMPTY` input → NULL.
- `ST_GeomFromText(NULL)` input → NULL.

## Did this PR include necessary documentation updates?

- Yes, I am adding a new API. I am using the [current SNAPSHOT version number](https://github.com/apache/sedona/blob/master/pom.xml) in `vX.Y.Z` format.

  — documentation update for `ST_Box2D` lands with the rest of the Phase 1 surface (#2877) once `ST_MakeBox2D`, `ST_Extent`, accessor overloads, and the cast/text functions exist; documenting one isolated function before the rest read awkwardly. Tracking under #2877.