### PR TITLE
[GH-2909] Translate documentation landing pages to Chinese

### DIFF
--- a/docs-overrides/assets/stylesheets/components/_lang-switch.scss
+++ b/docs-overrides/assets/stylesheets/components/_lang-switch.scss
@@ -1,0 +1,50 @@
+.sd-lang-switch {
+  display: inline-flex;
+  align-items: stretch;
+  margin: 0 0.4rem;
+  padding: 2px;
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 0.72rem;
+  line-height: 1;
+
+  &__item {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.28rem 0.7rem;
+    color: rgba(255, 255, 255, 0.85);
+    text-decoration: none;
+    border-radius: 999px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    transition: background-color 120ms ease, color 120ms ease;
+
+    &:hover,
+    &:focus {
+      color: #ffffff;
+      background-color: rgba(255, 255, 255, 0.18);
+    }
+
+    &--active {
+      color: #ca463a;
+      background-color: #ffffff;
+
+      &:hover,
+      &:focus {
+        color: #ca463a;
+        background-color: #ffffff;
+      }
+    }
+  }
+}
+
+@media (max-width: 600px) {
+  .sd-lang-switch {
+    font-size: 0.68rem;
+
+    &__item {
+      padding: 0.22rem 0.55rem;
+    }
+  }
+}

--- a/docs-overrides/assets/stylesheets/extra.scss
+++ b/docs-overrides/assets/stylesheets/extra.scss
@@ -13,6 +13,7 @@
 @import "components/footer";
 @import "components/sidebar";
 @import "components/search-tags";
+@import "components/lang-switch";
 
 // Pages
 @import "pages/page-home";

--- a/docs-overrides/main.html
+++ b/docs-overrides/main.html
@@ -1,14 +1,17 @@
 {% extends "base.html" %}
 
+{# Locale shared across all blocks below. Detected once via mkdocs-static-i18n's
+   reconfigure_material flag, which sets config.theme.language per build. #}
+{%- set cur_lang = config.theme.language if config.theme.language in ['en', 'zh'] else 'en' -%}
+
 {% block outdated %}
-{%- set lang = config.theme.language if config.theme.language in ['en', 'zh'] else 'en' -%}
 {%- set outdated_msg = {
     'en': ['You\'re not viewing the latest stable version.', 'Click here to go to the latest stable version.'],
     'zh': ['您当前查看的不是最新稳定版本。', '点击此处跳转到最新稳定版本。']
 } -%}
-{{ outdated_msg[lang][0] }}
+{{ outdated_msg[cur_lang][0] }}
 <a href="{{ '../' ~ base_url }}">
-  <strong>{{ outdated_msg[lang][1] }}</strong>
+  <strong>{{ outdated_msg[cur_lang][1] }}</strong>
 </a>
 {% endblock %}
 
@@ -25,13 +28,12 @@
 {% endblock %}
 
 {% block header %}
-  {%- set lang = config.theme.language if config.theme.language in ['en', 'zh'] else 'en' -%}
   {%- set announcement = {
       'en': 'Apache Sedona 1.9.0 is out now, featuring Spark 4.1 support, proj4sedona CRS transformation, Bing Tile functions, and more!',
       'zh': 'Apache Sedona 1.9.0 已正式发布，新增 Spark 4.1 支持、proj4sedona 坐标系转换、Bing Tile 函数等众多特性！'
   } -%}
   <div style="background: #CA463A; color: white; text-align: center; padding: 0.5rem;">
-    <a href="setup/release-notes/" title="Announcement">{{ announcement[lang] }}</a>
+    <a href="{{ 'setup/release-notes/' | url }}" title="Announcement">{{ announcement[cur_lang] }}</a>
   </div>
   {{ super() }} {# This renders the original header below your test bar #}
 {% endblock %}
@@ -39,7 +41,6 @@
 {% block container %}
     {% set is_home = page.is_homepage or (page.file and page.file.src_uri in ['index.md', 'index.zh.md']) %}
     {% if is_home %}
-    {%- set lang = config.theme.language if config.theme.language in ['en', 'zh'] else 'en' -%}
     {%- set i18n = {
         'en': {
             'hero_subtitle': 'Apache Sedona™ makes it easy to process spatial datasets of any scale.',
@@ -92,14 +93,16 @@
             'feature_portable_title': 'Portable',
             'feature_portable_desc': 'Easy to run locally, in the cloud, or with any data platform.',
             'feature_fast_title': 'Fast',
-            'feature_fast_desc': 'Optimized execution for single node or distribute cluster environments.',
+            'feature_fast_desc': 'Optimized execution for single node or distributed cluster environments.',
             'feature_fast_cta': 'See the benchmarks',
             'feature_familiar_title': 'Familiar',
             'feature_familiar_desc': 'Supports many programming languages and runnable in the environment where you feel most comfortable.',
             'community_title': 'Join the community',
             'community_desc': 'Discover what our community has to say about their Apache Sedona experience.',
             'events_title': 'Monthly community meetings and programming conferences',
-            'events_cta': 'Find Events'
+            'events_cta': 'Find Events',
+            'events_decor_pre': 'Sedona ',
+            'events_decor_strong': 'Events'
         },
         'zh': {
             'hero_subtitle': 'Apache Sedona™ 让处理任意规模的空间数据变得轻而易举。',
@@ -159,10 +162,12 @@
             'community_title': '加入社区',
             'community_desc': '听听社区对 Apache Sedona 使用体验的分享。',
             'events_title': '每月社区会议与技术大会',
-            'events_cta': '查看活动'
+            'events_cta': '查看活动',
+            'events_decor_pre': 'Sedona ',
+            'events_decor_strong': '活动'
         }
     } -%}
-    {%- set t = i18n[lang] -%}
+    {%- set t = i18n[cur_lang] -%}
     <div class="page-home">
 
       <!-- Section Hero -->
@@ -774,10 +779,9 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
             </div>
             <img src="{{ "image/home/events/corner-mountains.svg" | url }}" alt="" class="corner-img">
             <div class="events-line">
-              {%- set events_decor = {'en': ['Sedona ', 'Events'], 'zh': ['Sedona ', '活动']} -%}
-              <div>{{ events_decor[lang][0] }}<strong>{{ events_decor[lang][1] }}</strong></div>
-              <div>{{ events_decor[lang][0] }}<strong>{{ events_decor[lang][1] }}</strong></div>
-              <div>{{ events_decor[lang][0] }}<strong>{{ events_decor[lang][1] }}</strong></div>
+              <div>{{ t.events_decor_pre }}<strong>{{ t.events_decor_strong }}</strong></div>
+              <div>{{ t.events_decor_pre }}<strong>{{ t.events_decor_strong }}</strong></div>
+              <div>{{ t.events_decor_pre }}<strong>{{ t.events_decor_strong }}</strong></div>
             </div>
           </div>
         </div>

--- a/docs-overrides/main.html
+++ b/docs-overrides/main.html
@@ -170,7 +170,7 @@
         <div class="container">
 
           <div class="logo-wrap">
-            <img src="image/home/hero/logo.svg" alt="" class="logo">
+            <img src="{{ "image/home/hero/logo.svg" | url }}" alt="" class="logo">
             <h1 class="page-title">Apache Sedona</h1>
           </div>
 
@@ -187,7 +187,7 @@
         </div>
 
         <div class="img-bg-wrap">
-          <img src="image/home/hero/mountains-desktop.svg" alt="" class="img-bg">
+          <img src="{{ "image/home/hero/mountains-desktop.svg" | url }}" alt="" class="img-bg">
         </div>
       </section>
 
@@ -324,7 +324,7 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
 
             <div class="info-item">
               <div class="info-item__tag">
-                <img src="image/home/deploy/desktop.svg" alt="" class="">
+                <img src="{{ "image/home/deploy/desktop.svg" | url }}" alt="" class="">
                 <div class="caption">
                   {{ t.tag_local }}
                 </div>
@@ -346,7 +346,7 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
 
             <div class="info-item">
               <div class="info-item__tag">
-                <img src="image/home/deploy/database.svg" alt="" class="">
+                <img src="{{ "image/home/deploy/database.svg" | url }}" alt="" class="">
                 <div class="caption">
                   {{ t.tag_batch }}
                 </div>
@@ -368,7 +368,7 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
 
             <div class="info-item">
               <div class="info-item__tag">
-                <img src="image/home/deploy/signal.svg" alt="" class="">
+                <img src="{{ "image/home/deploy/signal.svg" | url }}" alt="" class="">
                 <div class="caption">
                   {{ t.tag_streaming }}
                 </div>
@@ -390,7 +390,7 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
 
             <div class="info-item">
               <div class="info-item__tag">
-                <img src="image/home/deploy/snowflake.svg" alt="" class="">
+                <img src="{{ "image/home/deploy/snowflake.svg" | url }}" alt="" class="">
                 <div class="caption">
                     {{ t.tag_batch }}
                 </div>
@@ -414,7 +414,7 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
 
             <div class="info-item info-item--wide">
               <div class="info-item__tag">
-                <img src="image/home/deploy/cloud.svg" alt="" class="">
+                <img src="{{ "image/home/deploy/cloud.svg" | url }}" alt="" class="">
                 <div class="caption">
                   {{ t.tag_cloud }}
                 </div>
@@ -480,63 +480,63 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
                 <div data-tab="Mobility" class="industries-tabs__body-item active">
                   <div class="industries-grid">
                     <div class="grid-item">
-                      <img src="image/home/industries/bmw.svg" alt="" class="">
+                      <img src="{{ "image/home/industries/bmw.svg" | url }}" alt="" class="">
                     </div>
                     <div class="grid-item">
-                      <img src="image/home/industries/gm.svg" alt="" class="">
+                      <img src="{{ "image/home/industries/gm.svg" | url }}" alt="" class="">
                     </div>
                     <div class="grid-item">
-                      <img src="image/home/industries/placer-ai.svg" alt="" class="">
+                      <img src="{{ "image/home/industries/placer-ai.svg" | url }}" alt="" class="">
                     </div>
                     <div class="grid-item">
-                      <img src="image/home/industries/arity.svg" alt="" class="">
+                      <img src="{{ "image/home/industries/arity.svg" | url }}" alt="" class="">
                     </div>
                   </div>
                 </div>
 
                 <div data-tab="Telecom" class="industries-tabs__body-item">
                   <div class="industries-grid">
-                    <div class="grid-item"><img src="image/home/industries/comcast.svg" alt="" class=""></div>
-                    <div class="grid-item"><img src="image/home/industries/at&t.svg" alt="" class=""></div>
-                    <div class="grid-item"><img src="image/home/industries/telus.svg" alt="" class=""></div>
-                    <div class="grid-item"><img src="image/home/industries/t-mobile.svg" alt="" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/comcast.svg" | url }}" alt="" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/at&t.svg" | url }}" alt="" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/telus.svg" | url }}" alt="" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/t-mobile.svg" | url }}" alt="" class=""></div>
                   </div>
                 </div>
 
                 <div data-tab="Data and map production" class="industries-tabs__body-item">
                   <div class="industries-grid">
-                    <div class="grid-item"><img src="image/home/industries/space-x.svg" alt="" class=""></div>
-                    <div class="grid-item"><img src="image/home/industries/maxar.svg" alt="" class=""></div>
-                    <div class="grid-item"><img src="image/home/industries/mapbox.svg" alt="" class=""></div>
-                    <div class="grid-item"><img src="image/home/industries/tom-tom.svg" alt="" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/space-x.svg" | url }}" alt="" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/maxar.svg" | url }}" alt="" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/mapbox.svg" | url }}" alt="" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/tom-tom.svg" | url }}" alt="" class=""></div>
                   </div>
                 </div>
 
                 <div data-tab="Logistics" class="industries-tabs__body-item">
                   <div class="industries-grid">
-                    <div class="grid-item"><img src="image/home/industries/instacart.svg" alt="" class=""></div>
-                    <div class="grid-item"><img src="image/home/industries/uber.svg" alt="" class=""></div>
-                    <div class="grid-item"><img src="image/home/industries/UnitedAirlines.svg" alt="" class=""></div>
-                    <div class="grid-item"><img src="image/home/industries/Boeing.svg" alt="" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/instacart.svg" | url }}" alt="" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/uber.svg" | url }}" alt="" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/UnitedAirlines.svg" | url }}" alt="" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/Boeing.svg" | url }}" alt="" class=""></div>
                   </div>
                 </div>
 
                 <div data-tab="Energy" class="industries-tabs__body-item">
                   <div class="industries-grid">
-                    <div class="grid-item"><img src="image/home/industries/shell.svg" alt="" class=""></div>
-                    <div class="grid-item"><img src="image/home/industries/DukeEnergy.svg" alt="" class=""></div>
-                    <div class="grid-item"><img src="image/home/industries/PG&E.svg" alt="" class=""></div>
-                    <div class="grid-item"><img src="image/home/industries/Southern_Company.svg" alt="" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/shell.svg" | url }}" alt="" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/DukeEnergy.svg" | url }}" alt="" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/PG&E.svg" | url }}" alt="" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/Southern_Company.svg" | url }}" alt="" class=""></div>
                   </div>
                 </div>
 
                 <div data-tab="Finance" class="industries-tabs__body-item">
                   <div class="industries-grid">
-                    <div class="grid-item"><img src="image/home/industries/Allstate.svg" alt="" class=""></div>
-                    <div class="grid-item"><img src="image/home/industries/CapitalOne.svg" alt="" class=""></div>
-                    <div class="grid-item"><img src="image/home/industries/cigna.svg" alt="" class=""></div>
-                    <div class="grid-item"><img src="image/home/industries/JPMorganChase.svg" alt="" class=""></div>
-                    <div class="grid-item"><img src="image/home/industries/StateFarm.svg" alt="" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/Allstate.svg" | url }}" alt="" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/CapitalOne.svg" | url }}" alt="" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/cigna.svg" | url }}" alt="" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/JPMorganChase.svg" | url }}" alt="" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/StateFarm.svg" | url }}" alt="" class=""></div>
                   </div>
                 </div>
 
@@ -568,7 +568,7 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
 
             <div class="feature-item">
               <div class="feature-item__icon">
-                <img src="image/home/features/scalable.svg" alt="" class="">
+                <img src="{{ "image/home/features/scalable.svg" | url }}" alt="" class="">
               </div>
               <h3 class="feature-item__title">{{ t.feature_scalable_title }}</h3>
               <div class="feature-item__description editor">{{ t.feature_scalable_desc }}</div>
@@ -576,7 +576,7 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
 
             <div class="feature-item">
               <div class="feature-item__icon">
-                <img src="image/home/features/waves.svg" alt="" class="">
+                <img src="{{ "image/home/features/waves.svg" | url }}" alt="" class="">
               </div>
               <h3 class="feature-item__title">{{ t.feature_complete_title }}</h3>
               <div class="feature-item__description editor">{{ t.feature_complete_desc }}</div>
@@ -584,7 +584,7 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
 
             <div class="feature-item">
               <div class="feature-item__icon">
-                <img src="image/home/features/picture.svg" alt="" class="">
+                <img src="{{ "image/home/features/picture.svg" | url }}" alt="" class="">
               </div>
               <h3 class="feature-item__title">{{ t.feature_raster_title }}</h3>
               <div class="feature-item__description editor">{{ t.feature_raster_desc }}</div>
@@ -592,7 +592,7 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
 
             <div class="feature-item">
               <div class="feature-item__icon">
-                <img src="image/home/features/cloud.svg" alt="" class="">
+                <img src="{{ "image/home/features/cloud.svg" | url }}" alt="" class="">
               </div>
               <h3 class="feature-item__title">{{ t.feature_portable_title }}</h3>
               <div class="feature-item__description editor">{{ t.feature_portable_desc }}</div>
@@ -600,7 +600,7 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
 
             <div class="feature-item">
               <div class="feature-item__icon">
-                <img src="image/home/features/rocket.svg" alt="" class="">
+                <img src="{{ "image/home/features/rocket.svg" | url }}" alt="" class="">
               </div>
               <h3 class="feature-item__title">{{ t.feature_fast_title }}</h3>
               <div class="feature-item__description editor">{{ t.feature_fast_desc }}</div>
@@ -619,7 +619,7 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
 
             <div class="feature-item">
               <div class="feature-item__icon">
-                <img src="image/home/features/code.svg" alt="" class="">
+                <img src="{{ "image/home/features/code.svg" | url }}" alt="" class="">
               </div>
               <h3 class="feature-item__title">{{ t.feature_familiar_title }}</h3>
               <div class="feature-item__description editor">{{ t.feature_familiar_desc }}</div>
@@ -681,7 +681,7 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
             <div class="community-card">
               <div class="community-card__author">
                 <div class="author-avatar">
-                  <img src="image/home/community/author.jpg" alt="" class="">
+                  <img src="{{ "image/home/community/author.jpg" | url }}" alt="" class="">
                 </div>
                 <div class="author-info">
                   <div class="author-name">Sean Rose</div>
@@ -695,7 +695,7 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
             <div class="community-card">
               <div class="community-card__author">
                 <div class="author-avatar">
-                  <img src="image/home/community/author.jpg" alt="" class="">
+                  <img src="{{ "image/home/community/author.jpg" | url }}" alt="" class="">
                 </div>
                 <div class="author-info">
                   <div class="author-name">Sean Rose</div>
@@ -709,7 +709,7 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
             <div class="community-card">
               <div class="community-card__author">
                 <div class="author-avatar">
-                  <img src="image/home/community/author.jpg" alt="" class="">
+                  <img src="{{ "image/home/community/author.jpg" | url }}" alt="" class="">
                 </div>
                 <div class="author-info">
                   <div class="author-name">Sean Rose</div>
@@ -723,7 +723,7 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
             <div class="community-card">
               <div class="community-card__author">
                 <div class="author-avatar">
-                  <img src="image/home/community/author.jpg" alt="" class="">
+                  <img src="{{ "image/home/community/author.jpg" | url }}" alt="" class="">
                 </div>
                 <div class="author-info">
                   <div class="author-name">Sean Rose</div>
@@ -737,7 +737,7 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
             <div class="community-card">
               <div class="community-card__author">
                 <div class="author-avatar">
-                  <img src="image/home/community/author.jpg" alt="" class="">
+                  <img src="{{ "image/home/community/author.jpg" | url }}" alt="" class="">
                 </div>
                 <div class="author-info">
                   <div class="author-name">Sean Rose</div>
@@ -772,7 +772,7 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
                 </a>
               </div>
             </div>
-            <img src="image/home/events/corner-mountains.svg" alt="" class="corner-img">
+            <img src="{{ "image/home/events/corner-mountains.svg" | url }}" alt="" class="corner-img">
             <div class="events-line">
               {%- set events_decor = {'en': ['Sedona ', 'Events'], 'zh': ['Sedona ', '活动']} -%}
               <div>{{ events_decor[lang][0] }}<strong>{{ events_decor[lang][1] }}</strong></div>

--- a/docs-overrides/main.html
+++ b/docs-overrides/main.html
@@ -1,9 +1,14 @@
 {% extends "base.html" %}
 
 {% block outdated %}
-You're not viewing the latest stable version.
+{%- set lang = config.theme.language if config.theme.language in ['en', 'zh'] else 'en' -%}
+{%- set outdated_msg = {
+    'en': ['You\'re not viewing the latest stable version.', 'Click here to go to the latest stable version.'],
+    'zh': ['您当前查看的不是最新稳定版本。', '点击此处跳转到最新稳定版本。']
+} -%}
+{{ outdated_msg[lang][0] }}
 <a href="{{ '../' ~ base_url }}">
-  <strong>Click here to go to the latest stable version.</strong>
+  <strong>{{ outdated_msg[lang][1] }}</strong>
 </a>
 {% endblock %}
 
@@ -20,14 +25,144 @@ You're not viewing the latest stable version.
 {% endblock %}
 
 {% block header %}
+  {%- set lang = config.theme.language if config.theme.language in ['en', 'zh'] else 'en' -%}
+  {%- set announcement = {
+      'en': 'Apache Sedona 1.9.0 is out now, featuring Spark 4.1 support, proj4sedona CRS transformation, Bing Tile functions, and more!',
+      'zh': 'Apache Sedona 1.9.0 已正式发布，新增 Spark 4.1 支持、proj4sedona 坐标系转换、Bing Tile 函数等众多特性！'
+  } -%}
   <div style="background: #CA463A; color: white; text-align: center; padding: 0.5rem;">
-    <a href="setup/release-notes/" title="Announcement">Apache Sedona 1.9.0 is out now, featuring Spark 4.1 support, proj4sedona CRS transformation, Bing Tile functions, and more!</a>
+    <a href="setup/release-notes/" title="Announcement">{{ announcement[lang] }}</a>
   </div>
   {{ super() }} {# This renders the original header below your test bar #}
 {% endblock %}
 
 {% block container %}
-    {% if page.is_homepage %}
+    {% set is_home = page.is_homepage or (page.file and page.file.src_uri in ['index.md', 'index.zh.md']) %}
+    {% if is_home %}
+    {%- set lang = config.theme.language if config.theme.language in ['en', 'zh'] else 'en' -%}
+    {%- set i18n = {
+        'en': {
+            'hero_subtitle': 'Apache Sedona™ makes it easy to process spatial datasets of any scale.',
+            'hero_cta': 'Get Started',
+            'global_scale_title_1': 'QUERY and JOIN',
+            'global_scale_title_2': 'from local to global scale',
+            'typed_gps': 'GPS points',
+            'typed_buildings': 'buildings',
+            'typed_parcels': 'parcels',
+            'typed_trips': 'trips',
+            'typed_places': 'places',
+            'typed_businesses': 'businesses',
+            'typed_land': 'land',
+            'typed_vegetation': 'vegetation',
+            'typed_rasters': 'rasters',
+            'typed_vectors': 'vectors',
+            'typed_tabular': 'tabular tables',
+            'get_started_title': 'Get started in seconds',
+            'get_started_desc': 'Install SedonaDB, or run Sedona on distributed systems when you need additional scale.',
+            'install_sedonadb_cta': 'Install SedonaDB',
+            'deploy_title': 'Deploy Sedona where you need it',
+            'deploy_desc': 'Choose the right runtime for your infrastructure, from local setups to distributed and cloud-native systems.',
+            'tag_local': 'Local',
+            'tag_batch': 'Batch',
+            'tag_streaming': 'Streaming',
+            'tag_cloud': 'Cloud',
+            'sedonadb_desc': 'Standalone runtime for local processing and development.',
+            'sedonaspark_desc': 'Distributed batch processing on Apache Spark clusters.',
+            'sedonaflink_desc': 'Real-time spatial analytics using Apache Flink.',
+            'sedonasnow_desc': 'Native spatial support inside Snowflake environments.',
+            'sedona_cloud_title': 'Sedona in the Cloud',
+            'sedona_cloud_desc': 'Integrated spatial support in your preferred cloud environment',
+            'sedona_cloud_cta': 'Explore the ecosystem',
+            'industries_title': 'Want to share your Sedona use case?',
+            'industries_subtitle': 'Join our Discord or create a GitHub Discussion so we can collaborate.',
+            'industry_mobility': 'Mobility',
+            'industry_telecom': 'Telecom',
+            'industry_data': 'Data and map production',
+            'industry_logistics': 'Logistics',
+            'industry_energy': 'Energy',
+            'industry_finance': 'Finance',
+            'features_title': 'Apache Sedona at a glance',
+            'features_desc': 'Core features that define Sedona’s geospatial performance',
+            'feature_scalable_title': 'Scalable',
+            'feature_scalable_desc': 'Works with small or large datasets with Spark, Flink, or locally.',
+            'feature_complete_title': 'Feature Complete',
+            'feature_complete_desc': '300+ spatial functions, support for spatial file formats, and compatible with lakehouses and databases.',
+            'feature_raster_title': 'Raster and Vector Support',
+            'feature_raster_desc': 'Analyze both raster and vector datasets.',
+            'feature_portable_title': 'Portable',
+            'feature_portable_desc': 'Easy to run locally, in the cloud, or with any data platform.',
+            'feature_fast_title': 'Fast',
+            'feature_fast_desc': 'Optimized execution for single node or distribute cluster environments.',
+            'feature_fast_cta': 'See the benchmarks',
+            'feature_familiar_title': 'Familiar',
+            'feature_familiar_desc': 'Supports many programming languages and runnable in the environment where you feel most comfortable.',
+            'community_title': 'Join the community',
+            'community_desc': 'Discover what our community has to say about their Apache Sedona experience.',
+            'events_title': 'Monthly community meetings and programming conferences',
+            'events_cta': 'Find Events'
+        },
+        'zh': {
+            'hero_subtitle': 'Apache Sedona™ 让处理任意规模的空间数据变得轻而易举。',
+            'hero_cta': '立即开始',
+            'global_scale_title_1': '查询与连接',
+            'global_scale_title_2': '从本地到全球规模',
+            'typed_gps': 'GPS 轨迹点',
+            'typed_buildings': '建筑',
+            'typed_parcels': '地块',
+            'typed_trips': '出行',
+            'typed_places': '场所',
+            'typed_businesses': '商户',
+            'typed_land': '土地',
+            'typed_vegetation': '植被',
+            'typed_rasters': '栅格',
+            'typed_vectors': '矢量',
+            'typed_tabular': '表格数据',
+            'get_started_title': '几秒钟即可上手',
+            'get_started_desc': '安装 SedonaDB，或在需要更大规模时将 Sedona 部署到分布式系统。',
+            'install_sedonadb_cta': '安装 SedonaDB',
+            'deploy_title': '在任何需要的地方部署 Sedona',
+            'deploy_desc': '从本地环境到分布式与云原生系统，选择最适合您基础设施的运行时。',
+            'tag_local': '本地',
+            'tag_batch': '批处理',
+            'tag_streaming': '流处理',
+            'tag_cloud': '云端',
+            'sedonadb_desc': '面向本地处理与开发的独立运行时。',
+            'sedonaspark_desc': '在 Apache Spark 集群上的分布式批处理。',
+            'sedonaflink_desc': '基于 Apache Flink 的实时空间分析。',
+            'sedonasnow_desc': '在 Snowflake 环境中提供原生空间支持。',
+            'sedona_cloud_title': '云端的 Sedona',
+            'sedona_cloud_desc': '在您所选的云环境中集成空间能力',
+            'sedona_cloud_cta': '探索生态系统',
+            'industries_title': '想分享您的 Sedona 应用案例？',
+            'industries_subtitle': '加入我们的 Discord，或在 GitHub Discussions 发起讨论，与我们协作。',
+            'industry_mobility': '出行',
+            'industry_telecom': '电信',
+            'industry_data': '数据与地图生产',
+            'industry_logistics': '物流',
+            'industry_energy': '能源',
+            'industry_finance': '金融',
+            'features_title': 'Apache Sedona 概览',
+            'features_desc': '定义 Sedona 地理空间性能的核心特性',
+            'feature_scalable_title': '可扩展',
+            'feature_scalable_desc': '可在 Spark、Flink 或本地处理小型或大型数据集。',
+            'feature_complete_title': '功能完备',
+            'feature_complete_desc': '300+ 空间函数，支持多种空间文件格式，并与数据湖仓和数据库兼容。',
+            'feature_raster_title': '同时支持栅格与矢量',
+            'feature_raster_desc': '可同时分析栅格与矢量数据集。',
+            'feature_portable_title': '可移植',
+            'feature_portable_desc': '易于在本地、云端或任何数据平台上运行。',
+            'feature_fast_title': '高性能',
+            'feature_fast_desc': '面向单节点或分布式集群环境的优化执行。',
+            'feature_fast_cta': '查看基准测试',
+            'feature_familiar_title': '熟悉易用',
+            'feature_familiar_desc': '支持多种编程语言，可在您最熟悉的环境中使用。',
+            'community_title': '加入社区',
+            'community_desc': '听听社区对 Apache Sedona 使用体验的分享。',
+            'events_title': '每月社区会议与技术大会',
+            'events_cta': '查看活动'
+        }
+    } -%}
+    {%- set t = i18n[lang] -%}
     <div class="page-home">
 
       <!-- Section Hero -->
@@ -40,12 +175,12 @@ You're not viewing the latest stable version.
           </div>
 
           <div class="section-description editor">
-            Apache Sedona™ makes it easy to process spatial datasets of any scale.
+            {{ t.hero_subtitle }}
           </div>
 
           <div class="btn-group">
             <a href="{{ page.next_page.url | url }}" title="{{ page.next_page.title | striptags }}" class="btn btn-black">
-              Get Started
+              {{ t.hero_cta }}
             </a>
           </div>
 
@@ -63,24 +198,24 @@ You're not viewing the latest stable version.
 
             <div class="col-left">
               <div class="section-title">
-                <div>QUERY and JOIN</div>
+                <div>{{ t.global_scale_title_1 }}</div>
 
                 <p class="typed-wrap"><span class="typed"></span></p>
                 <div class="typed-strings">
-                  <p>GPS points</p>
-                  <p>buildings</p>
-                  <p>parcels</p>
-                  <p>trips</p>
-                  <p>places</p>
-                  <p>businesses</p>
-                  <p>land</p>
-                  <p>vegetation</p>
-                  <p>rasters</p>
-                  <p>vectors</p>
-                  <p>tabular tables</p>
+                  <p>{{ t.typed_gps }}</p>
+                  <p>{{ t.typed_buildings }}</p>
+                  <p>{{ t.typed_parcels }}</p>
+                  <p>{{ t.typed_trips }}</p>
+                  <p>{{ t.typed_places }}</p>
+                  <p>{{ t.typed_businesses }}</p>
+                  <p>{{ t.typed_land }}</p>
+                  <p>{{ t.typed_vegetation }}</p>
+                  <p>{{ t.typed_rasters }}</p>
+                  <p>{{ t.typed_vectors }}</p>
+                  <p>{{ t.typed_tabular }}</p>
                 </div>
 
-                <div>from local to global scale</div>
+                <div>{{ t.global_scale_title_2 }}</div>
               </div>
               <div class="section-description editor"></div>
             </div>
@@ -163,15 +298,15 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
             </div>
             <div class="col-right">
               <h2 class="section-title">
-                Get started in seconds
+                {{ t.get_started_title }}
               </h2>
               <div class="section-description editor">
-                Install SedonaDB, or run Sedona on distributed systems when you need additional scale.
+                {{ t.get_started_desc }}
               </div>
               <div class="bth-group">
                 <a href="/sedonadb" class="btn btn-red">
                      <span class="caption">
-                   Install SedonaDB
+                   {{ t.install_sedonadb_cta }}
                   </span>
                 </a>
               </div>
@@ -183,19 +318,19 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
       <!-- Section Deploy -->
       <section class="section-deploy">
         <div class="container">
-          <h2 class="section-title">Deploy Sedona where you need it</h2>
-          <div class="section-description editor">Choose the right runtime for your infrastructure, from local setups to distributed and cloud-native systems.</div>
+          <h2 class="section-title">{{ t.deploy_title }}</h2>
+          <div class="section-description editor">{{ t.deploy_desc }}</div>
           <div class="info-grid">
 
             <div class="info-item">
               <div class="info-item__tag">
                 <img src="image/home/deploy/desktop.svg" alt="" class="">
                 <div class="caption">
-                  Local
+                  {{ t.tag_local }}
                 </div>
               </div>
               <h3 class="info-item__title">SedonaDB</h3>
-              <div class="info-item__description editor">Standalone runtime for local processing and development.</div>
+              <div class="info-item__description editor">{{ t.sedonadb_desc }}</div>
               <div class="info-item__cta">
                 <a href="/sedonadb" class="btn-link">
                   <span class="caption">SedonaDB</span>
@@ -213,11 +348,11 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
               <div class="info-item__tag">
                 <img src="image/home/deploy/database.svg" alt="" class="">
                 <div class="caption">
-                  Batch
+                  {{ t.tag_batch }}
                 </div>
               </div>
               <h3 class="info-item__title">SedonaSpark</h3>
-              <div class="info-item__description editor">Distributed batch processing on Apache Spark clusters.</div>
+              <div class="info-item__description editor">{{ t.sedonaspark_desc }}</div>
               <div class="info-item__cta">
                 <a href="sedonaspark" class="btn-link">
                   <span class="caption">SedonaSpark</span>
@@ -235,11 +370,11 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
               <div class="info-item__tag">
                 <img src="image/home/deploy/signal.svg" alt="" class="">
                 <div class="caption">
-                  Streaming
+                  {{ t.tag_streaming }}
                 </div>
               </div>
               <h3 class="info-item__title">SedonaFlink</h3>
-              <div class="info-item__description editor">Real-time spatial analytics using Apache Flink.</div>
+              <div class="info-item__description editor">{{ t.sedonaflink_desc }}</div>
               <div class="info-item__cta">
                 <a href="sedonaflink" class="btn-link">
                   <span class="caption">SedonaFlink</span>
@@ -257,12 +392,12 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
               <div class="info-item__tag">
                 <img src="image/home/deploy/snowflake.svg" alt="" class="">
                 <div class="caption">
-                    Batch
+                    {{ t.tag_batch }}
                 </div>
               </div>
               <h3 class="info-item__title">SedonaSnow</h3>
               <div class="info-item__description editor">
-                Native spatial support inside Snowflake environments.
+                {{ t.sedonasnow_desc }}
               </div>
               <div class="info-item__cta">
                 <a href="sedonasnow" class="btn-link">
@@ -281,14 +416,14 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
               <div class="info-item__tag">
                 <img src="image/home/deploy/cloud.svg" alt="" class="">
                 <div class="caption">
-                  Cloud
+                  {{ t.tag_cloud }}
                 </div>
               </div>
-              <h3 class="info-item__title">Sedona in the Cloud</h3>
-              <div class="info-item__description editor">Integrated spatial support in your preferred cloud environment</div>
+              <h3 class="info-item__title">{{ t.sedona_cloud_title }}</h3>
+              <div class="info-item__description editor">{{ t.sedona_cloud_desc }}</div>
               <div class="info-item__cta">
                 <a href="setup/overview/" class="btn-link">
-                  <span class="caption">Explore the ecosystem</span>
+                  <span class="caption">{{ t.sedona_cloud_cta }}</span>
                   <span class="icon">
                         <svg width="19" height="19" viewBox="0 0 19 19" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M3.95831 9.5H15.0416" stroke="#CA463A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
@@ -309,10 +444,10 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
         <div class="container">
           <div class="content-box">
 
-            <h2 class="section-title">Want to share your Sedona use case?</h2>
+            <h2 class="section-title">{{ t.industries_title }}</h2>
 
             <div class="section__subtitle editor">
-              Join our Discord or create a GitHub Discussion so we can collaborate.
+              {{ t.industries_subtitle }}
             </div>
 
             <div class="industries-tabs">
@@ -320,22 +455,22 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
               <div class="industries-tabs__head-wrap">
                 <div class="industries-tabs__head">
                   <div class="industries-tabs__head-item active">
-                    Mobility
+                    {{ t.industry_mobility }}
                   </div>
                   <div class="industries-tabs__head-item ">
-                    Telecom
+                    {{ t.industry_telecom }}
                   </div>
                   <div class="industries-tabs__head-item">
-                    Data and map production
+                    {{ t.industry_data }}
                   </div>
                   <div class="industries-tabs__head-item">
-                    Logistics
+                    {{ t.industry_logistics }}
                   </div>
                   <div class="industries-tabs__head-item">
-                    Energy
+                    {{ t.industry_energy }}
                   </div>
                   <div class="industries-tabs__head-item">
-                    Finance
+                    {{ t.industry_finance }}
                   </div>
                 </div>
               </div>
@@ -427,51 +562,51 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
       <!-- Section Features -->
       <section class="section-features">
         <div class="container">
-          <h2 class="section-title">Apache Sedona at a glance</h2>
-          <div class="section-description editor">Core features that define Sedona’s geospatial performance</div>
+          <h2 class="section-title">{{ t.features_title }}</h2>
+          <div class="section-description editor">{{ t.features_desc }}</div>
           <div class="features-grid">
 
             <div class="feature-item">
               <div class="feature-item__icon">
                 <img src="image/home/features/scalable.svg" alt="" class="">
               </div>
-              <h3 class="feature-item__title">Scalable</h3>
-              <div class="feature-item__description editor">Works with small or large datasets with Spark, Flink, or locally.</div>
+              <h3 class="feature-item__title">{{ t.feature_scalable_title }}</h3>
+              <div class="feature-item__description editor">{{ t.feature_scalable_desc }}</div>
             </div>
 
             <div class="feature-item">
               <div class="feature-item__icon">
                 <img src="image/home/features/waves.svg" alt="" class="">
               </div>
-              <h3 class="feature-item__title">Feature Complete</h3>
-              <div class="feature-item__description editor">300+ spatial functions, support for spatial file formats, and compatible with lakehouses and databases.</div>
+              <h3 class="feature-item__title">{{ t.feature_complete_title }}</h3>
+              <div class="feature-item__description editor">{{ t.feature_complete_desc }}</div>
             </div>
 
             <div class="feature-item">
               <div class="feature-item__icon">
                 <img src="image/home/features/picture.svg" alt="" class="">
               </div>
-              <h3 class="feature-item__title">Raster and Vector Support</h3>
-              <div class="feature-item__description editor">Analyze both raster and vector datasets.</div>
+              <h3 class="feature-item__title">{{ t.feature_raster_title }}</h3>
+              <div class="feature-item__description editor">{{ t.feature_raster_desc }}</div>
             </div>
 
             <div class="feature-item">
               <div class="feature-item__icon">
                 <img src="image/home/features/cloud.svg" alt="" class="">
               </div>
-              <h3 class="feature-item__title">Portable</h3>
-              <div class="feature-item__description editor">Easy to run locally, in the cloud, or with any data platform.</div>
+              <h3 class="feature-item__title">{{ t.feature_portable_title }}</h3>
+              <div class="feature-item__description editor">{{ t.feature_portable_desc }}</div>
             </div>
 
             <div class="feature-item">
               <div class="feature-item__icon">
                 <img src="image/home/features/rocket.svg" alt="" class="">
               </div>
-              <h3 class="feature-item__title">Fast</h3>
-              <div class="feature-item__description editor">Optimized execution for single node or distribute cluster environments.</div>
+              <h3 class="feature-item__title">{{ t.feature_fast_title }}</h3>
+              <div class="feature-item__description editor">{{ t.feature_fast_desc }}</div>
               <div class="feature-item__cta">
                 <a href="https://github.com/apache/sedona-spatialbench" class="btn-link">
-                  <span class="caption">See the benchmarks</span>
+                  <span class="caption">{{ t.feature_fast_cta }}</span>
                   <span class="icon">
                         <svg width="19" height="19" viewBox="0 0 19 19" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M3.95831 9.5H15.0416" stroke="#CA463A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
@@ -486,8 +621,8 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
               <div class="feature-item__icon">
                 <img src="image/home/features/code.svg" alt="" class="">
               </div>
-              <h3 class="feature-item__title">Familiar</h3>
-              <div class="feature-item__description editor">Supports many programming languages and runnable in the environment where you feel most comfortable.</div>
+              <h3 class="feature-item__title">{{ t.feature_familiar_title }}</h3>
+              <div class="feature-item__description editor">{{ t.feature_familiar_desc }}</div>
             </div>
 
 
@@ -510,8 +645,8 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
       <!-- Section Community -->
       <section class="section-community">
         <div class="container">
-          <h2 class="section-title">Join the community</h2>
-          <div class="section-description editor">Discover what our community has to say about their Apache Sedona experience.</div>
+          <h2 class="section-title">{{ t.community_title }}</h2>
+          <div class="section-description editor">{{ t.community_desc }}</div>
           <div class="btn-group">
             <a href="https://github.com/apache/sedona/discussions" class="btn btn-light-red">
                   <span class="caption">
@@ -627,21 +762,22 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
           <div class="content-box">
             <div class="content-box__inner">
               <h2 class="section-title">
-                Monthly community meetings and programming conferences
+                {{ t.events_title }}
               </h2>
               <div class="btn-group">
                 <a href="community/contact/" class="btn btn-red">
                      <span class="caption">
-                    Find Events
+                    {{ t.events_cta }}
                   </span>
                 </a>
               </div>
             </div>
             <img src="image/home/events/corner-mountains.svg" alt="" class="corner-img">
             <div class="events-line">
-              <div>Sedona <strong>Events</strong></div>
-              <div>Sedona <strong>Events</strong></div>
-              <div>Sedona <strong>Events</strong></div>
+              {%- set events_decor = {'en': ['Sedona ', 'Events'], 'zh': ['Sedona ', '活动']} -%}
+              <div>{{ events_decor[lang][0] }}<strong>{{ events_decor[lang][1] }}</strong></div>
+              <div>{{ events_decor[lang][0] }}<strong>{{ events_decor[lang][1] }}</strong></div>
+              <div>{{ events_decor[lang][0] }}<strong>{{ events_decor[lang][1] }}</strong></div>
             </div>
           </div>
         </div>

--- a/docs-overrides/partials/alternate.html
+++ b/docs-overrides/partials/alternate.html
@@ -1,0 +1,15 @@
+{% if config.extra.alternate and config.extra.alternate | length > 1 %}
+<nav class="sd-lang-switch" aria-label="{{ lang.t('select.language') }}">
+  {% for alt in config.extra.alternate %}
+    {%- set is_active = (alt.lang == config.theme.language) -%}
+    <a
+      href="{{ alt.link | url }}"
+      hreflang="{{ alt.lang }}"
+      lang="{{ alt.lang }}"
+      target="_self"
+      class="sd-lang-switch__item{% if is_active %} sd-lang-switch__item--active{% endif %}"
+      {% if is_active %}aria-current="true"{% endif %}
+    >{{ alt.name }}</a>
+  {% endfor %}
+</nav>
+{% endif %}

--- a/docs/download.zh.md
+++ b/docs/download.zh.md
@@ -1,0 +1,63 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+## GitHub 代码仓库
+
+最新源代码：[GitHub 代码仓库](https://github.com/apache/sedona/)
+
+历史 GeoSpark 版本：[GitHub Releases](https://github.com/apache/sedona/releases)
+
+每次提交到 master 分支后自动构建的二进制 JAR 包：[GitHub Action](https://github.com/apache/sedona/actions/workflows/java.yml)
+
+## 校验完整性
+
+[公钥](https://downloads.apache.org/sedona/KEYS)
+
+[校验说明](https://www.apache.org/info/verification.html)
+
+## 版本
+
+### 1.9.0
+
+| |                                    从 ASF 下载                                     |                                         校验和                                          |                                      签名                                      |
+|:-----------------:|:----------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------:|
+|    源代码    | [src](https://www.apache.org/dyn/closer.lua/sedona/1.9.0/apache-sedona-1.9.0-src.tar.gz) | [sha512](https://downloads.apache.org/sedona/1.9.0/apache-sedona-1.9.0-src.tar.gz.sha512) | [asc](https://downloads.apache.org/sedona/1.9.0/apache-sedona-1.9.0-src.tar.gz.asc) |
+|       二进制      | [bin](https://www.apache.org/dyn/closer.lua/sedona/1.9.0/apache-sedona-1.9.0-bin.tar.gz) | [sha512](https://downloads.apache.org/sedona/1.9.0/apache-sedona-1.9.0-bin.tar.gz.sha512) | [asc](https://downloads.apache.org/sedona/1.9.0/apache-sedona-1.9.0-bin.tar.gz.asc) |
+
+### 1.8.1
+
+| |                                    从 ASF 下载                                     |                                         校验和                                          |                                      签名                                      |
+|:-----------------:|:----------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------:|
+|    源代码    | [src](https://www.apache.org/dyn/closer.lua/sedona/1.8.1/apache-sedona-1.8.1-src.tar.gz) | [sha512](https://downloads.apache.org/sedona/1.8.1/apache-sedona-1.8.1-src.tar.gz.sha512) | [asc](https://downloads.apache.org/sedona/1.8.1/apache-sedona-1.8.1-src.tar.gz.asc) |
+|       二进制      | [bin](https://www.apache.org/dyn/closer.lua/sedona/1.8.1/apache-sedona-1.8.1-bin.tar.gz) | [sha512](https://downloads.apache.org/sedona/1.8.1/apache-sedona-1.8.1-bin.tar.gz.sha512) | [asc](https://downloads.apache.org/sedona/1.8.1/apache-sedona-1.8.1-bin.tar.gz.asc) |
+
+### 1.7.2
+
+| |                                    从 ASF 下载                                     |                                         校验和                                          |                                      签名                                      |
+|:-----------------:|:----------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------:|
+|    源代码    | [src](https://www.apache.org/dyn/closer.lua/sedona/1.7.2/apache-sedona-1.7.2-src.tar.gz) | [sha512](https://downloads.apache.org/sedona/1.7.2/apache-sedona-1.7.2-src.tar.gz.sha512) | [asc](https://downloads.apache.org/sedona/1.7.2/apache-sedona-1.7.2-src.tar.gz.asc) |
+|       二进制      | [bin](https://www.apache.org/dyn/closer.lua/sedona/1.7.2/apache-sedona-1.7.2-bin.tar.gz) | [sha512](https://downloads.apache.org/sedona/1.7.2/apache-sedona-1.7.2-bin.tar.gz.sha512) | [asc](https://downloads.apache.org/sedona/1.7.2/apache-sedona-1.7.2-bin.tar.gz.asc) |
+
+### 历史版本
+
+历史版本的 Sedona 已归档，可在以下位置找到：[Apache 归档](https://archive.apache.org/dist/sedona/)（1.2.1-incubating 及之后的版本）。
+
+## 安全
+
+如有安全相关问题，请参阅 https://www.apache.org/security/

--- a/docs/sedonaflink.zh.md
+++ b/docs/sedonaflink.zh.md
@@ -1,0 +1,111 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# SedonaFlink
+
+SedonaFlink 将地理空间函数集成到 Apache Flink 中，是构建依赖地理空间数据的流式管道的理想选择。
+
+以下是 SedonaFlink 的一些典型应用场景：
+
+* 从 Kafka 读取地理空间数据并写入 Iceberg
+* [实时分析交通密度](https://www.alibabacloud.com/help/en/flink/realtime-flink/use-cases/analyze-traffic-density-with-flink-and-apache-sedona)
+* 电信行业的实时网络规划与优化
+
+下面是一些示例代码片段：
+
+=== "Java"
+
+    ```java
+    sedona.createTemporaryView("myTable", tbl)
+    Table geomTbl = sedona.sqlQuery("SELECT ST_GeomFromWKT(geom_polygon) as geom_polygon, name_polygon FROM myTable")
+    geomTbl.execute().print()
+    ```
+
+=== "PyFlink"
+
+    ```python
+    table_env.sql_query("SELECT ST_ASBinary(ST_Point(1.0, 2.0))").execute().collect()
+    ```
+
+## 主要特性
+
+* **实时地理空间流处理**，满足低延迟处理需求。
+* **可扩展**，适用于大规模流式管道。
+* 基于 Flink 的时间窗口实现**事件时间处理**。
+* 提供**精确一次（Exactly Once）**处理保证。
+* **可移植**，易于在任何 Flink 运行时中部署。
+* **开源**，遵循 Apache 软件基金会的准则进行管理。
+
+## 为什么在 Flink 上使用 Sedona？
+
+Flink 是为流式数据而设计的，Sedona 在此基础上为其加入了地理空间处理能力。
+
+大多数地理空间处理发生在 Spark 或 PostGIS 这类批处理系统中，对于延迟要求不高的场景这没有问题。
+
+而当需要实时处理地理空间数据时，Sedona on Flink 的优势就会显现出来。
+
+Flink 可以为地理空间查询提供毫秒级的延迟。
+
+Flink 拥有完善的容错机制，即使在故障发生时，地理空间管道也不会丢失数据。
+
+Sedona on Flink 可以在 Flink 支持的任何环境中运行，包括 Kubernetes、YARN 以及独立集群。
+
+## 工作原理
+
+Sedona 直接集成到 Flink 的 Table API 和 SQL 引擎中。
+
+在搭建 Flink 环境时注册 Sedona 的空间函数，即可在 SQL 查询中使用 `ST_Point`、`ST_Contains`、`ST_Distance` 等函数。
+
+Sedona 同时支持 Flink 的 DataStream API 与 Table API，可根据自身工作流程选用。
+
+空间运算作为 Flink 分布式执行的一部分运行，因此地理空间计算会自动在集群中并行执行。
+
+Sedona 在 Flink 内部以二进制方式存储几何对象，从而保持较低的内存占用与较高的处理速度。
+
+执行空间连接时，Sedona 在底层使用空间索引，使查询能够快速完成。
+
+容错由 Flink 的检查点（checkpoint）机制处理。如果某个节点崩溃，地理空间状态可以从最近一次检查点恢复。
+
+通常的流程是：从 Kafka 或文件系统等数据源读取地理空间数据，使用 Sedona 的空间函数进行处理，然后将结果写入 Iceberg 等数据汇。
+
+整条 SedonaFlink 管道持续运行，新事件会实时流过空间转换逻辑。
+
+## 与其他方案的对比
+
+对于较小的数据集，可能并不需要分布式集群，使用 SedonaDB 即可。
+
+对于大规模批处理管道，可以使用 SedonaSpark。
+
+下面是 SedonaFlink 与几种流式方案的直接对比。
+
+**SedonaFlink 与 Sedona on Spark Structured Streaming**
+
+Spark Streaming 采用微批（micro-batch）模式，而 Flink 是逐事件处理。在某些工作流中，这能让 Flink 的延迟更低。
+
+Flink 的状态管理也更为成熟。
+
+如果已经深度使用 Spark 生态，且 Spark Structured Streaming 的延迟可以满足需求，可以选择 Spark；如果对延迟有非常严苛的要求，建议选择 Flink。
+
+**Sedona on Flink 与 PostGIS**
+
+PostGIS 非常适合用于 OLTP 工作负载下的地理空间数据存储与查询，但它并不是为流式处理而设计的。
+
+如果使用 PostGIS 处理流式工作负载，需要持续从流处理器中查询数据库，这会增加延迟，并对数据库造成压力。
+
+SedonaFlink 在数据流转过程中即对地理空间数据进行处理，从而避免了与数据库之间的往返开销。

--- a/docs/sedonasnow.zh.md
+++ b/docs/sedonasnow.zh.md
@@ -1,0 +1,55 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# SedonaSnow
+
+SedonaSnow 将 Apache Sedona 的 200 多个地理空间函数直接引入到 Snowflake 环境中，作为 Snowflake 原生空间函数的有力补充。
+
+## 主要优势
+
+* **200+ 空间函数**：例如 3D 距离、几何对象校验、精度归约等
+* **高性能空间连接**：Sedona 针对空间连接做了专门优化
+* **无缝集成**：与 Snowflake 原生函数协同工作
+* **数据无需移动**：所有处理都在 Snowflake 内部完成
+
+## 快速上手
+
+下面是一个使用 SedonaSnow 在 Snowflake 表上执行查询的示例。
+
+```sql
+USE DATABASE SEDONASNOW;
+
+SELECT SEDONA.ST_GeomFromWKT(wkt) AS geom
+FROM your_table;
+
+SELECT SEDONA.ST_3DDistance(geom1, geom2) FROM spatial_data;
+```
+
+下面是一个空间连接的示例：
+
+```sql
+SELECT * FROM lefts, rights
+WHERE lefts.cellId = rights.cellId;
+```
+
+可以看出，SedonaSnow 能够无缝地接入现有的 Snowflake 环境。
+
+## 后续步骤
+
+如果您正在 Snowflake 中进行严肃的空间分析工作，SedonaSnow 是一个非常合适的选择。它运行速度快，并提供了丰富的空间函数。SedonaSnow 在不需要将数据迁移到其他平台的前提下，突破了 Snowflake 内置空间函数的能力限制。

--- a/docs/sedonaspark.zh.md
+++ b/docs/sedonaspark.zh.md
@@ -124,7 +124,7 @@ SedonaKepler.add_df(kepler_map, df=res, name="Tri-state water")
 
 地图效果非常出色！
 
-![New York City water](../image/nyc_base_water.png)
+![New York City water](image/nyc_base_water.png)
 
 通过这张地图，可以清晰地看到纽约市地区的所有河流、湖泊乃至游泳池。
 

--- a/docs/sedonaspark.zh.md
+++ b/docs/sedonaspark.zh.md
@@ -1,0 +1,135 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# SedonaSpark
+
+SedonaSpark 在 Apache Spark 之上扩展了一套丰富、开箱即用的分布式空间数据集和函数，能够在多台机器之间高效地加载、处理和分析大规模空间数据。当数据集规模超过单机处理能力时，SedonaSpark 是一个非常合适的选择。
+
+=== "SQL"
+
+    ```sql
+    SELECT superhero.name
+    FROM city, superhero
+    WHERE ST_Contains(city.geom, superhero.geom)
+    AND city.name = 'Gotham'
+    ```
+
+=== "PySpark"
+
+    ```python
+    sedona.sql("""
+        SELECT superhero.name
+        FROM city, superhero
+        WHERE ST_Contains(city.geom, superhero.geom)
+        AND city.name = 'Gotham'
+    """)
+    ```
+
+=== "Java"
+
+    ```java
+    Dataset<Row> result = spark.sql(
+    "SELECT superhero.name " +
+    "FROM city, superhero " +
+    "WHERE ST_Contains(city.geom, superhero.geom) " +
+    "AND city.name = 'Gotham'"
+    );
+    ```
+
+=== "Scala"
+
+    ```scala
+    sedona.sql("""
+        SELECT superhero.name
+        FROM city, superhero
+        WHERE ST_Contains(city.geom, superhero.geom)
+        AND city.name = 'Gotham'
+    """)
+    ```
+
+=== "R"
+
+    ```r
+    result <- sql("
+    SELECT superhero.name
+    FROM city, superhero
+    WHERE ST_Contains(city.geom, superhero.geom)
+    AND city.name = 'Gotham'
+    ")
+    ```
+
+## 主要特性
+
+* **极致性能**：SedonaSpark 在集群中的多个节点上并行执行计算，使大规模计算能够快速完成。
+* 支持**多种文件格式**，包括 GeoJSON、Shapefile、GeoParquet、STAC、JDBC、OSM PBF、CSV 和 PostGIS。
+* 提供多种**语言 API**，包括 SQL、Python、Java、Scala 和 R。
+* **可扩展**：可根据数据规模水平扩展到数十、数百乃至数千个节点，使用 SedonaSpark 处理海量空间数据集。
+* **可移植**：易于在自定义环境中运行，可在本地或云端（如 AWS EMR、Microsoft Fabric、Google DataProc）部署。
+* **可扩展定制**：可以使用自定义逻辑对 SedonaSpark 进行扩展，以满足特定的地理空间数据分析需求。
+* **开源**：Apache Sedona 是一个开源项目，遵循 Apache 软件基金会的相关准则进行管理。
+* 提供更多扩展能力，例如 [最近邻搜索](https://sedona.apache.org/latest/api/sql/NearestNeighbourSearching/) 以及诸如 [DBSCAN](https://sedona.apache.org/latest/tutorial/sql/#cluster-with-dbscan) 等空间统计算法。
+
+## 可移植性
+
+SedonaSpark 易于在本地、Docker 中或主流云平台上运行。
+
+SedonaSpark 设计为可在任何能运行 Spark 的环境中运行。许多云厂商都提供 Spark 运行时，Sedona 可以作为依赖库添加进去。
+
+在本地运行 Sedona 也很方便，可以在将代码部署到生产数据集之前快速迭代。
+
+## 使用 Spark 和 Sedona 处理矢量数据的示例
+
+下面看一下如何使用 Spark 和 Sedona 在矢量数据集上完成一次完整的工作流程。
+
+我们使用 Overture Maps Foundation 提供的基础水体数据，将纽约市地区的所有水体绘制到地图上。首先读取数据并创建视图：
+
+```
+base_water = sedona.table("open_data.overture_maps_foundation.base_water")
+base_water.createOrReplaceTempView("base_water_view")
+```
+
+然后过滤出纽约市地区范围内的水体：
+
+```python
+spot = "POLYGON ((-74.174194 40.509623, -73.635864 40.509623, -73.635864 40.93634, -74.174194 40.93634, -74.174194 40.509623))"
+query = f"""
+select id, geometry from base_water_view
+where ST_Contains(ST_GeomFromWKT('{spot}'), geometry)
+"""
+res = sedona.sql(query)
+```
+
+Sedona 与主流的可视化库无缝集成，可以轻松地从 Sedona DataFrame 创建地图。仅需两行代码即可生成一张地图：
+
+```python
+kepler_map = SedonaKepler.create_map()
+SedonaKepler.add_df(kepler_map, df=res, name="Tri-state water")
+```
+
+地图效果非常出色！
+
+![New York City water](../image/nyc_base_water.png)
+
+通过这张地图，可以清晰地看到纽约市地区的所有河流、湖泊乃至游泳池。
+
+## 有疑问？
+
+欢迎在 GitHub Discussions 发起讨论，或者加入 Discord 社区向开发者提问。
+
+我们期待与您协作！


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2909, part of EPIC #2867.

## What changes were proposed in this PR?

Phase 2 of the Chinese-documentation EPIC (#2867). This PR translates the top-level landing pages and makes the homepage hero template locale-aware so Chinese visitors see translated content end-to-end on `/zh/`.

- Add Chinese translations for the four product landing pages: `docs/sedonaspark.zh.md`, `docs/sedonaflink.zh.md`, `docs/sedonasnow.zh.md`, `docs/download.zh.md`.
- Refactor `docs-overrides/main.html` to source all hardcoded English strings from a per-locale translation dict keyed off `config.theme.language`. The covered surfaces are:
  - hero subtitle and CTA
  - QUERY-and-JOIN typed-rotation strings
  - Get-started-in-seconds section
  - Deploy section (tags + per-runtime descriptions)
  - Industries tabs
  - Feature grid (six cards + benchmarks CTA)
  - Community section
  - Events section + decorative event line
  - Outdated-version banner
  - Top-of-page release announcement banner
- Broaden the homepage detection in `main.html` so the hero template renders for both `index.md` and `index.zh.md`. mkdocs sets `page.is_homepage` only on the default-locale index, so `/zh/` would otherwise fall through to plain markdown.
- The English locale is unaffected — the default branch of the translation dict reproduces the existing copy verbatim.

## How was this patch tested?

Built the docs locally with `uv sync --group docs && uv run mkdocs build` and verified:

- Build succeeds with no new warnings.
- `site/zh/index.html` renders the full hero template with translated strings (e.g. `让处理任意规模的空间数据变得轻而易举`, `立即开始`, `加入社区`, `查看活动`).
- `site/index.html` is byte-identical in line count to the previous English-only build (6,299 lines) — no regression on the default locale.
- `site/zh/sedonaspark/index.html`, `site/zh/sedonaflink/index.html`, `site/zh/sedonasnow/index.html`, `site/zh/download/index.html` render the new Chinese content.
- The release announcement banner at the top of `/zh/` reads the Chinese string (`Apache Sedona 1.9.0 已正式发布…`).

## Did this PR include necessary documentation updates?

- Yes, this PR is a documentation-only change. Subsequent phases (#2910-#2919) translate the remaining sections.