### PR TITLE
[GH-2867] Wire mkdocs-static-i18n for Chinese documentation

### DIFF
--- a/docs/index.zh.md
+++ b/docs/index.zh.md
@@ -1,0 +1,26 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+### 2025/09/12：Sedona 1.8.0 发布。本次重要版本引入了 GeoPandas 兼容 API、PyFlink 支持、Java 11 升级、Spark 4.0 支持，以及向量化 UDF、Moran I 自相关、MySQL 几何类型支持和增强的空间过滤下推等众多新特性。
+
+### 2025/06/07：Sedona 1.7.2 发布。本次为纯 Bug 修复版本，也是 Java 8 上的最后一个发布版本。
+
+### 2025/03/15：Sedona 1.7.1 发布。包含 KNN 连接性能改进、GeoStats 的 SQL 接口、STAC catalog 读取器、OSM PBF 读取器，以及更优的 GeoParquet 文件分区。
+
+### 2024/12/02：Sedona 1.7.0 发布。引入了名为 KNN Join 的新连接类型、名为 GeoStats 的新统计模块、用于 Shapefile 和 GeoPackage 的基于 DataFrame 的读取器，以及众多新的 ST 函数。

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -252,6 +252,123 @@ plugins:
       archive_date_format: MMMM yyyy
       # Maximum number of authors to display in the post excerpt
       post_excerpt_max_authors: 5
+  - i18n:
+      docs_structure: suffix
+      fallback_to_default: true
+      reconfigure_material: true
+      reconfigure_search: true
+      languages:
+        - locale: en
+          default: true
+          name: English
+          build: true
+        - locale: zh
+          name: 中文
+          build: true
+          site_name: Apache Sedona
+          site_description: Apache Sedona 是一个用于处理大规模空间数据的集群计算系统。Sedona 在 Apache Spark、Apache Flink 和 Snowflake 等现有集群计算系统的基础上，提供了一套开箱即用的分布式空间数据集和空间 SQL，可以高效地跨机器加载、处理和分析大规模空间数据。
+          nav_translations:
+            Home: 首页
+            Install: 安装
+            Overview: 概述
+            Modules: 模块
+            Language wrappers: 语言封装
+            Maven Central coordinate: Maven Central 坐标
+            Use Sedona in Docker: 在 Docker 中使用 Sedona
+            Install Sedona in your local Spark cluster: 在本地 Spark 集群中安装 Sedona
+            Install Sedona Scala/Java: 安装 Sedona Scala/Java
+            Install Sedona Python: 安装 Sedona Python
+            Install Sedona R: 安装 Sedona R
+            Install Sedona-Zeppelin: 安装 Sedona-Zeppelin
+            Set up Spark cluster manually: 手动搭建 Spark 集群
+            Cloud platforms: 云平台
+            Install on Wherobots: 在 Wherobots 上安装
+            Install on Databricks: 在 Databricks 上安装
+            Install on AWS EMR: 在 AWS EMR 上安装
+            Install on AWS Glue: 在 AWS Glue 上安装
+            Install on Microsoft Fabric: 在 Microsoft Fabric 上安装
+            Install on Azure Synapse Analytics: 在 Azure Synapse Analytics 上安装
+            Programming Guide: 编程指南
+            Programming Guides: 编程指南
+            Spatial DataFrame / SQL app: 空间 DataFrame / SQL 应用
+            Raster DataFrame / SQL app: 栅格 DataFrame / SQL 应用
+            Pure SQL environment: 纯 SQL 环境
+            GeoPandas API on Sedona: Sedona 上的 GeoPandas API
+            Spatial RDD app: 空间 RDD 应用
+            Sedona R: Sedona R
+            Work with GeoPandas and Shapely: 与 GeoPandas 和 Shapely 配合使用
+            Files: 文件
+            Concepts: 概念
+            Spatial Joins: 空间连接
+            Clustering Algorithms: 聚类算法
+            Distance: 距离
+            Map visualization SQL app: 地图可视化 SQL 应用
+            Use Apache Zeppelin: 使用 Apache Zeppelin
+            Gallery: 案例库
+            Performance tuning: 性能调优
+            Benchmark: 基准测试
+            Tune RDD application: 调优 RDD 应用
+            Storing large raster geometries in Parquet files: 在 Parquet 文件中存储大型栅格几何对象
+            API: API
+            SQL: SQL
+            Quick start: 快速开始
+            Vector data: 矢量数据
+            Geometry Functions: 几何函数
+            Geography Functions: 地理函数
+            DataFrame Style functions: DataFrame 风格函数
+            Query optimization: 查询优化
+            CRS Transformation: 坐标系转换
+            Nearest-Neighbour searching: 最近邻搜索
+            Reading Legacy Parquet Files: 读取旧版 Parquet 文件
+            Visualization: 可视化
+            Raster data: 栅格数据
+            Raster Functions: 栅格函数
+            Raster map algebra: 栅格地图代数
+            Raster affine transformation: 栅格仿射变换
+            Parameter: 参数
+            RDD (core): RDD（核心）
+            Scala/Java doc: Scala/Java 文档
+            Stats: 统计
+            DataFrame: DataFrame
+            Viz: 可视化
+            DataFrame/SQL: DataFrame/SQL
+            RDD: RDD
+            Sedona Python: Sedona Python
+            Release notes: 发布说明
+            Sedona with Apache Flink: 在 Apache Flink 上使用 Sedona
+            Spatial SQL app (Flink): 空间 SQL 应用（Flink）
+            Spatial SQL app (PyFlink): 空间 SQL 应用（PyFlink）
+            Examples: 示例
+            Scala/Java: Scala/Java
+            Python: Python
+            Overview (Flink): 概述（Flink）
+            Install Sedona SQL: 安装 Sedona SQL
+            Spatial SQL app (Snowflake): 空间 SQL 应用（Snowflake）
+            Overview (Snowflake): 概述（Snowflake）
+            Blog: 博客
+            Community: 社区
+            Download: 下载
+            Compile the code: 编译源码
+            Contributor Guide: 贡献者指南
+            Rules: 规则
+            Develop: 开发
+            Contribute to Geopandas API on Sedona: 为 Sedona 的 Geopandas API 贡献代码
+            Committer Guide: 提交者指南
+            Project Management Committee: 项目管理委员会
+            Become a release manager: 成为发布经理
+            Publish a snapshot version: 发布快照版本
+            Make a release: 发布版本
+            Vote a release: 投票发布
+            Publications: 论文
+            Apache Software Foundation: Apache 软件基金会
+            Foundation: 基金会
+            License: 许可证
+            Events: 活动
+            Sponsorship: 赞助
+            Thanks: 致谢
+            Security: 安全
+            Privacy: 隐私
+            Telemetry: 遥测
   - git-revision-date-localized:
       type: datetime
   - mike:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ docs = [
   "mkdocs-git-revision-date-localized-plugin",
   "mkdocs-jupyter",
   "mkdocs-macros-plugin",
+  "mkdocs-static-i18n",
   "pymdown-extensions",
   "mike",
   "blacken-docs",


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Part of #2867 (EPIC).

## What changes were proposed in this PR?

Phase 1 of the EPIC #2867 — wires up the `mkdocs-static-i18n` plugin so the docs site can serve a Chinese (`zh`) version alongside English. The default locale stays English and pages without a `*.zh.md` translation fall back to the English content automatically, so subsequent translation PRs can land incrementally per section.

- Register `mkdocs-static-i18n` in the `docs` dependency group in `pyproject.toml`
- Configure suffix-mode i18n in `mkdocs.yml` (`file.zh.md` next to `file.md`) with `reconfigure_material` and `reconfigure_search` so the language switcher appears in the header and search indexes both locales
- Translate ~120 top-level navigation labels (Install, Programming Guide, API, Community, etc.) for the `zh` build via `nav_translations`
- Seed `docs/index.zh.md` so the Chinese tree builds with content; future PRs translate the rest

Translation lands as a series of follow-up PRs (#2909-#2919), one per documentation section, so each PR stays small and reviewable. See #2867 for the full checklist.

## How was this patch tested?

Built the docs locally with `uv sync --group docs && uv run mkdocs build` and verified:

- The build succeeds and reports `Translated 120 navigation elements to 'zh'`
- `site/` contains the English tree at root and a parallel `site/zh/` tree
- `site/index.html` contains `<link rel="alternate" hreflang="en">` and `hreflang="zh"` tags (language switcher wired in the header)
- `site/zh/index.html` shows the Chinese announcement bullets from `index.zh.md`
- `site/zh/sedonaspark/index.html` falls back to the English content (since no `sedonaspark.zh.md` exists yet)
- `site/zh/index.html` navigation shows translated labels (e.g. "安装", "编程指南", "发布说明")

## Did this PR include necessary documentation updates?

- Yes, this PR is itself a documentation infrastructure change. The homepage hero strings live in `docs-overrides/main.html`, not in `index.md`, so they will appear in English on the `/zh/` homepage until Phase 2 (#2909) makes the template locale-aware. Auto-generated content (R `pkgdown` under `api/rdocs`, Python Sphinx under `api/pydocs`, JavaDoc, ScalaDoc) stays English-only — those are produced from source comments, not Markdown.