### PR TITLE
[GH-2882] Overload ST_XMin/XMax/YMin/YMax for Box2D

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/Functions.java
+++ b/common/src/main/java/org/apache/sedona/common/Functions.java
@@ -699,6 +699,10 @@ public class Functions {
     return min == Double.MAX_VALUE ? null : min;
   }
 
+  public static Double xMin(Box2D box) {
+    return box == null ? null : box.getXMin();
+  }
+
   public static Double xMax(Geometry geometry) {
     Coordinate[] points = geometry.getCoordinates();
     double max = -Double.MAX_VALUE;
@@ -706,6 +710,10 @@ public class Functions {
       max = Math.max(points[i].getX(), max);
     }
     return max == -Double.MAX_VALUE ? null : max;
+  }
+
+  public static Double xMax(Box2D box) {
+    return box == null ? null : box.getXMax();
   }
 
   public static Double yMin(Geometry geometry) {
@@ -717,6 +725,10 @@ public class Functions {
     return min == Double.MAX_VALUE ? null : min;
   }
 
+  public static Double yMin(Box2D box) {
+    return box == null ? null : box.getYMin();
+  }
+
   public static Double yMax(Geometry geometry) {
     Coordinate[] points = geometry.getCoordinates();
     double max = -Double.MAX_VALUE;
@@ -724,6 +736,10 @@ public class Functions {
       max = Math.max(points[i].getY(), max);
     }
     return max == -Double.MAX_VALUE ? null : max;
+  }
+
+  public static Double yMax(Box2D box) {
+    return box == null ? null : box.getYMax();
   }
 
   public static Double zMax(Geometry geometry) {

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
@@ -19,6 +19,7 @@
 package org.apache.spark.sql.sedona_sql.expressions
 
 import org.apache.sedona.common.{Functions, FunctionsGeoTools, FunctionsProj4}
+import org.apache.sedona.common.geometryObjects.Box2D
 import org.apache.sedona.common.sphere.{Haversine, Spheroid}
 import org.apache.sedona.common.utils.{InscribedCircle, ValidDetail}
 import org.apache.sedona.core.utils.SedonaConf
@@ -69,7 +70,9 @@ private[apache] case class ST_Distance(inputExpressions: Seq[Expression])
 }
 
 private[apache] case class ST_YMax(inputExpressions: Seq[Expression])
-    extends InferredExpression(Functions.yMax _) {
+    extends InferredExpression(
+      inferrableFunction1((g: Geometry) => Functions.yMax(g)),
+      inferrableFunction1((b: Box2D) => Functions.yMax(b))) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
@@ -77,7 +80,9 @@ private[apache] case class ST_YMax(inputExpressions: Seq[Expression])
 }
 
 private[apache] case class ST_YMin(inputExpressions: Seq[Expression])
-    extends InferredExpression(Functions.yMin _) {
+    extends InferredExpression(
+      inferrableFunction1((g: Geometry) => Functions.yMin(g)),
+      inferrableFunction1((b: Box2D) => Functions.yMin(b))) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
@@ -1489,7 +1494,9 @@ private[apache] case class ST_IsEmpty(inputExpressions: Seq[Expression])
  * @param inputExpressions
  */
 private[apache] case class ST_XMax(inputExpressions: Seq[Expression])
-    extends InferredExpression(Functions.xMax _) {
+    extends InferredExpression(
+      inferrableFunction1((g: Geometry) => Functions.xMax(g)),
+      inferrableFunction1((b: Box2D) => Functions.xMax(b))) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
@@ -1502,7 +1509,9 @@ private[apache] case class ST_XMax(inputExpressions: Seq[Expression])
  * @param inputExpressions
  */
 private[apache] case class ST_XMin(inputExpressions: Seq[Expression])
-    extends InferredExpression(Functions.xMin _) {
+    extends InferredExpression(
+      inferrableFunction1((g: Geometry) => Functions.xMin(g)),
+      inferrableFunction1((b: Box2D) => Functions.xMin(b))) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/InferredExpression.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/InferredExpression.scala
@@ -217,6 +217,8 @@ object InferredTypes {
       expr.toGeography(input)
     } else if (t =:= typeOf[Array[Geography]]) { expr => input =>
       expr.toGeographyArray(input)
+    } else if (t =:= typeOf[Box2D]) { expr => input =>
+      expr.toBox2D(input)
     } else if (InferredRasterExpression.isRasterType(t)) {
       InferredRasterExpression.rasterExtractor
     } else if (t =:= typeOf[Array[Double]]) { expr => input =>

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/implicits.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/implicits.scala
@@ -19,6 +19,7 @@
 package org.apache.spark.sql.sedona_sql.expressions
 
 import org.apache.sedona.common.S2Geography.{Geography, GeographyWKBSerializer}
+import org.apache.sedona.common.geometryObjects.Box2D
 import org.apache.sedona.sql.utils.GeometrySerializer
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Expression
@@ -68,6 +69,19 @@ object implicits {
         case _ =>
           inputExpression.eval(input).asInstanceOf[Array[Byte]] match {
             case binary: Array[Byte] => GeographyWKBSerializer.deserialize(binary)
+            case _ => null
+          }
+      }
+    }
+
+    def toBox2D(input: InternalRow): Box2D = {
+      inputExpression match {
+        case serdeAware: SerdeAware =>
+          serdeAware.evalWithoutSerialization(input).asInstanceOf[Box2D]
+        case _ =>
+          inputExpression.eval(input) match {
+            case row: InternalRow =>
+              new Box2D(row.getDouble(0), row.getDouble(1), row.getDouble(2), row.getDouble(3))
             case _ => null
           }
       }

--- a/spark/common/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
@@ -274,6 +274,28 @@ class functionTestScala
       assert(test.take(1)(0).get(0).asInstanceOf[Double] == -3.0)
     }
 
+    it("Passed ST_XMin / XMax / YMin / YMax for Box2D") {
+      val df = sparkSession.sql("""
+        WITH t AS (
+          SELECT ST_Box2D(ST_GeomFromText('POLYGON((1 2, 1 5, 4 5, 4 2, 1 2))')) AS bbox,
+                 ST_Box2D(ST_GeomFromText(NULL))                                  AS bbox_null
+        )
+        SELECT
+          ST_XMin(bbox),  ST_YMin(bbox),  ST_XMax(bbox),  ST_YMax(bbox),
+          ST_XMin(bbox_null), ST_YMin(bbox_null), ST_XMax(bbox_null), ST_YMax(bbox_null)
+        FROM t
+      """)
+      val row = df.collect()(0)
+      assert(row.getDouble(0) == 1.0)
+      assert(row.getDouble(1) == 2.0)
+      assert(row.getDouble(2) == 4.0)
+      assert(row.getDouble(3) == 5.0)
+      assert(row.isNullAt(4))
+      assert(row.isNullAt(5))
+      assert(row.isNullAt(6))
+      assert(row.isNullAt(7))
+    }
+
     it("Passed ST_ZMax") {
       val test = sparkSession.sql(
         "SELECT ST_ZMax(ST_GeomFromWKT('POLYGON((0 0 0,0 5 0,5 0 0,0 0 5),(1 1 0,3 1 0,1 3 0,1 1 0))'))")


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2882

## What changes were proposed in this PR?

Overloads the four 2D coordinate accessors (`ST_XMin`, `ST_XMax`, `ST_YMin`, `ST_YMax`) to accept a `Box2D` argument in addition to the existing `Geometry` argument. PostGIS-compatible.

```sql
SELECT ST_XMin(ST_Box2D(geom)), ST_YMax(ST_Box2D(geom)) FROM ...
```

- `common/.../Functions.java` — new `xMin/xMax/yMin/yMax(Box2D)` overloads (each is a NULL-safe field accessor).
- `spark/common/.../expressions/Functions.scala` — the four `ST_*` case classes now extend `InferredExpression` with two overloaded function references (Geometry + Box2D). `FunctionResolver` picks the right backing function based on the input type at planning time.
- `spark/common/.../expressions/implicits.scala` — `toBox2D(input: InternalRow)` extractor that handles the struct UDT representation.
- `spark/common/.../expressions/InferredExpression.scala` — `typeOf[Box2D]` branch in `buildArgumentExtractor`.

The output-side plumbing (`InferrableType[Box2D]`, struct serializer, Spark return-type mapping) was added in #2890. This PR adds the symmetrical input-side plumbing. Future Box2D-consuming functions (cast to geometry, `ST_AsText`, future predicates) plug in by reusing this scaffolding.

## How was this patch tested?

`functionTestScala` (added "Passed ST_XMin / XMax / YMin / YMax for Box2D"):
- Polygon → Box2D → all four accessors return the expected axis bounds.
- NULL Box2D input → all four accessors return NULL.

The existing Geometry-input tests continue to exercise the original overloads.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public SQL API documentation surface in isolation. Documentation for the Box2D accessor overloads will land with the rest of the Phase 1 surface (#2877) in a single coherent docs update once `ST_MakeBox2D`, `ST_Extent`, and the cast/text functions exist. Scala DataFrame API wrappers tracked separately in #2891.