### PR TITLE
[GH-2887] Box2D DataFrame API + Python bindings for Phase 1

### DIFF
--- a/python/sedona/spark/sql/st_aggregates.py
+++ b/python/sedona/spark/sql/st_aggregates.py
@@ -42,6 +42,21 @@ def ST_Envelope_Aggr(geometry: ColumnOrName) -> Column:
 
 
 @validate_argument_types
+def ST_Extent(geometry: ColumnOrName) -> Column:
+    """Aggregate Function: Get the bounding box (Box2D) of a geometry column.
+
+    Returns NULL when the input contains no rows or all rows are null/empty
+    geometries. Mirrors PostGIS ST_Extent.
+
+    :param geometry: Geometry column to aggregate.
+    :type geometry: ColumnOrName
+    :return: Box2D representing the union of bounding boxes of the geometry column.
+    :rtype: Column
+    """
+    return _call_aggregate_function("ST_Extent", geometry)
+
+
+@validate_argument_types
 def ST_Intersection_Aggr(geometry: ColumnOrName) -> Column:
     """Aggregate Function: Get the aggregate intersection of a geometry column.
 

--- a/python/sedona/spark/sql/st_constructors.py
+++ b/python/sedona/spark/sql/st_constructors.py
@@ -551,6 +551,42 @@ def ST_MakePoint(
 
 
 @validate_argument_types
+def ST_MakeBox2D(
+    lower_left: ColumnOrName,
+    upper_right: ColumnOrName,
+) -> Column:
+    """Construct a Box2D from two corner points (lower-left, upper-right).
+
+    Coordinates are taken verbatim — no swapping or ordering validation. NULL or
+    empty point inputs return NULL. Non-point inputs raise an error.
+
+    :param lower_left: Lower-left corner Point.
+    :type lower_left: ColumnOrName
+    :param upper_right: Upper-right corner Point.
+    :type upper_right: ColumnOrName
+    :return: Box2D column.
+    :rtype: Column
+    """
+    return _call_constructor_function("ST_MakeBox2D", (lower_left, upper_right))
+
+
+@validate_argument_types
+def ST_GeomFromBox2D(box: ColumnOrName) -> Column:
+    """Convert a Box2D to a Geometry.
+
+    Dispatches on dimensionality (matching PostGIS box2d::geometry and
+    Sedona's ST_Envelope): POINT for 0-D boxes, LINESTRING for 1-D boxes,
+    POLYGON otherwise. NULL on null input.
+
+    :param box: Box2D column to convert.
+    :type box: ColumnOrName
+    :return: Geometry column.
+    :rtype: Column
+    """
+    return _call_constructor_function("ST_GeomFromBox2D", box)
+
+
+@validate_argument_types
 def ST_MakeEnvelope(
     min_x: ColumnOrNameOrNumber,
     min_y: ColumnOrNameOrNumber,

--- a/python/sedona/spark/sql/st_functions.py
+++ b/python/sedona/spark/sql/st_functions.py
@@ -650,6 +650,20 @@ def ST_EndPoint(line_string: ColumnOrName) -> Column:
 
 
 @validate_argument_types
+def ST_Box2D(geometry: ColumnOrName) -> Column:
+    """Get the planar bounding box (Box2D) of a geometry.
+
+    Returns NULL for null or empty input.
+
+    :param geometry: Geometry column to compute the bounding box of.
+    :type geometry: ColumnOrName
+    :return: Box2D bounding box of the geometry.
+    :rtype: Column
+    """
+    return _call_st_function("ST_Box2D", geometry)
+
+
+@validate_argument_types
 def ST_Envelope(geometry: ColumnOrName) -> Column:
     """Calculate the envelope boundary of a geometry column.
 

--- a/python/tests/sql/test_aggregate_functions.py
+++ b/python/tests/sql/test_aggregate_functions.py
@@ -22,6 +22,29 @@ from tests.test_base import TestBase
 
 class TestConstructors(TestBase):
 
+    def test_st_extent(self):
+        df = self.spark.sql("""
+            SELECT ST_GeomFromWKT(wkt) AS geom
+            FROM VALUES ('POINT (1 2)'), ('POINT (4 5)'), ('LINESTRING (-3 0, 0 0)') AS t(wkt)
+            """)
+        df.createOrReplaceTempView("extent_input")
+        bbox = self.spark.sql("SELECT ST_Extent(geom) FROM extent_input").first()[0]
+        assert bbox.xmin == -3.0
+        assert bbox.ymin == 0.0
+        assert bbox.xmax == 4.0
+        assert bbox.ymax == 5.0
+
+    def test_st_extent_returns_null_for_empty_input(self):
+        df = self.spark.sql("""
+            SELECT ST_GeomFromWKT(wkt) AS geom
+            FROM VALUES (CAST(NULL AS STRING)), ('POINT EMPTY') AS t(wkt)
+            """)
+        df.createOrReplaceTempView("empty_extent_input")
+        result = self.spark.sql(
+            "SELECT ST_Extent(geom) FROM empty_extent_input"
+        ).first()[0]
+        assert result is None
+
     def test_st_envelope_aggr(self):
         point_csv_df = (
             self.spark.read.format("csv")

--- a/python/tests/sql/test_constructor_test.py
+++ b/python/tests/sql/test_constructor_test.py
@@ -164,6 +164,34 @@ class TestConstructors(TestBase):
         )
         assert polygon_df.count() == 8
 
+    def test_st_make_box_2d(self):
+        bbox_df = self.spark.sql(
+            "SELECT ST_MakeBox2D(ST_Point(1.0, 2.0), ST_Point(4.0, 5.0)) AS bbox"
+        )
+        bbox = bbox_df.first()[0]
+        assert bbox.xmin == 1.0
+        assert bbox.ymin == 2.0
+        assert bbox.xmax == 4.0
+        assert bbox.ymax == 5.0
+
+        # NULL right-hand input → NULL
+        null_df = self.spark.sql(
+            "SELECT ST_MakeBox2D(ST_Point(1.0, 2.0), ST_GeomFromText(NULL)) AS bbox"
+        )
+        assert null_df.first()[0] is None
+
+    def test_st_geom_from_box_2d(self):
+        df = self.spark.sql("""
+            SELECT
+              ST_AsText(ST_GeomFromBox2D(ST_MakeBox2D(ST_Point(1.0, 2.0), ST_Point(4.0, 5.0)))) AS poly,
+              ST_AsText(ST_GeomFromBox2D(ST_MakeBox2D(ST_Point(3.0, 3.0), ST_Point(3.0, 3.0)))) AS pt,
+              ST_AsText(ST_GeomFromBox2D(ST_MakeBox2D(ST_Point(1.0, 5.0), ST_Point(4.0, 5.0)))) AS line
+            """)
+        row = df.first()
+        assert row[0] == "POLYGON ((1 2, 1 5, 4 5, 4 2, 1 2))"
+        assert row[1] == "POINT (3 3)"
+        assert row[2] == "LINESTRING (1 5, 4 5)"
+
     def test_st_make_envelope(self):
         polygonDF = self.spark.sql(
             "select ST_MakeEnvelope(double(1.234),double(2.234),double(3.345),double(3.345), 1111) as geom"

--- a/python/tests/sql/test_dataframe_api.py
+++ b/python/tests/sql/test_dataframe_api.py
@@ -174,7 +174,8 @@ test_configurations = [
         ("a", "b"),
         "two_points",
         "",
-        Box2D(0.0, 0.0, 3.0, 4.0),
+        # two_points has a=(0,0,0), b=(3,0,4); ST_MakeBox2D drops Z, so y is 0 for both.
+        Box2D(0.0, 0.0, 3.0, 0.0),
     ),
     (
         stc.ST_GeomFromBox2D,

--- a/python/tests/sql/test_dataframe_api.py
+++ b/python/tests/sql/test_dataframe_api.py
@@ -26,6 +26,7 @@ from pyspark.sql import functions as f
 from shapely.geometry.base import BaseGeometry
 from tests.test_base import TestBase
 
+from sedona.spark.core.geom.box2d import Box2D
 from sedona.spark.core.geom.geography import Geography
 from sedona.spark.sql import st_aggregates as sta
 from sedona.spark.sql import st_constructors as stc
@@ -167,6 +168,24 @@ test_configurations = [
         "constructor",
         "ST_AsText(geom)",
         "POINT M(0 1 2)",
+    ),
+    (
+        stc.ST_MakeBox2D,
+        ("a", "b"),
+        "two_points",
+        "",
+        Box2D(0.0, 0.0, 3.0, 4.0),
+    ),
+    (
+        stc.ST_GeomFromBox2D,
+        (
+            lambda: stc.ST_MakeBox2D(
+                f.expr("ST_Point(1.0, 2.0)"), f.expr("ST_Point(4.0, 5.0)")
+            ),
+        ),
+        "min_max_x_y",
+        "ST_AsText(geom)",
+        "POLYGON ((1 2, 1 5, 4 5, 4 2, 1 2))",
     ),
     (
         stc.ST_MakeEnvelope,
@@ -520,6 +539,13 @@ test_configurations = [
         ],
     ),
     (stf.ST_EndPoint, ("line",), "linestring_geom", "", "POINT (5 0)"),
+    (
+        stf.ST_Box2D,
+        ("line",),
+        "linestring_geom",
+        "",
+        Box2D(0.0, 0.0, 5.0, 0.0),
+    ),
     (
         stf.ST_Envelope,
         ("geom",),
@@ -1283,6 +1309,13 @@ test_configurations = [
         "exploded_points",
         "",
         "MULTIPOINT ((0 0), (1 1))",
+    ),
+    (
+        sta.ST_Extent,
+        ("geom",),
+        "exploded_points",
+        "",
+        Box2D(0.0, 0.0, 1.0, 1.0),
     ),
     # Test aliases for *_Aggr functions with *_Agg suffix
     (

--- a/python/tests/sql/test_function.py
+++ b/python/tests/sql/test_function.py
@@ -185,6 +185,28 @@ class TestPredicateJoin(TestBase):
         actual = function_df.take(1)[0][0].wkt
         assert actual == "LINESTRING (179 10, -179 10)"
 
+    def test_st_box_2d(self):
+        df = self.spark.sql("""
+            SELECT
+              ST_Box2D(ST_GeomFromText('POLYGON((1 2, 1 5, 4 5, 4 2, 1 2))')) AS bbox,
+              ST_Box2D(ST_GeomFromText('POINT EMPTY')) AS bbox_empty,
+              ST_Box2D(ST_GeomFromText(NULL)) AS bbox_null
+            """)
+        row = df.first()
+        bbox = row[0]
+        assert bbox.xmin == 1.0
+        assert bbox.ymin == 2.0
+        assert bbox.xmax == 4.0
+        assert bbox.ymax == 5.0
+        assert row[1] is None
+        assert row[2] is None
+
+    def test_st_as_text_box_2d(self):
+        result = self.spark.sql("""
+            SELECT ST_AsText(ST_Box2D(ST_GeomFromText('POLYGON((1 2, 1 5, 4 5, 4 2, 1 2))')))
+            """).first()[0]
+        assert result == "BOX(1.0 2.0, 4.0 5.0)"
+
     def test_st_envelope(self):
         polygon_from_wkt = (
             self.spark.read.format("csv")

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/st_aggregates.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/st_aggregates.scala
@@ -63,6 +63,16 @@ object st_aggregates {
     aggrFunc(col(geometry))
   }
 
+  def ST_Extent(geometry: Column): Column = {
+    val aggrFunc = udaf(new ST_Extent)
+    aggrFunc(geometry)
+  }
+
+  def ST_Extent(geometry: String): Column = {
+    val aggrFunc = udaf(new ST_Extent)
+    aggrFunc(col(geometry))
+  }
+
   // Aliases for *_Aggr functions with *_Agg suffix
   def ST_Envelope_Agg(geometry: Column): Column = ST_Envelope_Aggr(geometry)
 

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/st_constructors.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/st_constructors.scala
@@ -253,6 +253,14 @@ object st_constructors {
   def ST_MakeEnvelope(minX: Double, minY: Double, maxX: Double, maxY: Double, srid: Int): Column =
     wrapExpression[ST_MakeEnvelope](minX, minY, maxX, maxY, srid)
 
+  def ST_MakeBox2D(lowerLeft: Column, upperRight: Column): Column =
+    wrapExpression[ST_MakeBox2D](lowerLeft, upperRight)
+  def ST_MakeBox2D(lowerLeft: String, upperRight: String): Column =
+    wrapExpression[ST_MakeBox2D](lowerLeft, upperRight)
+
+  def ST_GeomFromBox2D(box: Column): Column = wrapExpression[ST_GeomFromBox2D](box)
+  def ST_GeomFromBox2D(box: String): Column = wrapExpression[ST_GeomFromBox2D](box)
+
   def ST_PolygonFromEnvelope(minX: Column, minY: Column, maxX: Column, maxY: Column): Column =
     wrapExpression[ST_PolygonFromEnvelope](minX, minY, maxX, maxY)
   def ST_PolygonFromEnvelope(minX: String, minY: String, maxX: String, maxY: String): Column =

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/st_functions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/st_functions.scala
@@ -205,6 +205,9 @@ object st_functions {
   def ST_EndPoint(lineString: Column): Column = wrapExpression[ST_EndPoint](lineString)
   def ST_EndPoint(lineString: String): Column = wrapExpression[ST_EndPoint](lineString)
 
+  def ST_Box2D(geometry: Column): Column = wrapExpression[ST_Box2D](geometry)
+  def ST_Box2D(geometry: String): Column = wrapExpression[ST_Box2D](geometry)
+
   def ST_Envelope(geometry: Column): Column = wrapExpression[ST_Envelope](geometry)
   def ST_Envelope(geometry: String): Column = wrapExpression[ST_Envelope](geometry)
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2887, closes #2891

## What changes were proposed in this PR?

Adds the Scala DataFrame API wrappers and matching PySpark Column wrappers for the Phase 1 Box2D surface.

The two pieces ship together because they're a hard dependency: the Python wrappers dispatch through the Scala `st_functions` / `st_constructors` / `st_aggregates` objects (see `dataframe_api.py:78-79`), so the Python bindings would fail at runtime without the Scala wrappers. The original plan to defer DataFrame API work (#2891) has been folded into this PR.

### Scala DataFrame API (closes #2891)

`org.apache.spark.sql.sedona_sql.expressions.*`:

| Wrapper | Object |
|---|---|
| `ST_Box2D(geom: Column \| String)` | `st_functions` |
| `ST_MakeBox2D(ll, ur)` | `st_constructors` |
| `ST_GeomFromBox2D(box)` | `st_constructors` |
| `ST_Extent(geom)` | `st_aggregates` |

The existing `ST_XMin/XMax/YMin/YMax` and `ST_AsText` wrappers already accept any `Column`, so no Scala-side changes are needed for them — JVM overload resolution handles Box2D arguments.

### Python bindings (closes #2887)

`sedona.spark.sql.*`:

| Wrapper | Module |
|---|---|
| `ST_Box2D(geometry)` | `st_functions` |
| `ST_MakeBox2D(p1, p2)` | `st_constructors` |
| `ST_GeomFromBox2D(box)` | `st_constructors` |
| `ST_Extent(geom)` | `st_aggregates` |

The Python `Box2DType` UDT and `Box2D` value class were added in #2878. Collected results materialize as `Box2D` objects with `xmin/ymin/xmax/ymax` attributes.

## How was this patch tested?

- `python/tests/sql/test_function.py` — `test_st_box_2d`, `test_st_as_text_box_2d`.
- `python/tests/sql/test_constructor_test.py` — `test_st_make_box_2d`, `test_st_geom_from_box_2d` (POLYGON/POINT/LINESTRING dispatch).
- `python/tests/sql/test_aggregate_functions.py` — `test_st_extent`, `test_st_extent_returns_null_for_empty_input`.
- `python/tests/sql/test_dataframe_api.py` — parametric coverage for `ST_Box2D`, `ST_MakeBox2D`, `ST_GeomFromBox2D`, `ST_Extent` exercising the Column-API wrapper dispatch end-to-end.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public SQL API documentation surface in isolation. Documentation for the Phase 1 Box2D surface (#2877) lands as a single coherent docs update once the Flink bindings (#2888) and GeoParquet writer (#2886) are in.