### PR TITLE
[GH-2867] Make language switcher respect mike version prefix

### DIFF
--- a/docs-overrides/partials/alternate.html
+++ b/docs-overrides/partials/alternate.html
@@ -4,11 +4,20 @@
     <span class="sd-lang-switch__glyph" aria-hidden="true"><span class="sd-lang-switch__glyph-cn">文</span><span class="sd-lang-switch__glyph-en">A</span></span>
   </summary>
   <ul class="sd-lang-switch__menu">
+    {#-
+      mkdocs-static-i18n stores `alt.link` as a server-absolute path like
+      `/zh/sedonaspark/`. Passing that directly to `| url` keeps the leading
+      slash, so the link bypasses any deployment prefix added by mike (e.g.
+      `/latest-snapshot/`) and lands at the wrong version. Strip the leading
+      slash so `| url` resolves against the docs root and stays inside the
+      current mike version.
+    -#}
     {% for alt in config.extra.alternate %}
       {%- set is_active = (alt.lang == config.theme.language) -%}
+      {%- set alt_link = alt.link[1:] if alt.link.startswith('/') else alt.link -%}
       <li>
         <a
-          href="{{ alt.link | url }}"
+          href="{{ alt_link | url }}"
           hreflang="{{ alt.lang }}"
           lang="{{ alt.lang }}"
           target="_self"


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Bug fix on EPIC #2867 — the 文A language switcher introduced earlier in the EPIC drops the active mike version when clicked.

## What changes were proposed in this PR?

The 文A header switcher built links from `alt.link | url` where `alt.link` is set by mkdocs-static-i18n to a server-absolute path like `/zh/sedonaspark/`. mkdocs's `| url` filter passes leading-slash paths through unchanged, so on a mike-deployed site the link bypasses the version prefix entirely:

- Reproducer: visit https://sedona.apache.org/latest-snapshot/ and click 中文.
- Expected: navigate to `https://sedona.apache.org/latest-snapshot/zh/`.
- Actual: navigate to `https://sedona.apache.org/zh/`, which falls outside the `latest-snapshot` mike version (404 in our case).

Strip the leading slash before passing to `| url`. mkdocs then treats the path as relative to the docs root and computes a page-relative URL that stays inside the current mike version. The active locale's `--active` highlight is unaffected since that's still keyed off `config.theme.language`.

## How was this patch tested?

Built the docs locally with `npx --prefix docs-overrides gulp build && uv sync --group docs && uv run mkdocs build` and inspected the rendered `<a href>` for both locales:

| current page | English link | Chinese link |
|---|---|---|
| `/index.html` | `.` | `zh/` |
| `/sedonaspark/index.html` | `./` | `../zh/sedonaspark/` |
| `/zh/index.html` | `..` | `./` |
| `/zh/sedonaspark/index.html` | `../../sedonaspark/` | `./` |

All four cases produce relative paths. Under any mike version prefix (e.g. `/latest-snapshot/...`) the relative paths resolve correctly within that version.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.