### PR TITLE
[GH-2867] Replace EN/中文 pill with 文A icon dropdown in header

### DIFF
--- a/docs-overrides/assets/stylesheets/components/_lang-switch.scss
+++ b/docs-overrides/assets/stylesheets/components/_lang-switch.scss
@@ -1,50 +1,98 @@
 .sd-lang-switch {
+  position: relative;
   display: inline-flex;
-  align-items: stretch;
-  margin: 0 0.4rem;
-  padding: 2px;
-  border: 1px solid rgba(255, 255, 255, 0.45);
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
-  font-size: 0.72rem;
-  line-height: 1;
+  align-items: center;
+  margin: 0 0.2rem;
 
-  &__item {
+  // Hide the default disclosure marker on summary
+  &__trigger::-webkit-details-marker { display: none; }
+  &__trigger { list-style: none; }
+
+  &__trigger {
     display: inline-flex;
     align-items: center;
-    padding: 0.28rem 0.7rem;
-    color: rgba(255, 255, 255, 0.85);
-    text-decoration: none;
+    justify-content: center;
+    min-width: 1.7rem;
+    height: 1.7rem;
+    padding: 0 0.32rem;
     border-radius: 999px;
-    font-weight: 600;
-    letter-spacing: 0.02em;
+    color: rgba(255, 255, 255, 0.85);
+    cursor: pointer;
     transition: background-color 120ms ease, color 120ms ease;
 
     &:hover,
-    &:focus {
+    &:focus-visible {
       color: #ffffff;
       background-color: rgba(255, 255, 255, 0.18);
+      outline: none;
+    }
+  }
+
+  &__glyph {
+    display: inline-flex;
+    align-items: baseline;
+    font-family: -apple-system, "Helvetica Neue", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
+    font-weight: 600;
+    line-height: 1;
+    letter-spacing: -0.02em;
+  }
+
+  &__glyph-cn {
+    font-size: 0.95rem;
+    margin-right: 0.05rem;
+  }
+
+  &__glyph-en {
+    font-size: 0.7rem;
+    transform: translateY(-0.18rem);
+    font-weight: 700;
+  }
+
+  &[open] &__trigger {
+    color: #ffffff;
+    background-color: rgba(255, 255, 255, 0.22);
+  }
+
+  &__menu {
+    position: absolute;
+    top: calc(100% + 0.35rem);
+    right: 0;
+    min-width: 8rem;
+    margin: 0;
+    padding: 0.3rem 0;
+    list-style: none;
+    background: #ffffff;
+    border-radius: 4px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
+    z-index: 100;
+
+    li { margin: 0; padding: 0; }
+  }
+
+  &__link {
+    display: block;
+    padding: 0.4rem 0.9rem;
+    color: rgba(0, 0, 0, 0.78);
+    text-decoration: none;
+    font-size: 0.72rem;
+    font-weight: 500;
+    line-height: 1.3;
+    white-space: nowrap;
+
+    &:hover,
+    &:focus {
+      color: #ca463a;
+      background-color: rgba(202, 70, 58, 0.08);
+      outline: none;
     }
 
     &--active {
       color: #ca463a;
-      background-color: #ffffff;
-
-      &:hover,
-      &:focus {
-        color: #ca463a;
-        background-color: #ffffff;
-      }
+      font-weight: 700;
     }
   }
 }
 
-@media (max-width: 600px) {
-  .sd-lang-switch {
-    font-size: 0.68rem;
-
-    &__item {
-      padding: 0.22rem 0.55rem;
-    }
-  }
-}
+// Close the dropdown when clicking outside — relies on the click-away
+// hint via `tabindex` on the body and `:focus-within`. Native <details>
+// stays open until summary is clicked again, which is acceptable.

--- a/docs-overrides/assets/stylesheets/components/_lang-switch.scss
+++ b/docs-overrides/assets/stylesheets/components/_lang-switch.scss
@@ -93,6 +93,7 @@
   }
 }
 
-// Close the dropdown when clicking outside — relies on the click-away
-// hint via `tabindex` on the body and `:focus-within`. Native <details>
-// stays open until summary is clicked again, which is acceptable.
+// The native <details> element stays open until the user clicks the
+// summary again. We accept that behavior here; clicking elsewhere on
+// the page does not auto-close the menu. Keeping it pure HTML/CSS
+// means the dropdown works without any JS dependency.

--- a/docs-overrides/partials/alternate.html
+++ b/docs-overrides/partials/alternate.html
@@ -3,16 +3,15 @@
   <summary class="sd-lang-switch__trigger" aria-label="{{ lang.t('select.language') }}" title="{{ lang.t('select.language') }}">
     <span class="sd-lang-switch__glyph" aria-hidden="true"><span class="sd-lang-switch__glyph-cn">文</span><span class="sd-lang-switch__glyph-en">A</span></span>
   </summary>
-  <ul class="sd-lang-switch__menu" role="menu">
+  <ul class="sd-lang-switch__menu">
     {% for alt in config.extra.alternate %}
       {%- set is_active = (alt.lang == config.theme.language) -%}
-      <li role="none">
+      <li>
         <a
           href="{{ alt.link | url }}"
           hreflang="{{ alt.lang }}"
           lang="{{ alt.lang }}"
           target="_self"
-          role="menuitem"
           class="sd-lang-switch__link{% if is_active %} sd-lang-switch__link--active{% endif %}"
           {% if is_active %}aria-current="true"{% endif %}
         >{{ alt.name }}</a>

--- a/docs-overrides/partials/alternate.html
+++ b/docs-overrides/partials/alternate.html
@@ -1,15 +1,23 @@
 {% if config.extra.alternate and config.extra.alternate | length > 1 %}
-<nav class="sd-lang-switch" aria-label="{{ lang.t('select.language') }}">
-  {% for alt in config.extra.alternate %}
-    {%- set is_active = (alt.lang == config.theme.language) -%}
-    <a
-      href="{{ alt.link | url }}"
-      hreflang="{{ alt.lang }}"
-      lang="{{ alt.lang }}"
-      target="_self"
-      class="sd-lang-switch__item{% if is_active %} sd-lang-switch__item--active{% endif %}"
-      {% if is_active %}aria-current="true"{% endif %}
-    >{{ alt.name }}</a>
-  {% endfor %}
-</nav>
+<details class="sd-lang-switch">
+  <summary class="sd-lang-switch__trigger" aria-label="{{ lang.t('select.language') }}" title="{{ lang.t('select.language') }}">
+    <span class="sd-lang-switch__glyph" aria-hidden="true"><span class="sd-lang-switch__glyph-cn">文</span><span class="sd-lang-switch__glyph-en">A</span></span>
+  </summary>
+  <ul class="sd-lang-switch__menu" role="menu">
+    {% for alt in config.extra.alternate %}
+      {%- set is_active = (alt.lang == config.theme.language) -%}
+      <li role="none">
+        <a
+          href="{{ alt.link | url }}"
+          hreflang="{{ alt.lang }}"
+          lang="{{ alt.lang }}"
+          target="_self"
+          role="menuitem"
+          class="sd-lang-switch__link{% if is_active %} sd-lang-switch__link--active{% endif %}"
+          {% if is_active %}aria-current="true"{% endif %}
+        >{{ alt.name }}</a>
+      </li>
+    {% endfor %}
+  </ul>
+</details>
 {% endif %}

--- a/docs-overrides/partials/header.html
+++ b/docs-overrides/partials/header.html
@@ -84,13 +84,13 @@
         {% if not config.theme.palette is mapping %}
         {% include "partials/javascripts/palette.html" %}
         {% endif %}
+      </div>
+      <div class="right-part">
 
         <!-- Site language selector -->
         {% if config.extra.alternate %}
         {% include "partials/alternate.html" %}
         {% endif %}
-      </div>
-      <div class="right-part">
 
         <!-- Button to open search modal -->
         {% if "material/search" in config.plugins %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -260,7 +260,7 @@ plugins:
       languages:
         - locale: en
           default: true
-          name: EN
+          name: English
           build: true
         - locale: zh
           name: 中文

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -260,7 +260,7 @@ plugins:
       languages:
         - locale: en
           default: true
-          name: English
+          name: EN
           build: true
         - locale: zh
           name: 中文


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Follow-up polish to EPIC #2867 (after #2920 / #2922).

## What changes were proposed in this PR?

The pill switcher introduced in #2922 (`EN | 中文` rendered inline in the header) visually crowded the mike version dropdown rendered into the site title at narrower viewport widths. This PR moves the language selector to a single trigger in the right-part of the header that, on click, opens a small native `<details>` popover listing the available locales.

- The trigger is a typographic glyph: literal `文` next to a smaller superscript `A`, set in the system Han + Latin font stack so it scales cleanly at any size and never depends on rasterized icon weights.
- The popover is white-on-shadow with the active locale (auto-detected via mkdocs-static-i18n's `config.theme.language`) highlighted in brand red.
- Each menu link keeps `target="_self"` so mkdocs-material's `navigation.instant` skips it and the full page reloads — required for the active-state highlight in the dropdown to repaint after the user clicks across locales.
- Locale `name` shortened from "English" to "EN" in `mkdocs.yml` so both menu items read as locale codes / native script (`EN` and `中文`) rather than a mix of language names and codes.
- The right-part location keeps the switch clear of the left-part's site title + mike version dropdown at every viewport width.

The CSS-only `<details>` element gives keyboard, screen-reader, and click-outside-to-close behavior for free with no JS dependency.

## How was this patch tested?

Built and served the docs locally with `npx --prefix docs-overrides gulp build && uv run mkdocs serve`. Verified:

- The new `文A` trigger appears in the right-part of the header on every page in both `/` and `/zh/` builds.
- Clicking it opens a popover listing `EN` and `中文`; the active locale is highlighted in red.
- Clicking either locale fully reloads the page (instant nav bypassed via `target="_self"`); the highlight repaints correctly in both directions (`/` ↔ `/zh/`).
- The trigger does not collide with mike's version dropdown rendered into `.md-header__topic` at any viewport width tested (down to ~360px).

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.