### PR TITLE
[GH-2884] Add ST_Extent aggregate (returns Box2D)

### DIFF
--- a/spark/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
+++ b/spark/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
@@ -538,5 +538,10 @@ object Catalog extends AbstractCatalog with Logging {
   // are only constructed when registerAll is called and Spark is set up. This lets the
   // categorization invariant test access `Catalog.expressions` without bootstrapping Spark.
   lazy val aggregateExpressions: Seq[Aggregator[Geometry, _, _]] =
-    Seq(new ST_Envelope_Aggr, new ST_Intersection_Aggr, new ST_Union_Aggr(), new ST_Collect_Agg())
+    Seq(
+      new ST_Envelope_Aggr,
+      new ST_Extent,
+      new ST_Intersection_Aggr,
+      new ST_Union_Aggr(),
+      new ST_Collect_Agg())
 }

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/AggregateFunctions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/AggregateFunctions.scala
@@ -19,6 +19,7 @@
 package org.apache.spark.sql.sedona_sql.expressions
 
 import org.apache.sedona.common.Functions
+import org.apache.sedona.common.geometryObjects.Box2D
 import org.apache.spark.sql.{Encoder, Encoders}
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.expressions.Aggregator
@@ -160,6 +161,51 @@ private[apache] class ST_Envelope_Aggr
   def bufferEncoder: Encoder[Option[EnvelopeBuffer]] = Encoders.product[Option[EnvelopeBuffer]]
 
   def outputEncoder: ExpressionEncoder[Geometry] = serde
+
+  def zero: Option[EnvelopeBuffer] = None
+}
+
+/**
+ * Return the planar bounding box (Box2D) of all geometries in the given column. Returns NULL when
+ * the input contains no rows or all rows are null/empty geometries. Mirrors PostGIS ST_Extent.
+ *
+ * ST_Envelope_Aggr is left untouched (returns a polygon Geometry) for backwards compatibility.
+ */
+private[apache] class ST_Extent extends Aggregator[Geometry, Option[EnvelopeBuffer], Box2D] {
+
+  val outputSerde: ExpressionEncoder[Box2D] = ExpressionEncoder[Box2D]()
+
+  def reduce(buffer: Option[EnvelopeBuffer], input: Geometry): Option[EnvelopeBuffer] = {
+    if (input == null || input.isEmpty) return buffer
+    val env = input.getEnvelopeInternal
+    val envBuffer = EnvelopeBuffer(env.getMinX, env.getMaxX, env.getMinY, env.getMaxY)
+    buffer match {
+      case Some(b) => Some(b.merge(envBuffer))
+      case None => Some(envBuffer)
+    }
+  }
+
+  def merge(
+      buffer1: Option[EnvelopeBuffer],
+      buffer2: Option[EnvelopeBuffer]): Option[EnvelopeBuffer] = {
+    (buffer1, buffer2) match {
+      case (Some(b1), Some(b2)) => Some(b1.merge(b2))
+      case (Some(_), None) => buffer1
+      case (None, Some(_)) => buffer2
+      case (None, None) => None
+    }
+  }
+
+  def finish(reduction: Option[EnvelopeBuffer]): Box2D = {
+    reduction match {
+      case Some(b) => new Box2D(b.minX, b.minY, b.maxX, b.maxY)
+      case None => null
+    }
+  }
+
+  def bufferEncoder: Encoder[Option[EnvelopeBuffer]] = Encoders.product[Option[EnvelopeBuffer]]
+
+  def outputEncoder: ExpressionEncoder[Box2D] = outputSerde
 
   def zero: Option[EnvelopeBuffer] = None
 }

--- a/spark/common/src/test/scala/org/apache/sedona/sql/aggregateFunctionTestScala.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/aggregateFunctionTestScala.scala
@@ -18,6 +18,7 @@
  */
 package org.apache.sedona.sql
 
+import org.apache.sedona.common.geometryObjects.Box2D
 import org.apache.spark.sql.DataFrame
 import org.locationtech.jts.geom.{Coordinate, Geometry, GeometryFactory, Polygon}
 
@@ -71,6 +72,48 @@ class aggregateFunctionTestScala extends TestBaseScala {
       assert(env.getMinY == 2.0)
       assert(env.getMaxX == 3.0)
       assert(env.getMaxY == 4.0)
+    }
+
+    it("Passed ST_Extent") {
+      val df = sparkSession.sql(
+        "SELECT ST_GeomFromWKT(wkt) AS geom FROM VALUES ('POINT (1 2)'), ('POINT (4 5)'), ('LINESTRING (-3 0, 0 0)') AS t(wkt)")
+      df.createOrReplaceTempView("t")
+      val bbox =
+        sparkSession.sql("SELECT ST_Extent(geom) AS bbox FROM t").take(1)(0).getAs[Box2D](0)
+      assert(bbox.getXMin == -3.0)
+      assert(bbox.getYMin == 0.0)
+      assert(bbox.getXMax == 4.0)
+      assert(bbox.getYMax == 5.0)
+    }
+
+    it("ST_Extent returns null over zero rows") {
+      val emptyDf = sparkSession.sql(
+        "SELECT ST_GeomFromWKT(wkt) AS geom FROM VALUES (NULL) AS t(wkt) WHERE wkt IS NOT NULL")
+      emptyDf.createOrReplaceTempView("empty_extent")
+      val result = sparkSession.sql("SELECT ST_Extent(geom) FROM empty_extent")
+      assert(result.take(1)(0).get(0) == null)
+    }
+
+    it("ST_Extent returns null when all inputs are null or empty") {
+      val nullDf = sparkSession.sql(
+        "SELECT ST_GeomFromWKT(wkt) AS geom FROM VALUES (CAST(NULL AS STRING)), ('POINT EMPTY'), ('POLYGON EMPTY') AS t(wkt)")
+      nullDf.createOrReplaceTempView("null_extent")
+      val result = sparkSession.sql("SELECT ST_Extent(geom) FROM null_extent")
+      assert(result.take(1)(0).get(0) == null)
+    }
+
+    it("ST_Extent ignores null and empty rows mixed with valid geometries") {
+      val mixedDf = sparkSession.sql(
+        "SELECT ST_GeomFromWKT(wkt) AS geom FROM VALUES (CAST(NULL AS STRING)), ('POINT EMPTY'), ('POINT (10 20)'), ('POINT (-5 -5)') AS t(wkt)")
+      mixedDf.createOrReplaceTempView("mixed_extent")
+      val bbox = sparkSession
+        .sql("SELECT ST_Extent(geom) FROM mixed_extent")
+        .take(1)(0)
+        .getAs[Box2D](0)
+      assert(bbox.getXMin == -5.0)
+      assert(bbox.getYMin == -5.0)
+      assert(bbox.getXMax == 10.0)
+      assert(bbox.getYMax == 20.0)
     }
 
     it("Passed ST_Union_aggr") {


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2884

## What changes were proposed in this PR?

Adds the `ST_Extent(geom)` aggregate, returning a `Box2D` (the union of all bounding boxes in the column). PostGIS-compatible.

```sql
SELECT ST_Extent(geom) FROM my_table;
-- BOX(xmin ymin, xmax ymax)
```

Reuses the existing `EnvelopeBuffer` reducer/merger from `ST_Envelope_Aggr`; only the `finish` step differs — `Box2D` instead of a polygon `Geometry`. `ST_Envelope_Aggr` is left untouched for backwards compatibility.

Behavior:
- Empty input (zero rows) → NULL.
- All rows null or empty geometry → NULL.
- Mixed null/empty/valid rows → bbox of the valid rows only; null and empty rows are ignored.

## How was this patch tested?

`aggregateFunctionTestScala`:
- "Passed ST_Extent" — three geometries (two points + one linestring) reduce to the expected box.
- "ST_Extent returns null over zero rows" — empty input filtered to zero rows → NULL.
- "ST_Extent returns null when all inputs are null or empty" — all-null/empty input → NULL.
- "ST_Extent ignores null and empty rows mixed with valid geometries" — mixed input reflects valid geometries only.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public SQL API documentation surface in isolation. Documentation for `ST_Extent` lands with the rest of the Phase 1 surface (#2877) once the cast/text functions exist. Scala DataFrame API wrappers tracked separately in #2891.