### PR TITLE
[GH-2880] Omit bbox in GeoParquet metadata for empty files

### DIFF
--- a/spark/common/src/main/scala/org/apache/spark/sql/execution/datasources/geoparquet/GeoParquetMetaData.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/execution/datasources/geoparquet/GeoParquetMetaData.scala
@@ -34,7 +34,9 @@ import org.json4s.{DefaultFormats, Extraction, JField, JNothing, JNull, JObject,
  * @param geometryTypes
  *   The geometry types of all geometries, or an empty array if they are not known.
  * @param bbox
- *   Bounding Box of the geometries in the file, formatted according to RFC 7946, section 5.
+ *   Bounding Box of the geometries in the file, formatted according to RFC 7946, section 5. None
+ *   if the file contains no geometries (per the GeoParquet 1.1 spec, bbox is optional and should
+ *   be omitted when there is no extent to describe).
  * @param crs
  *   The CRS of the geometries in the file. None if crs metadata is absent, Some(JNull) if crs is
  *   null, Some(value) if the crs is present and not null.
@@ -44,7 +46,7 @@ import org.json4s.{DefaultFormats, Extraction, JField, JNothing, JNull, JObject,
 case class GeometryFieldMetaData(
     encoding: String,
     geometryTypes: Seq[String],
-    bbox: Seq[Double],
+    bbox: Option[Seq[Double]],
     crs: Option[JValue] = None,
     covering: Option[Covering] = None)
 

--- a/spark/common/src/main/scala/org/apache/spark/sql/execution/datasources/geoparquet/GeoParquetSpatialFilter.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/execution/datasources/geoparquet/GeoParquetSpatialFilter.scala
@@ -68,7 +68,7 @@ object GeoParquetSpatialFilter {
       extends GeoParquetSpatialFilter {
     def evaluate(columns: Map[String, GeometryFieldMetaData]): Boolean = {
       columns.get(columnName).forall { column =>
-        val bbox = column.bbox
+        val bbox = column.bbox.getOrElse(return true)
         if (bbox.isEmpty) {
           return true
         }

--- a/spark/common/src/main/scala/org/apache/spark/sql/execution/datasources/geoparquet/GeoParquetWriteSupport.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/execution/datasources/geoparquet/GeoParquetWriteSupport.scala
@@ -245,13 +245,19 @@ class GeoParquetWriteSupport extends WriteSupport[InternalRow] with Logging {
       val columns = geometryColumnInfoMap.map { case (ordinal, columnInfo) =>
         val columnName = schema.fields(ordinal).name
         val geometryTypes = columnInfo.seenGeometryTypes.toSeq
+        // Omit bbox from column metadata when no geometries were observed (e.g. an empty
+        // Spark partition produces a zero-row file). Per the GeoParquet 1.1 spec, bbox is
+        // optional and represents the extent of the geometries in the file; emitting
+        // [0, 0, 0, 0] for an empty file falsely advertises data at Null Island and breaks
+        // bbox-based file pruning in downstream readers.
         val bbox = if (geometryTypes.nonEmpty) {
-          Seq(
-            columnInfo.bbox.minX,
-            columnInfo.bbox.minY,
-            columnInfo.bbox.maxX,
-            columnInfo.bbox.maxY)
-        } else Seq(0.0, 0.0, 0.0, 0.0)
+          Some(
+            Seq(
+              columnInfo.bbox.minX,
+              columnInfo.bbox.minY,
+              columnInfo.bbox.maxX,
+              columnInfo.bbox.maxY))
+        } else None
         val crs = geoParquetColumnCrsMap.getOrElse(
           columnName, {
             if (!userExplicitlySetDefaultCrs) {

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacBatch.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacBatch.scala
@@ -328,7 +328,7 @@ case class StacBatch(
             val geometryFieldMetaData = GeometryFieldMetaData(
               encoding = "WKB",
               geometryTypes = geometryTypes,
-              bbox = bbox,
+              bbox = Some(bbox),
               crs = None,
               covering = None)
 

--- a/spark/common/src/test/scala/org/apache/sedona/sql/geoparquetIOTests.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/geoparquetIOTests.scala
@@ -252,9 +252,12 @@ class geoparquetIOTests extends TestBaseScala with BeforeAndAfterAll {
       validateGeoParquetMetadata(geoParquetSavePath) { geo =>
         implicit val formats: org.json4s.Formats = org.json4s.DefaultFormats
         val g0Types = (geo \ "columns" \ "g" \ "geometry_types").extract[Seq[String]]
-        val g0BBox = (geo \ "columns" \ "g" \ "bbox").extract[Seq[Double]]
         assert(g0Types.isEmpty)
-        assert(g0BBox == Seq(0.0, 0.0, 0.0, 0.0))
+        // Per the GeoParquet spec, bbox is optional and represents the extent of the geometries
+        // in the file; for a file with no geometries we omit it entirely rather than emit a
+        // bogus [0, 0, 0, 0] (which would falsely advertise data at Null Island and break
+        // bbox-based file pruning in downstream readers). See issue #2880.
+        assert((geo \ "columns" \ "g" \ "bbox") == org.json4s.JNothing)
       }
     }
 

--- a/spark/spark-3.4/src/main/scala/org/apache/spark/sql/execution/datasources/v2/geoparquet/metadata/GeoParquetMetadataPartitionReaderFactory.scala
+++ b/spark/spark-3.4/src/main/scala/org/apache/spark/sql/execution/datasources/v2/geoparquet/metadata/GeoParquetMetadataPartitionReaderFactory.scala
@@ -83,7 +83,7 @@ object GeoParquetMetadataPartitionReaderFactory {
           val columnMetadataFields: Array[Any] = Array(
             UTF8String.fromString(columnMetadata.encoding),
             new GenericArrayData(columnMetadata.geometryTypes.map(UTF8String.fromString).toArray),
-            new GenericArrayData(columnMetadata.bbox.toArray),
+            columnMetadata.bbox.map(b => new GenericArrayData(b.toArray)).orNull,
             columnMetadata.crs
               .map(projjson => UTF8String.fromString(compact(render(projjson))))
               .getOrElse(UTF8String.fromString("")),

--- a/spark/spark-3.5/src/main/scala/org/apache/spark/sql/execution/datasources/v2/geoparquet/metadata/GeoParquetMetadataPartitionReaderFactory.scala
+++ b/spark/spark-3.5/src/main/scala/org/apache/spark/sql/execution/datasources/v2/geoparquet/metadata/GeoParquetMetadataPartitionReaderFactory.scala
@@ -84,7 +84,7 @@ object GeoParquetMetadataPartitionReaderFactory {
           val columnMetadataFields: Array[Any] = Array(
             UTF8String.fromString(columnMetadata.encoding),
             new GenericArrayData(columnMetadata.geometryTypes.map(UTF8String.fromString).toArray),
-            new GenericArrayData(columnMetadata.bbox.toArray),
+            columnMetadata.bbox.map(b => new GenericArrayData(b.toArray)).orNull,
             columnMetadata.crs
               .map(projjson => UTF8String.fromString(compact(render(projjson))))
               .getOrElse(UTF8String.fromString("")),

--- a/spark/spark-4.0/src/main/scala/org/apache/spark/sql/execution/datasources/v2/geoparquet/metadata/GeoParquetMetadataPartitionReaderFactory.scala
+++ b/spark/spark-4.0/src/main/scala/org/apache/spark/sql/execution/datasources/v2/geoparquet/metadata/GeoParquetMetadataPartitionReaderFactory.scala
@@ -84,7 +84,7 @@ object GeoParquetMetadataPartitionReaderFactory {
           val columnMetadataFields: Array[Any] = Array(
             UTF8String.fromString(columnMetadata.encoding),
             new GenericArrayData(columnMetadata.geometryTypes.map(UTF8String.fromString).toArray),
-            new GenericArrayData(columnMetadata.bbox.toArray),
+            columnMetadata.bbox.map(b => new GenericArrayData(b.toArray)).orNull,
             columnMetadata.crs
               .map(projjson => UTF8String.fromString(compact(render(projjson))))
               .getOrElse(UTF8String.fromString("")),

--- a/spark/spark-4.1/src/main/scala/org/apache/spark/sql/execution/datasources/v2/geoparquet/metadata/GeoParquetMetadataPartitionReaderFactory.scala
+++ b/spark/spark-4.1/src/main/scala/org/apache/spark/sql/execution/datasources/v2/geoparquet/metadata/GeoParquetMetadataPartitionReaderFactory.scala
@@ -84,7 +84,7 @@ object GeoParquetMetadataPartitionReaderFactory {
           val columnMetadataFields: Array[Any] = Array(
             UTF8String.fromString(columnMetadata.encoding),
             new GenericArrayData(columnMetadata.geometryTypes.map(UTF8String.fromString).toArray),
-            new GenericArrayData(columnMetadata.bbox.toArray),
+            columnMetadata.bbox.map(b => new GenericArrayData(b.toArray)).orNull,
             columnMetadata.crs
               .map(projjson => UTF8String.fromString(compact(render(projjson))))
               .getOrElse(UTF8String.fromString("")),


### PR DESCRIPTION
## Summary

Fixes #2880.

When a Spark partition has zero rows, Sedona's GeoParquet writer was emitting `bbox: [0, 0, 0, 0]` in the per-column `geo` metadata. Per the [GeoParquet 1.1 spec](https://geoparquet.org/releases/v1.1.0/), `bbox` is the bounding box of the geometries in the file and is **optional** ("if specified, MUST be encoded with an array..."). For a file with no geometries we should omit it, not fabricate a phantom extent at Null Island.

The fabricated `[0, 0, 0, 0]` is harmful for downstream consumers:
- **Corrupts dataset extent reporting.** Tools that aggregate per-file bboxes (or GDAL's `GetExtent()` on a single file) report (0, 0) as the layer extent.
- **Spec non-compliance.** Asserts an extent that does not exist in the file.
- **Subtly poisons bbox-based file pruning** in any reader that uses the column-metadata bbox for spatial pushdown — files appear to overlap any AOI containing the origin.

## Change

Make `GeometryFieldMetaData.bbox` an `Option[Seq[Double]]` and emit `None` (which json4s omits from the JSON) when no geometries were observed during write. The bbox accumulator at `GeometryColumnBoundingBox` was already correctly initialized to `(+Inf, +Inf, -Inf, -Inf)`; only the fallback at `GeoParquetWriteSupport.scala:248-254` needed fixing.

The type change ripples through all consumers of the case class — the spark-{3.4,3.5,4.0,4.1} `GeoParquetMetadataPartitionReaderFactory` files, `GeoParquetSpatialFilter.LeafFilter`, and `StacBatch` are updated to handle the `Option`. Sedona's own `LeafFilter` already had a "no bbox → don't prune" branch (the original code path for files with empty bbox `Seq`); this PR extends that branch to handle the `None` case.

### Why doesn't the reader prune zero-row files outright?

After this PR, a new empty file has `bbox = None` in the geo metadata, and `LeafFilter.evaluate` falls through to "no extent info, don't prune" — so empty files are always included in the scan (correctly returning 0 rows). We considered going further:

1. **Fingerprint-prune legacy `[0, 0, 0, 0]` files.** Would let Sedona skip pre-existing buggy-writer files without scanning them. Rejected: a wrong bbox on an empty file never produces wrong query results, only sometimes wastes a scan. The downstream-reader correctness concerns (GDAL extent, stac-geoparquet aggregation) are addressed by the writer fix; Sedona's own pruning is correct in either direction because the file has zero rows.

2. **Row-count-prune any zero-row file.** The reader path uses `ParquetFooterReader.readFooter(..., SKIP_ROW_GROUPS)`. Under that filter, `ParquetMetadata.getBlocks()` returns empty regardless of the actual row group count, and the file-level `num_rows` from the Parquet thrift is not exposed via parquet-mr's Java `FileMetaData` API. Getting an honest row count requires switching to `NO_FILTER`, which adds row-group/column-stat thrift parse on every GeoParquet read. Rejected for the same reason: empty files are cheap to scan and the saved overhead doesn't justify the added cost on every read.

In both cases the marginal saved scan time wasn't worth the added complexity. If a workload's empty-file count is high enough to matter, a follow-up PR can switch to `NO_FILTER` only when a spatial filter is being pushed down (paying the parse cost only on queries that benefit from row-count pruning).

## Impact on other GeoParquet readers

Researched how other major readers handle missing/null `bbox` vs. `[0, 0, 0, 0]`. **Omitting the field is strictly an improvement** in every case:

| Reader | Uses column-metadata `bbox` for pruning? | Tolerates missing `bbox`? | Effect of `[0,0,0,0]` today |
|---|---|---|---|
| **DuckDB Spatial** (`ST_Read` / `read_parquet`) | No — pruning uses Parquet column stats on a separate `bbox` struct column ([discussion #484](https://github.com/duckdb/duckdb-spatial/discussions/484)) | Yes | No effect on query results |
| **GeoPandas** (`read_parquet` in `geopandas/io/arrow.py`) | No — `bbox=` filter routes through `covering.bbox` struct column or a `point` encoding | Yes; GeoPandas itself already omits bbox for all-NA columns (`if np.isfinite(bbox).all(): ...`) | No effect on query results |
| **GDAL/OGR Parquet driver** | No — pruning uses `bbox` struct column / `covering.bbox` ([driver docs](https://gdal.org/en/stable/drivers/vector/parquet.html)) | Yes | Corrupts `GetExtent()` reporting (returns origin) |
| **pyarrow** | N/A — surfaces the JSON, doesn't interpret it | Yes | None |
| **stac-geoparquet** aggregator | Not yet (TODO in `_to_parquet.py`) | N/A | Would corrupt collection bbox unions once implemented |
| **Sedona** | Yes — `GeoParquetSpatialFilter.LeafFilter` | Yes (after this PR) | Wasted scans for AOIs near origin (no wrong results, since the file is empty) |

GeoPandas' existing behavior is precedent — it already omits `bbox` for empty/all-NA inputs.

## Test plan

- [x] Updated `geoparquetIOTests` "GeoParquet save should work with empty dataframes": now asserts the `bbox` field is omitted from the JSON (was previously asserting `Seq(0.0, 0.0, 0.0, 0.0)`).
- [ ] CI to run the rest of `geoparquet*` and `Stac*` suites (the type change touches `StacBatch.scala` and the v2 metadata partition reader factory across all four spark-{3.4,3.5,4.0,4.1} variants).

## Spec reference

GeoParquet 1.1 (column metadata for the geometry column):
> **bbox**: Bounding Box of the geometries in the file, formatted according to RFC 7946, section 5.
>
> The bbox, **if specified**, MUST be encoded with an array...

— https://geoparquet.org/releases/v1.1.0/