### PR TITLE
[GH-2886] Recognize Box2D columns as GeoParquet bbox covering columns

### DIFF
--- a/spark/common/src/main/scala/org/apache/spark/sql/execution/datasources/geoparquet/GeoParquetMetaData.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/execution/datasources/geoparquet/GeoParquetMetaData.scala
@@ -237,14 +237,18 @@ object GeoParquetMetaData {
     schema(coveringColumnIndex).dataType match {
       case coveringColumnType: StructType =>
         coveringColumnTypeToCovering(coveringColumnName, coveringColumnType)
-      case _: Box2DUDT =>
+      case udt: Box2DUDT =>
         // Box2DUDT exposes a struct<xmin, ymin, xmax, ymax: double> sqlType, which is the exact
         // shape required by GeoParquet 1.1 bbox covering columns. Treat the underlying struct as
         // the covering struct so users can write a Box2D column and have it referenced as a
         // covering column in GeoParquet metadata without any manual struct construction.
-        coveringColumnTypeToCovering(
-          coveringColumnName,
-          new Box2DUDT().sqlType.asInstanceOf[StructType])
+        udt.sqlType match {
+          case structType: StructType =>
+            coveringColumnTypeToCovering(coveringColumnName, structType)
+          case other =>
+            throw new IllegalStateException(
+              s"Box2DUDT.sqlType is expected to be a StructType, got $other")
+        }
       case _ =>
         throw new IllegalArgumentException(
           s"Covering column $coveringColumnName is not a struct type")

--- a/spark/common/src/main/scala/org/apache/spark/sql/execution/datasources/geoparquet/GeoParquetMetaData.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/execution/datasources/geoparquet/GeoParquetMetaData.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.execution.datasources.geoparquet
 
 import scala.util.control.NonFatal
 
+import org.apache.spark.sql.sedona_sql.UDT.Box2DUDT
 import org.apache.spark.sql.types.{DoubleType, FloatType, StructType}
 import org.datasyslab.proj4sedona.core.Proj
 import org.datasyslab.proj4sedona.parser.CRSSerializer
@@ -236,6 +237,14 @@ object GeoParquetMetaData {
     schema(coveringColumnIndex).dataType match {
       case coveringColumnType: StructType =>
         coveringColumnTypeToCovering(coveringColumnName, coveringColumnType)
+      case _: Box2DUDT =>
+        // Box2DUDT exposes a struct<xmin, ymin, xmax, ymax: double> sqlType, which is the exact
+        // shape required by GeoParquet 1.1 bbox covering columns. Treat the underlying struct as
+        // the covering struct so users can write a Box2D column and have it referenced as a
+        // covering column in GeoParquet metadata without any manual struct construction.
+        coveringColumnTypeToCovering(
+          coveringColumnName,
+          new Box2DUDT().sqlType.asInstanceOf[StructType])
       case _ =>
         throw new IllegalArgumentException(
           s"Covering column $coveringColumnName is not a struct type")

--- a/spark/common/src/test/scala/org/apache/sedona/sql/geoparquetIOTests.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/geoparquetIOTests.scala
@@ -1021,6 +1021,53 @@ class geoparquetIOTests extends TestBaseScala with BeforeAndAfterAll {
       }
     }
 
+    it("GeoParquet supports writing covering metadata from a Box2D column") {
+      // User-provided Box2D column referenced via the geoparquet.covering option.
+      val df = sparkSession
+        .range(0, 100)
+        .toDF("id")
+        .withColumn("id", expr("CAST(id AS DOUBLE)"))
+        .withColumn("geometry", expr("ST_Point(id, id + 1)"))
+        .withColumn("test_cov", expr("ST_Box2D(geometry)"))
+      val geoParquetSavePath = geoparquetoutputlocation + "/gp_with_box2d_covering.parquet"
+      df.write
+        .format("geoparquet")
+        .option("geoparquet.covering.geometry", "test_cov")
+        .mode("overwrite")
+        .save(geoParquetSavePath)
+      validateGeoParquetMetadata(geoParquetSavePath) { geo =>
+        implicit val formats: org.json4s.Formats = org.json4s.DefaultFormats
+        val coveringJsValue = geo \ "columns" \ "geometry" \ "covering"
+        val covering = coveringJsValue.extract[Covering]
+        assert(covering.bbox.xmin == Seq("test_cov", "xmin"))
+        assert(covering.bbox.ymin == Seq("test_cov", "ymin"))
+        assert(covering.bbox.xmax == Seq("test_cov", "xmax"))
+        assert(covering.bbox.ymax == Seq("test_cov", "ymax"))
+      }
+    }
+
+    it("GeoParquet auto populates covering metadata for a Box2D <geom>_bbox column") {
+      // Auto-detect path: when a column named <geom>_bbox is a Box2D, reuse it as the
+      // covering column instead of synthesizing a separate float64 struct.
+      val df = sparkSession
+        .range(0, 100)
+        .toDF("id")
+        .withColumn("id", expr("CAST(id AS DOUBLE)"))
+        .withColumn("geometry", expr("ST_Point(id, id + 1)"))
+        .withColumn("geometry_bbox", expr("ST_Box2D(geometry)"))
+      val geoParquetSavePath = geoparquetoutputlocation + "/gp_box2d_auto_covering.parquet"
+      df.write.format("geoparquet").mode("overwrite").save(geoParquetSavePath)
+      validateGeoParquetMetadata(geoParquetSavePath) { geo =>
+        implicit val formats: org.json4s.Formats = org.json4s.DefaultFormats
+        val coveringJsValue = geo \ "columns" \ "geometry" \ "covering"
+        val covering = coveringJsValue.extract[Covering]
+        assert(covering.bbox.xmin == Seq("geometry_bbox", "xmin"))
+        assert(covering.bbox.ymin == Seq("geometry_bbox", "ymin"))
+        assert(covering.bbox.xmax == Seq("geometry_bbox", "xmax"))
+        assert(covering.bbox.ymax == Seq("geometry_bbox", "ymax"))
+      }
+    }
+
     it("GeoParquet auto populates covering metadata for single geometry column") {
       val df = sparkSession
         .range(0, 100)


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2886

## What changes were proposed in this PR?

When a user has a `Box2D`-typed column in the schema being written, both the explicit covering option (`geoparquet.covering[.geom]=<col>`) and the auto-detect `<geom>_bbox` path now register it in GeoParquet metadata as the bbox covering column for the associated geometry.

`Box2DUDT.sqlType` is `struct<xmin, ymin, xmax, ymax: double>` — exactly the shape required by the GeoParquet 1.1 covering spec — so **no data-path change is needed**: the existing `UserDefinedType` → struct fallback in `GeoParquetWriteSupport.makeWriter` already serializes correctly. Only the metadata path needed to learn that a UDT-wrapped struct is a valid covering source.

The change is one new case in `GeoParquetMetaData.createCoveringColumnMetadata` that recognizes `Box2DUDT` and dispatches to the existing struct-shaped covering builder.

## Why Float32 + conservative rounding is deferred

The original issue scoped Float32 + `Math.nextUp` / `Math.nextDown` outward rounding for size and bit-compatibility with `apache/sedona-db`'s `next_after` writer. Shipping that without a paired reader-side change would create a write/read asymmetry: a written `Box2D` column comes back as a generic `struct<float>` (not a `Box2D`) because the on-disk Float32 schema no longer matches `Box2DUDT.sqlType` (which is Float64), so PySpark's UDT resolver doesn't claim it.

That asymmetry would regress the user-visible type round-trip we just shipped across #2890–#2906. Pairing Float32 with reader auto-materialization is its own follow-up; this PR delivers the metadata side cleanly without committing the read-path regression.

## How was this patch tested?

`geoparquetIOTests`:
- "GeoParquet supports writing covering metadata from a Box2D column" — user-supplied Box2D column referenced via `geoparquet.covering.geometry`; verifies the GeoParquet metadata has matching `covering.bbox.{xmin,ymin,xmax,ymax}` paths.
- "GeoParquet auto populates covering metadata for a Box2D `<geom>_bbox` column" — auto-detect path: a Box2D-typed `geometry_bbox` column gets registered without explicit configuration.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public SQL API documentation surface in isolation. Documentation for the Phase 1 Box2D surface (#2877) lands as a single coherent docs update once any deferred follow-ups (Float32 covering writer + reader auto-materialization) are scoped.