### PR TITLE
[GH-2926] Add ST_BoxIntersects and ST_BoxContains for Box2D

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/Predicates.java
+++ b/common/src/main/java/org/apache/sedona/common/Predicates.java
@@ -29,11 +29,20 @@ public class Predicates {
   }
 
   /**
-   * Closed-interval bbox intersection: true if {@code a} and {@code b} share any point on either
-   * axis (matches PostGIS {@code &&} on box2d). Either argument being null returns null at the SQL
-   * layer; this Java entry point throws {@link NullPointerException} on null input.
+   * Closed-interval bbox intersection: true if {@code a} and {@code b} overlap on <em>both</em> the
+   * X and Y axes (matches PostGIS {@code &&} on box2d). Edge- and corner-touching boxes count as
+   * intersecting.
+   *
+   * <p>Both arguments must have ordered bounds ({@code xmin <= xmax} and {@code ymin <= ymax}).
+   * Sedona's Box2D type allows inverted bounds ({@code xmin > xmax}) — that ordering is reserved
+   * for a future antimeridian-wraparound semantics on geography bboxes (cf. sedona-db's {@code
+   * WraparoundInterval}). Until those semantics ship, planar predicates throw on inverted input
+   * rather than silently returning misleading results. SQL callers see NULL in/out null
+   * propagation; this Java entry point throws on null.
    */
   public static boolean boxIntersects(Box2D a, Box2D b) {
+    requireOrderedPlanarBox(a, "a");
+    requireOrderedPlanarBox(b, "b");
     return !(a.getXMax() < b.getXMin()
         || a.getXMin() > b.getXMax()
         || a.getYMax() < b.getYMin()
@@ -41,15 +50,31 @@ public class Predicates {
   }
 
   /**
-   * True if {@code a} fully contains {@code b} (closed intervals; matches PostGIS {@code ~} on
-   * box2d). Either argument being null returns null at the SQL layer; this Java entry point throws
-   * {@link NullPointerException} on null input.
+   * True if {@code a} fully contains {@code b} on <em>both</em> the X and Y axes (closed intervals;
+   * matches PostGIS {@code ~} on box2d). Equal boxes contain each other.
+   *
+   * <p>Same ordered-bound contract as {@link #boxIntersects(Box2D, Box2D)} — inverted bounds throw
+   * because planar containment with inverted intervals has no defined meaning until antimeridian
+   * wraparound semantics ship.
    */
   public static boolean boxContains(Box2D a, Box2D b) {
+    requireOrderedPlanarBox(a, "a");
+    requireOrderedPlanarBox(b, "b");
     return a.getXMin() <= b.getXMin()
         && a.getYMin() <= b.getYMin()
         && a.getXMax() >= b.getXMax()
         && a.getYMax() >= b.getYMax();
+  }
+
+  private static void requireOrderedPlanarBox(Box2D box, String argName) {
+    if (box.getXMin() > box.getXMax() || box.getYMin() > box.getYMax()) {
+      throw new IllegalArgumentException(
+          "Box2D argument '"
+              + argName
+              + "' has inverted bounds (xmin > xmax or ymin > ymax). Planar Box2D predicates "
+              + "require ordered intervals; inverted bounds are reserved for future antimeridian "
+              + "wraparound semantics.");
+    }
   }
 
   public static boolean intersects(Geometry leftGeometry, Geometry rightGeometry) {

--- a/common/src/main/java/org/apache/sedona/common/Predicates.java
+++ b/common/src/main/java/org/apache/sedona/common/Predicates.java
@@ -18,6 +18,7 @@
  */
 package org.apache.sedona.common;
 
+import org.apache.sedona.common.geometryObjects.Box2D;
 import org.apache.sedona.common.sphere.Spheroid;
 import org.locationtech.jts.geom.*;
 import org.locationtech.jts.operation.relate.RelateOp;
@@ -25,6 +26,30 @@ import org.locationtech.jts.operation.relate.RelateOp;
 public class Predicates {
   public static boolean contains(Geometry leftGeometry, Geometry rightGeometry) {
     return leftGeometry.contains(rightGeometry);
+  }
+
+  /**
+   * Closed-interval bbox intersection: true if {@code a} and {@code b} share any point on either
+   * axis (matches PostGIS {@code &&} on box2d). Either argument being null returns null at the SQL
+   * layer; this Java entry point throws {@link NullPointerException} on null input.
+   */
+  public static boolean boxIntersects(Box2D a, Box2D b) {
+    return !(a.getXMax() < b.getXMin()
+        || a.getXMin() > b.getXMax()
+        || a.getYMax() < b.getYMin()
+        || a.getYMin() > b.getYMax());
+  }
+
+  /**
+   * True if {@code a} fully contains {@code b} (closed intervals; matches PostGIS {@code ~} on
+   * box2d). Either argument being null returns null at the SQL layer; this Java entry point throws
+   * {@link NullPointerException} on null input.
+   */
+  public static boolean boxContains(Box2D a, Box2D b) {
+    return a.getXMin() <= b.getXMin()
+        && a.getYMin() <= b.getYMin()
+        && a.getXMax() >= b.getXMax()
+        && a.getYMax() >= b.getYMax();
   }
 
   public static boolean intersects(Geometry leftGeometry, Geometry rightGeometry) {

--- a/common/src/test/java/org/apache/sedona/common/PredicatesTest.java
+++ b/common/src/test/java/org/apache/sedona/common/PredicatesTest.java
@@ -66,6 +66,23 @@ public class PredicatesTest extends TestBase {
   }
 
   @Test
+  public void testBoxPredicatesRejectInvertedBounds() {
+    // Box2D allows xmin > xmax (reserved for future antimeridian wraparound); planar predicates
+    // refuse to evaluate them rather than silently returning misleading results.
+    Box2D normal = new Box2D(0.0, 0.0, 5.0, 5.0);
+    Box2D wrapX = new Box2D(170.0, 10.0, -170.0, 20.0); // longitude crosses antimeridian
+    Box2D wrapY = new Box2D(0.0, 5.0, 5.0, 0.0); // ymin > ymax
+
+    IllegalArgumentException ex1 =
+        assertThrows(IllegalArgumentException.class, () -> Predicates.boxIntersects(wrapX, normal));
+    assertTrue(ex1.getMessage().contains("inverted bounds"));
+
+    IllegalArgumentException ex2 =
+        assertThrows(IllegalArgumentException.class, () -> Predicates.boxContains(normal, wrapY));
+    assertTrue(ex2.getMessage().contains("inverted bounds"));
+  }
+
+  @Test
   public void testDWithinSuccess() {
     Geometry point1 = GEOMETRY_FACTORY.createPoint(new Coordinate(1, 1));
     Geometry point2 = GEOMETRY_FACTORY.createPoint(new Coordinate(2, 2));

--- a/common/src/test/java/org/apache/sedona/common/PredicatesTest.java
+++ b/common/src/test/java/org/apache/sedona/common/PredicatesTest.java
@@ -22,6 +22,7 @@ import static org.apache.sedona.common.Constructors.geomFromEWKT;
 import static org.apache.sedona.common.Functions.crossesDateLine;
 import static org.junit.Assert.*;
 
+import org.apache.sedona.common.geometryObjects.Box2D;
 import org.junit.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
@@ -31,6 +32,38 @@ import org.locationtech.jts.io.ParseException;
 public class PredicatesTest extends TestBase {
 
   private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory();
+
+  @Test
+  public void testBoxIntersects() {
+    Box2D a = new Box2D(0.0, 0.0, 5.0, 5.0);
+
+    // Full overlap
+    assertTrue(Predicates.boxIntersects(a, new Box2D(1.0, 1.0, 2.0, 2.0)));
+    // Partial overlap
+    assertTrue(Predicates.boxIntersects(a, new Box2D(3.0, 3.0, 7.0, 7.0)));
+    // Edge-touching (closed intervals)
+    assertTrue(Predicates.boxIntersects(a, new Box2D(5.0, 0.0, 10.0, 5.0)));
+    // Corner-touching (closed intervals)
+    assertTrue(Predicates.boxIntersects(a, new Box2D(5.0, 5.0, 10.0, 10.0)));
+    // Disjoint on X
+    assertFalse(Predicates.boxIntersects(a, new Box2D(6.0, 0.0, 10.0, 5.0)));
+    // Disjoint on Y
+    assertFalse(Predicates.boxIntersects(a, new Box2D(0.0, 6.0, 5.0, 10.0)));
+  }
+
+  @Test
+  public void testBoxContains() {
+    Box2D outer = new Box2D(0.0, 0.0, 10.0, 10.0);
+
+    assertTrue(Predicates.boxContains(outer, new Box2D(2.0, 2.0, 5.0, 5.0)));
+    // Boundaries are inclusive
+    assertTrue(Predicates.boxContains(outer, new Box2D(0.0, 0.0, 10.0, 10.0)));
+    assertTrue(Predicates.boxContains(outer, new Box2D(0.0, 0.0, 1.0, 1.0)));
+    // Outside on X
+    assertFalse(Predicates.boxContains(outer, new Box2D(-1.0, 0.0, 5.0, 5.0)));
+    // Crosses boundary on X
+    assertFalse(Predicates.boxContains(outer, new Box2D(5.0, 0.0, 11.0, 5.0)));
+  }
 
   @Test
   public void testDWithinSuccess() {

--- a/flink/src/main/java/org/apache/sedona/flink/Catalog.java
+++ b/flink/src/main/java/org/apache/sedona/flink/Catalog.java
@@ -247,6 +247,8 @@ public class Catalog {
 
   public static UserDefinedFunction[] getPredicates() {
     return new UserDefinedFunction[] {
+      new Predicates.ST_BoxContains(),
+      new Predicates.ST_BoxIntersects(),
       new Predicates.ST_Intersects(),
       new Predicates.ST_Contains(),
       new Predicates.ST_Crosses(),

--- a/flink/src/main/java/org/apache/sedona/flink/expressions/Predicates.java
+++ b/flink/src/main/java/org/apache/sedona/flink/expressions/Predicates.java
@@ -20,10 +20,48 @@ package org.apache.sedona.flink.expressions;
 
 import org.apache.flink.table.annotation.DataTypeHint;
 import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.sedona.common.geometryObjects.Box2D;
+import org.apache.sedona.flink.Box2DTypeSerializer;
 import org.apache.sedona.flink.GeometryTypeSerializer;
 import org.locationtech.jts.geom.Geometry;
 
 public class Predicates {
+
+  public static class ST_BoxIntersects extends ScalarFunction {
+    @DataTypeHint("Boolean")
+    public Boolean eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = Box2DTypeSerializer.class,
+                bridgedTo = Box2D.class)
+            Box2D a,
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = Box2DTypeSerializer.class,
+                bridgedTo = Box2D.class)
+            Box2D b) {
+      if (a == null || b == null) return null;
+      return org.apache.sedona.common.Predicates.boxIntersects(a, b);
+    }
+  }
+
+  public static class ST_BoxContains extends ScalarFunction {
+    @DataTypeHint("Boolean")
+    public Boolean eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = Box2DTypeSerializer.class,
+                bridgedTo = Box2D.class)
+            Box2D a,
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = Box2DTypeSerializer.class,
+                bridgedTo = Box2D.class)
+            Box2D b) {
+      if (a == null || b == null) return null;
+      return org.apache.sedona.common.Predicates.boxContains(a, b);
+    }
+  }
 
   public static class ST_Intersects extends ScalarFunction {
     /** Constructor for relation checking without duplicate removal */

--- a/flink/src/test/java/org/apache/sedona/flink/PredicateTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/PredicateTest.java
@@ -35,6 +35,34 @@ public class PredicateTest extends TestBase {
   }
 
   @Test
+  public void testBoxIntersects() {
+    Table t =
+        tableEnv.sqlQuery(
+            "WITH boxes AS ("
+                + " SELECT ST_Box2D(ST_GeomFromWKT('POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))')) AS a,"
+                + " ST_Box2D(ST_GeomFromWKT('POLYGON((3 3, 3 7, 7 7, 7 3, 3 3))')) AS overlap,"
+                + " ST_Box2D(ST_GeomFromWKT('POLYGON((6 6, 6 7, 7 7, 7 6, 6 6))')) AS disjoint)"
+                + " SELECT ST_BoxIntersects(a, overlap), ST_BoxIntersects(a, disjoint) FROM boxes");
+    org.apache.flink.types.Row row = first(t);
+    assertEquals(true, row.getField(0));
+    assertEquals(false, row.getField(1));
+  }
+
+  @Test
+  public void testBoxContains() {
+    Table t =
+        tableEnv.sqlQuery(
+            "WITH boxes AS ("
+                + " SELECT ST_Box2D(ST_GeomFromWKT('POLYGON((0 0, 0 10, 10 10, 10 0, 0 0))')) AS outer_box,"
+                + " ST_Box2D(ST_GeomFromWKT('POLYGON((2 2, 2 5, 5 5, 5 2, 2 2))')) AS inner_box,"
+                + " ST_Box2D(ST_GeomFromWKT('POLYGON((5 5, 5 11, 11 11, 11 5, 5 5))')) AS overlap)"
+                + " SELECT ST_BoxContains(outer_box, inner_box), ST_BoxContains(outer_box, overlap) FROM boxes");
+    org.apache.flink.types.Row row = first(t);
+    assertEquals(true, row.getField(0));
+    assertEquals(false, row.getField(1));
+  }
+
+  @Test
   public void testIntersects() {
     Table pointTable = createPointTable(testDataSize);
     String polygon = createPolygonWKT(testDataSize).get(0).getField(0).toString();

--- a/python/sedona/spark/sql/st_predicates.py
+++ b/python/sedona/spark/sql/st_predicates.py
@@ -31,6 +31,38 @@ _call_predicate_function = partial(call_sedona_function, "st_predicates")
 
 
 @validate_argument_types
+def ST_BoxContains(a: ColumnOrName, b: ColumnOrName) -> Column:
+    """Check whether Box2D a fully contains Box2D b (closed intervals).
+
+    Mirrors PostGIS ``~`` on box2d. NULL on null input.
+
+    :param a: Outer Box2D column.
+    :type a: ColumnOrName
+    :param b: Inner Box2D column.
+    :type b: ColumnOrName
+    :return: True if a contains b, false otherwise.
+    :rtype: Column
+    """
+    return _call_predicate_function("ST_BoxContains", (a, b))
+
+
+@validate_argument_types
+def ST_BoxIntersects(a: ColumnOrName, b: ColumnOrName) -> Column:
+    """Check whether Box2D a and Box2D b share any point (closed intervals).
+
+    Mirrors PostGIS ``&&`` on box2d. NULL on null input.
+
+    :param a: First Box2D column.
+    :type a: ColumnOrName
+    :param b: Second Box2D column.
+    :type b: ColumnOrName
+    :return: True if a and b overlap, false otherwise.
+    :rtype: Column
+    """
+    return _call_predicate_function("ST_BoxIntersects", (a, b))
+
+
+@validate_argument_types
 def ST_Contains(a: ColumnOrName, b: ColumnOrName) -> Column:
     """Check whether geometry a contains geometry b.
 

--- a/python/tests/sql/test_predicate.py
+++ b/python/tests/sql/test_predicate.py
@@ -26,6 +26,30 @@ from tests.test_base import TestBase
 
 class TestPredicate(TestBase):
 
+    def test_st_box_intersects_and_contains(self):
+        df = self.spark.sql("""
+            WITH t AS (
+              SELECT
+                ST_Box2D(ST_GeomFromText('POLYGON((0 0, 0 10, 10 10, 10 0, 0 0))')) AS a,
+                ST_Box2D(ST_GeomFromText('POLYGON((2 2, 2 5, 5 5, 5 2, 2 2))'))      AS inside,
+                ST_Box2D(ST_GeomFromText('POLYGON((5 5, 5 11, 11 11, 11 5, 5 5))'))  AS overlap,
+                ST_Box2D(ST_GeomFromText('POLYGON((11 11, 11 12, 12 12, 12 11, 11 11))')) AS disjoint
+            )
+            SELECT
+              ST_BoxIntersects(a, inside)   AS i_inside,
+              ST_BoxIntersects(a, overlap)  AS i_overlap,
+              ST_BoxIntersects(a, disjoint) AS i_disjoint,
+              ST_BoxContains(a, inside)     AS c_inside,
+              ST_BoxContains(a, overlap)    AS c_overlap
+            FROM t
+            """)
+        row = df.first()
+        assert row[0] is True
+        assert row[1] is True
+        assert row[2] is False
+        assert row[3] is True
+        assert row[4] is False
+
     def test_st_contains(self):
         point_csv_df = (
             self.spark.read.format("csv")

--- a/spark/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
+++ b/spark/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
@@ -163,6 +163,8 @@ object Catalog extends AbstractCatalog with Logging {
 
   // Predicates
   val predicateExprs: Seq[FunctionDescription] = Seq(
+    function[ST_BoxContains](),
+    function[ST_BoxIntersects](),
     function[ST_Contains](),
     function[ST_CoveredBy](),
     function[ST_Covers](),

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Predicates.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Predicates.scala
@@ -19,6 +19,7 @@
 package org.apache.spark.sql.sedona_sql.expressions
 
 import org.apache.sedona.common.Predicates
+import org.apache.sedona.common.geometryObjects.Box2D
 import org.apache.sedona.sql.utils.GeometrySerializer
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
@@ -95,6 +96,22 @@ private[apache] case class ST_Contains(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
+private[apache] case class ST_BoxIntersects(inputExpressions: Seq[Expression])
+    extends InferredExpression(Predicates.boxIntersects _) {
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
+}
+
+private[apache] case class ST_BoxContains(inputExpressions: Seq[Expression])
+    extends InferredExpression(Predicates.boxContains _) {
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
+}
+
 private[apache] case class ST_Intersects(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(Predicates.intersects),

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Predicates.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Predicates.scala
@@ -19,7 +19,6 @@
 package org.apache.spark.sql.sedona_sql.expressions
 
 import org.apache.sedona.common.Predicates
-import org.apache.sedona.common.geometryObjects.Box2D
 import org.apache.sedona.sql.utils.GeometrySerializer
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
@@ -91,8 +90,11 @@ private[apache] case class ST_Contains(inputExpressions: Seq[Expression])
 }
 
 /**
- * Test if leftGeometry full intersects rightGeometry. Supports both Geometry (JTS) and Geography
- * (S2) inputs via InferredExpression dual dispatch.
+ * Closed-interval bbox intersection over two Box2D arguments. Returns true if the boxes overlap
+ * on both the X and Y axes (matches PostGIS `&&` on box2d). Edge- and corner-touching boxes count
+ * as intersecting. Throws on inverted bounds (xmin>xmax / ymin>ymax) since planar predicates have
+ * no defined meaning for inverted intervals; that ordering is reserved for future
+ * antimeridian-wraparound semantics.
  *
  * @param inputExpressions
  */
@@ -104,6 +106,13 @@ private[apache] case class ST_BoxIntersects(inputExpressions: Seq[Expression])
   }
 }
 
+/**
+ * Closed-interval bbox containment over two Box2D arguments. Returns true if argument `a` fully
+ * contains argument `b` on both axes (matches PostGIS `~` on box2d). Equal boxes contain each
+ * other. Throws on inverted bounds for the same reason as ST_BoxIntersects.
+ *
+ * @param inputExpressions
+ */
 private[apache] case class ST_BoxContains(inputExpressions: Seq[Expression])
     extends InferredExpression(Predicates.boxContains _) {
 
@@ -112,6 +121,12 @@ private[apache] case class ST_BoxContains(inputExpressions: Seq[Expression])
   }
 }
 
+/**
+ * Test if leftGeometry full intersects rightGeometry. Supports both Geometry (JTS) and Geography
+ * (S2) inputs via InferredExpression dual dispatch.
+ *
+ * @param inputExpressions
+ */
 private[apache] case class ST_Intersects(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(Predicates.intersects),

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/st_predicates.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/st_predicates.scala
@@ -24,6 +24,12 @@ import org.apache.spark.sql.Column
 import org.apache.spark.sql.sedona_sql.DataFrameShims._
 
 object st_predicates {
+  def ST_BoxContains(a: Column, b: Column): Column = wrapExpression[ST_BoxContains](a, b)
+  def ST_BoxContains(a: String, b: String): Column = wrapExpression[ST_BoxContains](a, b)
+
+  def ST_BoxIntersects(a: Column, b: Column): Column = wrapExpression[ST_BoxIntersects](a, b)
+  def ST_BoxIntersects(a: String, b: String): Column = wrapExpression[ST_BoxIntersects](a, b)
+
   def ST_Contains(a: Column, b: Column): Column = wrapExpression[ST_Contains](a, b)
   def ST_Contains(a: String, b: String): Column = wrapExpression[ST_Contains](a, b)
 

--- a/spark/common/src/test/scala/org/apache/sedona/sql/predicateTestScala.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/predicateTestScala.scala
@@ -25,6 +25,41 @@ class predicateTestScala extends TestBaseScala {
 
   describe("Sedona-SQL Predicate Test") {
 
+    it("Passed ST_BoxIntersects and ST_BoxContains") {
+      val df = sparkSession.sql("""
+        WITH t AS (
+          SELECT
+            ST_Box2D(ST_GeomFromText('POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))'))   AS a,
+            ST_Box2D(ST_GeomFromText('POLYGON((1 1, 1 2, 2 2, 2 1, 1 1))'))   AS inside,
+            ST_Box2D(ST_GeomFromText('POLYGON((3 3, 3 7, 7 7, 7 3, 3 3))'))   AS overlap,
+            ST_Box2D(ST_GeomFromText('POLYGON((5 0, 5 5, 10 5, 10 0, 5 0))')) AS edge,
+            ST_Box2D(ST_GeomFromText('POLYGON((6 6, 6 7, 7 7, 7 6, 6 6))'))   AS disjoint,
+            ST_Box2D(ST_GeomFromText(NULL))                                    AS box_null
+        )
+        SELECT
+          ST_BoxIntersects(a, inside),
+          ST_BoxIntersects(a, overlap),
+          ST_BoxIntersects(a, edge),
+          ST_BoxIntersects(a, disjoint),
+          ST_BoxIntersects(a, box_null),
+          ST_BoxContains(a, inside),
+          ST_BoxContains(a, overlap),
+          ST_BoxContains(a, a),
+          ST_BoxContains(a, box_null)
+        FROM t
+        """)
+      val row = df.collect()(0)
+      assert(row.getBoolean(0)) // intersects: inside
+      assert(row.getBoolean(1)) // intersects: overlap
+      assert(row.getBoolean(2)) // intersects: edge-touch
+      assert(!row.getBoolean(3)) // intersects: disjoint
+      assert(row.isNullAt(4)) // intersects: NULL propagates
+      assert(row.getBoolean(5)) // contains: inside
+      assert(!row.getBoolean(6)) // contains: overlap (extends past)
+      assert(row.getBoolean(7)) // contains: equal
+      assert(row.isNullAt(8)) // contains: NULL propagates
+    }
+
     it("Passed ST_Contains") {
       var pointCsvDF = sparkSession.read
         .format("csv")


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2926

## What changes were proposed in this PR?

Adds two planar bbox predicates that operate on `Box2D` arguments:

- `ST_BoxIntersects(a: Box2D, b: Box2D) -> Boolean` — true if the two bboxes share any point on either axis. Mirrors PostGIS `&&` on `box2d`.
- `ST_BoxContains(a: Box2D, b: Box2D) -> Boolean` — true if `a` fully contains `b`. Mirrors PostGIS `~` on `box2d`.

Both use **closed intervals**, matching PostGIS semantics — edge-touching and corner-touching count as intersection; equal boxes contain each other. NULL on null input.

### Where the changes land

| Layer | Change |
|---|---|
| `common/.../Predicates.java` | Two new helpers `boxIntersects(Box2D, Box2D)` and `boxContains(Box2D, Box2D)` |
| `spark/common/.../expressions/Predicates.scala` | Two new `ST_BoxIntersects` / `ST_BoxContains` case classes |
| `spark/common/.../UDF/Catalog.scala` | Register both in `predicateExprs` |
| `spark/common/.../expressions/st_predicates.scala` | Scala DataFrame API wrappers (Column + String overloads) |
| `python/sedona/spark/sql/st_predicates.py` | PySpark wrappers |
| `flink/.../expressions/Predicates.java` | Two new ScalarFunction classes |
| `flink/.../Catalog.java` | Register both |

## How was this patch tested?

- `common/.../PredicatesTest.java` — `testBoxIntersects` (full overlap, partial overlap, edge-touching, corner-touching, disjoint X, disjoint Y) and `testBoxContains` (inside, equal, smaller-inside, outside, crosses-boundary).
- `spark/common/.../predicateTestScala.scala` — "Passed ST_BoxIntersects and ST_BoxContains" — full SQL-level coverage of both predicates including NULL propagation.
- `flink/.../PredicateTest.java` — `testBoxIntersects` and `testBoxContains` through Flink Table API.
- `python/tests/sql/test_predicate.py` — `test_st_box_intersects_and_contains` through PySpark SQL.

## What's not in scope

- **Mixed Box2D / Geometry predicates**. Users can wrap geometry inputs with `ST_Box2D(geom)` first.
- **Spatial join planner integration** that uses Box2D predicates for partitioning. That's a separate optimizer change.
- **3D box predicates** — wait for `Box3D` (#2928).

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public SQL API documentation surface in isolation. Documentation lands as part of the consolidated Phase 1+2 Box2D docs update once the remaining deferred follow-ups are scoped.