### PR TITLE
[GH-2883] Add ST_MakeBox2D(p1, p2) scalar constructor

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/Constructors.java
+++ b/common/src/main/java/org/apache/sedona/common/Constructors.java
@@ -24,6 +24,7 @@ import java.nio.ByteOrder;
 import javax.xml.parsers.ParserConfigurationException;
 import org.apache.sedona.common.enums.FileDataSplitter;
 import org.apache.sedona.common.enums.GeometryType;
+import org.apache.sedona.common.geometryObjects.Box2D;
 import org.apache.sedona.common.utils.FormatUtils;
 import org.apache.sedona.common.utils.GeoHashDecoder;
 import org.locationtech.jts.geom.*;
@@ -286,6 +287,26 @@ public class Constructors {
 
   public static Geometry makeEnvelope(double minX, double minY, double maxX, double maxY) {
     return makeEnvelope(minX, minY, maxX, maxY, 0);
+  }
+
+  /**
+   * Build a {@link Box2D} from two corner points. The corners are taken verbatim — no swapping or
+   * validation of ordering — so {@code xmin > xmax} or {@code ymin > ymax} are preserved as
+   * supplied. NULL or empty point inputs return NULL.
+   */
+  public static Box2D makeBox2D(Geometry lowerLeft, Geometry upperRight) {
+    if (lowerLeft == null || upperRight == null) {
+      return null;
+    }
+    if (!(lowerLeft instanceof Point) || !(upperRight instanceof Point)) {
+      throw new IllegalArgumentException("ST_MakeBox2D requires two POINT geometries");
+    }
+    if (lowerLeft.isEmpty() || upperRight.isEmpty()) {
+      return null;
+    }
+    Point ll = (Point) lowerLeft;
+    Point ur = (Point) upperRight;
+    return new Box2D(ll.getX(), ll.getY(), ur.getX(), ur.getY());
   }
 
   public static Geometry geomFromGeoHash(String geoHash, Integer precision) {

--- a/spark/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
+++ b/spark/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
@@ -61,6 +61,7 @@ object Catalog extends AbstractCatalog with Logging {
     function[ST_GeomFromGML](),
     function[ST_GeomFromKML](),
     function[ST_Point](),
+    function[ST_MakeBox2D](),
     function[ST_MakeEnvelope](),
     function[ST_MakePoint](null, null),
     function[ST_MakePointM](),

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Constructors.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Constructors.scala
@@ -538,6 +538,20 @@ private[apache] case class ST_PolygonFromEnvelope(inputExpressions: Seq[Expressi
   }
 }
 
+/**
+ * Construct a Box2D from two corner points (lower-left, upper-right). Coordinates are taken
+ * verbatim; ordering is not validated.
+ *
+ * @param inputExpressions
+ */
+private[apache] case class ST_MakeBox2D(inputExpressions: Seq[Expression])
+    extends InferredExpression(Constructors.makeBox2D _) {
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
+}
+
 private[apache] trait UserDataGenerator {
   def generateUserData(
       minInputLength: Integer,

--- a/spark/common/src/test/scala/org/apache/sedona/sql/constructorTestScala.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/constructorTestScala.scala
@@ -18,6 +18,7 @@
  */
 package org.apache.sedona.sql
 
+import org.apache.sedona.common.geometryObjects.Box2D
 import org.apache.sedona.core.formatMapper.GeoJsonReader
 import org.apache.sedona.core.formatMapper.shapefileParser.ShapefileReader
 import org.apache.sedona.sql.utils.Adapter
@@ -136,6 +137,42 @@ class constructorTestScala extends TestBaseScala with Matchers {
       val polygonDF = sparkSession.sql(
         "select ST_PolygonFromEnvelope(double(1.234),double(2.234),double(3.345),double(3.345))")
       assert(polygonDF.count() == 1)
+    }
+
+    it("Passed ST_MakeBox2D") {
+      val df = sparkSession.sql("""
+        SELECT
+          ST_MakeBox2D(ST_Point(1.0, 2.0), ST_Point(4.0, 5.0))           AS bbox,
+          ST_MakeBox2D(ST_Point(10.0, 20.0), ST_GeomFromText(NULL))       AS bbox_null,
+          ST_MakeBox2D(ST_GeomFromText('POINT EMPTY'), ST_Point(1.0, 1.0)) AS bbox_empty
+      """)
+      val row = df.collect()(0)
+      val bbox = row.getAs[Box2D]("bbox")
+      assert(bbox.getXMin == 1.0)
+      assert(bbox.getYMin == 2.0)
+      assert(bbox.getXMax == 4.0)
+      assert(bbox.getYMax == 5.0)
+      assert(row.isNullAt(1))
+      assert(row.isNullAt(2))
+    }
+
+    it("ST_MakeBox2D preserves swapped corners") {
+      // No swapping or reordering; lower-left/upper-right are taken verbatim.
+      // This leaves xmin > xmax / ymin > ymax available for future antimeridian semantics.
+      val df = sparkSession.sql(
+        "SELECT ST_MakeBox2D(ST_Point(170.0, 10.0), ST_Point(-170.0, 20.0)) AS bbox")
+      val bbox = df.collect()(0).getAs[Box2D]("bbox")
+      assert(bbox.getXMin == 170.0)
+      assert(bbox.getXMax == -170.0)
+    }
+
+    it("ST_MakeBox2D rejects non-point input") {
+      val ex = intercept[Exception] {
+        sparkSession
+          .sql("SELECT ST_MakeBox2D(ST_GeomFromText('LINESTRING(0 0, 1 1)'), ST_Point(2.0, 2.0))")
+          .collect()
+      }
+      assert(ex.getMessage.contains("ST_MakeBox2D requires two POINT geometries"))
     }
 
     it("Passed ST_PointFromText") {

--- a/spark/common/src/test/scala/org/apache/sedona/sql/constructorTestScala.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/constructorTestScala.scala
@@ -166,6 +166,16 @@ class constructorTestScala extends TestBaseScala with Matchers {
       assert(bbox.getXMax == -170.0)
     }
 
+    it("ST_MakeBox2D ignores Z on 3D point input") {
+      val df = sparkSession.sql(
+        "SELECT ST_MakeBox2D(ST_PointZ(1.0, 2.0, 99.0), ST_PointZ(4.0, 5.0, 99.0)) AS bbox")
+      val bbox = df.collect()(0).getAs[Box2D]("bbox")
+      assert(bbox.getXMin == 1.0)
+      assert(bbox.getYMin == 2.0)
+      assert(bbox.getXMax == 4.0)
+      assert(bbox.getYMax == 5.0)
+    }
+
     it("ST_MakeBox2D rejects non-point input") {
       val ex = intercept[Exception] {
         sparkSession


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2883

## What changes were proposed in this PR?

Adds the `ST_MakeBox2D(lower_left: Point, upper_right: Point) -> Box2D` scalar constructor. PostGIS-compatible.

```sql
SELECT ST_MakeBox2D(ST_Point(1.0, 2.0), ST_Point(4.0, 5.0));
-- BOX(1.0 2.0, 4.0 5.0)
```

Behavior:

- Coordinates are taken **verbatim** — no swapping or ordering validation. `xmin > xmax` / `ymin > ymax` are preserved as supplied. This is deliberate: it leaves those orderings reserved for a future antimeridian-wraparound semantics on the longitude axis (cf. `apache/sedona-db`'s `WraparoundInterval`).
- NULL or empty point inputs return NULL.
- Non-point inputs raise `IllegalArgumentException("ST_MakeBox2D requires two POINT geometries")`.

## How was this patch tested?

`constructorTestScala`:
- "Passed ST_MakeBox2D" — happy path, NULL right-hand input → NULL, empty left-hand input → NULL.
- "ST_MakeBox2D preserves swapped corners" — `ST_MakeBox2D(ST_Point(170,10), ST_Point(-170,20))` round-trips with `xmin=170, xmax=-170` (no auto-swap).
- "ST_MakeBox2D rejects non-point input" — LINESTRING raises with the documented message.
- "ST_MakeBox2D ignores Z on 3D point input" — `ST_PointZ` inputs round-trip with Z ignored.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public SQL API documentation surface in isolation. Documentation for `ST_MakeBox2D` lands with the rest of the Phase 1 surface (#2877) once `ST_Extent`, the cast/text functions, and bindings exist. Scala DataFrame API wrappers tracked separately in #2891.