### PR TITLE
[GH-2911] Translate Tutorial / Programming Guide (part 4) to Chinese

### DIFF
--- a/docs/tutorial/rdd.zh.md
+++ b/docs/tutorial/rdd.zh.md
@@ -1,0 +1,864 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+本页介绍如何使用 Sedona-core 创建空间 RDD（SpatialRDD）并执行空间查询。
+
+## 配置依赖
+
+请参阅 [配置依赖](sql.md#set-up-dependencies) 进行依赖配置。
+
+## 创建 Sedona 配置
+
+请参阅 [创建 Sedona 配置](sql.md#create-sedona-config) 创建 Sedona 配置。
+
+## 初始化 SedonaContext
+
+请参阅 [初始化 SedonaContext](sql.md#initiate-sedonacontext) 初始化 SedonaContext。
+
+## 从 SedonaSQL DataFrame 创建 SpatialRDD
+
+请先按 [创建 Geometry 类型列](sql.md#create-a-geometry-type-column) 创建 Geometry 类型列，然后从 DataFrame 创建 SpatialRDD：
+
+=== "Scala"
+
+	```scala
+	var spatialRDD = StructuredAdapter.toSpatialRdd(spatialDf, "usacounty")
+	```
+
+=== "Java"
+
+	```java
+	SpatialRDD spatialRDD = StructuredAdapter.toSpatialRdd(spatialDf, "usacounty")
+	```
+
+=== "Python"
+
+	```python
+	from sedona.spark import StructuredAdapter
+
+	spatialRDD = StructuredAdapter.toSpatialRdd(spatialDf, "usacounty")
+	```
+
+`"usacounty"` 是几何列的列名，可选参数。如果不提供，将使用第一个几何列。
+
+## 转换坐标参考系
+
+Sedona 不会自动管理 SpatialRDD 中所有几何对象的坐标单位（基于度还是基于米）。SedonaSQL 中所有相关距离的单位与 SpatialRDD 中几何对象的单位保持一致。
+
+自 `v1.5.0` 起，该函数默认使用 lon/lat 顺序（之前为 lat/lon 顺序）。可以使用 ==spatialRDD.flipCoordinates== 交换 X 与 Y。
+
+转换 SpatialRDD 的坐标参考系：
+
+=== "Scala"
+
+	```scala
+	val sourceCrsCode = "epsg:4326" // WGS84，最常见的基于度的 CRS
+	val targetCrsCode = "epsg:3857" // 最常见的基于米的 CRS
+	objectRDD.CRSTransform(sourceCrsCode, targetCrsCode, false)
+	```
+
+=== "Java"
+
+	```java
+	String sourceCrsCode = "epsg:4326" // WGS84，最常见的基于度的 CRS
+	String targetCrsCode = "epsg:3857" // 最常见的基于米的 CRS
+	objectRDD.CRSTransform(sourceCrsCode, targetCrsCode, false)
+	```
+
+=== "Python"
+
+	```python
+	sourceCrsCode = "epsg:4326" // WGS84，最常见的基于度的 CRS
+	targetCrsCode = "epsg:3857" // 最常见的基于米的 CRS
+	objectRDD.CRSTransform(sourceCrsCode, targetCrsCode, False)
+	```
+
+`CRSTransform(sourceCrsCode, targetCrsCode, false)` 的第三个参数为 `false` 表示不容忍 Datum shift；如果希望宽松处理，请改为 `true`。
+
+!!!warning
+	CRS 转换应在创建每个 SpatialRDD 之后立即进行，否则会导致查询结果错误。例如：
+
+=== "Scala"
+
+	```scala
+	val objectRDD = WktReader.readToGeometryRDD(sedona.sparkContext, inputLocation, wktColumn, allowTopologyInvalidGeometries, skipSyntaxInvalidGeometries)
+	objectRDD.CRSTransform("epsg:4326", "epsg:3857", false)
+	```
+
+=== "Java"
+
+	```java
+	SpatialRDD objectRDD = WktReader.readToGeometryRDD(sedona.sparkContext, inputLocation, wktColumn, allowTopologyInvalidGeometries, skipSyntaxInvalidGeometries)
+	objectRDD.CRSTransform("epsg:4326", "epsg:3857", false)
+	```
+
+=== "Python"
+
+	```python
+	objectRDD = WktReader.readToGeometryRDD(sedona.sparkContext, inputLocation, wktColumn, allowTopologyInvalidGeometries, skipSyntaxInvalidGeometries)
+	objectRDD.CRSTransform("epsg:4326", "epsg:3857", False)
+	```
+
+详细的 CRS 信息可在 [EPSG.io](https://epsg.io/) 查询。
+
+## 编写空间范围查询
+
+空间范围查询接收一个查询窗口与一个 SpatialRDD，返回与查询窗口满足指定关系的所有几何对象。
+
+假设您已经有一个 SpatialRDD（typed 或 generic），可以用以下代码执行空间范围查询。
+
+==spatialPredicate== 可以设置为 `SpatialPredicate.INTERSECTS`，返回与查询窗口相交的所有几何对象。支持的空间谓词包括：
+
+* `CONTAINS`：几何对象完全位于查询窗口内部
+* `INTERSECTS`：几何对象与查询窗口至少有一个公共点
+* `WITHIN`：几何对象完全位于查询窗口之内（不接触边）
+* `COVERS`：查询窗口的所有点都在几何对象上
+* `COVERED_BY`：几何对象的所有点都在查询窗口上
+* `OVERLAPS`：几何对象与查询窗口在空间上相互重叠
+* `CROSSES`：几何对象与查询窗口在空间上相交穿过
+* `TOUCHES`：几何对象与查询窗口仅在边界上有公共点
+* `EQUALS`：几何对象与查询窗口在空间上相等
+
+!!!note
+	空间范围查询等价于带空间谓词作为搜索条件的 SELECT。例如：
+	```sql
+	SELECT *
+	FROM checkin
+	WHERE ST_Intersects(checkin.location, queryWindow)
+	```
+
+=== "Scala"
+
+	```scala
+	val rangeQueryWindow = new Envelope(-90.01, -80.01, 30.01, 40.01)
+	val spatialPredicate = SpatialPredicate.COVERED_BY // 仅返回完全被窗口覆盖的几何对象
+	val usingIndex = false
+	var queryResult = RangeQuery.SpatialRangeQuery(spatialRDD, rangeQueryWindow, spatialPredicate, usingIndex)
+	```
+
+=== "Java"
+
+	```java
+	Envelope rangeQueryWindow = new Envelope(-90.01, -80.01, 30.01, 40.01)
+	SpatialPredicate spatialPredicate = SpatialPredicate.COVERED_BY // 仅返回完全被窗口覆盖的几何对象
+	boolean usingIndex = false
+	JavaRDD queryResult = RangeQuery.SpatialRangeQuery(spatialRDD, rangeQueryWindow, spatialPredicate, usingIndex)
+	```
+
+=== "Python"
+
+	```python
+	from sedona.spark import Envelope
+	from sedona.spark import RangeQuery
+
+	range_query_window = Envelope(-90.01, -80.01, 30.01, 40.01)
+	consider_boundary_intersection = False  ## 仅返回完全被窗口覆盖的几何对象
+	using_index = False
+	query_result = RangeQuery.SpatialRangeQuery(spatial_rdd, range_query_window, consider_boundary_intersection, using_index)
+	```
+
+!!!note
+    Sedona Python 用户：如果希望在转换为 Spatial DataFrame 时避免 jvm-python serde，请改用同一模块下的 `RangeQueryRaw`。其参数与 `RangeQuery` 相同，但返回的是 jvm rdd 引用，可由 Adapter 不经 Python-jvm serde 直接转换为 DataFrame。
+
+    示例：
+    ```python
+    from sedona.spark import Envelope
+    from sedona.spark import RangeQueryRaw
+    from sedona.spark import Adapter
+
+    range_query_window = Envelope(-90.01, -80.01, 30.01, 40.01)
+    consider_boundary_intersection = False  ## 仅返回完全被窗口覆盖的几何对象
+    using_index = False
+    query_result = RangeQueryRaw.SpatialRangeQuery(
+        spatial_rdd, range_query_window, consider_boundary_intersection, using_index
+    )
+    gdf = StructuredAdapter.toDf(query_result, spark, ["col1", ..., "coln"])
+    ```
+
+### 范围查询窗口
+
+除了矩形（Envelope）类型之外，Sedona 范围查询窗口还可以是 Point/Polygon/LineString。
+
+构造一个点、4 顶点折线、4 顶点多边形的代码如下：
+
+=== "Scala"
+
+	```scala
+	val geometryFactory = new GeometryFactory()
+	val pointObject = geometryFactory.createPoint(new Coordinate(-84.01, 34.01))
+
+	val geometryFactory = new GeometryFactory()
+	val coordinates = new Array[Coordinate](5)
+	coordinates(0) = new Coordinate(0,0)
+	coordinates(1) = new Coordinate(0,4)
+	coordinates(2) = new Coordinate(4,4)
+	coordinates(3) = new Coordinate(4,0)
+	coordinates(4) = coordinates(0) // 末尾坐标与首坐标相同以构成闭环
+	val polygonObject = geometryFactory.createPolygon(coordinates)
+
+	val geometryFactory = new GeometryFactory()
+	val coordinates = new Array[Coordinate](4)
+	coordinates(0) = new Coordinate(0,0)
+	coordinates(1) = new Coordinate(0,4)
+	coordinates(2) = new Coordinate(4,4)
+	coordinates(3) = new Coordinate(4,0)
+	val linestringObject = geometryFactory.createLineString(coordinates)
+	```
+
+=== "Java"
+
+	```java
+	GeometryFactory geometryFactory = new GeometryFactory()
+	Point pointObject = geometryFactory.createPoint(new Coordinate(-84.01, 34.01))
+
+	GeometryFactory geometryFactory = new GeometryFactory()
+	Coordinate[] coordinates = new Array[Coordinate](5)
+	coordinates(0) = new Coordinate(0,0)
+	coordinates(1) = new Coordinate(0,4)
+	coordinates(2) = new Coordinate(4,4)
+	coordinates(3) = new Coordinate(4,0)
+	coordinates(4) = coordinates(0) // 末尾坐标与首坐标相同以构成闭环
+	Polygon polygonObject = geometryFactory.createPolygon(coordinates)
+
+	GeometryFactory geometryFactory = new GeometryFactory()
+	val coordinates = new Array[Coordinate](4)
+	coordinates(0) = new Coordinate(0,0)
+	coordinates(1) = new Coordinate(0,4)
+	coordinates(2) = new Coordinate(4,4)
+	coordinates(3) = new Coordinate(4,0)
+	LineString linestringObject = geometryFactory.createLineString(coordinates)
+	```
+
+=== "Python"
+
+	可以将 Shapely 几何对象作为查询窗口。Shapely 几何对象的创建方法请参阅 [Shapely 官方文档](https://shapely.readthedocs.io/en/stable/manual.html)。
+
+### 使用空间索引
+
+Sedona 提供两种空间索引：Quad-Tree 与 R-Tree。指定索引类型后，Sedona 会在每个 SpatialRDD 分区上构建本地索引。
+
+在空间范围查询中使用空间索引：
+
+=== "Scala"
+
+	```scala
+	val rangeQueryWindow = new Envelope(-90.01, -80.01, 30.01, 40.01)
+	val spatialPredicate = SpatialPredicate.COVERED_BY // 仅返回完全被窗口覆盖的几何对象
+
+	val buildOnSpatialPartitionedRDD = false // 仅在执行 join 查询时设为 TRUE
+	spatialRDD.buildIndex(IndexType.QUADTREE, buildOnSpatialPartitionedRDD)
+
+	val usingIndex = true
+	var queryResult = RangeQuery.SpatialRangeQuery(spatialRDD, rangeQueryWindow, spatialPredicate, usingIndex)
+	```
+
+=== "Java"
+
+	```java
+	Envelope rangeQueryWindow = new Envelope(-90.01, -80.01, 30.01, 40.01)
+	SpatialPredicate spatialPredicate = SpatialPredicate.COVERED_BY // 仅返回完全被窗口覆盖的几何对象
+
+	boolean buildOnSpatialPartitionedRDD = false // 仅在执行 join 查询时设为 TRUE
+	spatialRDD.buildIndex(IndexType.QUADTREE, buildOnSpatialPartitionedRDD)
+
+	boolean usingIndex = true
+	JavaRDD queryResult = RangeQuery.SpatialRangeQuery(spatialRDD, rangeQueryWindow, spatialPredicate, usingIndex)
+	```
+
+=== "Python"
+
+	```python
+	from sedona.spark import Envelope
+	from sedona.spark import IndexType
+	from sedona.spark import RangeQuery
+
+	range_query_window = Envelope(-90.01, -80.01, 30.01, 40.01)
+	consider_boundary_intersection = False ## 仅返回完全被窗口覆盖的几何对象
+
+	build_on_spatial_partitioned_rdd = False ## 仅在执行 join 查询时设为 TRUE
+	spatial_rdd.buildIndex(IndexType.QUADTREE, build_on_spatial_partitioned_rdd)
+
+	using_index = True
+
+	query_result = RangeQuery.SpatialRangeQuery(
+	    spatial_rdd,
+	    range_query_window,
+	    consider_boundary_intersection,
+	    using_index
+	)
+	```
+
+!!!tip
+	不一定每次都使用索引，因为构建索引本身也会花时间。空间索引在数据为复杂多边形、折线时尤其有用。
+
+### 输出格式
+
+=== "Scala/Java"
+
+	空间范围查询的输出格式仍然是一个 SpatialRDD。
+
+=== "Python"
+
+	空间范围查询返回另一个 RDD，元素为 GeoData 对象。
+
+	`SpatialRangeQuery` 的结果可以像普通 Spark RDD 一样使用 `map` 等操作；通过 `collect` 收集后则成为 Python 对象列表。
+	示例：
+
+	```python
+	query_result.map(lambda x: x.geom.length).collect()
+	```
+
+	```
+	[
+	 1.5900840000000045,
+	 1.5906639999999896,
+	 1.1110299999999995,
+	 1.1096700000000084,
+	 1.1415619999999933,
+	 1.1386399999999952,
+	 1.1415619999999933,
+	 1.1418860000000137,
+	 1.1392780000000045,
+	 ...
+	]
+	```
+
+	也可以转换为 GeoPandas GeoDataFrame：
+
+	```python
+	import geopandas as gpd
+	gpd.GeoDataFrame(
+	    query_result.map(lambda x: [x.geom, x.userData]).collect(),
+	    columns=["geom", "user_data"],
+	    geometry="geom"
+	)
+	```
+
+## 编写空间 KNN 查询
+
+空间 K 最近邻（KNN）查询接收 K、查询点与一个 SpatialRDD，返回 RDD 中距查询点最近的 K 个几何对象。
+
+假设您已经有一个 SpatialRDD（typed 或 generic），可以用以下代码执行空间 KNN 查询：
+
+=== "Scala"
+
+	```scala
+	val geometryFactory = new GeometryFactory()
+	val pointObject = geometryFactory.createPoint(new Coordinate(-84.01, 34.01))
+	val K = 1000 // K 个最近邻
+	val usingIndex = false
+	val result = KNNQuery.SpatialKnnQuery(objectRDD, pointObject, K, usingIndex)
+	```
+
+=== "Java"
+
+	```java
+	GeometryFactory geometryFactory = new GeometryFactory()
+	Point pointObject = geometryFactory.createPoint(new Coordinate(-84.01, 34.01))
+	int K = 1000 // K 个最近邻
+	boolean usingIndex = false
+	JavaRDD result = KNNQuery.SpatialKnnQuery(objectRDD, pointObject, K, usingIndex)
+	```
+
+=== "Python"
+
+	```python
+	from sedona.spark import KNNQuery
+	from shapely.geometry import Point
+
+	point = Point(-84.01, 34.01)
+	k = 1000 ## K 个最近邻
+	using_index = False
+	result = KNNQuery.SpatialKnnQuery(object_rdd, point, k, using_index)
+	```
+
+!!!note
+	返回 5 个最近邻的空间 KNN 查询等价于以下 Spatial SQL：
+	```sql
+	SELECT ck.name, ck.rating, ST_Distance(ck.location, myLocation) AS distance
+	FROM checkins ck
+	ORDER BY distance DESC
+	LIMIT 5
+	```
+
+### 查询中心几何
+
+除了 Point，Sedona 的 KNN 查询中心也可以是 Polygon 与 LineString。
+
+=== "Scala/Java"
+
+	创建 Polygon 与 LineString 的方法见 [范围查询窗口](#range-query-window)。
+
+=== "Python"
+
+	创建 Polygon 或 LineString 请参阅 [Shapely 官方文档](https://shapely.readthedocs.io/en/stable/manual.html)。
+
+### 使用空间索引
+
+在空间 KNN 查询中使用空间索引：
+
+=== "Scala"
+
+	```scala
+	val geometryFactory = new GeometryFactory()
+	val pointObject = geometryFactory.createPoint(new Coordinate(-84.01, 34.01))
+	val K = 1000 // K 个最近邻
+
+
+	val buildOnSpatialPartitionedRDD = false // 仅在执行 join 查询时设为 TRUE
+	objectRDD.buildIndex(IndexType.RTREE, buildOnSpatialPartitionedRDD)
+
+	val usingIndex = true
+	val result = KNNQuery.SpatialKnnQuery(objectRDD, pointObject, K, usingIndex)
+	```
+
+=== "Java"
+
+	```java
+	GeometryFactory geometryFactory = new GeometryFactory()
+	Point pointObject = geometryFactory.createPoint(new Coordinate(-84.01, 34.01))
+	val K = 1000 // K 个最近邻
+
+
+	boolean buildOnSpatialPartitionedRDD = false // 仅在执行 join 查询时设为 TRUE
+	objectRDD.buildIndex(IndexType.RTREE, buildOnSpatialPartitionedRDD)
+
+	boolean usingIndex = true
+	JavaRDD result = KNNQuery.SpatialKnnQuery(objectRDD, pointObject, K, usingIndex)
+	```
+
+=== "Python"
+
+	```python
+	from sedona.spark import KNNQuery
+	from sedona.spark import IndexType
+	from shapely.geometry import Point
+
+	point = Point(-84.01, 34.01)
+	k = 5 ## K 个最近邻
+
+	build_on_spatial_partitioned_rdd = False ## 仅在执行 join 查询时设为 TRUE
+	spatial_rdd.buildIndex(IndexType.RTREE, build_on_spatial_partitioned_rdd)
+
+	using_index = True
+	result = KNNQuery.SpatialKnnQuery(spatial_rdd, point, k, using_index)
+	```
+
+!!!warning
+	空间 KNN 查询仅支持 R-Tree 索引。
+
+### 输出格式
+
+=== "Scala/Java"
+
+	空间 KNN 查询的输出格式是一个几何对象列表，列表中包含 K 个几何对象。
+
+=== "Python"
+
+	输出格式是 GeoData 对象列表，包含 K 个 GeoData 对象。
+
+	示例：
+	```python
+	>> result
+
+	[GeoData, GeoData, GeoData, GeoData, GeoData]
+	```
+
+## 编写空间连接查询
+
+空间连接查询接收两个 SpatialRDD A 与 B。对于 A 中的每个几何对象，从 B 中找出与之 covered/intersected 的几何对象。A 与 B 可以是任意几何类型，且类型不必相同。
+
+假设您已经有两个 SpatialRDD（typed 或 generic），可以用以下代码执行空间连接查询：
+
+=== "Scala"
+
+	```scala
+	val spatialPredicate = SpatialPredicate.COVERED_BY // 仅返回完全被 queryWindowRDD 中各窗口覆盖的几何对象
+	val usingIndex = false
+
+	objectRDD.analyze()
+
+	objectRDD.spatialPartitioning(GridType.KDBTREE)
+	queryWindowRDD.spatialPartitioning(objectRDD.getPartitioner)
+
+	val result = JoinQuery.SpatialJoinQuery(objectRDD, queryWindowRDD, usingIndex, spatialPredicate)
+	```
+
+=== "Java"
+
+	```java
+	SpatialPredicate spatialPredicate = SpatialPredicate.COVERED_BY // 仅返回完全被 queryWindowRDD 中各窗口覆盖的几何对象
+	val usingIndex = false
+
+	objectRDD.analyze()
+
+	objectRDD.spatialPartitioning(GridType.KDBTREE)
+	queryWindowRDD.spatialPartitioning(objectRDD.getPartitioner)
+
+	JavaPairRDD result = JoinQuery.SpatialJoinQuery(objectRDD, queryWindowRDD, usingIndex, spatialPredicate)
+	```
+
+=== "Python"
+
+	```python
+	from sedona.spark import GridType
+	from sedona.spark import JoinQuery
+
+	consider_boundary_intersection = False ## 仅返回完全被 queryWindowRDD 中各窗口覆盖的几何对象
+	using_index = False
+
+	object_rdd.analyze()
+
+	object_rdd.spatialPartitioning(GridType.KDBTREE)
+	query_window_rdd.spatialPartitioning(object_rdd.getPartitioner())
+
+	result = JoinQuery.SpatialJoinQuery(object_rdd, query_window_rdd, using_index, consider_boundary_intersection)
+	```
+
+!!!note
+	空间连接查询等价于以下 Spatial SQL：
+	```sql
+	SELECT superhero.name
+	FROM city, superhero
+	WHERE ST_Contains(city.geom, superhero.geom);
+	```
+	找出每座城市内的所有超级英雄。
+
+### 使用空间分区
+
+Sedona 的空间分区方法可以显著加速连接查询。可选的空间分区方式有 KDB-Tree、Quad-Tree 与 R-Tree。两个 SpatialRDD 必须使用相同方式分区。
+
+如果先对 A 分区，则必须使用 A 的分区器对 B 分区。
+
+=== "Scala/Java"
+
+	```scala
+	objectRDD.spatialPartitioning(GridType.KDBTREE)
+	queryWindowRDD.spatialPartitioning(objectRDD.getPartitioner)
+	```
+
+=== "Python"
+
+	```python
+	object_rdd.spatialPartitioning(GridType.KDBTREE)
+	query_window_rdd.spatialPartitioning(object_rdd.getPartitioner())
+	```
+
+或者：
+
+=== "Scala/Java"
+
+	```scala
+	queryWindowRDD.spatialPartitioning(GridType.KDBTREE)
+	objectRDD.spatialPartitioning(queryWindowRDD.getPartitioner)
+	```
+
+=== "Python"
+
+	```python
+	query_window_rdd.spatialPartitioning(GridType.KDBTREE)
+	object_rdd.spatialPartitioning(query_window_rdd.getPartitioner())
+	```
+
+### 使用空间索引
+
+在空间连接查询中使用空间索引：
+
+=== "Scala"
+
+	```scala
+	objectRDD.spatialPartitioning(joinQueryPartitioningType)
+	queryWindowRDD.spatialPartitioning(objectRDD.getPartitioner)
+
+	val buildOnSpatialPartitionedRDD = true // 仅在执行 join 查询时设为 TRUE
+	val usingIndex = true
+	queryWindowRDD.buildIndex(IndexType.QUADTREE, buildOnSpatialPartitionedRDD)
+
+	val result = JoinQuery.SpatialJoinQueryFlat(objectRDD, queryWindowRDD, usingIndex, spatialPredicate)
+	```
+
+=== "Java"
+
+	```java
+	objectRDD.spatialPartitioning(joinQueryPartitioningType)
+	queryWindowRDD.spatialPartitioning(objectRDD.getPartitioner)
+
+	boolean buildOnSpatialPartitionedRDD = true // 仅在执行 join 查询时设为 TRUE
+	boolean usingIndex = true
+	queryWindowRDD.buildIndex(IndexType.QUADTREE, buildOnSpatialPartitionedRDD)
+
+	JavaPairRDD result = JoinQuery.SpatialJoinQueryFlat(objectRDD, queryWindowRDD, usingIndex, spatialPredicate)
+	```
+
+=== "Python"
+
+	```python
+	from sedona.spark import GridType
+	from sedona.spark import IndexType
+	from sedona.spark import JoinQuery
+
+	object_rdd.spatialPartitioning(GridType.KDBTREE)
+	query_window_rdd.spatialPartitioning(object_rdd.getPartitioner())
+
+	build_on_spatial_partitioned_rdd = True ## 仅在执行 join 查询时设为 TRUE
+	using_index = True
+	query_window_rdd.buildIndex(IndexType.QUADTREE, build_on_spatial_partitioned_rdd)
+
+	result = JoinQuery.SpatialJoinQueryFlat(object_rdd, query_window_rdd, using_index, True)
+	```
+
+索引应当只在两个 SpatialRDD 中的一个上构建，一般建议在较大的那一个上构建。
+
+### 输出格式
+
+=== "Scala/Java"
+
+	空间连接查询的输出格式是一个 PairRDD，每个元素是一对几何对象：左侧来自 objectRDD，右侧来自 queryWindowRDD。
+
+	```
+	Point,Polygon
+	Point,Polygon
+	Point,Polygon
+	Polygon,Polygon
+	LineString,LineString
+	Polygon,LineString
+	...
+	```
+
+	左侧对象会被右侧对象 covered/intersected。
+
+=== "Python"
+
+	该查询的结果是一个 RDD，元素为长度为 2 的 GeoData 列表。
+	示例：
+	```python
+	result.collect()
+	```
+
+	```
+	[[GeoData, GeoData], [GeoData, GeoData] ...]
+	```
+
+	可以对结果做 RDD 操作，例如取多边形质心：
+	```python
+	result.map(lambda x: x[0].geom.centroid).collect()
+	```
+
+!!!note
+    Sedona Python 用户：以下方法建议使用同一模块下的 `JoinQueryRaw`：
+
+    - spatialJoin
+
+    - DistanceJoinQueryFlat
+
+    - SpatialJoinQueryFlat
+
+    通过 Adapter 转换 DataFrame 时性能更好。这种方式可以避免 Python 与 jvm 之间昂贵的序列化，使您直接操作 Python 对象而不是原生几何。
+
+    示例：
+    ```python
+    from sedona.spark import CircleRDD
+    from sedona.spark import GridType
+    from sedona.spark import JoinQueryRaw
+    from sedona.spark import StructuredAdapter
+
+    object_rdd.analyze()
+
+    circle_rdd = CircleRDD(object_rdd, 0.1)  ## 用给定距离创建 CircleRDD
+    circle_rdd.analyze()
+
+    circle_rdd.spatialPartitioning(GridType.KDBTREE)
+    spatial_rdd.spatialPartitioning(circle_rdd.getPartitioner())
+
+    consider_boundary_intersection = (
+        False  ## 仅返回完全被 queryWindowRDD 中各窗口覆盖的几何对象
+    )
+    using_index = False
+
+    result = JoinQueryRaw.DistanceJoinQueryFlat(
+        spatial_rdd, circle_rdd, using_index, consider_boundary_intersection
+    )
+
+    gdf = StructuredAdapter.toDf(
+        result, ["left_col1", ..., "lefcoln"], ["rightcol1", ..., "rightcol2"], spark
+    )
+    ```
+
+## 编写距离连接查询
+
+!!!warning
+	RDD 距离连接仅在点几何上稳定可靠。其他几何类型请使用 Spatial SQL。
+
+距离连接查询接收两个 SpatialRDD A、B 与一个距离参数。对 A 中每个几何对象，从 B 中找出与其距离不超过给定距离的几何对象。A 与 B 可以是任意几何类型，且类型不必相同。距离的单位说明见 [此处](#transform-the-coordinate-reference-system)。
+
+如果不希望转换数据，且可以接受查询精度的损失，可以使用近似的角度作为距离。可借助 [此换算工具](https://lucidar.me/en/online-unit-converter-length-to-angle/convert-degrees-to-meters/#online-converter)。
+
+假设您已经有两个 SpatialRDD（typed 或 generic），可以用以下代码执行距离连接查询：
+
+=== "Scala"
+
+	```scala
+	objectRddA.analyze()
+
+	val circleRDD = new CircleRDD(objectRddA, 0.1) // 用给定距离创建 CircleRDD
+
+	circleRDD.spatialPartitioning(GridType.KDBTREE)
+	objectRddB.spatialPartitioning(circleRDD.getPartitioner)
+
+	val spatialPredicate = SpatialPredicate.COVERED_BY // 仅返回完全被各查询窗口覆盖的几何对象
+	val usingIndex = false
+
+	val result = JoinQuery.DistanceJoinQueryFlat(objectRddB, circleRDD, usingIndex, spatialPredicate)
+	```
+
+=== "Java"
+
+	```java
+	objectRddA.analyze()
+
+	CircleRDD circleRDD = new CircleRDD(objectRddA, 0.1) // 用给定距离创建 CircleRDD
+
+	circleRDD.spatialPartitioning(GridType.KDBTREE)
+	objectRddB.spatialPartitioning(circleRDD.getPartitioner)
+
+	SpatialPredicate spatialPredicate = SpatialPredicate.COVERED_BY // 仅返回完全被各查询窗口覆盖的几何对象
+	boolean usingIndex = false
+
+	JavaPairRDD result = JoinQuery.DistanceJoinQueryFlat(objectRddB, circleRDD, usingIndex, spatialPredicate)
+	```
+
+=== "Python"
+
+	```python
+	from sedona.spark import CircleRDD
+	from sedona.spark import GridType
+	from sedona.spark import JoinQuery
+
+	object_rdd.analyze()
+
+	circle_rdd = CircleRDD(object_rdd, 0.1) ## 用给定距离创建 CircleRDD
+	circle_rdd.analyze()
+
+	circle_rdd.spatialPartitioning(GridType.KDBTREE)
+	spatial_rdd.spatialPartitioning(circle_rdd.getPartitioner())
+
+	consider_boundary_intersection = False ## 仅返回完全被各查询窗口覆盖的几何对象
+	using_index = False
+
+	result = JoinQuery.DistanceJoinQueryFlat(spatial_rdd, circle_rdd, using_index, consider_boundary_intersection)
+	```
+
+距离连接仅支持 `COVERED_BY` 与 `INTERSECTS` 两种空间谓词。其他部分与空间连接查询相同。
+
+空间分区的细节见 [此处](#use-spatial-partitioning)。
+
+在连接查询中使用空间索引的细节见 [此处](#use-spatial-indexes_2)。
+
+距离连接查询的输出格式见 [此处](#output-format_2)。
+
+!!!note
+	距离连接查询等价于以下 Spatial SQL：
+	```sql
+	SELECT superhero.name
+	FROM city, superhero
+	WHERE ST_Distance(city.geom, superhero.geom) <= 10;
+	```
+	找出与每座城市相距不超过 10 英里的超级英雄。
+
+## 保存到永久存储
+
+可以随时把 SpatialRDD 写回到 HDFS、Amazon S3 等永久存储。
+
+### 保存 SpatialRDD（未建索引）
+
+把 SpatialRDD 保存为分布式 object file：
+
+=== "Scala/Java"
+
+	```scala
+	objectRDD.rawSpatialRDD.saveAsObjectFile("hdfs://PATH")
+	```
+
+=== "Python"
+
+	```python
+	object_rdd.rawJvmSpatialRDD.saveAsObjectFile("hdfs://PATH")
+	```
+
+!!!note
+	分布式 object file 中的每个对象都是字节数组（不可读）。这是 Geometry 或 SpatialIndex 的序列化格式。
+
+### 保存 SpatialRDD（已建索引）
+
+已建索引的 typed SpatialRDD 与 generic SpatialRDD 都可以保存到永久存储，但已建索引的 SpatialRDD 必须保存为分布式 object file。
+
+```
+objectRDD.indexedRawRDD.saveAsObjectFile("hdfs://PATH")
+```
+
+### 保存 SpatialRDD（已分区，未建索引）
+
+经过空间分区的 RDD 可以保存到永久存储，但 Spark 无法保留原 RDD 的分区 ID。这会导致 join 查询结果错误，相关解决方案仍在开发中，敬请关注！
+
+### 重新加载已保存的 SpatialRDD
+
+您可以轻松重新加载保存为==分布式 object file==的 SpatialRDD：
+
+=== "Scala"
+
+	```scala
+	var savedRDD = new SpatialRDD[Geometry]
+	savedRDD.rawSpatialRDD = sc.objectFile[Geometry]("hdfs://PATH")
+	```
+
+=== "Java"
+
+	```java
+	SpatialRDD savedRDD = new SpatialRDD<Geometry>
+	savedRDD.rawSpatialRDD = sc.objectFile<Geometry>("hdfs://PATH")
+	```
+
+=== "Python"
+
+	```python
+	saved_rdd = load_spatial_rdd_from_disc(sc, "hdfs://PATH", GeoType.GEOMETRY)
+	```
+
+重新加载已建索引的 SpatialRDD：
+
+=== "Scala"
+
+	```scala
+	var savedRDD = new SpatialRDD[Geometry]
+	savedRDD.indexedRawRDD = sc.objectFile[SpatialIndex]("hdfs://PATH")
+	```
+
+=== "Java"
+
+	```java
+	SpatialRDD savedRDD = new SpatialRDD<Geometry>
+	savedRDD.indexedRawRDD = sc.objectFile<SpatialIndex>("hdfs://PATH")
+	```
+
+=== "Python"
+
+	```python
+	saved_rdd = SpatialRDD()
+	saved_rdd.indexedRawRDD = load_spatial_index_rdd_from_disc(sc, "hdfs://PATH")
+	```

--- a/docs/tutorial/sql.zh.md
+++ b/docs/tutorial/sql.zh.md
@@ -1,0 +1,1414 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+本页介绍如何使用 SedonaSQL 管理空间数据。
+
+!!!note
+    Sedona 假定地理坐标按 lon/lat 顺序排列。如果您的数据是 lat/lon 顺序，请使用 `ST_FlipCoordinates` 交换 X 与 Y。
+
+SedonaSQL 支持 SQL/MM Part3 空间 SQL 标准，提供四类 SQL 算子，所有算子都可以直接通过以下方式调用：
+
+=== "Scala"
+
+	```scala
+	var myDataFrame = sedona.sql("YOUR_SQL")
+	myDataFrame.createOrReplaceTempView("spatialDf")
+	```
+
+=== "Java"
+
+	```java
+	Dataset<Row> myDataFrame = sedona.sql("YOUR_SQL")
+	myDataFrame.createOrReplaceTempView("spatialDf")
+	```
+
+=== "Python"
+
+	```python
+	myDataFrame = sedona.sql("YOUR_SQL")
+	myDataFrame.createOrReplaceTempView("spatialDf")
+	```
+
+SedonaSQL 详细 API 说明请参阅 [SedonaSQL API](../api/sql/Overview.md)。示例 county 数据（即 `county_small.tsv`）可在 [Sedona GitHub 仓库](https://github.com/apache/sedona/tree/master/spark/common/src/test/resources) 找到。
+
+## 配置依赖
+
+=== "Scala/Java"
+
+	1. 阅读 [Sedona Maven Central 坐标](../setup/maven-coordinates.md) 并在 build.sbt 或 pom.xml 中添加 Sedona 依赖。
+	2. 在 build.sbt 或 pom.xml 中添加 [Apache Spark core](https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.11) 与 [Apache SparkSQL](https://mvnrepository.com/artifact/org.apache.spark/spark-sql) 依赖。
+	3. 参考 [SQL 示例项目](demo.md)。
+
+=== "Python"
+
+	1. 请阅读 [快速开始](../setup/install-python.md) 安装 Sedona Python。
+	2. 本教程基于 [Sedona SQL Jupyter Notebook 示例](jupyter-notebook.md)。
+
+## 创建 Sedona 配置
+
+在程序起始处使用以下代码创建 Sedona 配置。如果您已经有了由 AWS EMR / Databricks / Microsoft Fabric 创建的 SparkSession（通常名为 `spark`），请==跳过此步骤==。
+
+可以在 builder 中追加额外的 Spark 运行时配置，例如 `SedonaContext.builder().config("spark.sql.autoBroadcastJoinThreshold", "10485760")`。
+
+=== "Scala"
+
+	```scala
+	import org.apache.sedona.spark.SedonaContext
+
+	val config = SedonaContext.builder()
+	.master("local[*]") // 集群模式下请删除此行
+	.appName("readTestScala") // 改成合适的名字
+	.getOrCreate()
+	```
+	如果同时使用 SedonaViz 与 SedonaSQL，请在 `SedonaContext.builder()` 之后追加以下行启用 Sedona Kryo 序列化器：
+	```scala
+	.config("spark.kryo.registrator", classOf[SedonaVizKryoRegistrator].getName) // org.apache.sedona.viz.core.Serde.SedonaVizKryoRegistrator
+	```
+
+=== "Java"
+
+	```java
+	import org.apache.sedona.spark.SedonaContext;
+
+	SparkSession config = SedonaContext.builder()
+	.master("local[*]") // 集群模式下请删除此行
+	.appName("readTestJava") // 改成合适的名字
+	.getOrCreate()
+	```
+	如果同时使用 SedonaViz 与 SedonaSQL，请在 `SedonaContext.builder()` 之后追加以下行启用 Sedona Kryo 序列化器：
+	```java
+	.config("spark.kryo.registrator", SedonaVizKryoRegistrator.class.getName()) // org.apache.sedona.viz.core.Serde.SedonaVizKryoRegistrator
+	```
+
+=== "Python"
+
+	```python
+	from sedona.spark import *
+
+	config = SedonaContext.builder() .\
+	    config('spark.jars.packages',
+	           'org.apache.sedona:sedona-spark-shaded-3.3_2.12:{{ sedona.current_version }},'
+	           'org.datasyslab:geotools-wrapper:{{ sedona.current_geotools }}'). \
+	    getOrCreate()
+	```
+    如使用其他 Spark 版本，请将 sedona-spark-shaded 包名中的 `3.3` 替换为对应的 Spark major.minor 版本，例如 `sedona-spark-shaded-3.4_2.12:{{ sedona.current_version }}`。
+
+## 初始化 SedonaContext
+
+在创建 Sedona 配置之后加上以下代码。如果您已经有了由 AWS EMR / Databricks / Microsoft Fabric 创建的 SparkSession（通常名为 `spark`），请改为调用 `sedona = SedonaContext.create(spark)`。
+
+=== "Scala"
+
+	```scala
+	import org.apache.sedona.spark.SedonaContext
+
+	val sedona = SedonaContext.create(config)
+	```
+
+=== "Java"
+
+	```java
+	import org.apache.sedona.spark.SedonaContext;
+
+	SparkSession sedona = SedonaContext.create(config)
+	```
+
+=== "Python"
+
+	```python
+	from sedona.spark import *
+
+	sedona = SedonaContext.create(config)
+	```
+
+也可以通过在 `spark-submit` 或 `spark-shell` 中传入 `--conf spark.sql.extensions=org.apache.sedona.sql.SedonaSqlExtensions` 完成注册。
+
+## 从文本文件加载数据
+
+假设有一个 WKT 文件 `usa-county.tsv`，路径为 `/Download/usa-county.tsv`，内容如下：
+
+```
+POLYGON (..., ...)	Cuming County
+POLYGON (..., ...)	Wahkiakum County
+POLYGON (..., ...)	De Baca County
+POLYGON (..., ...)	Lancaster County
+```
+
+文件中可能还有许多其他列。
+
+### 加载原始 DataFrame
+
+使用以下代码加载数据并创建原始 DataFrame：
+
+=== "Scala"
+	```scala
+	var rawDf = sedona.read.format("csv").option("delimiter", "\t").option("header", "false").load("/Download/usa-county.tsv")
+	rawDf.createOrReplaceTempView("rawdf")
+	rawDf.show()
+	```
+
+=== "Java"
+	```java
+	Dataset<Row> rawDf = sedona.read.format("csv").option("delimiter", "\t").option("header", "false").load("/Download/usa-county.tsv")
+	rawDf.createOrReplaceTempView("rawdf")
+	rawDf.show()
+	```
+
+=== "Python"
+	```python
+	rawDf = sedona.read.format("csv").option("delimiter", "\t").option("header", "false").load("/Download/usa-county.tsv")
+	rawDf.createOrReplaceTempView("rawdf")
+	rawDf.show()
+	```
+
+输出大致如下：
+
+```
+|                 _c0|_c1|_c2|     _c3|  _c4|        _c5|                 _c6|_c7|_c8|  _c9|_c10| _c11|_c12|_c13|      _c14|    _c15|       _c16|        _c17|
++--------------------+---+---+--------+-----+-----------+--------------------+---+---+-----+----+-----+----+----+----------+--------+-----------+------------+
+|POLYGON ((-97.019...| 31|039|00835841|31039|     Cuming|       Cuming County| 06| H1|G4020|null| null|null|   A|1477895811|10447360|+41.9158651|-096.7885168|
+|POLYGON ((-123.43...| 53|069|01513275|53069|  Wahkiakum|    Wahkiakum County| 06| H1|G4020|null| null|null|   A| 682138871|61658258|+46.2946377|-123.4244583|
+|POLYGON ((-104.56...| 35|011|00933054|35011|    De Baca|      De Baca County| 06| H1|G4020|null| null|null|   A|6015539696|29159492|+34.3592729|-104.3686961|
+|POLYGON ((-96.910...| 31|109|00835876|31109|  Lancaster|    Lancaster County| 06| H1|G4020| 339|30700|null|   A|2169240202|22877180|+40.7835474|-096.6886584|
+```
+
+### 创建 Geometry 类型列
+
+SedonaSQL 中所有几何运算都作用在 Geometry 类型对象上。因此在执行任何查询之前，需要在 DataFrame 上构造一列 Geometry 类型列。
+
+```sql
+SELECT ST_GeomFromWKT(_c0) AS countyshape, _c1, _c2
+```
+
+可以选取更多属性来组成这个 `spatialdDf`。输出大致如下：
+
+```
+|                 countyshape|_c1|_c2|     _c3|  _c4|        _c5|                 _c6|_c7|_c8|  _c9|_c10| _c11|_c12|_c13|      _c14|    _c15|       _c16|        _c17|
++--------------------+---+---+--------+-----+-----------+--------------------+---+---+-----+----+-----+----+----+----------+--------+-----------+------------+
+|POLYGON ((-97.019...| 31|039|00835841|31039|     Cuming|       Cuming County| 06| H1|G4020|null| null|null|   A|1477895811|10447360|+41.9158651|-096.7885168|
+|POLYGON ((-123.43...| 53|069|01513275|53069|  Wahkiakum|    Wahkiakum County| 06| H1|G4020|null| null|null|   A| 682138871|61658258|+46.2946377|-123.4244583|
+|POLYGON ((-104.56...| 35|011|00933054|35011|    De Baca|      De Baca County| 06| H1|G4020|null| null|null|   A|6015539696|29159492|+34.3592729|-104.3686961|
+|POLYGON ((-96.910...| 31|109|00835876|31109|  Lancaster|    Lancaster County| 06| H1|G4020| 339|30700|null|   A|2169240202|22877180|+40.7835474|-096.6886584|
+```
+
+虽然外观与输入一致，但 `countyshape` 列的类型已经变为 ==Geometry==。
+
+可以通过打印 schema 进行验证：
+
+```scala
+spatialDf.printSchema()
+```
+
+输出如下：
+
+```
+root
+ |-- countyshape: geometry (nullable = false)
+ |-- _c1: string (nullable = true)
+ |-- _c2: string (nullable = true)
+ |-- _c3: string (nullable = true)
+ |-- _c4: string (nullable = true)
+ |-- _c5: string (nullable = true)
+ |-- _c6: string (nullable = true)
+ |-- _c7: string (nullable = true)
+```
+
+!!!note
+	SedonaSQL 提供了大量构造 Geometry 列的函数，详见 [SedonaSQL 构造器 API](../api/sql/Geometry-Functions.md)。
+
+## 加载 GeoJSON 数据
+
+自 `v1.6.1` 起，Sedona 支持通过 `geojson` 数据源读取 GeoJSON 文件。它专门用于处理几何对象采用 [GeoJSON 格式](https://datatracker.ietf.org/doc/html/rfc7946) 的 JSON 文件。
+
+读取多行 GeoJSON 文件请将 `multiLine` 选项设为 `True`。
+
+=== "Python"
+
+    ```python
+    df = (
+        sedona.read.format("geojson")
+        .option("multiLine", "true")
+        .load("PATH/TO/MYFILE.json")
+        .selectExpr("explode(features) as features")  # 展开 envelope
+        .select("features.*")  # 解包 features 结构体
+        .withColumn("prop0", f.expr("properties['prop0']"))
+        .drop("properties")
+        .drop("type")
+    )
+
+    df.show()
+    df.printSchema()
+    ```
+
+=== "Scala"
+
+    ```scala
+    val df = sedona.read.format("geojson").option("multiLine", "true").load("PATH/TO/MYFILE.json")
+    val parsedDf = df.selectExpr("explode(features) as features").select("features.*")
+            .withColumn("prop0", expr("properties['prop0']")).drop("properties").drop("type")
+
+    parsedDf.show()
+    parsedDf.printSchema()
+    ```
+
+=== "Java"
+
+    ```java
+    Dataset<Row> df = sedona.read.format("geojson").option("multiLine", "true").load("PATH/TO/MYFILE.json")
+     .selectExpr("explode(features) as features") // 展开 envelope，每行一个 feature
+     .select("features.*") // 解包 features 结构体
+     .withColumn("prop0", expr("properties['prop0']")).drop("properties").drop("type")
+
+    df.show();
+    df.printSchema();
+    ```
+
+加载 GeoJSON 文件的更多信息请参阅 [此页](files/geojson-sedona-spark.md)。
+
+## 加载 Shapefile
+
+自 v`1.7.0` 起，Sedona 支持把 Shapefile 加载为 DataFrame。
+
+=== "Scala/Java"
+
+    ```scala
+    val df = sedona.read.format("shapefile").load("/path/to/shapefile")
+    ```
+
+=== "Java"
+
+    ```java
+    Dataset<Row> df = sedona.read().format("shapefile").load("/path/to/shapefile")
+    ```
+
+=== "Python"
+
+    ```python
+    df = sedona.read.format("shapefile").load("/path/to/shapefile")
+    ```
+
+输入路径既可以是包含一个或多个 Shapefile 的目录，也可以是 `.shp` 文件本身。
+
+加载 Shapefile 的更多信息请参阅 [此页](files/shapefiles-sedona-spark.md)。
+
+## 加载 GeoParquet
+
+自 v`1.3.0` 起，Sedona 原生支持加载 GeoParquet 文件。Sedona 会通过 GeoParquet 文件中的 “geo” 元数据推断几何字段。
+
+=== "Scala/Java"
+
+	```scala
+	val df = sedona.read.format("geoparquet").load(geoparquetdatalocation1)
+	df.printSchema()
+	```
+
+=== "Java"
+
+	```java
+	Dataset<Row> df = sedona.read.format("geoparquet").load(geoparquetdatalocation1)
+	df.printSchema()
+	```
+
+=== "Python"
+
+	```python
+	df = sedona.read.format("geoparquet").load(geoparquetdatalocation1)
+	df.printSchema()
+	```
+
+输出如下：
+
+```
+root
+ |-- pop_est: long (nullable = true)
+ |-- continent: string (nullable = true)
+ |-- name: string (nullable = true)
+ |-- iso_a3: string (nullable = true)
+ |-- gdp_md_est: double (nullable = true)
+ |-- geometry: geometry (nullable = true)
+```
+
+Sedona 支持 GeoParquet 文件的空间谓词下推，详见 [SedonaSQL 查询优化器](../api/sql/Optimizer.md) 文档。
+
+GeoParquet 文件读取器也可用于读取 Apache Sedona 1.3.1-incubating 及更早版本写出的旧版 Parquet 文件，详见 [读取旧版 Parquet 文件](../api/sql/Reading-legacy-parquet.md)。
+
+加载 GeoParquet 的更多信息请参阅 [此页](files/geoparquet-sedona-spark.md)。
+
+## 从 STAC catalog 加载数据
+
+Sedona 的 STAC 数据源允许从 SpatioTemporal Asset Catalog（STAC）API 读取数据，支持读取 STAC items 与 collections。
+
+可以从 S3 上的 collection 文件加载 STAC collection：
+
+```python
+df = sedona.read.format("stac").load(
+    "s3a://example.com/stac_bucket/stac_collection.json"
+)
+```
+
+也可以从 HTTP/HTTPS 端点加载：
+
+```python
+df = sedona.read.format("stac").load(
+    "https://earth-search.aws.element84.com/v1/collections/sentinel-2-pre-c1-l2a"
+)
+```
+
+STAC 数据源支持空间和时间过滤的下推，可以将这些过滤直接下推到底层数据源以减少需要读取的数据量。
+
+加载 STAC 数据的更多信息请参阅 [此页](files/stac-sedona-spark.md)。
+
+## 从 JDBC 数据源加载数据
+
+可以使用 Spark SQL JDBC 数据源的 'query' 选项把几何列转换成 Sedona 能识别的格式。该方式适用于大多数支持空间的 JDBC 数据源。Postgis 由于使用 EWKB 作为其传输格式，无需添加查询进行类型转换。
+
+=== "Scala"
+
+	```scala
+	// 适用于任意 JDBC 数据源（包括 Postgis）
+	val df = sedona.read.format("jdbc")
+		// 其他选项
+		.option("query", "SELECT id, ST_AsBinary(geom) as geom FROM my_table")
+		.load()
+		.withColumn("geom", expr("ST_GeomFromWKB(geom)"))
+
+	// Postgis 上的简化写法
+	val df = sedona.read.format("jdbc")
+		// 其他选项
+		.option("dbtable", "my_table")
+		.load()
+		.withColumn("geom", expr("ST_GeomFromWKB(geom)"))
+	```
+
+=== "Java"
+
+	```java
+	// 适用于任意 JDBC 数据源（包括 Postgis）
+	Dataset<Row> df = sedona.read().format("jdbc")
+		// 其他选项
+		.option("query", "SELECT id, ST_AsBinary(geom) as geom FROM my_table")
+		.load()
+		.withColumn("geom", expr("ST_GeomFromWKB(geom)"))
+
+	// Postgis 上的简化写法
+	Dataset<Row> df = sedona.read().format("jdbc")
+		// 其他选项
+		.option("dbtable", "my_table")
+		.load()
+		.withColumn("geom", expr("ST_GeomFromWKB(geom)"))
+	```
+
+=== "Python"
+
+	```python
+	# 适用于任意 JDBC 数据源（包括 Postgis）
+	df = (sedona.read.format("jdbc")
+		# 其他选项
+		.option("query", "SELECT id, ST_AsBinary(geom) as geom FROM my_table")
+		.load()
+		.withColumn("geom", f.expr("ST_GeomFromWKB(geom)")))
+
+	# Postgis 上的简化写法
+	df = (sedona.read.format("jdbc")
+		# 其他选项
+		.option("dbtable", "my_table")
+		.load()
+		.withColumn("geom", f.expr("ST_GeomFromWKB(geom)")))
+	```
+
+## 加载 GeoPackage
+
+自 v1.7.0 起，Sedona 支持把 GeoPackage 文件加载为 DataFrame。
+
+=== "Scala/Java"
+
+	```scala
+	val df = sedona.read.format("geopackage").option("tableName", "tab").load("/path/to/geopackage")
+	```
+
+=== "Java"
+
+	```java
+	Dataset<Row> df = sedona.read().format("geopackage").option("tableName", "tab").load("/path/to/geopackage")
+	```
+
+=== "Python"
+
+	```python
+	df = sedona.read.format("geopackage").option("tableName", "tab").load("/path/to/geopackage")
+	```
+
+加载 GeoPackage 的更多信息请参阅 [此页](files/geopackage-sedona-spark.md)。
+
+## 加载 OSM PBF
+
+自 v1.7.1 起，Sedona 支持把 OSM PBF 文件加载为 DataFrame。
+
+=== "Scala/Java"
+
+	```scala
+	val df = sedona.read.format("osmpbf").load("/path/to/osmpbf")
+	```
+
+=== "Java"
+
+	```java
+	Dataset<Row> df = sedona.read().format("osmpbf").load("/path/to/osmpbf")
+	```
+
+=== "Python"
+
+	```python
+	df = sedona.read.format("osmpbf").load("/path/to/osmpbf")
+	```
+
+OSM PBF 文件可以包含 nodes、ways 与 relations。Sedona 目前支持 Nodes、DenseNodes、Ways 与 Relations。加载后的 DataFrame schema 如下：
+
+```
+root
+ |-- id: long (nullable = true)
+ |-- kind: string (nullable = true)
+ |-- location: struct (nullable = true)
+ |    |-- longitude: double (nullable = true)
+ |    |-- latitude: double (nullable = true)
+ |-- tags: map (nullable = true)
+ |    |-- key: string
+ |    |-- value: string (valueContainsNull = true)
+ |-- refs: array (nullable = true)
+ |    |-- element: long (containsNull = true)
+ |-- ref_roles: array (nullable = true)
+ |    |-- element: string (containsNull = true)
+ |-- ref_types: array (nullable = true)
+ |    |-- element: string (containsNull = true)
+```
+
+各字段含义：
+
+- `id`：对象的唯一标识。
+- `kind`：对象类型，可能为 `node`、`way` 或 `relation`。
+- `location`：对象的位置，包含 `longitude` 与 `latitude`。
+- `tags`：键值对的 map，表示对象的 tags。
+- `refs`：对象引用的数组。
+- `ref_roles`：引用对应的角色数组。
+- `ref_types`：引用对应的类型数组。
+
+nodes 的 DataFrame 大致如下：
+
+```
++---------+----+--------------------+--------------------+----+---------+---------+
+|       id|kind|            location|                tags|refs|ref_roles|ref_types|
++---------+----+--------------------+--------------------+----+---------+---------+
+|248675410|node|{21.0884952545166...|{tactile_paving -...|NULL|     NULL|     NULL|
+|260821820|node|{21.0191555023193...|{created_by -> JOSM}|NULL|     NULL|     NULL|
+|349189665|node|{22.1437530517578...|{source -> http:/...|NULL|     NULL|     NULL|
+|353366899|node|{22.9787712097167...|{source -> http:/...|NULL|     NULL|     NULL|
+|359460224|node|{22.4816703796386...|{source -> http:/...|NULL|     NULL|     NULL|
++---------+----+--------------------+--------------------+----+---------+---------+
+only showing top 5 rows
+```
+
+ways 的大致样子：
+
+```
++-------+----+--------+--------------------+--------------------+---------+---------+
+|     id|kind|location|                tags|                refs|ref_roles|ref_types|
++-------+----+--------+--------------------+--------------------+---------+---------+
+|4307329| way|    NULL|{junction -> roun...|[2448759046, 7093...|     NULL|     NULL|
+|4307330| way|    NULL|{surface -> aspha...|[26063923, 260639...|     NULL|     NULL|
+|4308966| way|    NULL|{sidewalk -> sepa...|[3387797238, 9252...|     NULL|     NULL|
+|4308968| way|    NULL|{surface -> pavin...|[26083890, 744724...|     NULL|     NULL|
+|4308969| way|    NULL|{cycleway:both ->...|[9526831176, 1218...|     NULL|     NULL|
++-------+----+--------+--------------------+--------------------+---------+---------+
+```
+
+relations 的大致样子：
+
+```
++-----+--------+--------+--------------------+--------------------+--------------------+--------------------+
+|   id|    kind|location|                tags|                refs|           ref_roles|           ref_types|
++-----+--------+--------+--------------------+--------------------+--------------------+--------------------+
+|28124|relation|    NULL|{official_name ->...|[26382394, 26259985]|      [inner, outer]|          [WAY, WAY]|
+|28488|relation|    NULL|  {type -> junction}|[26409253, 303249...|[roundabout, roun...|[WAY, WAY, WAY, WAY]|
+|32939|relation|    NULL|{ref -> E 67, rou...|[140673970, 14067...|        [, , , , , ]|[WAY, WAY, RELATI...|
+|34387|relation|    NULL|{note -> rząd III...|[209161000, 52154...|[main_stream, mai...|[WAY, WAY, WAY, W...|
+|34392|relation|    NULL|{distance -> 1047...|[150033976, 25076...|[main_stream, mai...|[WAY, WAY, WAY, W...|
++-----+--------+--------+--------------------+--------------------+--------------------+--------------------+
+```
+
+## 转换坐标参考系
+
+Sedona 不会自动管理一列 Geometry 中所有几何对象的坐标单位（基于度还是基于米）。SedonaSQL 中所有相关距离的单位与 Geometry 列中几何对象的单位保持一致。
+
+自 `v1.5.0` 起，该函数默认使用 lon/lat 顺序（之前为 lat/lon 顺序）。可以使用 ==ST_FlipCoordinates== 交换 X 与 Y。
+
+更多细节请参阅 Sedona API 参考中的 `ST_Transform` 章节。
+
+转换前述 Geometry 列的坐标参考系：
+
+```sql
+SELECT ST_Transform(countyshape, "epsg:4326", "epsg:3857") AS newcountyshape, _c1, _c2, _c3, _c4, _c5, _c6, _c7
+FROM spatialdf
+```
+
+`ST_Transform` 第一个 EPSG 代码 EPSG:4326 是源 CRS——也就是最常见的基于度的 CRS（WGS84）。
+
+第二个 EPSG 代码 EPSG:3857 是目标 CRS——最常见的基于米的 CRS。
+
+`ST_Transform` 会把这些几何对象的 CRS 从 EPSG:4326 转换到 EPSG:3857。详细 CRS 信息可在 [EPSG.io](https://epsg.io/) 找到。
+
+多边形坐标已发生变化。输出大致如下：
+
+```
++--------------------+---+---+--------+-----+-----------+--------------------+---+
+|      newcountyshape|_c1|_c2|     _c3|  _c4|        _c5|                 _c6|_c7|
++--------------------+---+---+--------+-----+-----------+--------------------+---+
+|POLYGON ((-108001...| 31|039|00835841|31039|     Cuming|       Cuming County| 06|
+|POLYGON ((-137408...| 53|069|01513275|53069|  Wahkiakum|    Wahkiakum County| 06|
+|POLYGON ((-116403...| 35|011|00933054|35011|    De Baca|      De Baca County| 06|
+|POLYGON ((-107880...| 31|109|00835876|31109|  Lancaster|    Lancaster County| 06|
+
+```
+
+## 使用 DBSCAN 进行聚类
+
+Sedona 提供 [DBSCAN](https://en.wikipedia.org/wiki/Dbscan) 算法的实现，用于对空间数据进行聚类。
+
+该算法以 Scala 与 Python 函数的形式提供，作用在空间 DataFrame 上。返回的 DataFrame 中会增加两列：所属簇的唯一标识，以及一个表示该记录是否为核心点的布尔列。
+
+第一个参数是 DataFrame，后两个是 DBSCAN 的 epsilon 与 min_points 参数。
+
+=== "Scala"
+
+	```scala
+	import org.apache.sedona.stats.clustering.DBSCAN.dbscan
+
+	dbscan(df, 0.1, 5).show()
+	```
+
+=== "Java"
+
+	```java
+	import org.apache.sedona.stats.clustering.DBSCAN;
+
+	DBSCAN.dbscan(df, 0.1, 5).show();
+	```
+
+=== "Python"
+
+	```python
+	from sedona.spark.stats import dbscan
+
+	dbscan(df, 0.1, 5).show()
+	```
+
+输出大致如下：
+
+```
++----------------+---+------+-------+
+|        geometry| id|isCore|cluster|
++----------------+---+------+-------+
+|   POINT (2.5 4)|  3| false|      1|
+|     POINT (3 4)|  2| false|      1|
+|     POINT (3 5)|  5| false|      1|
+|     POINT (1 3)|  9|  true|      0|
+| POINT (2.5 4.5)|  7|  true|      1|
+|     POINT (1 2)|  1|  true|      0|
+| POINT (1.5 2.5)|  4|  true|      0|
+| POINT (1.2 2.5)|  8|  true|      0|
+|   POINT (1 2.5)| 11|  true|      0|
+|     POINT (1 5)| 10| false|     -1|
+|     POINT (5 6)| 12| false|     -1|
+|POINT (12.8 4.5)|  6| false|     -1|
+|     POINT (4 3)| 13| false|     -1|
++----------------+---+------+-------+
+```
+
+DBSCAN 算法的更多内容请参阅 [此页](concepts/clustering-algorithms.md)。
+
+## 计算 Local Outlier Factor（LOF）
+
+Sedona 提供 [Local Outlier Factor](https://en.wikipedia.org/wiki/Local_outlier_factor) 算法的实现，用于识别空间数据中的异常点。
+
+该算法以 Scala 与 Python 函数的形式提供，作用在空间 DataFrame 上。返回的 DataFrame 中会增加一列保存 local outlier factor。
+
+第一个参数是 DataFrame，第二个参数是计算评分时考虑的最近邻数量。
+
+=== "Scala"
+
+	```scala
+	import org.apache.sedona.stats.outlierDetection.LocalOutlierFactor.localOutlierFactor
+
+    localOutlierFactor(df, 20).show()
+	```
+
+=== "Java"
+
+	```java
+	import org.apache.sedona.stats.outlierDetection.LocalOutlierFactor;
+
+	LocalOutlierFactor.localOutlierFactor(df, 20).show();
+	```
+
+=== "Python"
+
+	```python
+	from sedona.spark.stats import local_outlier_factor
+
+	local_outlier_factor(df, 20).show()
+	```
+
+输出大致如下：
+
+```
++--------------------+------------------+
+|            geometry|               lof|
++--------------------+------------------+
+|POINT (-2.0231305...| 0.952098153363662|
+|POINT (-2.0346944...|0.9975325496668104|
+|POINT (-2.2040074...|1.0825843906411081|
+|POINT (1.61573501...|1.7367129352162634|
+|POINT (-2.1176324...|1.5714144683150393|
+|POINT (-2.2349759...|0.9167275845938276|
+|POINT (1.65470192...| 1.046231536764447|
+|POINT (0.62624112...|1.1988700676990034|
+|POINT (2.01746261...|1.1060219481067417|
+|POINT (-2.0483857...|1.0775553430145446|
+|POINT (2.43969463...|1.1129132178576646|
+|POINT (-2.2425480...| 1.104108012697006|
+|POINT (-2.7859235...|  2.86371824574529|
+|POINT (-1.9738858...|1.0398822680356794|
+|POINT (2.00153403...| 0.927409656346015|
+|POINT (2.06422812...|0.9222203762264445|
+|POINT (-1.7533819...|1.0273650471626696|
+|POINT (-2.2030766...| 0.964744555830738|
+|POINT (-1.8509857...|1.0375927869698574|
+|POINT (2.10849080...|1.0753419197322656|
++--------------------+------------------+
+```
+
+## 执行 Getis-Ord Gi(*) 热点分析
+
+Sedona 提供 [Gi 与 Gi*](https://en.wikipedia.org/wiki/Getis%E2%80%93Ord_statistics) 算法的实现，用于识别空间数据中的局部热点。
+
+该算法以 Scala 与 Python 函数的形式提供，作用在空间 DataFrame 上。返回的 DataFrame 中会增加 G 统计量、E[G]、V[G]、Z 分数与 p 值等列。
+
+使用 Gi 时，先为每条记录生成邻居列表，再调用 g_local 函数。
+=== "Scala"
+
+	```scala
+	import org.apache.sedona.stats.Weighting.addBinaryDistanceBandColumn
+	import org.apache.sedona.stats.hotspotDetection.GetisOrd.gLocal
+
+	val distanceRadius = 1.0
+	val weightedDf = addBinaryDistanceBandColumn(df, distanceRadius)
+    gLocal(weightedDf, "val").show()
+	```
+
+=== "Java"
+
+	```java
+	import org.apache.sedona.stats.Weighting;
+	import org.apache.sedona.stats.hotspotDetection.GetisOrd;
+	import org.apache.spark.sql.DataFrame;
+
+	double distanceRadius = 1.0;
+	DataFrame weightedDf = Weighting.addBinaryDistanceBandColumn(df, distanceRadius);
+	GetisOrd.gLocal(weightedDf, "val").show();
+	```
+
+=== "Python"
+
+	```python
+	from sedona.spark.stats import add_binary_distance_band_column
+	from sedona.spark.stats import g_local
+
+	distance_radius = 1.0
+	weighted_df = addBinaryDistanceBandColumn(df, distance_radius)
+    g_local(weightedDf, "val").show()
+	```
+
+输出大致如下：
+
+<pre>
+<code>
++-----------+---+--------------------+-------------------+-------------------+--------------------+--------------------+--------------------+
+|   geometry|val|             weights|                  G|                 EG|                  VG|                   Z|                   P|
++-----------+---+--------------------+-------------------+-------------------+--------------------+--------------------+--------------------+
+|POINT (2 2)|0.9|[&#123;&#123;POINT (2 3), 1...| 0.4488188976377953|0.45454545454545453| 0.00356321373799772|-0.09593402008347063|  0.4617864875295957|
+|POINT (2 3)|1.2|[&#123;&#123;POINT (2 2), 0...|0.35433070866141736|0.36363636363636365|0.003325666155464539|-0.16136436037034918|  0.4359032175415549|
+|POINT (3 3)|1.2|[&#123;&#123;POINT (2 3), 1...|0.28346456692913385| 0.2727272727272727|0.002850570990398176| 0.20110780337013057| 0.42030714022155924|
+|POINT (3 2)|1.2|[&#123;&#123;POINT (2 2), 0...| 0.4488188976377953|0.45454545454545453| 0.00356321373799772|-0.09593402008347063|  0.4617864875295957|
+|POINT (3 1)|1.2|[&#123;&#123;POINT (3 2), 3...| 0.3622047244094489| 0.2727272727272727|0.002850570990398176|  1.6758983614177538| 0.04687905137429871|
+|POINT (2 1)|2.2|[&#123;&#123;POINT (2 2), 0...| 0.4330708661417323|0.36363636363636365|0.003325666155464539|  1.2040263812249166| 0.11428969105925013|
+|POINT (1 1)|1.2|[&#123;&#123;POINT (2 1), 5...| 0.2834645669291339| 0.2727272727272727|0.002850570990398176|  0.2011078033701316|  0.4203071402215588|
+|POINT (1 2)|0.2|[&#123;&#123;POINT (2 2), 0...|0.35433070866141736|0.45454545454545453| 0.00356321373799772|   -1.67884535146075|0.046591093685710794|
+|POINT (1 3)|1.2|[&#123;&#123;POINT (2 3), 1...| 0.2047244094488189| 0.2727272727272727|0.002850570990398176| -1.2736827546774914| 0.10138793530151635|
+|POINT (0 2)|1.0|[&#123;&#123;POINT (1 2), 7...|0.09448818897637795|0.18181818181818182|0.002137928242798632| -1.8887168824332323|0.029464887612748458|
+|POINT (4 2)|1.2|[&#123;&#123;POINT (3 2), 3...| 0.1889763779527559|0.18181818181818182|0.002137928242798632| 0.15481285921583854| 0.43848442662481324|
++-----------+---+--------------------+-------------------+-------------------+--------------------+--------------------+--------------------+
+</code>
+</pre>
+
+## 执行空间查询
+
+构造完 Geometry 类型列后，即可执行各类空间查询。
+
+### 范围查询
+
+使用 ==ST_Contains==、==ST_Intersects==、==ST_Within== 在单列上执行范围查询。
+
+下例查找位于给定多边形内的所有 county：
+
+```sql
+SELECT *
+FROM spatialdf
+WHERE ST_Contains (ST_PolygonFromEnvelope(1.0,100.0,1000.0,1100.0), newcountyshape)
+```
+
+!!!note
+	了解如何创建 Geometry 类型的查询窗口请参阅 [SedonaSQL 构造器 API](../api/sql/Geometry-Functions.md)。
+
+### KNN 查询
+
+使用 ==ST_Distance== 计算距离并排序。
+
+下面的代码返回距离给定多边形最近的 5 个对象：
+
+```sql
+SELECT countyname, ST_Distance(ST_PolygonFromEnvelope(1.0,100.0,1000.0,1100.0), newcountyshape) AS distance
+FROM spatialdf
+ORDER BY distance DESC
+LIMIT 5
+```
+
+### 连接查询
+
+连接查询的细节请参阅 [Join query](../api/sql/Optimizer.md)。
+
+### KNN 连接查询
+
+KNN 连接查询的细节请参阅 [KNN join query](../api/sql/NearestNeighbourSearching.md)。
+
+### 其他查询
+
+还有许多函数可以与上述查询组合使用，详见 [SedonaSQL 函数](../api/sql/Overview.md) 与 [SedonaSQL 聚合函数](../api/sql/Geometry-Functions.md#aggregate-functions)。
+
+## 可视化查询结果
+
+Sedona 提供 `SedonaPyDeck` 与 `SedonaKepler` 两种封装，都提供了在 Jupyter 环境中基于 SedonaDataFrame 创建交互式地图可视化的 API。
+
+!!!Note
+	`SedonaPyDeck` 与 `SedonaKepler` 默认要求几何对象按 lon-lat 顺序排列。如果您的 DataFrame 是 lat-lon 顺序，请使用 [ST_FlipCoordinates](../api/sql/Geometry-Editors/ST_FlipCoordinates.md)。
+
+!!!Note
+	`SedonaPyDeck` 与 `SedonaKepler` 设计上仅处理只含 1 个几何列的 SedonaDataFrame，传入包含多个几何列的 DataFrame 会出错。
+
+### SedonaPyDeck
+
+可在 Jupyter Lab/Notebook 中通过 SedonaPyDeck 可视化空间查询结果。
+
+SedonaPyDeck 基于 [pydeck](https://deckgl.readthedocs.io)（构建于 [deck.gl](https://deck.gl/) 之上）提供创建交互式地图的 API。
+
+!!!Note
+	使用 SedonaPyDeck 需要安装 sedona 的 `pydeck-map` 附加项：
+	```
+	pip install apache-sedona[pydeck-map]
+	```
+
+下面的教程展示了 SedonaPyDeck 可创建的多种地图，所用数据集均为公开数据。
+
+每个 SedonaPyDeck API 都通过可选参数提供定制能力，所有可用参数详见 [SedonaPyDeck API 文档](../api/sql/Visualization-SedonaPyDeck.md)。
+
+#### 使用 SedonaPyDeck 创建 Choropleth 地图
+
+SedonaPyDeck 的 `create_choropleth_map` API 可基于包含多边形与观测值的 SedonaDataFrame 创建 choropleth 地图：
+
+示例：
+
+```python
+SedonaPyDeck.create_choropleth_map(df=groupedresult, plot_col="AirportCount")
+```
+
+!!!Note
+	`plot_col` 是必填参数，用于告诉 SedonaPyDeck 渲染 choropleth 时使用哪一列。
+
+![使用 SedonaPyDeck 创建 Choropleth 地图](../image/choropleth.gif)
+
+所用数据集见 [此处](https://github.com/apache/sedona/tree/b66e768155866a38ba2e3404f1151cac14fad5ea/docs/usecases/data/ne_50m_airports)，对应示例 notebook 见 [此处](https://github.com/apache/sedona/blob/master/docs/usecases/legacy/ApacheSedonaSQL_SpatialJoin_AirportsPerCountry.ipynb)。
+
+#### 使用 SedonaPyDeck 创建 Geometry 地图
+
+SedonaPyDeck 的 `create_geometry_map` API 可可视化任意类型几何对象的 SedonaDataFrame：
+
+示例：
+
+```python
+SedonaPyDeck.create_geometry_map(df_building, elevation_col="height")
+```
+
+![使用 SedonaPyDeck 创建 Geometry 地图](../image/buildings.gif)
+
+!!!Tip
+	`elevation_col` 是可选参数，用于渲染 3D 地图。请把对应几何对象 “高度” 信息所在的列名传入此参数。
+
+#### 使用 SedonaPyDeck 创建 Scatterplot 地图
+
+SedonaPyDeck 的 `create_scatterplot_map` API 可基于包含点的 SedonaDataFrame 创建散点地图：
+
+示例：
+
+```python
+SedonaPyDeck.create_scatterplot_map(df=crimes_df)
+```
+
+![使用 SedonaPyDeck 创建 Scatterplot 地图](../image/points.gif)
+
+所用的是 Chicago crimes 数据集，见 [此处](https://github.com/apache/sedona/blob/sedona-1.5.0/spark/common/src/test/resources/Chicago_Crimes.csv)。
+
+#### 使用 SedonaPyDeck 创建热力图
+
+SedonaPyDeck 的 `create_heatmap` API 可基于包含点的 SedonaDataFrame 创建热力图：
+
+示例：
+
+```python
+SedonaPyDeck.create_heatmap(df=crimes_df)
+```
+
+![使用 SedonaPyDeck 创建热力图](../image/heatmap.gif)
+
+所用同样是 Chicago crimes 数据集，见 [此处](https://github.com/apache/sedona/blob/sedona-1.5.0/spark/common/src/test/resources/Chicago_Crimes.csv)。
+
+### SedonaKepler
+
+可在 Jupyter Lab/Notebook 中通过 SedonaKepler 可视化空间查询结果。
+
+SedonaKepler 提供基于 [KeplerGl](https://kepler.gl/) 的交互式、可定制地图可视化 API。
+
+!!!Note
+	使用 SedonaKepler 需要安装 sedona 的 `kepler-map` 附加项：
+	```
+	pip install apache-sedona[kepler-map]
+	```
+
+下面演示如何使用 SedonaKepler 立即可视化地理空间数据。
+
+示例（取自 binder 提供的示例 notebook）：
+
+```python
+SedonaKepler.create_map(df=groupedresult, name="AirportCount")
+```
+
+![使用 SedonaKepler 可视化地理空间数据](../image/sedona_customization.gif)
+
+所用数据集见 [此处](https://github.com/apache/sedona/tree/b66e768155866a38ba2e3404f1151cac14fad5ea/docs/usecases/data/ne_50m_airports)，示例 notebook 见 [此处](https://github.com/apache/sedona/blob/master/docs/usecases/legacy/ApacheSedonaSQL_SpatialJoin_AirportsPerCountry.ipynb)。
+
+SedonaKepler 提供的所有 API 详见 [SedonaKepler API 文档](../api/sql/Visualization-SedonaKepler.md)。
+
+## 创建用户自定义函数（UDF）
+
+用户自定义函数（UDF）是用户编写的函数，可以对单行数据执行操作。为了覆盖几乎所有的使用场景，下面给出 4 种不同形式的 UDF 示例，演示如何在 UDF 中使用几何对象。Sedona 的序列化器会把 SQL 几何类型反序列化为 [JTS Geometry](https://locationtech.github.io/jts/javadoc-1.18.0/org/locationtech/jts/geom/Geometry.html)（Scala/Java）或 [Shapely Geometry](https://shapely.readthedocs.io/en/stable/geometry.html)（Python），可以充分利用这两个生态实现自定义逻辑。
+
+### Geometry 转 primitive
+
+下例 UDF 接收 Geometry 类型输入，返回基本类型输出：
+
+=== "Scala"
+
+	```scala
+	import org.locationtech.jts.geom.Geometry
+	import org.apache.spark.sql.types._
+
+	def lengthPoly(geom: Geometry): Double = {
+        geom.getLength
+	}
+
+	sedona.udf.register("udf_lengthPoly", lengthPoly _)
+
+	df.selectExpr("udf_lengthPoly(geom)").show()
+	```
+
+=== "Java"
+
+	```java
+	import org.apache.spark.sql.api.java.UDF1;
+	import org.apache.spark.sql.types.DataTypes;
+
+	// 使用 lambda 注册 UDF
+	sparkSession.udf().register(
+			"udf_lengthPoly",
+			(UDF1<Geometry, Double>) Geometry::getLength,
+			DataTypes.DoubleType);
+
+	df.selectExpr("udf_lengthPoly(geom)").show()
+	```
+
+=== "Python"
+
+	```python
+	from sedona.spark.sql.types import GeometryType
+	from pyspark.sql.types import DoubleType
+
+	def lengthPoly(geom: GeometryType()):
+		return geom.length
+
+	sedona.udf.register("udf_lengthPoly", lengthPoly, DoubleType())
+
+	df.selectExpr("udf_lengthPoly(geom)").show()
+	```
+
+输出：
+
+```
++--------------------+
+|udf_lengthPoly(geom)|
++--------------------+
+|   3.414213562373095|
++--------------------+
+```
+
+### Geometry 转 Geometry
+
+下例 UDF 接收 Geometry 类型输入，返回 Geometry 类型输出：
+
+=== "Scala"
+
+	```scala
+	import org.locationtech.jts.geom.Geometry
+	import org.apache.spark.sql.types._
+
+	def bufferFixed(geom: Geometry): Geometry = {
+        geom.buffer(5.5)
+	}
+
+	sedona.udf.register("udf_bufferFixed", bufferFixed _)
+
+	df.selectExpr("udf_bufferFixed(geom)").show()
+	```
+
+=== "Java"
+
+	```java
+	import org.apache.spark.sql.api.java.UDF1;
+	import org.apache.spark.sql.types.DataTypes;
+
+	// 使用 lambda 注册 UDF
+	sparkSession.udf().register(
+			"udf_bufferFixed",
+			(UDF1<Geometry, Geometry>) geom ->
+                geom.buffer(5.5),
+			new GeometryUDT());
+
+	df.selectExpr("udf_bufferFixed(geom)").show()
+	```
+
+=== "Python"
+
+	```python
+	from sedona.spark import GeometryType
+	from pyspark.sql.types import DoubleType
+
+	def bufferFixed(geom: GeometryType()):
+    	return geom.buffer(5.5)
+
+	sedona.udf.register("udf_bufferFixed", bufferFixed, GeometryType())
+
+	df.selectExpr("udf_bufferFixed(geom)").show()
+	```
+
+输出：
+
+```
++--------------------------------------------------+
+|                             udf_bufferFixed(geom)|
++--------------------------------------------------+
+|POLYGON ((1 -4.5, -0.0729967710887076 -4.394319...|
++--------------------------------------------------+
+```
+
+### Geometry + primitive 转 Geometry
+
+下例 UDF 接收 Geometry 与基本类型两个输入，返回 Geometry 输出：
+
+=== "Scala"
+
+	```scala
+	import org.locationtech.jts.geom.Geometry
+	import org.apache.spark.sql.types._
+
+	def bufferIt(geom: Geometry, distance: Double): Geometry = {
+        geom.buffer(distance)
+	}
+
+	sedona.udf.register("udf_buffer", bufferIt _)
+
+	df.selectExpr("udf_buffer(geom, distance)").show()
+	```
+
+=== "Java"
+
+	```java
+	import org.apache.spark.sql.api.java.UDF2;
+	import org.apache.spark.sql.types.DataTypes;
+
+	// 使用 lambda 注册 UDF
+	sparkSession.udf().register(
+			"udf_buffer",
+			(UDF2<Geometry, Double, Geometry>) Geometry::buffer,
+			new GeometryUDT());
+
+	df.selectExpr("udf_buffer(geom, distance)").show()
+	```
+
+=== "Python"
+
+	```python
+	from sedona.spark import GeometryType
+	from pyspark.sql.types import DoubleType
+
+	def bufferIt(geom: GeometryType(), distance: DoubleType()):
+    	return geom.buffer(distance)
+
+	sedona.udf.register("udf_buffer", bufferIt, GeometryType())
+
+	df.selectExpr("udf_buffer(geom, distance)").show()
+	```
+
+输出：
+
+```
++--------------------------------------------------+
+|                        udf_buffer(geom, distance)|
++--------------------------------------------------+
+|POLYGON ((1 -9, -0.9509032201612866 -8.80785280...|
++--------------------------------------------------+
+```
+
+### Geometry + primitive 转 Geometry + primitive
+
+下例 UDF 接收 Geometry 与基本类型两个输入，同时返回 Geometry 与基本类型两个输出：
+
+=== "Scala"
+
+	```scala
+	import org.locationtech.jts.geom.Geometry
+	import org.apache.spark.sql.types._
+	import org.apache.spark.sql.api.java.UDF2
+
+	val schemaUDF = StructType(Array(
+		StructField("buffed", GeometryUDT),
+		StructField("length", DoubleType)
+	))
+
+	val udf_bufferLength = udf(
+		new UDF2[Geometry, Double, (Geometry, Double)] {
+			def call(geom: Geometry, distance: Double): (Geometry, Double) = {
+				val buffed = geom.buffer(distance)
+				val length = geom.getLength
+				(buffed, length)
+			}
+		}, schemaUDF)
+
+	sedona.udf.register("udf_bufferLength", udf_bufferLength)
+
+	data.withColumn("bufferLength", expr("udf_bufferLengths(geom, distance)"))
+        .select("geom", "distance", "bufferLength.*")
+		.show()
+	```
+
+=== "Java"
+
+	```java
+	import org.apache.spark.sql.api.java.UDF2;
+	import org.apache.spark.sql.types.DataTypes;
+	import org.apache.spark.sql.types.StructType;
+	import scala.Tuple2;
+
+	StructType schemaUDF = new StructType()
+                .add("buffedGeom", new GeometryUDT())
+                .add("length", DataTypes.DoubleType);
+
+	// 使用 lambda 注册 UDF
+	sparkSession.udf().register("udf_bufferLength",
+                (UDF2<Geometry, Double, Tuple2<Geometry, Double>>) (geom, distance) -> {
+                    Geometry buffed = geom.buffer(distance);
+                    Double length = buffed.getLength();
+                    return new Tuple2<>(buffed, length);
+                },
+                schemaUDF);
+
+	df.withColumn("bufferLength", functions.expr("udf_bufferLength(geom, distance)"))
+                .select("geom", "distance", "bufferLength.*")
+				.show();
+	```
+
+=== "Python"
+
+	```python
+	from sedona.spark import GeometryType
+	from pyspark.sql.types import *
+
+	schemaUDF = StructType([
+        StructField("buffed", GeometryType()),
+        StructField("length", DoubleType())
+    ])
+
+	def bufferAndLength(geom: GeometryType(), distance: DoubleType()):
+		buffed = geom.buffer(distance)
+		length = buffed.length
+		return [buffed, length]
+
+	sedona.udf.register("udf_bufferLength", bufferAndLength, schemaUDF)
+
+	df.withColumn("bufferLength", expr("udf_bufferLength(geom, buffer)")) \
+				.select("geom", "buffer", "bufferLength.*") \
+				.show()
+	```
+
+输出：
+
+```
++------------------------------+--------+--------------------------------------------------+-----------------+
+|                          geom|distance|                                        buffedGeom|           length|
++------------------------------+--------+--------------------------------------------------+-----------------+
+|POLYGON ((1 1, 1 2, 2 1, 1 1))|    10.0|POLYGON ((1 -9, -0.9509032201612866 -8.80785280...|66.14518337329191|
++------------------------------+--------+--------------------------------------------------+-----------------+
+```
+
+## 空间向量化 UDF（仅 Python）
+
+默认情况下，您在 Python 中创建的 UDF 不是向量化的，会逐行调用，速度较慢。可以使用 `vectorized` UDF，通过 Apache Arrow 以批模式执行，从而加速。
+
+要创建向量化 UDF，请使用 `sedona_vectorized_udf` 装饰器。当前仅支持标量 UDF，向量化 UDF 通常比普通 UDF 快得多，可能达到 2 倍。
+
+!!!note
+	当输入类型为几何对象时，请在使用 GEO_SERIES 向量化 UDF 时显式包含 BaseGeometry 类型（例如 shapely 的 Point 或 GeoPandas 的 GeoSeries），Sedona 会借此推断类型并判断数据是否需要转换。
+
+装饰器签名如下：
+
+```python
+def sedona_vectorized_udf(
+    udf_type: SedonaUDFType = SedonaUDFType.SHAPELY_SCALAR, return_type: DataType
+): ...
+```
+
+其中 `udf_type` 是 UDF 函数的类型，目前支持：
+
+- SHAPELY_SCALAR
+- GEO_SERIES
+
+主要差异在于函数所接收的输入数据形式不同。下面通过两个示例对几何对象执行 buffer 操作来说明。
+
+### Shapely 标量 UDF
+
+```python
+import shapely.geometry.base as b
+from sedona.spark import sedona_vectorized_udf
+
+
+@sedona_vectorized_udf(return_type=GeometryType())
+def vectorized_buffer(geom: b.BaseGeometry) -> b.BaseGeometry:
+    return geom.buffer(0.1)
+```
+
+### GeoSeries UDF
+
+```python
+import geopandas as gpd
+from sedona.spark import sedona_vectorized_udf, SedonaUDFType
+from sedona.spark import GeometryType
+
+
+@sedona_vectorized_udf(udf_type=SedonaUDFType.GEO_SERIES, return_type=GeometryType())
+def vectorized_geo_series_buffer(series: gpd.GeoSeries) -> gpd.GeoSeries:
+    buffered = series.buffer(0.1)
+
+    return buffered
+```
+
+调用 UDF 的方式如下：
+
+```python
+# Shapely 标量 UDF
+df.withColumn("buffered", vectorized_buffer(df.geom)).show()
+
+# GeoSeries UDF
+df.withColumn("buffered", vectorized_geo_series_buffer(df.geom)).show()
+```
+
+## 保存到永久存储
+
+要把空间 DataFrame 保存到 Hive 表、HDFS 等永久存储，最简单的做法是把 Geometry 列里的每个几何对象转换回普通字符串，再把得到的 DataFrame 保存到任意位置。
+
+把 DataFrame 中的 Geometry 列还原为 WKT 字符串列：
+
+```sql
+SELECT ST_AsText(countyshape)
+FROM polygondf
+```
+
+## 保存为 GeoJSON
+
+自 `v1.6.1` 起，Sedona 中的 GeoJSON 数据源可把空间 DataFrame 保存为单行 JSON 文件，几何对象按 GeoJSON 格式写出：
+
+```sparksql
+df.write.format("geojson").save("YOUR/PATH.json")
+```
+
+写出 GeoJSON 的更多信息请参阅 [此页](files/geojson-sedona-spark.md)。
+
+## 保存为 GeoParquet
+
+自 v`1.3.0` 起，Sedona 原生支持写出 GeoParquet 文件：
+
+```scala
+df.write.format("geoparquet").save(geoparquetoutputlocation + "/GeoParquet_File_Name.parquet")
+```
+
+写出 GeoParquet 的更多信息请参阅 [此页](files/geoparquet-sedona-spark.md)。
+
+## 保存到 Postgis
+
+遗憾的是，Spark SQL JDBC 数据源的 'createTableColumnTypes' 选项不支持在 PostGIS 中创建几何类型，仅识别 Spark 内置类型。这意味着您需要在 Spark 之外单独管理 PostGIS 的 schema。一种做法是先在 PostGIS 中创建好包含几何列的表，再用 Spark 写入数据；也可以先用 Spark 写入数据，然后再手动把列类型改为 geometry。
+
+PostGIS 使用 EWKB 序列化几何对象。如果您在 Sedona 中把几何对象转换为 EWKB 格式，PostGIS 端就无需再做额外转换。
+
+```
+my_postgis_db# create table my_table (id int8, geom geometry);
+
+df.withColumn("geom", expr("ST_AsEWKB(geom)")
+	.write.format("jdbc")
+	.option("truncate","true") // 不让 Spark 重建表
+	// 其他选项
+	.save()
+
+// 如果写入前没有创建表，可以在写入后修改列类型
+my_postgis_db# alter table my_table alter column geom type geometry;
+
+```
+
+## 在 DataFrame 与 SpatialRDD 之间互转
+
+### DataFrame 转 SpatialRDD
+
+使用 SedonaSQL 的 DataFrame-RDD Adapter 将 DataFrame 转换为 SpatialRDD：
+
+=== "Scala"
+
+	```scala
+	var spatialRDD = StructuredAdapter.toSpatialRdd(spatialDf, "usacounty")
+	```
+
+=== "Java"
+
+	```java
+	SpatialRDD spatialRDD = StructuredAdapter.toSpatialRdd(spatialDf, "usacounty")
+	```
+
+=== "Python"
+
+	```python
+	from sedona.spark import StructuredAdapter
+
+	spatialRDD = StructuredAdapter.toSpatialRdd(spatialDf, "usacounty")
+	```
+
+`"usacounty"` 是几何列的列名，可选参数。如果不提供，将使用第一个几何列。
+
+### SpatialRDD 转 DataFrame
+
+使用 SedonaSQL 的 DataFrame-RDD Adapter 将 SpatialRDD 转换为 DataFrame。详见 [Adapter Scaladoc](../api/javadoc/sql/org/apache/sedona/sql/utils/index.html)。
+
+=== "Scala"
+
+	```scala
+	var spatialDf = StructuredAdapter.toDf(spatialRDD, sedona)
+	```
+
+=== "Java"
+
+	```java
+	Dataset<Row> spatialDf = StructuredAdapter.toDf(spatialRDD, sedona)
+	```
+
+=== "Python"
+
+	```python
+	from sedona.spark import StructuredAdapter
+
+	spatialDf = StructuredAdapter.toDf(spatialRDD, sedona)
+	```
+
+### 保留空间分区的 SpatialRDD 转 DataFrame
+
+`StructuredAdapter.toDf()` 默认不保留空间分区，因为对于大多数空间数据保留空间分区会引入重复要素。这些重复是为了在执行空间连接时保证正确性而有意引入的；但当使用 Sedona 准备数据用于分发时，通常不希望出现这些重复。
+
+可以使用 `StructuredAdapter` 与 `spatialRDD.spatialPartitioningWithoutDuplicates` 函数得到不含重复的、按空间分区的 Sedona DataFrame。这在生成均衡的 GeoParquet 文件时特别有用，可以在文件内保留空间邻近性，从而最大化 GeoParquet 的过滤下推性能。
+
+=== "Scala"
+
+	```scala
+	spatialRDD.spatialPartitioningWithoutDuplicates(GridType.KDBTREE)
+	// 期望分区数为 10（实际数量可能略有不同）
+	// spatialRDD.spatialPartitioningWithoutDuplicates(GridType.KDBTREE, 10)
+	var spatialDf = StructuredAdapter.toSpatialPartitionedDf(spatialRDD, sedona)
+	```
+
+=== "Java"
+
+	```java
+	spatialRDD.spatialPartitioningWithoutDuplicates(GridType.KDBTREE)
+	// 期望分区数为 10（实际数量可能略有不同）
+	// spatialRDD.spatialPartitioningWithoutDuplicates(GridType.KDBTREE, 10)
+	Dataset<Row> spatialDf = StructuredAdapter.toSpatialPartitionedDf(spatialRDD, sedona)
+	```
+
+=== "Python"
+
+	```python
+	from sedona.spark import StructuredAdapter
+
+	spatialRDD.spatialPartitioningWithoutDuplicates(GridType.KDBTREE)
+	# 期望分区数为 10（实际数量可能略有不同）
+	# spatialRDD.spatialPartitioningWithoutDuplicates(GridType.KDBTREE, 10)
+	spatialDf = StructuredAdapter.toSpatialPartitionedDf(spatialRDD, sedona)
+	```
+
+### SpatialPairRDD 转 DataFrame
+
+PairRDD 是空间连接查询或距离连接查询的结果。SedonaSQL 的 DataFrame-RDD Adapter 可以把它转换为 DataFrame，但需要提供左、右 RDD 的 schema。
+
+=== "Scala"
+
+	```scala
+	var joinResultDf = StructuredAdapter.toDf(joinResultPairRDD, leftDf.schema, rightDf.schema, sedona)
+	```
+
+=== "Java"
+
+	```java
+	Dataset joinResultDf = StructuredAdapter.toDf(joinResultPairRDD, leftDf.schema, rightDf.schema, sedona);
+	```
+=== "Python"
+
+	```python
+	from sedona.spark import StructuredAdapter
+
+	joinResultDf = StructuredAdapter.pairRddToDf(result_pair_rdd, leftDf.schema, rightDf.schema, spark)
+	```


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2911 (Phase 4 of EPIC #2867). Final PR in the Phase 4 series — follows up on #2931, #2933, #2934.

## What changes were proposed in this PR?

Phase 4d of the Chinese-documentation EPIC (#2867). Translates the final 2 tutorial pages, completing Phase 4.

**Translated in this PR:**

- `tutorial/rdd.md` (871 lines)
- `tutorial/sql.md` (1,438 lines — the largest single tutorial page)

After this PR merges, **all 27 tutorial pages** have Chinese versions on the docs site. Phase 4 of #2867 is complete.

Code blocks, command snippets, version macros (`{{ sedona.current_version }}`, `{{ sedona.current_geotools }}`), admonitions, and inline tab attributes (`=== "Scala"`, etc.) are preserved verbatim. Only prose, headings, table headers, and explanatory inline comments are translated.

## How was this patch tested?

Built the docs locally with `uv sync --group docs && uv run mkdocs build` and verified:

- The build succeeds.
- The 2 new `*.zh.md` files render under `/zh/tutorial/`.
- `pre-commit run --all-files` passes (license headers auto-added by `insert-license`, re-staged before commit).

## Did this PR include necessary documentation updates?

- Yes, this PR is itself a documentation translation. Phase 4 (Tutorial / Programming Guide) is now complete — subsequent phases (#2912-#2919) translate other doc sections.