### PR TITLE
[GH-2885] Add ST_GeomFromBox2D and ST_AsText(box2d)

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/Constructors.java
+++ b/common/src/main/java/org/apache/sedona/common/Constructors.java
@@ -297,19 +297,7 @@ public class Constructors {
     if (box == null) {
       return null;
     }
-    double xmin = box.getXMin();
-    double ymin = box.getYMin();
-    double xmax = box.getXMax();
-    double ymax = box.getYMax();
-    Coordinate[] coords =
-        new Coordinate[] {
-          new Coordinate(xmin, ymin),
-          new Coordinate(xmin, ymax),
-          new Coordinate(xmax, ymax),
-          new Coordinate(xmax, ymin),
-          new Coordinate(xmin, ymin)
-        };
-    return GEOMETRY_FACTORY.createPolygon(coords);
+    return polygonFromEnvelope(box.getXMin(), box.getYMin(), box.getXMax(), box.getYMax());
   }
 
   /**

--- a/common/src/main/java/org/apache/sedona/common/Constructors.java
+++ b/common/src/main/java/org/apache/sedona/common/Constructors.java
@@ -290,14 +290,36 @@ public class Constructors {
   }
 
   /**
-   * Convert a {@link Box2D} to a closed rectangular polygon. NULL on null input. Mirrors PostGIS
-   * {@code box2d::geometry}.
+   * Convert a {@link Box2D} to a Geometry. Mirrors PostGIS {@code box2d::geometry}: dispatches on
+   * dimensionality so the result matches what {@code ST_Envelope(geom)} would have produced for the
+   * source geometry. Degenerate boxes return:
+   *
+   * <ul>
+   *   <li>{@code POINT} when {@code xmin == xmax && ymin == ymax}
+   *   <li>{@code LINESTRING} when exactly one of the X / Y intervals collapses
+   *   <li>{@code POLYGON} otherwise
+   * </ul>
+   *
+   * Returns NULL on null input.
    */
   public static Geometry geomFromBox2D(Box2D box) {
     if (box == null) {
       return null;
     }
-    return polygonFromEnvelope(box.getXMin(), box.getYMin(), box.getXMax(), box.getYMax());
+    double xmin = box.getXMin();
+    double ymin = box.getYMin();
+    double xmax = box.getXMax();
+    double ymax = box.getYMax();
+    boolean xCollapsed = xmin == xmax;
+    boolean yCollapsed = ymin == ymax;
+    if (xCollapsed && yCollapsed) {
+      return GEOMETRY_FACTORY.createPoint(new Coordinate(xmin, ymin));
+    }
+    if (xCollapsed || yCollapsed) {
+      return GEOMETRY_FACTORY.createLineString(
+          new Coordinate[] {new Coordinate(xmin, ymin), new Coordinate(xmax, ymax)});
+    }
+    return polygonFromEnvelope(xmin, ymin, xmax, ymax);
   }
 
   /**

--- a/common/src/main/java/org/apache/sedona/common/Constructors.java
+++ b/common/src/main/java/org/apache/sedona/common/Constructors.java
@@ -290,6 +290,29 @@ public class Constructors {
   }
 
   /**
+   * Convert a {@link Box2D} to a closed rectangular polygon. NULL on null input. Mirrors PostGIS
+   * {@code box2d::geometry}.
+   */
+  public static Geometry geomFromBox2D(Box2D box) {
+    if (box == null) {
+      return null;
+    }
+    double xmin = box.getXMin();
+    double ymin = box.getYMin();
+    double xmax = box.getXMax();
+    double ymax = box.getYMax();
+    Coordinate[] coords =
+        new Coordinate[] {
+          new Coordinate(xmin, ymin),
+          new Coordinate(xmin, ymax),
+          new Coordinate(xmax, ymax),
+          new Coordinate(xmax, ymin),
+          new Coordinate(xmin, ymin)
+        };
+    return GEOMETRY_FACTORY.createPolygon(coords);
+  }
+
+  /**
    * Build a {@link Box2D} from two corner points. The corners are taken verbatim — no swapping or
    * validation of ordering — so {@code xmin > xmax} or {@code ymin > ymax} are preserved as
    * supplied. NULL or empty point inputs return NULL.

--- a/common/src/main/java/org/apache/sedona/common/Functions.java
+++ b/common/src/main/java/org/apache/sedona/common/Functions.java
@@ -868,6 +868,22 @@ public class Functions {
     return GeomUtils.getWKT(geometry);
   }
 
+  /** PostGIS-format text for a Box2D: {@code BOX(xmin ymin, xmax ymax)}. NULL on null input. */
+  public static String asWKT(Box2D box) {
+    if (box == null) {
+      return null;
+    }
+    return "BOX("
+        + box.getXMin()
+        + " "
+        + box.getYMin()
+        + ", "
+        + box.getXMax()
+        + " "
+        + box.getYMax()
+        + ")";
+  }
+
   public static byte[] asEWKB(Geometry geometry) {
     return GeomUtils.getEWKB(geometry);
   }

--- a/common/src/main/java/org/apache/sedona/common/Functions.java
+++ b/common/src/main/java/org/apache/sedona/common/Functions.java
@@ -868,8 +868,13 @@ public class Functions {
     return GeomUtils.getWKT(geometry);
   }
 
-  /** PostGIS-format text for a Box2D: {@code BOX(xmin ymin, xmax ymax)}. NULL on null input. */
-  public static String asWKT(Box2D box) {
+  /**
+   * PostGIS-format text for a Box2D: {@code BOX(xmin ymin, xmax ymax)}. NULL on null input.
+   *
+   * <p>Note: not WKT (WKT has no BOX type), so this lives outside the {@code asWKT} family to keep
+   * that API a true geometry serializer.
+   */
+  public static String box2dAsText(Box2D box) {
     if (box == null) {
       return null;
     }

--- a/common/src/main/java/org/apache/sedona/common/Functions.java
+++ b/common/src/main/java/org/apache/sedona/common/Functions.java
@@ -869,10 +869,16 @@ public class Functions {
   }
 
   /**
-   * PostGIS-format text for a Box2D: {@code BOX(xmin ymin, xmax ymax)}. NULL on null input.
+   * PostGIS-format text for a Box2D: {@code BOX(x1 y1, x2 y2)}. NULL on null input.
    *
-   * <p>Note: not WKT (WKT has no BOX type), so this lives outside the {@code asWKT} family to keep
-   * that API a true geometry serializer.
+   * <p>Values are emitted exactly as stored on the Box2D — this method does not normalize the
+   * corners. Sedona's Box2D allows {@code xmin > xmax} (or {@code ymin > ymax}); that ordering is
+   * reserved for a future antimeridian-wraparound semantics on geography bboxes (cf. sedona-db's
+   * {@code WraparoundInterval}). The text faithfully reflects what {@code ST_XMin} / {@code
+   * ST_XMax} / etc. would return.
+   *
+   * <p>Not WKT (WKT has no {@code BOX} type), so this lives outside the {@code asWKT} family to
+   * keep that API a true geometry serializer.
    */
   public static String box2dAsText(Box2D box) {
     if (box == null) {

--- a/common/src/test/java/org/apache/sedona/common/ConstructorsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/ConstructorsTest.java
@@ -244,13 +244,24 @@ public class ConstructorsTest {
 
   @Test
   public void geomFromBox2D() {
+    // 2-D box → POLYGON
     Geometry polygon = Constructors.geomFromBox2D(new Box2D(1.0, 2.0, 4.0, 5.0));
     assertTrue(polygon instanceof Polygon);
     assertEquals("POLYGON ((1 2, 1 5, 4 5, 4 2, 1 2))", Functions.asWKT(polygon));
 
-    // Degenerate box collapsed to a point/line is still a valid (closed-ring) polygon.
-    Geometry degenerate = Constructors.geomFromBox2D(new Box2D(3.0, 3.0, 3.0, 3.0));
-    assertTrue(degenerate instanceof Polygon);
+    // Collapsed in both axes → POINT (matches PostGIS box2d::geometry and ST_Envelope(point)).
+    Geometry point = Constructors.geomFromBox2D(new Box2D(3.0, 3.0, 3.0, 3.0));
+    assertTrue(point instanceof Point);
+    assertEquals("POINT (3 3)", Functions.asWKT(point));
+
+    // Collapsed in one axis → LINESTRING (matches ST_Envelope of an axis-aligned line).
+    Geometry horizontalLine = Constructors.geomFromBox2D(new Box2D(1.0, 5.0, 4.0, 5.0));
+    assertTrue(horizontalLine instanceof LineString);
+    assertEquals("LINESTRING (1 5, 4 5)", Functions.asWKT(horizontalLine));
+
+    Geometry verticalLine = Constructors.geomFromBox2D(new Box2D(2.0, 1.0, 2.0, 4.0));
+    assertTrue(verticalLine instanceof LineString);
+    assertEquals("LINESTRING (2 1, 2 4)", Functions.asWKT(verticalLine));
 
     assertNull(Constructors.geomFromBox2D(null));
   }

--- a/common/src/test/java/org/apache/sedona/common/ConstructorsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/ConstructorsTest.java
@@ -20,6 +20,7 @@ package org.apache.sedona.common;
 
 import static org.junit.Assert.*;
 
+import org.apache.sedona.common.geometryObjects.Box2D;
 import org.apache.sedona.common.utils.GeomUtils;
 import org.junit.Test;
 import org.locationtech.jts.geom.*;
@@ -239,6 +240,19 @@ public class ConstructorsTest {
     assertTrue(geom instanceof Polygon);
     actual = Functions.asWKT(geom);
     assertEquals(expected, actual);
+  }
+
+  @Test
+  public void geomFromBox2D() {
+    Geometry polygon = Constructors.geomFromBox2D(new Box2D(1.0, 2.0, 4.0, 5.0));
+    assertTrue(polygon instanceof Polygon);
+    assertEquals("POLYGON ((1 2, 1 5, 4 5, 4 2, 1 2))", Functions.asWKT(polygon));
+
+    // Degenerate box collapsed to a point/line is still a valid (closed-ring) polygon.
+    Geometry degenerate = Constructors.geomFromBox2D(new Box2D(3.0, 3.0, 3.0, 3.0));
+    assertTrue(degenerate instanceof Polygon);
+
+    assertNull(Constructors.geomFromBox2D(null));
   }
 
   @Test

--- a/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
@@ -26,6 +26,7 @@ import com.google.common.geometry.S2CellId;
 import com.google.common.math.DoubleMath;
 import java.util.*;
 import java.util.stream.Collectors;
+import org.apache.sedona.common.geometryObjects.Box2D;
 import org.apache.sedona.common.sphere.Haversine;
 import org.apache.sedona.common.sphere.Spheroid;
 import org.apache.sedona.common.utils.*;
@@ -164,6 +165,15 @@ public class FunctionsTest extends TestBase {
     actual = geomFromEWKT(expectedResult);
     assertEquals(geometry, actual);
     assertEquals(expectedResult, actualResult);
+  }
+
+  @Test
+  public void box2dAsText() {
+    assertEquals("BOX(1.0 2.0, 4.0 5.0)", Functions.box2dAsText(new Box2D(1.0, 2.0, 4.0, 5.0)));
+    assertEquals(
+        "BOX(-180.0 -90.0, 180.0 90.0)",
+        Functions.box2dAsText(new Box2D(-180.0, -90.0, 180.0, 90.0)));
+    assertNull(Functions.box2dAsText(null));
   }
 
   @Test

--- a/spark/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
+++ b/spark/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
@@ -57,6 +57,7 @@ object Catalog extends AbstractCatalog with Logging {
     function[ST_GeomFromEWKT](),
     function[ST_GeomFromWKB](),
     function[ST_GeomFromEWKB](),
+    function[ST_GeomFromBox2D](),
     function[ST_GeomFromGeoJSON](),
     function[ST_GeomFromGML](),
     function[ST_GeomFromKML](),

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Constructors.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Constructors.scala
@@ -552,6 +552,22 @@ private[apache] case class ST_MakeBox2D(inputExpressions: Seq[Expression])
   }
 }
 
+/**
+ * Convert a Box2D to a closed rectangular polygon Geometry. Equivalent to PostGIS {@code
+ * box2d::geometry}. Exposed as a function rather than a Catalyst implicit cast because UDT-to-UDT
+ * implicit casts require Catalyst-level work; ST_GeomFromBox2D lives alongside the other
+ * ST_GeomFrom* constructors.
+ *
+ * @param inputExpressions
+ */
+private[apache] case class ST_GeomFromBox2D(inputExpressions: Seq[Expression])
+    extends InferredExpression(Constructors.geomFromBox2D _) {
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
+}
+
 private[apache] trait UserDataGenerator {
   def generateUserData(
       minInputLength: Integer,

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
@@ -615,7 +615,7 @@ private[apache] case class ST_AsText(inputExpressions: Seq[Expression])
       inferrableFunction1((g: Geometry) => Functions.asWKT(g)),
       inferrableFunction1((g: Geography) =>
         org.apache.sedona.common.geography.Functions.asText(g)),
-      inferrableFunction1((b: Box2D) => Functions.asWKT(b))) {
+      inferrableFunction1((b: Box2D) => Functions.box2dAsText(b))) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
@@ -612,8 +612,10 @@ private[apache] case class ST_SimplifyPolygonHull(inputExpressions: Seq[Expressi
 
 private[apache] case class ST_AsText(inputExpressions: Seq[Expression])
     extends InferredExpression(
-      inferrableFunction1(Functions.asWKT),
-      inferrableFunction1(org.apache.sedona.common.geography.Functions.asText)) {
+      inferrableFunction1((g: Geometry) => Functions.asWKT(g)),
+      inferrableFunction1((g: Geography) =>
+        org.apache.sedona.common.geography.Functions.asText(g)),
+      inferrableFunction1((b: Box2D) => Functions.asWKT(b))) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)

--- a/spark/common/src/test/scala/org/apache/sedona/sql/constructorTestScala.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/constructorTestScala.scala
@@ -179,12 +179,16 @@ class constructorTestScala extends TestBaseScala with Matchers {
     it("Passed ST_GeomFromBox2D") {
       val df = sparkSession.sql("""
         SELECT
-          ST_AsText(ST_GeomFromBox2D(ST_MakeBox2D(ST_Point(1.0, 2.0), ST_Point(4.0, 5.0)))) AS wkt,
+          ST_AsText(ST_GeomFromBox2D(ST_MakeBox2D(ST_Point(1.0, 2.0), ST_Point(4.0, 5.0)))) AS poly,
+          ST_AsText(ST_GeomFromBox2D(ST_MakeBox2D(ST_Point(3.0, 3.0), ST_Point(3.0, 3.0)))) AS point,
+          ST_AsText(ST_GeomFromBox2D(ST_MakeBox2D(ST_Point(1.0, 5.0), ST_Point(4.0, 5.0)))) AS line,
           ST_GeomFromBox2D(ST_MakeBox2D(ST_GeomFromText(NULL), ST_Point(1.0, 1.0))) AS null_geom
       """)
       val row = df.collect()(0)
       assert(row.getString(0) == "POLYGON ((1 2, 1 5, 4 5, 4 2, 1 2))")
-      assert(row.isNullAt(1))
+      assert(row.getString(1) == "POINT (3 3)")
+      assert(row.getString(2) == "LINESTRING (1 5, 4 5)")
+      assert(row.isNullAt(3))
     }
 
     it("ST_MakeBox2D rejects non-point input") {

--- a/spark/common/src/test/scala/org/apache/sedona/sql/constructorTestScala.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/constructorTestScala.scala
@@ -176,6 +176,17 @@ class constructorTestScala extends TestBaseScala with Matchers {
       assert(bbox.getYMax == 5.0)
     }
 
+    it("Passed ST_GeomFromBox2D") {
+      val df = sparkSession.sql("""
+        SELECT
+          ST_AsText(ST_GeomFromBox2D(ST_MakeBox2D(ST_Point(1.0, 2.0), ST_Point(4.0, 5.0)))) AS wkt,
+          ST_GeomFromBox2D(ST_MakeBox2D(ST_GeomFromText(NULL), ST_Point(1.0, 1.0))) AS null_geom
+      """)
+      val row = df.collect()(0)
+      assert(row.getString(0) == "POLYGON ((1 2, 1 5, 4 5, 4 2, 1 2))")
+      assert(row.isNullAt(1))
+    }
+
     it("ST_MakeBox2D rejects non-point input") {
       val ex = intercept[Exception] {
         sparkSession

--- a/spark/common/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
@@ -274,6 +274,17 @@ class functionTestScala
       assert(test.take(1)(0).get(0).asInstanceOf[Double] == -3.0)
     }
 
+    it("Passed ST_AsText for Box2D") {
+      val df = sparkSession.sql("""
+        SELECT
+          ST_AsText(ST_Box2D(ST_GeomFromText('POLYGON((1 2, 1 5, 4 5, 4 2, 1 2))'))) AS wkt,
+          ST_AsText(ST_Box2D(ST_GeomFromText(NULL))) AS null_wkt
+      """)
+      val row = df.collect()(0)
+      assert(row.getString(0) == "BOX(1.0 2.0, 4.0 5.0)")
+      assert(row.isNullAt(1))
+    }
+
     it("Passed ST_XMin / XMax / YMin / YMax for Box2D") {
       val df = sparkSession.sql("""
         WITH t AS (


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2885

## What changes were proposed in this PR?

Two related conversions on `Box2D`:

### 1. `ST_GeomFromBox2D(box2d) -> Polygon`

Converts a `Box2D` to a closed rectangular polygon. Equivalent to PostGIS `box2d::geometry`.

```sql
SELECT ST_AsText(ST_GeomFromBox2D(ST_MakeBox2D(ST_Point(1, 2), ST_Point(4, 5))));
-- POLYGON ((1 2, 1 5, 4 5, 4 2, 1 2))
```

**Why a function instead of an implicit cast.** PostGIS uses `box2d::geometry` cast syntax. Spark Catalyst supports UDT-to-UDT implicit casts but registering one requires extending Catalyst's `Cast` resolution rule, which is a real piece of work and orthogonal to the bbox feature itself. Sedona's existing `ST_GeomFrom*` family (`ST_GeomFromWKT`, `ST_GeomFromGeoJSON`, etc.) is the natural home for an explicit constructor. NULL input → NULL output.

### 2. `ST_AsText(box2d) -> 'BOX(xmin ymin, xmax ymax)'`

Overloads the existing `ST_AsText` (which already handles `Geometry` and `Geography`) to accept a `Box2D` and return PostGIS-format text:

```sql
SELECT ST_AsText(ST_Box2D(ST_GeomFromText('POLYGON((1 2, 1 5, 4 5, 4 2, 1 2))')));
-- BOX(1.0 2.0, 4.0 5.0)
```

NULL on null input.

## How was this patch tested?

`constructorTestScala`:
- "Passed ST_GeomFromBox2D" — round-trip through `ST_MakeBox2D` → `ST_GeomFromBox2D` → `ST_AsText`, and NULL propagation.

`functionTestScala`:
- "Passed ST_AsText for Box2D" — happy-path format `BOX(1.0 2.0, 4.0 5.0)`, and NULL propagation.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public SQL API documentation surface in isolation. Documentation for the Phase 1 Box2D surface (#2877) lands as a single coherent docs update once the cross-language bindings (#2887, #2888) are in. Scala DataFrame API wrappers tracked separately in #2891.