### PR TITLE
[GH-2912] Translate Community & ASF section to Chinese

### DIFF
--- a/docs/asf/asf.zh.md
+++ b/docs/asf/asf.zh.md
@@ -1,0 +1,22 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# 版权
+
+Apache Sedona、Sedona、Apache、Apache 羽毛 logo，以及 Apache Sedona 项目 logo，均为 Apache 软件基金会在美国及其他国家的注册商标或商标。本页提及的其他商标或注册商标均归各自所有者所有。详情请访问 <a href="http://www.apache.org/">Apache 软件基金会</a>。

--- a/docs/asf/telemetry.zh.md
+++ b/docs/asf/telemetry.zh.md
@@ -1,0 +1,30 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+## Scarf
+
+Apache Sedona 使用 Scarf 收集匿名使用数据，以便帮助我们了解软件的使用情况以及未来的改进方向。您可以通过在本机或集群 driver 节点上将环境变量 `SCARF_NO_ANALYTICS` 或 `DO_NOT_TRACK` 设为 `true` 来选择不参与遥测数据收集。
+
+Scarf 完全符合 GDPR，并在 [Apache 软件基金会隐私政策](https://privacy.apache.org/faq/committers.html) 中获许使用。Scarf 的隐私政策见 [https://about.scarf.sh/privacy-policy](https://about.scarf.sh/privacy-policy)。
+
+## Matomo
+
+Apache Sedona 使用 Matomo 收集匿名使用数据，以便更好地了解用户对系统、网站与文档的使用方式，进而决定接下来重点改进的方向。
+
+Matomo 在 [Apache 软件基金会隐私政策](https://privacy.apache.org/faq/committers.html) 中获许使用。

--- a/docs/community/contact.zh.md
+++ b/docs/community/contact.zh.md
@@ -1,0 +1,65 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# 社区
+
+每一个志愿者项目都从参与其中的人那里汲取力量。我们邀请您按照自己希望的程度参与进来。
+
+您可以通过以下方式参与社区：
+
+* 使用我们的项目并提供反馈。
+* 向我们提供使用案例。
+* 报告 bug 并提交补丁。
+* 贡献代码与文档。
+
+## 社区活动
+
+欢迎大家加入我们的社区活动。我们每 4 周举办一次社区例会，可在以下链接报名要参加的活动：https://bit.ly/3UBmxFY
+
+## Sedona 在 LinkedIn
+
+[Apache Sedona@LinkedIn](https://www.linkedin.com/company/apache-sedona)
+
+## Sedona 在 X
+
+[Apache Sedona@X](https://X.com/ApacheSedona)
+
+## Discord 服务器
+
+[![Apache Sedona Community Discord Server](https://dcbadge.limes.pink/api/server/https://discord.gg/9A3k5dEBsY)](https://discord.gg/9A3k5dEBsY)
+
+## 寻求帮助
+
+您可以寻求帮助或为项目做出贡献。提交 issue 之前，请：
+
+* 确认 bug 确实存在。
+* 在 issue tracker 中搜索，确认尚无其他人报告同一 bug。
+* 考虑在 Sedona 源码中自行定位该 bug，并在提交 bug 报告时附上相应补丁。这能为 Sedona 开发者节省大量时间，并有助于尽快修复 bug。
+
+我们也欢迎对新功能的增强建议。建议越具体、越有理有据，被纳入未来发布版本的可能性就越大。
+
+* [Sedona JIRA](https://issues.apache.org/jira/projects/SEDONA)：bug 报告与功能请求
+* [Sedona GitHub Issues](https://github.com/apache/sedona/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen)：bug 报告与功能请求
+* [Sedona GitHub Discussion](https://github.com/apache/sedona/discussions)：项目开发与一般性问题
+* [Sedona 邮件列表](https://lists.apache.org/list.html?sedona.apache.org)：[dev@sedona.apache.org](https://lists.apache.org/list.html?dev@sedona.apache.org)，项目开发与一般性问题。
+
+发送邮件前请先订阅邮件列表。订阅方式：发送一封邮件（标题与正文均可留空）至 [dev-subscribe@sedona.apache.org](mailto:dev-subscribe@sedona.apache.org?subject=Subscribe&body=Subscribe)。
+
+!!!tip
+    投票等所有正式讨论只在邮件列表上进行，包括对每个发布候选版本或项目重大变更的投票。请关注邮件列表！

--- a/docs/community/contributor.zh.md
+++ b/docs/community/contributor.zh.md
@@ -1,0 +1,300 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+Sedona 收到了来自社区的诸多帮助。本页列出了 Apache Sedona 的 Committers 与项目管理委员会成员（PMC）。
+本页人员按姓氏排序。
+
+## Committers
+
+向 Sedona 贡献了足够多代码的贡献者会被晋升为 committer。Committer 拥有 Sedona 主仓库的写权限。
+
+## 项目管理委员会（PMC）
+
+当社区认为某位 committer 能够至少负责本项目的一个主要组件时，他/她会被晋升为 PMC 成员。
+
+当前 Sedona PMC 成员如下：
+
+|         姓名         |  GitHub ID   |        Apache ID        |
+|:--------------------:|:------------:|:-----------------------:|
+|     Adam Binford     |  Kimahriman  |  kimahriman@apache.org  |
+|  Kanchan Chowdhury   |  kanchanchy  |  kanchanchy@apache.org  |
+|  Kristin Cowalcijk   | Kontinuation | kontinuation@apache.org |
+|     Furqaan Khan     | furqaankhan  |   furqaan@apache.org    |
+|    Paweł Kociński    |   Imbruced   |   imbruced@apache.org   |
+|       Yitao Li       |   yitao-li   |   yitaoli@apache.org    |
+|    Netanel Malka     |  netanel246  |    malka@apache.org     |
+|    Mohamed Sarwat    |    Sarwat    |   mosarwat@apache.org   |
+|      Kengo Seki      |    sekikn    |    sekikn@apache.org    |
+|     Sachio Wakai     |   SW186000   |    swakai@apache.org    |
+|      Jinxuan Wu      |   jinxuan    |   jinxuanw@apache.org   |
+|        Jia Yu        |   jiayuasu   |    jiayu@apache.org     |
+|      Feng Zhang      | zhangfengcdt |  fengzhang@apache.org   |
+|     Zongsi Zhang     | zongsizhang  | zongsizhang@apache.org  |
+|     Felix Cheung     |              | felixcheung@apache.org  |
+|     Von Gosling      |              |  vongosling@apache.org  |
+|    Sunil Govindan    |              |    sunilg@apache.org    |
+| Jean-Baptiste Onofré |              |   jbonofre@apache.org   |
+|   George Percivall   |              |  percivall@apache.org   |
+
+## 成为 Committer
+
+开始为 Sedona 做贡献，请阅读 [如何贡献](rule.md) —— 任何人都可以向项目提交补丁、文档与示例。
+
+PMC 会根据贡献情况，定期把活跃的贡献者晋升为新的 committer。新 committer 的资格条件包括：
+
+* 对 Sedona 的持续贡献：committer 应当对 Sedona 有持续的重大贡献。
+* 贡献的质量：committer 比社区中的其他成员更应提交简洁、经过良好测试、设计良好的补丁，同时具备评审补丁的能力。
+* 社区参与度：committer 应在所有社区互动中保持建设性、友好的态度，活跃在 dev 邮件列表与 Discord，并帮助引导新贡献者与新用户。
+
+PMC 也会增加新的 PMC 成员。PMC 成员需履行 Apache 指南中所规定的 PMC 职责，包括参与发布投票、维护 Apache 项目商标、对法律与许可问题负责、确保项目遵循 Apache 项目规范等。PMC 会定期把已展示出对上述职责的理解与执行能力的 committer 加入 PMC。
+
+当前 Sedona Committers 如下：
+
+|       姓名       |  GitHub ID  |        Apache ID        |
+|:----------------:|:-----------:|:-----------------------:|
+|   John Bampton   |  jbampton   |   johnbam@apache.org    |
+| Dewey Dunnington | paleolimbot | paleolimbot@apache.org  |
+|  Nilesh Gajwani  |   iGN5117   |    nilesh@apache.org    |
+|   Peter Nguyen   |  petern48   |    petern@apache.org    |
+|   Pranav Toggi   |  prantogg   |   prantogg@apache.org   |
+
+## 提名 Committer 或 PMC 成员
+
+步骤如下：
+
+1. 发起投票（templates/committerVote.txt）。
+2. 投票结束。如果结果为正，发出邀请给新 committer。
+
+### 发起投票
+
+我们在 private@sedona.apache.org 进行投票与讨论，以便进行坦诚的交流。
+
+让 Vote 邮件运行一周。当达到 Consensus Approval（至少 3 个 +1 投票且无反对票）即视为通过。
+
+#### PMC 投票模板
+
+下面这封邮件用于发起对新 PMC 候选人的投票。新 PMC 成员需要先由现有 PMC 投票通过，再由董事会批准。
+
+```
+To: private@sedona.apache.org
+Subject: [VOTE] New PMC candidate: [New PMC NAME]
+
+[ 在此填写您提名该候选人的理由 ]
+
+Voting ends one week from today, or until at least 3 +1 votes are cast.
+
+```
+
+### 关闭投票
+
+下面这封邮件用于结束投票并向项目报告结果：
+
+```
+To: private@sedona.apache.org
+Subject: [VOTE][RESULT] New PMC candidate: [New PMC NAME]
+
+The vote has now closed: [paste the vote thread on https://lists.apache.org/list.html?private@sedona.apache.org]. The results are:
+
+Binding Votes:
+
++1 [TOTAL BINDING +1 VOTES]
+ 0 [TOTAL BINDING +0/-0 VOTES]
+-1 [TOTAL BINDING -1 VOTES]
+
+The vote is ***successful/not successful***
+```
+
+### 通知 ASF Board
+
+提名人需向 ASF Board（board@apache.org）发送一封邮件，附上投票结果链接，格式如下：
+
+```
+To: board at apache.org
+CC: private at sedona.apache.org
+Subject: [NOTICE] New PMC NAME for Apache Sedona PMC
+Body:
+
+New PMC NAME has been voted as a new member of the Apache Sedona PMC. The vote thread is at: *link to the vote result thread*
+```
+
+### 发送邀请
+
+```
+To: New PMC Email address
+CC: private@sedona.apache.org
+
+Hello [New PMC NAME],
+
+The Sedona Project Management Committee (PMC)
+hereby offers you committer privileges to the project
+[as well as membership in the PMC]. These privileges are
+offered on the understanding that you'll use them
+reasonably and with common sense. We like to work on trust
+rather than unnecessary constraints.
+
+Being a committer enables you to more easily make
+changes without needing to go through the patch
+submission process. Being a PMC member enables you
+to guide the direction of the project.
+
+Being a committer does not require you to
+participate any more than you already do. It does
+tend to make one even more committed. You will
+probably find that you spend more time here.
+
+Of course, you can decline and instead remain as a
+contributor, participating as you do now.
+
+A. This personal invitation is a chance for you to
+accept or decline in private. Either way, please
+let us know in reply to the private@sedona.apache.org
+address only.
+
+B. If you accept, the next step is to register an iCLA:
+    1. Details of the iCLA and the forms are found
+    through this link: https://www.apache.org/licenses/#clas
+
+    2. Instructions for its completion and return to
+    the Secretary of the ASF are found at
+    https://www.apache.org/licenses/#submitting
+
+    3. When you transmit the completed iCLA, request
+    to notify the Apache Sedona project and choose a
+    unique Apache ID. Look to see if your preferred
+    ID is already taken at
+    https://people.apache.org/committer-index.html
+    This will allow the Secretary to notify the PMC
+    when your iCLA has been recorded.
+
+When recording of your iCLA is noted, you will
+receive a follow-up message with the next steps for
+establishing you as a committer.
+
+```
+
+### PMC 接受邀请与 ICLA 说明
+
+```
+To: New PMC Email address
+Cc: private@sedona.apache.org
+Subject: Re: invitation to become Apache Sedona PMC
+
+Welcome. Here are the next steps in becoming a project committer. After that we will make an announcement to the dev@sedona.apache.org
+
+1. You need to send a Contributor License Agreement to the ASF.
+Normally you would send an Individual CLA. If you also make
+contributions done in work time or using work resources,
+see the Corporate CLA. Ask us if you have any issues.
+https://www.apache.org/licenses/#clas.
+
+You need to choose a preferred ASF user name and alternatives.
+In order to ensure it is available you can view a list of taken IDs at
+https://people.apache.org/committer-index.html
+
+Please notify us when you have submitted the CLA and by what means
+you did so. This will enable us to monitor its progress.
+
+We will arrange for your Apache user account when the CLA has
+been recorded.
+
+2. After that is done, please use your ASF email to subscribe to the dev@sedona.apache.org
+and private@sedona.apache.org by sending an email to dev-subscribe@sedona.apache.org and
+private-subscribe@sedona.apache.org. We generally discuss everything on the dev list and
+keep the private@sedona.apache.org list for occasional matters which must be private.
+
+The developer section of the website describes roles within the ASF and provides other
+resources:
+  https://www.apache.org/foundation/how-it-works.html
+  https://www.apache.org/dev/
+
+Just as before you became a committer, participation in any ASF community
+requires adherence to the ASF Code of Conduct:
+  https://www.apache.org/foundation/policies/conduct.html
+
+Yours,
+The Apache Sedona PMC
+```
+
+### 创建 ASF 账户
+
+ICLA 提交后，使用 [ASF New Account Request 表单](https://whimsy.apache.org/officers/acreq) 提交申请。Sedona 的 mentor 会请求账号。
+
+Sedona 毕业后，由 PMC 主席（Chair）来发起请求。
+
+### 加入到系统
+
+新 PMC 用其 ASF 账号订阅 Sedona 邮件列表后，PMC 中的某位成员需把新成员加入 Whimsy 系统（https://whimsy.apache.org/roster/pmc/sedona）。
+
+### PMC 公告
+
+账号创建完成后，下面这封邮件用于在 sedona-dev 列表中宣布新 committer：
+
+```
+To: dev@sedona.apache.org
+Subject: new committer: ###New PMC NAME
+
+The Project Management Committee (PMC) for Apache Sedona
+has invited New PMC NAME to become a committer and we are pleased
+to announce that they have accepted.
+
+### add specific details here ###
+
+Being a committer enables easier contribution to the
+project since there is no need to go via the patch
+submission process. This should enable better productivity.
+A PMC member helps manage and guide the direction of the project.
+```
+
+### Committer Done 模板
+
+在 committer 账号建立完成后：
+
+```
+To: New Committer Email
+CC: private@sedona.apache.org
+Subject: account request: New Committer NAME
+
+New Committer NAME, as you know, the ASF Infrastructure has set up your
+committer account with the username '####'.
+
+You have commit access to specific sections of the
+ASF repository, as follows:
+https://github.com/apache/sedona
+
+You need to link your ASF Account with your GitHub account.
+
+Here are the steps
+
+1. Verify you have a GitHub ID enabled with 2FA
+	* https://help.github.com/articles/securing-your-account-with-two-factor-authentication-2fa/
+2. Enter your GitHub ID into your Apache ID profile https://id.apache.org/
+3. Merge your Apache and GitHub accounts using
+	* GitBox (Apache Account Linking utility) https://gitbox.apache.org/setup/
+	* You should see 3 green checks in GitBox.
+	* Wait at least 30  minutes for an email inviting you to Apache GitHub Organization and accept invitation
+4. After accepting the GitHub Invitation verify that you are a
+member of the team https://github.com/orgs/apache/teams/sedona-committers
+
+Optionally, if you want, please follow the instructions to set up your GitHub, SSH, svn password, svn configuration, email forwarding, etc.
+https://www.apache.org/dev/#committers
+
+Additionally, if you have been elected to the Sedona
+ Project Mgmt. Committee (PMC): Verify you are part of the LDAP sedona
+  pmc https://whimsy.apache.org/roster/pmc/sedona
+```

--- a/docs/community/develop.zh.md
+++ b/docs/community/develop.zh.md
@@ -1,0 +1,189 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# 开发 Sedona
+
+## Scala/Java 开发者
+
+### IDE
+
+推荐使用安装了 Scala 插件的 [Intellij IDEA](https://www.jetbrains.com/idea/)。请确认项目的 SDK 设置为 JDK 1.8。
+
+### 导入项目
+
+#### 选择 `Open`
+
+![点击 Open 导入项目](../image/ide-java-1.png)
+
+#### 进入 Sedona 根目录（不是子模块目录）并选择 `open`
+
+![打开 Sedona 根目录](../image/ide-java-2.png)
+
+#### IDE 可能会显示错误
+
+IDE 通常难以理解 Sedona 中较为复杂的项目结构。
+
+![IDE 通常难以理解项目](../image/ide-java-4.png)
+
+#### 通过修改 `pom.xml` 修复错误
+
+需要在根目录的 `pom.xml` 中注释掉以下几行。==注意：请勿把这一改动提交到 Sedona。==
+
+```xml
+<!--    <parent>-->
+<!--        <groupId>org.apache</groupId>-->
+<!--        <artifactId>apache</artifactId>-->
+<!--        <version>23</version>-->
+<!--        <relativePath />-->
+<!--    </parent>-->
+```
+
+#### 重新加载 `pom.xml`
+
+确保重新加载 `pom.xml` 或重新加载整个 Maven 项目。IDE 会询问是否移除一些模块，请选择 `yes`。
+
+![重新加载 Maven 项目](../image/ide-java-5.png)
+
+#### 最终的项目结构应该是这样：
+
+![最终正确的项目结构](../image/ide-java-3.png)
+
+### 运行单元测试
+
+#### 运行所有单元测试
+
+在终端中进入 Sedona 根目录运行 `mvn clean install`。全部测试需要超过 15 分钟。如果只想构建 jar，运行 `mvn clean install -DskipTests`。
+
+!!!Note
+    `mvn clean install` 默认基于 Spark 3.3、Scala 2.12 编译 Sedona。如果 $SPARK_HOME 中是不同版本的 Spark，请通过 `-Dspark` 命令行参数指定。例如基于 Spark 3.4 与 Scala 2.12 编译：`mvn clean install -Dspark=3.4 -Dscala=2.12`。
+
+更多细节请参阅 [编译 Sedona](../setup/compile.md)。
+
+#### 运行单个单元测试
+
+在 IDE 中右键点击某个测试用例即可运行。
+
+![右键点击测试用例运行](../image/ide-java-6.png)
+
+运行 Scala 编写的测试用例时，IDE 可能会提示 “Path does not exist”，如下：
+
+![Path does not exist](../image/ide-java-7.png)
+
+进入 `Edit Configuration`：
+
+![Edit Configuration](../image/ide-java-8.png)
+
+把 `Working Directory` 的值改为 `$MODULE_WORKING_DIR$`：
+
+![修改 working directory](../image/ide-java-9.png)
+
+重新运行该测试用例。**不要**右键再次运行，请点击下图所示的按钮：
+
+![点击按钮重新运行测试用例](../image/ide-java-10.png)
+
+如果不想每次都修改 `Working Directory`，可以在 `Run/Debug Configurations` 窗口中修改 `Working Directory` 的默认值。点击 `Edit configuration templates...`，把 ScalaTest 的 `Working Directory` 设为 `$MODULE_WORKING_DIR$`。
+
+![Run/Debug Configurations 中点击 Edit configuration templates](../image/ide-java-11.png)
+![设置 ScalaTest 的 Working Directory](../image/ide-java-12.png)
+
+之后新建的 ScalaTest run configuration 都会自动使用正确的 `Working Directory`。
+
+### 使用 Java 11 时的 IDE 配置
+
+如果使用 Java 11，运行测试时可能遇到如下错误：
+
+```
+/path/to/sedona/common/src/main/java/org/apache/sedona/common/geometrySerde/UnsafeGeometryBuffer.java
+package sun.misc does not exist
+sun.misc.Unsafe
+```
+
+可在 IDE 设置中关闭 `Use '--release' option for cross-compilation` 来解决。
+
+![使用 Java 11 时关闭 “Use '--release' option for cross-compilation”](../image/ide-java-13.png)
+
+### 在不同 Spark/Scala 版本下运行测试
+
+如需在不同 Spark/Scala 版本下测试改动，可在 Maven 面板中选择对应的 Spark 与 Scala profile。选择后请重新加载 sedona-parent 项目，参考下图。
+
+!!!Note
+    Profile 切换不会自动更新 IDE 中的模块名。如果模块名仍带有 `-3.3-2.12` 等后缀，不必感到困惑。
+
+!!!Note
+    并非所有 Spark 与 Scala 的组合都受支持，部分组合会编译失败。
+
+![选择 Spark 与 Scala profile](../image/ide-java-14.png)
+
+## Python 开发者
+
+### IDE
+
+推荐使用 [PyCharm](https://www.jetbrains.com/pycharm/)。
+
+### 运行测试
+
+#### 运行所有 Python 测试
+
+按照 [此处](../setup/compile.md#run-python-test) 的步骤完成环境配置。
+
+环境就绪后，在 python 目录下运行：
+
+```bash
+cd python
+uv run pytest -v tests
+```
+
+#### 运行单个测试
+
+如需运行某个特定的 Python 测试文件，传入 `.py` 路径即可。
+
+例如运行 `python/tests/sql/test_function.py` 中的所有测试：
+
+```bash
+cd python
+uv run pytest -v tests/sql/test_function.py
+```
+
+要运行某个文件中的特定测试，向 `pytest` 传入 `file_name::class_name::test_name`。
+
+例如运行 `sql/test_predicate.py` 中关于 `ST_Contains` 的测试：
+
+```bash
+cd python
+uv run pytest -v tests/sql/test_predicate.py::TestPredicate::test_st_contains
+```
+
+### 构建包
+
+下面的命令会在 `dist` 目录中生成 sdist 与 whl 包：
+
+```bash
+cd python
+uv build
+```
+
+## R 开发者
+
+更多内容稍后补充。
+
+### IDE
+
+推荐使用 [RStudio](https://posit.co/products/open-source/rstudio/)。
+
+### 导入项目

--- a/docs/community/geopandas.zh.md
+++ b/docs/community/geopandas.zh.md
@@ -1,0 +1,85 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# 在 Sedona 上的 Geopandas
+
+本指南列出了在 Apache Sedona 的 GeoPandas 组件上以开发者身份贡献变更时需要注意的若干重要事项。请再次注意：**本指南面向贡献者**；面向用户的官方文档另有侧重。
+
+**总体思路**：本组件构建在 PySpark Pandas API 之上。`GeoDataFrame` 与 `GeoSeries` 类分别继承自 pyspark pandas 的 `ps.DataFrame` 与 `ps.Series`。在可能的情况下，应尽量复用 pyspark pandas 已有的实现并在其基础上扩展（即尽量通过 `super()` 调用，而不是把现有逻辑复制过来）。代码组织结构与 [Geopandas 仓库](https://github.com/geopandas/geopandas) 类似。
+
+**惰性求值**：Spark 使用惰性求值。Spark 的分布式与惰性特性有时会让我们无法完全照搬原版 GeoPandas 的实现方式。例如 GeoPandas 在多处对非法 CRS 做了校验（如 `GeoSeries.__init__()`、`set_crs()` 等）。Sedona 当前获取 `crs` 的实现相比 GeoPandas 较为昂贵，因为它需要跑一次立即求值的 `ST_SRID()` 查询。如果在每次 `GeoSeries` 初始化时都立即查询 CRS，那么所有函数调用（如 `.area()` 等）也会变成立即求值，性能会明显下降，用户体验变差。
+
+**保留顺序**：由于 Spark 使用分布式数据，在多次操作之间保留顺序需要付出额外的时间和精力。某些操作维持顺序意义不大，此时跳过额外的 sort 是合理的，否则会带来不必要的性能开销。文档中应说明这种行为。例如 `sjoin` 在执行连接后并不会保持传统 pandas DataFrame 的顺序，这与传统 PySpark Pandas 保持一致。用户随时可以通过 `sort_index()` 等额外函数后排序，但默认实现应避免不必要的排序。
+
+**约定**：Sedona Geopandas 包的常用别名是 `sgpd`，与 geopandas 的别名 `gpd` 类似，仅多了一个 `s` 前缀。相邻包的常用别名见下：
+
+```python
+import pandas as pd
+import geopandas as gpd
+import pyspark.pandas as ps
+import sedona.spark.geopandas as sgpd
+```
+
+**转换方法**：Sedona 的 Geopandas 实现提供了在多种 DataFrame 之间互转的便捷方法。下列方法对 `GeoDataFrame` 与 `GeoSeries` 都可用：
+
+- `to_geopandas()`：Sedona Geo(DataFrame/Series) 转为 Geopandas
+- `to_geoframe()`：Sedona GeoSeries 转为 Sedona GeoDataFrame
+- `to_spark_pandas()`：Sedona Geo(DataFrame/Series) 转为 Pandas on PySpark
+- `to_spark()`（继承）：Sedona GeoDataFrame 转为 Spark DataFrame
+- `to_frame()`（继承）：Sedona GeoSeries 转为 PySpark Pandas DataFrame
+
+**GeoSeries 函数**：Geopandas 中的几何操作大多是 GeoSeries 函数，但也可以从 `GeoDataFrame` 对象上调用，作用在其活动几何列（active geometry column）上。我们在 `GeoSeries` 类中实现这些函数；同时在 `base.py` 中加上 `_delegate_to_geometry_column()` 调用，让 `GeoDataFrame` 也可以在自己的活动几何列上执行该函数。我们把函数的 docstring 写在 `base.py` 而不是 `GeoSeries`，这样 `GeoDataFrame` 与 `GeoSeries` 都能继承同一份 docstring（避免重复）。
+
+**查看查询计划**：由于这些 DataFrame 抽象建立在 Spark 之上，可以通过 `.spark.explain()` 方法获取一次操作的查询计划。
+
+示例：
+
+```python
+geoseries = GeoSeries([Polygon([(0, 0), (1, 0), (1, 1), (0, 0)])])
+# PySpark pandas Series 目前没有 spark.explain() 方法，可先转为 DataFrame 再调用
+print(geoseries.area.to_frame().spark.explain(extended=True))
+```
+
+```
+== Parsed Logical Plan ==
+Project [__index_level_0__#19L, 0#27 AS None#31]
++- Project [ **org.apache.spark.sql.sedona_sql.expressions.ST_Area**   AS 0#27, __index_level_0__#19L, __natural_order__#23L]
+   +- Project [__index_level_0__#19L, 0#20, monotonically_increasing_id() AS __natural_order__#23L]
+      +- LogicalRDD [__index_level_0__#19L, 0#20], false
+
+== Analyzed Logical Plan ==
+...
+
+== Optimized Logical Plan ==
+...
+
+== Physical Plan ==
+Project [__index_level_0__#19L,  **org.apache.spark.sql.sedona_sql.expressions.ST_Area**   AS None#31]
++- *(1) Scan ExistingRDD[__index_level_0__#19L,0#20]
+```
+
+## 推荐阅读
+
+- [PySpark Pandas Best Practices](https://spark.apache.org/docs/latest/api/python/tutorial/pandas_on_spark/best_practices.html) —— 其中提到了一些值得注意的细节，比如为什么不支持 `__iter__()`。
+- [Geopandas 用户指南](https://geopandas.org/en/stable/docs/user_guide/data_structures.html) —— 特别有助于理解 GeoDataFrame 中 “活动几何列（active geometry column）” 的概念。
+
+## 其他参考
+
+- [Pandas API on Spark 公开 API 页面](https://spark.apache.org/docs/latest/api/python/reference/pyspark.pandas/index.html)
+- [Geopandas API 页面](https://geopandas.org/en/stable/docs/reference.html)

--- a/docs/community/publication.zh.md
+++ b/docs/community/publication.zh.md
@@ -1,0 +1,70 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# 论文与出版物
+
+Apache Sedona 前身名为 GeoSpark，由亚利桑那州立大学 [Data Systems Lab](https://www.datasyslab.org/) 发起。
+
+## 主要论文
+
+**"Spatial Data Management in Apache Spark: The GeoSpark Perspective and Beyond"** 是介绍整个 GeoSpark 生态系统的完整研究论文。如果您的工作引用 GeoSpark 核心系统，请引用本文。
+
+**"GeoSparkViz: A Scalable Geospatial Data Visualization Framework in the Apache Spark Ecosystem"** 是介绍 GeoSpark 中地图可视化系统的完整研究论文。如果您的工作引用 GeoSpark 可视化系统，请引用本文。
+
+**"Building A Microscopic Road Network Traffic Simulator in Apache Spark"** 是介绍 GeoSpark 中交通仿真器的完整研究论文。如果您的工作引用 GeoSparkSim 交通仿真器，请引用本文。
+
+## 第三方评估
+
+GeoSpark 曾被发表在数据库顶会的论文评估过。值得一提的是，我们与这些论文的作者并无任何合作关系。
+
+* SIGMOD 2020 论文 ["Architecting a Query Compiler for Spatial Workloads"](https://dl.acm.org/doi/abs/10.1145/3318464.3389701) Ruby Y. Tahboub, Tiark Rompf（普渡大学）。
+
+> 在图 16a 中，1 - 24 核机器上 GeoSpark 距离连接查询比 Simba（Spark 的一个空间扩展）快约 7x - 9x。
+
+* PVLDB 2018 论文 ["How Good Are Modern Spatial Analytics Systems?"](http://www.vldb.org/pvldb/vol11/p1661-pandey.pdf) Varun Pandey、Andreas Kipf、Thomas Neumann、Alfons Kemper（慕尼黑工业大学），原文摘录如下：
+
+> GeoSpark 已接近一个完整的空间分析系统，并在大多数情况下具有最佳性能。
+
+## 完整论文列表
+
+### GeoSpark 生态系统
+
+["Spatial Data Management in Apache Spark: The GeoSpark Perspective and Beyond"](https://jiayuasu.github.io/files/paper/GeoSpark_Geoinformatica_2018.pdf)（研究论文）。Jia Yu, Zongsi Zhang, Mohamed Sarwat. Geoinformatica Journal 2019。
+
+["A Demonstration of GeoSpark: A Cluster Computing Framework for Processing Big Spatial Data"](https://jiayuasu.github.io/files/paper/GeoSpark_DemoPaper.pdf)（演示论文）。Jia Yu, Jinxuan Wu, Mohamed Sarwat. IEEE International Conference on Data Engineering ICDE 2016, Helsinki, FI, May 2016。
+
+["GeoSpark: A Cluster Computing Framework for Processing Large-Scale Spatial Data"](https://jiayuasu.github.io/files/paper/GeoSpark_ShortPaper.pdf)（短论文）。Jia Yu, Jinxuan Wu, Mohamed Sarwat. ACM International Conference on Advances in Geographic Information Systems ACM SIGSPATIAL GIS 2015, Seattle, WA, USA, November 2015。
+
+### GeoSparkViz 可视化系统
+
+["GeoSparkViz in Action: A Data System with built-in support for Geospatial Visualization"](https://jiayuasu.github.io/files/paper/geosparkviz-icde2019-demo.pdf)（演示论文）Jia Yu, Anique Tahir, Mohamed Sarwat. International Conference on Data Engineering, ICDE, 2019。
+
+["GeoSparkViz: A Scalable Geospatial Data Visualization Framework in the Apache Spark Ecosystem"](https://jiayuasu.github.io/files/paper/geosparkviz-ssdbm-2018.pdf)（研究论文）。Jia Yu, Zongsi Zhang, Mohamed Sarwat. International Conference on Scientific and Statistical Database Management, SSDBM 2018, Bolzano-Bozen, Italy, July 2018。
+
+### GeoSparkSim 交通仿真器
+
+["Dissecting GeoSparkSim: a scalable microscopic road network traffic simulator in Apache Spark"](https://link.springer.com/article/10.1007/s10619-020-07306-x)（期刊论文）Jia Yu, Zishan Fu, Mohamed Sarwat. Distributed Parallel Databases 38(4): 963-994 (2020)。
+
+["Demonstrating GeoSparkSim: A Scalable Microscopic Road Network Traffic Simulator Based on Apache Spark"](https://jiayuasu.github.io/files/paper/geosparksim_sstd2019_demopaper.pdf). Zishan Fu, Jia Yu, Mohamed Sarwat. International Symposium on Spatial and Temporal Databases, SSTD, 2019。
+
+["Building A Microscopic Road Network Traffic Simulator in Apache Spark"](https://jiayuasu.github.io/files/paper/geosparksim_mdm2019_fullpaper.pdf)（研究论文）Zishan Fu, Jia Yu, Mohamed Sarwat. International Conference on Mobile Data Management, MDM, 2019。
+
+### Spark 上的地理空间数据管理教程
+
+["Geospatial Data Management in Apache Spark: A Tutorial"](https://jiayuasu.github.io/files/talk/jia-icde19-tutorial.pdf)（Tutorial）Jia Yu and Mohamed Sarwat. International Conference on Data Engineering, ICDE, 2019。

--- a/docs/community/publish.zh.md
+++ b/docs/community/publish.zh.md
@@ -1,0 +1,658 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# 发布 Sedona 版本
+
+本页面面向 Sedona PMC，用于发布 Sedona 版本。
+
+!!!warning
+    本页所有脚本都应在本地 Sedona Git 仓库 master 分支下，通过单一脚本文件运行。
+
+## 0. 准备一个空脚本文件
+
+1. 在本地 Sedona Git 仓库 master 分支下运行：
+
+```bash
+echo '#!/bin/bash' > create-release.sh
+chmod 777 create-release.sh
+```
+
+2. 用您喜欢的 GUI 文本编辑器打开 `create-release.sh`。
+3. 不断把本页上的脚本复制粘贴到该文件中，覆盖原有内容。
+4. 不要直接将脚本复制粘贴到终端，因为 `clipboard.js` 的一个 bug 会在这种情形下产生换行符问题。
+5. 每次更新该脚本后运行 `./create-release.sh` 来执行。
+
+## 1. 检查所有文件头中的 ASF 版权声明
+
+1. 运行以下脚本：
+
+```bash
+#!/bin/bash
+wget -q https://archive.apache.org/dist/creadur/apache-rat-0.15/apache-rat-0.15-bin.tar.gz
+tar -xvf  apache-rat-0.15-bin.tar.gz
+git clone --shared --branch master https://github.com/apache/sedona.git sedona-src
+java -jar apache-rat-0.15/apache-rat-0.15.jar -d sedona-src > report.txt
+```
+
+2. 阅读生成的 report.txt 文件，确保所有源代码文件都包含 ASF 版权声明。
+3. 删除生成的报告与克隆的源码：
+
+```bash
+#!/bin/bash
+rm -rf apache-rat-0.15
+rm -rf sedona-src
+rm report.txt
+```
+
+## 2. 更新 Sedona Python、R 与 Zeppelin 的版本号
+
+请确认以下文件中的 Sedona 版本均为 {{ sedona_create_release.current_version }}：
+
+1. https://github.com/apache/sedona/blob/master/python/sedona/version.py
+2. https://github.com/apache/sedona/blob/master/python/pyproject.toml（`[project]` 下的 `version` 字段）
+3. https://github.com/apache/sedona/blob/master/R/DESCRIPTION
+4. https://github.com/apache/sedona/blob/99239524f17389fc4ae9548ea88756f8ea538bb9/R/R/dependencies.R#L42
+5. https://github.com/apache/sedona/blob/master/zeppelin/package.json
+
+!!!warning
+    `python/pyproject.toml` 中的 `version` 字段是 `setuptools` 在构建 Python sdist 与 wheel 时使用的版本号。如果该字段未更新，即便 `python/sedona/version.py` 已更新，发布到 PyPI 的 artifact 仍会带有旧版本号。
+
+## 3. 更新发布说明
+
+在 cut release candidate 之前，请确保 `docs/setup/release-notes.md` 已包含 {{ sedona_create_release.current_version }} 的条目，总结自上一版本以来的所有变更。该文件会被投票邮件与公告邮件直接引用，因此必须出现在发布 tag 中。
+
+## 4. 更新 mkdocs.yml
+
+* 把 `mkdocs.yml` 中的以下变量改为本次要发布的版本：
+    * `sedona_create_release.current_version`
+    * `sedona_create_release.current_rc`
+    * `sedona_create_release.current_git_tag`
+    * `sedona_create_release.current_snapshot`
+* 然后通过 `mkdocs serve` 编译网站，本地浏览器中即可看到本页生成的脚本。
+* 如有需要，也可以发布该网站，发布步骤见本文末尾。
+
+## 5. 暂存并上传 release candidate
+
+```bash
+#!/bin/bash
+
+git checkout master
+git pull
+
+rm -f release.*
+rm -f pom.xml.*
+
+echo "*****Step 1. Stage the Release Candidate to GitHub."
+
+mvn -B clean release:prepare -Dtag={{ sedona_create_release.current_git_tag }} -DreleaseVersion={{ sedona_create_release.current_version }} -DdevelopmentVersion={{ sedona_create_release.current_snapshot }} -Dresume=false -Penable-all-submodules -Darguments="-DskipTests"
+mvn -B release:clean -Penable-all-submodules
+
+echo "*****Step 2: Upload the Release Candidate to https://repository.apache.org."
+
+## 注意：这里使用 maven-release-plugin 2.3.2 而非更新的版本（如 3.0.1），是为了规避一个会阻止我们使用 -Dtag=<tag> clone Git 仓库的 bug。
+## 详细信息见 https://issues.apache.org/jira/browse/MRELEASE-933 与 https://issues.apache.org/jira/browse/SCM-729。
+##
+## 同时请注意：系统属性 `-Dspark` 与 `-Dscala` 必须同时传给 release:perform 与 `-Darguments` 中的实际构建参数，
+## 因为 release:perform 任务激活的 build profile 会同时影响实际构建任务。最稳妥的做法是两处都明确指定。
+
+# 仓库信息
+REPO_URL="https://github.com/apache/sedona.git"
+RC_VERSION="{{ sedona_create_release.current_rc }}"
+SEDONA_VERSION="{{ sedona_create_release.current_version }}"
+TAG="sedona-${RC_VERSION}"
+LOCAL_DIR="sedona-release"
+
+# 如果已存在则先删除，然后克隆仓库
+rm -rf $LOCAL_DIR && git clone --depth 1 --branch $TAG $REPO_URL $LOCAL_DIR && cd $LOCAL_DIR
+
+# Maven release 插件版本
+MAVEN_PLUGIN_VERSION="2.3.2"
+
+# Spark 与 Scala 版本
+declare -a SPARK_VERSIONS=("3.4" "3.5" "4.0" "4.1")
+declare -a SCALA_VERSIONS=("2.12" "2.13")
+
+# 根据 Spark 版本确定所需 Java 版本
+get_java_version() {
+  local spark_version=$1
+  if [[ "$spark_version" == "4."* ]]; then
+    echo "17"
+  else
+    echo "11"
+  fi
+}
+
+# 查找 Maven 安装路径
+find_maven_path() {
+  # 通过多种方式定位 Maven
+  local mvn_path=""
+
+  # 方法 1：检查 mvn 是否在 PATH 中
+  if command -v mvn >/dev/null 2>&1; then
+    mvn_path=$(command -v mvn)
+  fi
+
+  # 方法 2：检查常见的 Homebrew 路径
+  if [[ -z "$mvn_path" ]]; then
+    for version_dir in /opt/homebrew/Cellar/maven/*/libexec/bin/mvn; do
+      if [[ -x "$version_dir" ]]; then
+        mvn_path="$version_dir"
+        break
+      fi
+    done
+  fi
+
+  # 方法 3：检查 /usr/local（旧版本 Homebrew）
+  if [[ -z "$mvn_path" ]]; then
+    for version_dir in /usr/local/Cellar/maven/*/libexec/bin/mvn; do
+      if [[ -x "$version_dir" ]]; then
+        mvn_path="$version_dir"
+        break
+      fi
+    done
+  fi
+
+  # 方法 4：检查系统路径
+  if [[ -z "$mvn_path" ]]; then
+    for path in /usr/bin/mvn /usr/local/bin/mvn; do
+      if [[ -x "$path" ]]; then
+        mvn_path="$path"
+        break
+      fi
+    done
+  fi
+
+  if [[ -z "$mvn_path" ]]; then
+    echo "ERROR: Could not find Maven installation" >&2
+    echo "Please ensure Maven is installed and available in PATH or in standard locations" >&2
+    exit 1
+  fi
+
+  echo "$mvn_path"
+}
+
+# 创建一个使用指定 Java 版本的 Maven 包装脚本
+create_mvn_wrapper() {
+  local java_version=$1
+  local mvn_wrapper="/tmp/mvn-java${java_version}"
+  local mvn_path=$(find_maven_path)
+
+  echo "Using Maven at: $mvn_path" >&2
+
+  # 创建包装脚本：先设置 JAVA_HOME 再执行 Maven
+  cat > "$mvn_wrapper" << EOF
+#!/bin/bash
+JAVA_HOME="\${JAVA_HOME:-\$(/usr/libexec/java_home -v ${java_version})}" exec "${mvn_path}" "\$@"
+EOF
+
+  chmod +x "$mvn_wrapper"
+  echo "$mvn_wrapper"
+}
+
+# 校验 Maven 包装脚本所用的 Java 版本
+verify_java_version() {
+  local mvn_wrapper=$1
+  local expected_java_version=$2
+
+  echo "Verifying Java version with Maven wrapper..."
+  local mvn_java_version=$($mvn_wrapper --version | grep "Java version" | sed 's/.*Java version: \([0-9]*\).*/\1/')
+  if [[ "$mvn_java_version" != "$expected_java_version" ]]; then
+    echo "ERROR: Maven wrapper is using Java $mvn_java_version, but expected Java $expected_java_version"
+    echo "Please ensure the correct Java version is installed"
+    exit 1
+  fi
+  echo "✓ Verified: Maven wrapper is using Java $mvn_java_version"
+}
+
+# 遍历 Spark 与 Scala 版本组合
+for SPARK in "${SPARK_VERSIONS[@]}"; do
+  for SCALA in "${SCALA_VERSIONS[@]}"; do
+    # Spark 4.0+ 与 Scala 2.12 不兼容，跳过
+    if [[ "$SPARK" == "4."* && "$SCALA" == "2.12" ]]; then
+      echo "Skipping Spark $SPARK with Scala $SCALA (not supported)"
+      continue
+    fi
+
+    JAVA_VERSION=$(get_java_version $SPARK)
+    echo "Running release:perform for Spark $SPARK and Scala $SCALA with Java $JAVA_VERSION..."
+
+    # 用合适的 Java 版本创建 Maven 包装脚本
+    MVN_WRAPPER=$(create_mvn_wrapper $JAVA_VERSION)
+    echo "Created Maven wrapper: $MVN_WRAPPER"
+
+    # 校验 Java 版本
+    verify_java_version $MVN_WRAPPER $JAVA_VERSION
+
+    # 通过包装脚本执行 Maven
+    $MVN_WRAPPER org.apache.maven.plugins:maven-release-plugin:$MAVEN_PLUGIN_VERSION:perform \
+      -DconnectionUrl=scm:git:file://$(pwd) \
+      -Dtag=$TAG \
+      -Dresume=false \
+      -Darguments="-DskipTests -Dspark=$SPARK -Dscala=$SCALA" \
+      -Dspark=$SPARK \
+      -Dscala=$SCALA
+
+    # 清理包装脚本
+    rm -f $MVN_WRAPPER
+  done
+done
+
+echo "*****Step 3: Upload Release Candidate on ASF SVN: https://dist.apache.org/repos/dist/dev/sedona"
+
+echo "Creating ${RC_VERSION} folder on SVN..."
+
+svn mkdir -m "Adding folder" https://dist.apache.org/repos/dist/dev/sedona/${RC_VERSION}
+
+echo "Creating release files locally..."
+
+# 回到上层目录进行后续文件操作
+cd ../..
+
+echo "Downloading source code..."
+
+wget https://github.com/apache/sedona/archive/refs/tags/sedona-${RC_VERSION}.tar.gz
+tar -xvf sedona-${RC_VERSION}.tar.gz
+mkdir apache-sedona-${SEDONA_VERSION}-src
+cp -r sedona-sedona-${RC_VERSION}/* apache-sedona-${SEDONA_VERSION}-src/
+tar czf apache-sedona-${SEDONA_VERSION}-src.tar.gz apache-sedona-${SEDONA_VERSION}-src
+rm sedona-${RC_VERSION}.tar.gz
+rm -rf sedona-sedona-${RC_VERSION}
+
+# 为源码包生成校验和与签名
+shasum -a 512 apache-sedona-${SEDONA_VERSION}-src.tar.gz > apache-sedona-${SEDONA_VERSION}-src.tar.gz.sha512
+gpg -ab apache-sedona-${SEDONA_VERSION}-src.tar.gz
+
+echo "Uploading source files..."
+
+# 先上传源码相关文件
+svn import -m "Adding file" apache-sedona-${SEDONA_VERSION}-src.tar.gz https://dist.apache.org/repos/dist/dev/sedona/${RC_VERSION}/apache-sedona-${SEDONA_VERSION}-src.tar.gz
+svn import -m "Adding file" apache-sedona-${SEDONA_VERSION}-src.tar.gz.asc https://dist.apache.org/repos/dist/dev/sedona/${RC_VERSION}/apache-sedona-${SEDONA_VERSION}-src.tar.gz.asc
+svn import -m "Adding file" apache-sedona-${SEDONA_VERSION}-src.tar.gz.sha512 https://dist.apache.org/repos/dist/dev/sedona/${RC_VERSION}/apache-sedona-${SEDONA_VERSION}-src.tar.gz.sha512
+
+echo "Compiling the source code..."
+
+mkdir apache-sedona-${SEDONA_VERSION}-bin
+
+# 根据 Spark 版本确定所需 Java 版本
+get_java_version() {
+  local spark_version=$1
+  if [[ "$spark_version" == "4."* ]]; then
+    echo "17"
+  else
+    echo "11"
+  fi
+}
+
+# 查找 Maven 安装路径
+find_maven_path() {
+  # 通过多种方式定位 Maven
+  local mvn_path=""
+
+  # 方法 1：检查 mvn 是否在 PATH 中
+  if command -v mvn >/dev/null 2>&1; then
+    mvn_path=$(command -v mvn)
+  fi
+
+  # 方法 2：检查常见的 Homebrew 路径
+  if [[ -z "$mvn_path" ]]; then
+    for version_dir in /opt/homebrew/Cellar/maven/*/libexec/bin/mvn; do
+      if [[ -x "$version_dir" ]]; then
+        mvn_path="$version_dir"
+        break
+      fi
+    done
+  fi
+
+  # 方法 3：检查 /usr/local（旧版本 Homebrew）
+  if [[ -z "$mvn_path" ]]; then
+    for version_dir in /usr/local/Cellar/maven/*/libexec/bin/mvn; do
+      if [[ -x "$version_dir" ]]; then
+        mvn_path="$version_dir"
+        break
+      fi
+    done
+  fi
+
+  # 方法 4：检查系统路径
+  if [[ -z "$mvn_path" ]]; then
+    for path in /usr/bin/mvn /usr/local/bin/mvn; do
+      if [[ -x "$path" ]]; then
+        mvn_path="$path"
+        break
+      fi
+    done
+  fi
+
+  if [[ -z "$mvn_path" ]]; then
+    echo "ERROR: Could not find Maven installation" >&2
+    echo "Please ensure Maven is installed and available in PATH or in standard locations" >&2
+    exit 1
+  fi
+
+  echo "$mvn_path"
+}
+
+# 创建一个使用指定 Java 版本的 Maven 包装脚本
+create_mvn_wrapper() {
+  local java_version=$1
+  local mvn_wrapper="/tmp/mvn-java${java_version}"
+  local mvn_path=$(find_maven_path)
+
+  echo "Using Maven at: $mvn_path" >&2
+
+  # 创建包装脚本：先设置 JAVA_HOME 再执行 Maven
+  cat > "$mvn_wrapper" << EOF
+#!/bin/bash
+JAVA_HOME="\${JAVA_HOME:-\$(/usr/libexec/java_home -v ${java_version})}" exec "${mvn_path}" "\$@"
+EOF
+
+  chmod +x "$mvn_wrapper"
+  echo "$mvn_wrapper"
+}
+
+# 校验 Maven 包装脚本所用的 Java 版本
+verify_java_version() {
+  local mvn_wrapper=$1
+  local expected_java_version=$2
+
+  echo "Verifying Java version with Maven wrapper..."
+  local mvn_java_version=$($mvn_wrapper --version | grep "Java version" | sed 's/.*Java version: \([0-9]*\).*/\1/')
+  if [[ "$mvn_java_version" != "$expected_java_version" ]]; then
+    echo "ERROR: Maven wrapper is using Java $mvn_java_version, but expected Java $expected_java_version"
+    echo "Please ensure the correct Java version is installed"
+    exit 1
+  fi
+  echo "✓ Verified: Maven wrapper is using Java $mvn_java_version"
+}
+
+# 使用 Java 11 编译 Spark 3.4
+JAVA_VERSION=$(get_java_version "3.4")
+MVN_WRAPPER=$(create_mvn_wrapper $JAVA_VERSION)
+verify_java_version $MVN_WRAPPER $JAVA_VERSION
+
+echo "Compiling for Spark 3.4 with Scala 2.12 using Java $JAVA_VERSION..."
+cd apache-sedona-${SEDONA_VERSION}-src && $MVN_WRAPPER clean && $MVN_WRAPPER install -DskipTests -Dspark=3.4 -Dscala=2.12 && cd ..
+cp apache-sedona-${SEDONA_VERSION}-src/spark-shaded/target/sedona-*${SEDONA_VERSION}.jar apache-sedona-${SEDONA_VERSION}-bin/
+
+echo "Compiling for Spark 3.4 with Scala 2.13 using Java $JAVA_VERSION..."
+cd apache-sedona-${SEDONA_VERSION}-src && $MVN_WRAPPER clean && $MVN_WRAPPER install -DskipTests -Dspark=3.4 -Dscala=2.13 && cd ..
+cp apache-sedona-${SEDONA_VERSION}-src/spark-shaded/target/sedona-*${SEDONA_VERSION}.jar apache-sedona-${SEDONA_VERSION}-bin/
+
+# 使用 Java 11 编译 Spark 3.5
+JAVA_VERSION=$(get_java_version "3.5")
+MVN_WRAPPER=$(create_mvn_wrapper $JAVA_VERSION)
+verify_java_version $MVN_WRAPPER $JAVA_VERSION
+
+echo "Compiling for Spark 3.5 with Scala 2.12 using Java $JAVA_VERSION..."
+cd apache-sedona-${SEDONA_VERSION}-src && $MVN_WRAPPER clean && $MVN_WRAPPER install -DskipTests -Dspark=3.5 -Dscala=2.12 && cd ..
+cp apache-sedona-${SEDONA_VERSION}-src/spark-shaded/target/sedona-*${SEDONA_VERSION}.jar apache-sedona-${SEDONA_VERSION}-bin/
+
+echo "Compiling for Spark 3.5 with Scala 2.13 using Java $JAVA_VERSION..."
+cd apache-sedona-${SEDONA_VERSION}-src && $MVN_WRAPPER clean && $MVN_WRAPPER install -DskipTests -Dspark=3.5 -Dscala=2.13 && cd ..
+cp apache-sedona-${SEDONA_VERSION}-src/spark-shaded/target/sedona-*${SEDONA_VERSION}.jar apache-sedona-${SEDONA_VERSION}-bin/
+
+# 使用 Java 17 编译 Spark 4.0
+JAVA_VERSION=$(get_java_version "4.0")
+MVN_WRAPPER=$(create_mvn_wrapper $JAVA_VERSION)
+verify_java_version $MVN_WRAPPER $JAVA_VERSION
+
+echo "Compiling for Spark 4.0 with Scala 2.13 using Java $JAVA_VERSION..."
+cd apache-sedona-${SEDONA_VERSION}-src && $MVN_WRAPPER clean && $MVN_WRAPPER install -DskipTests -Dspark=4.0 -Dscala=2.13 && cd ..
+cp apache-sedona-${SEDONA_VERSION}-src/spark-shaded/target/sedona-*${SEDONA_VERSION}.jar apache-sedona-${SEDONA_VERSION}-bin/
+
+# 使用 Java 17 编译 Spark 4.1
+JAVA_VERSION=$(get_java_version "4.1")
+MVN_WRAPPER=$(create_mvn_wrapper $JAVA_VERSION)
+verify_java_version $MVN_WRAPPER $JAVA_VERSION
+
+echo "Compiling for Spark 4.1 with Scala 2.13 using Java $JAVA_VERSION..."
+cd apache-sedona-${SEDONA_VERSION}-src && $MVN_WRAPPER clean && $MVN_WRAPPER install -DskipTests -Dspark=4.1 -Dscala=2.13 && cd ..
+cp apache-sedona-${SEDONA_VERSION}-src/spark-shaded/target/sedona-*${SEDONA_VERSION}.jar apache-sedona-${SEDONA_VERSION}-bin/
+
+# 清理 Maven 包装脚本
+rm -f /tmp/mvn-java11 /tmp/mvn-java17
+
+tar czf apache-sedona-${SEDONA_VERSION}-bin.tar.gz apache-sedona-${SEDONA_VERSION}-bin
+
+# 为二进制包生成校验和与签名
+shasum -a 512 apache-sedona-${SEDONA_VERSION}-bin.tar.gz > apache-sedona-${SEDONA_VERSION}-bin.tar.gz.sha512
+gpg -ab apache-sedona-${SEDONA_VERSION}-bin.tar.gz
+
+echo "Uploading binary files..."
+
+# 上传二进制相关文件
+svn import -m "Adding file" apache-sedona-${SEDONA_VERSION}-bin.tar.gz https://dist.apache.org/repos/dist/dev/sedona/${RC_VERSION}/apache-sedona-${SEDONA_VERSION}-bin.tar.gz
+svn import -m "Adding file" apache-sedona-${SEDONA_VERSION}-bin.tar.gz.asc https://dist.apache.org/repos/dist/dev/sedona/${RC_VERSION}/apache-sedona-${SEDONA_VERSION}-bin.tar.gz.asc
+svn import -m "Adding file" apache-sedona-${SEDONA_VERSION}-bin.tar.gz.sha512 https://dist.apache.org/repos/dist/dev/sedona/${RC_VERSION}/apache-sedona-${SEDONA_VERSION}-bin.tar.gz.sha512
+
+echo "Removing local release files..."
+
+rm apache-sedona-${SEDONA_VERSION}-src.tar.gz
+rm apache-sedona-${SEDONA_VERSION}-src.tar.gz.asc
+rm apache-sedona-${SEDONA_VERSION}-src.tar.gz.sha512
+rm apache-sedona-${SEDONA_VERSION}-bin.tar.gz
+rm apache-sedona-${SEDONA_VERSION}-bin.tar.gz.asc
+rm apache-sedona-${SEDONA_VERSION}-bin.tar.gz.sha512
+rm -rf apache-sedona-${SEDONA_VERSION}-src
+rm -rf apache-sedona-${SEDONA_VERSION}-bin
+
+```
+
+## 6. 在 dev sedona.apache.org 邮件列表上投票
+
+### 投票邮件
+
+如有需要，请在邮件末尾追加变更说明：
+
+```
+Subject: [VOTE] Release Apache Sedona {{ sedona_create_release.current_rc }}
+
+Hi all,
+
+This is a call for vote on Apache Sedona {{ sedona_create_release.current_rc }}. Please refer to the changes listed at the bottom of this email.
+
+Release notes:
+https://github.com/apache/sedona/blob/{{ sedona_create_release.current_git_tag }}/docs/setup/release-notes.md
+
+Build instructions:
+https://github.com/apache/sedona/blob/{{ sedona_create_release.current_git_tag }}/docs/setup/compile.md
+
+GitHub tag:
+https://github.com/apache/sedona/releases/tag/{{ sedona_create_release.current_git_tag }}
+
+GPG public key to verify the Release:
+https://downloads.apache.org/sedona/KEYS
+
+Source code and binaries:
+https://dist.apache.org/repos/dist/dev/sedona/{{ sedona_create_release.current_rc }}/
+
+The vote will be open for at least 72 hours or until at least 3 "+1" PMC votes are cast
+
+Instruction for checking items on the checklist: https://sedona.apache.org/latest/community/vote/
+
+We recommend you use this Jupyter notebook on MyBinder to perform this task: https://mybinder.org/v2/gh/jiayuasu/sedona-tools/HEAD?labpath=binder%2Fverify-release.ipynb
+
+**Please vote accordingly and you must provide your checklist for your vote**.
+
+
+[ ] +1 approve
+
+[ ] +0 no opinion
+
+[ ] -1 disapprove with the reason
+
+Checklist:
+
+[ ] Download links are valid.
+
+[ ] Checksums and PGP signatures are valid.
+
+[ ] Source code artifacts have correct names matching the current release.
+
+For a detailed checklist  please refer to:
+https://cwiki.apache.org/confluence/display/INCUBATOR/Incubator+Release+Checklist
+
+------------
+
+Changes according to the comments on the previous release
+Original comment (Permalink from https://lists.apache.org/list.html):
+
+
+```
+
+### 投票通过邮件
+
+请统计票数，并在邮件末尾加上投票邮件的 Permalink：
+
+```
+Subject: [RESULT][VOTE] Release Apache Sedona {{ sedona_create_release.current_rc }}
+
+Dear all,
+
+The vote closes now as 72hr have passed. The vote PASSES with
+
++? (binding): NAME1, NAME2, NAME3
++? (non-binding): NAME4
+No -1 votes
+
+The vote thread (Permalink from https://lists.apache.org/list.html):
+
+I will make an announcement soon.
+
+```
+
+### 公告邮件
+
+1. 该邮件应发送至 dev@sedona.apache.org。
+2. 请加上投票邮件的 permalink。
+3. 请加上投票结果邮件的 permalink。
+
+```
+Subject: [ANNOUNCE] Apache Sedona {{ sedona_create_release.current_version }} released
+
+Dear all,
+
+We are happy to report that we have released Apache Sedona {{ sedona_create_release.current_version }}. Thank you again for your help.
+
+Apache Sedona is a cluster computing system for processing large-scale spatial data.
+
+
+Vote thread (Permalink from https://lists.apache.org/list.html):
+
+
+Vote result thread (Permalink from https://lists.apache.org/list.html):
+
+
+Website:
+https://sedona.apache.org/
+
+Release notes:
+https://github.com/apache/sedona/blob/sedona-{{ sedona_create_release.current_version }}/docs/setup/release-notes.md
+
+Download links:
+https://github.com/apache/sedona/releases/tag/sedona-{{ sedona_create_release.current_version }}
+
+Additional resources:
+Mailing list: dev@sedona.apache.org
+Twitter: https://twitter.com/ApacheSedona
+Gitter: https://gitter.im/apache/sedona
+
+Regards,
+Apache Sedona Team
+```
+
+## 7. 投票失败
+
+如果投票未通过：
+
+1. 在投票邮件中说明我们将创建另一个 release candidate。
+2. 从第 4 步 `更新 mkdocs.yml` 重新开始。请把 release candidate ID 递增（如 `{{ sedona_create_release.current_version}}-rc2`），并相应更新 `mkdocs.yml` 中的 `sedona_create_release.current_rc` 与 `sedona_create_release.current_git_tag` 来生成本页脚本。
+
+## 8. 发布源码与 Maven 包
+
+### 上传发布版本
+
+```bash
+#!/bin/bash
+
+echo "Move all files in https://dist.apache.org/repos/dist/dev/sedona to https://dist.apache.org/repos/dist/release/sedona, using svn"
+svn mkdir -m "Adding folder" https://dist.apache.org/repos/dist/release/sedona/{{ sedona_create_release.current_version }}
+wget https://dist.apache.org/repos/dist/dev/sedona/{{ sedona_create_release.current_rc }}/apache-sedona-{{ sedona_create_release.current_version }}-src.tar.gz
+wget https://dist.apache.org/repos/dist/dev/sedona/{{ sedona_create_release.current_rc }}/apache-sedona-{{ sedona_create_release.current_version }}-src.tar.gz.asc
+wget https://dist.apache.org/repos/dist/dev/sedona/{{ sedona_create_release.current_rc }}/apache-sedona-{{ sedona_create_release.current_version }}-src.tar.gz.sha512
+wget https://dist.apache.org/repos/dist/dev/sedona/{{ sedona_create_release.current_rc }}/apache-sedona-{{ sedona_create_release.current_version }}-bin.tar.gz
+wget https://dist.apache.org/repos/dist/dev/sedona/{{ sedona_create_release.current_rc }}/apache-sedona-{{ sedona_create_release.current_version }}-bin.tar.gz.asc
+wget https://dist.apache.org/repos/dist/dev/sedona/{{ sedona_create_release.current_rc }}/apache-sedona-{{ sedona_create_release.current_version }}-bin.tar.gz.sha512
+svn import -m "Adding file" apache-sedona-{{ sedona_create_release.current_version }}-src.tar.gz https://dist.apache.org/repos/dist/release/sedona/{{ sedona_create_release.current_version }}/apache-sedona-{{ sedona_create_release.current_version }}-src.tar.gz
+svn import -m "Adding file" apache-sedona-{{ sedona_create_release.current_version }}-src.tar.gz.asc https://dist.apache.org/repos/dist/release/sedona/{{ sedona_create_release.current_version }}/apache-sedona-{{ sedona_create_release.current_version }}-src.tar.gz.asc
+svn import -m "Adding file" apache-sedona-{{ sedona_create_release.current_version }}-src.tar.gz.sha512 https://dist.apache.org/repos/dist/release/sedona/{{ sedona_create_release.current_version }}/apache-sedona-{{ sedona_create_release.current_version }}-src.tar.gz.sha512
+svn import -m "Adding file" apache-sedona-{{ sedona_create_release.current_version }}-bin.tar.gz https://dist.apache.org/repos/dist/release/sedona/{{ sedona_create_release.current_version }}/apache-sedona-{{ sedona_create_release.current_version }}-bin.tar.gz
+svn import -m "Adding file" apache-sedona-{{ sedona_create_release.current_version }}-bin.tar.gz.asc https://dist.apache.org/repos/dist/release/sedona/{{ sedona_create_release.current_version }}/apache-sedona-{{ sedona_create_release.current_version }}-bin.tar.gz.asc
+svn import -m "Adding file" apache-sedona-{{ sedona_create_release.current_version }}-bin.tar.gz.sha512 https://dist.apache.org/repos/dist/release/sedona/{{ sedona_create_release.current_version }}/apache-sedona-{{ sedona_create_release.current_version }}-bin.tar.gz.sha512
+rm apache-sedona-{{ sedona_create_release.current_version }}-src.tar.gz
+rm apache-sedona-{{ sedona_create_release.current_version }}-src.tar.gz.asc
+rm apache-sedona-{{ sedona_create_release.current_version }}-src.tar.gz.sha512
+rm apache-sedona-{{ sedona_create_release.current_version }}-bin.tar.gz
+rm apache-sedona-{{ sedona_create_release.current_version }}-bin.tar.gz.asc
+rm apache-sedona-{{ sedona_create_release.current_version }}-bin.tar.gz.sha512
+```
+
+### 手动 close 并 release Maven 包
+
+1. 在 https://repository.apache.org 的 `staging repository` 中找到 Sedona 暂存仓库，点击 `Close`。
+2. staging repo close 完成后，再点击 `Release`。
+
+## 9. 发布 Sedona Python
+
+创建 GitHub release 后，Sedona GitHub CI 会自动把 wheel 文件发布到 PyPI。
+
+## 10. 发布 Sedona Zeppelin
+
+```bash
+#!/bin/bash
+
+wget https://github.com/apache/sedona/archive/refs/tags/{{ sedona_create_release.current_git_tag}}.tar.gz
+tar -xvf {{ sedona_create_release.current_git_tag}}.tar.gz
+mkdir apache-sedona-{{ sedona_create_release.current_version }}-src
+cp -r sedona-{{ sedona_create_release.current_git_tag}}/* apache-sedona-{{ sedona_create_release.current_version }}-src/
+
+rm -rf apache-{{ sedona_create_release.current_git_tag}}
+
+cd apache-sedona-{{ sedona_create_release.current_version }}-src/zeppelin && npm publish && cd ..
+rm -rf apache-sedona-{{ sedona_create_release.current_version }}-src
+```
+
+## 11. 将 Sedona R 发布到 CRAN
+
+```bash
+#!/bin/bash
+R CMD build .
+R CMD check --as-cran apache.sedona_*.tar.gz
+```
+
+然后通过 [此网页表单](https://xmpalantir.wu.ac.at/cransubmit/) 提交到 CRAN。
+
+## 12. 发布文档网站
+
+1. 在本地仓库中把 {{ sedona_create_release.current_version }} 的 Git tag check out 到名为 `branch-{{ sedona_create_release.current_version }}` 的分支。
+2. 把下载链接添加到 [Download 页面](../download.md)。
+3. 把新闻添加到 `docs/index.md`。
+4. 将该分支的更改推送到 GitHub。
+5. GitHub CI 会自动捕捉这些更改并部署到 `website` 分支。
+6. 通常 [此仓库](https://github.com/jiayuasu/sedona-sync-action) 会按日自动发布该网站。

--- a/docs/community/release-manager.zh.md
+++ b/docs/community/release-manager.zh.md
@@ -1,0 +1,170 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# 成为发布经理
+
+只有第一次担任发布经理时，才需要执行下面这些步骤。
+
+## 0. 软件要求
+
+* JDK 11/17：`brew install openjdk@11` 或 `brew install openjdk@17`
+* Maven 3.X，且 Maven 必须指向 JDK 11 或 17。可通过 `mvn --version` 检查。
+* Git 与 SVN
+
+如果 `mvn --version` 显示 Maven 当前指向其他 JDK 版本，您必须把它切换到 JDK 11 或 17。步骤如下：
+
+1. 列出本机所有已安装的 Java 版本：`/usr/libexec/java_home -V`。应能看到包含 JDK 11 与 17 的多个版本。
+2. 运行 `whereis mvn` 获取 Maven 的安装位置。结果是一个指向真实位置的符号链接。
+3. 在终端中打开该文件（必要时使用 `sudo`）。内容大致如下：
+
+```
+#!/bin/bash
+JAVA_HOME="${JAVA_HOME:-$(/usr/libexec/java_home)}" exec "/usr/local/Cellar/maven/3.6.3/libexec/bin/mvn" "$@"
+```
+
+4. 将 `JAVA_HOME:-$(/usr/libexec/java_home)}` 改为 `JAVA_HOME:-$(/usr/libexec/java_home -v 11)}` 或 `JAVA_HOME:-$(/usr/libexec/java_home -v 17)}`。修改后大致如下：
+
+```
+#!/bin/bash
+JAVA_HOME="${JAVA_HOME:-$(/usr/libexec/java_home -v 11)}" exec "/usr/local/Cellar/maven/3.6.3/libexec/bin/mvn" "$@"
+```
+
+5. 再次运行 `mvn --version`，此时应已指向 JDK 11 或 17。
+
+## 1. 获得 Sedona GitHub 仓库的写权限
+
+1. 确认您的 GitHub 账号已启用 2FA：https://help.github.com/articles/securing-your-account-with-two-factor-authentication-2fa/
+2. 在 Apache ID 资料中填写您的 GitHub ID：https://id.apache.org/
+3. 通过 GitBox（Apache 账号关联工具）合并 Apache 与 GitHub 账号：https://gitbox.apache.org/setup/
+	* GitBox 中应能看到 5 个绿色对勾。
+	* 等待至少 30 分钟，您会收到一封邀请加入 Apache GitHub 组织的邮件，点击接受邀请即可。
+4. 接受邀请后，确认您已在团队中：https://github.com/orgs/apache/teams/sedona-committers
+5. 此外，如果您当选为 Sedona PMC 成员，还应确认自己出现在 LDAP 的 Sedona PMC 列表中：https://whimsy.apache.org/roster/pmc/sedona
+
+## 2. 准备 GPG 私钥
+
+1. 如果尚未安装 GNUPG，请先安装。Mac 上：`brew install gnupg gnupg2`。
+2. 生成一个私钥，必须是 RSA4096（4096 位）。
+   * 运行 `gpg --full-generate-key`；如果不可用，运行 `gpg --default-new-key-algo rsa4096 --gen-key`。
+   * 提示选择密钥类型时：选 `RSA`，按 `enter`。
+   * 提示选择密钥长度时：输入 `4096`。
+   * 提示选择密钥有效期时：直接 `enter`，让密钥永不过期。
+   * 确认所选项无误。
+   * 输入用户身份信息：使用真实姓名与 Apache 邮箱。
+   * 设置一个安全的口令（passphrase），请记住，后续会用到。
+   * 运行 `gpg --list-secret-keys --keyid-format=long` 查看长格式的 GPG key 列表。
+   * 从中复制您要使用的 key ID 长格式（如 `3AA5C34371567BD2`）。
+   * 运行 `gpg --export --armor 3AA5C34371567BD2`，替换为您的 key ID。
+   * 复制 `-----BEGIN PGP PUBLIC KEY BLOCK-----` 与 `-----END PGP PUBLIC KEY BLOCK-----` 之间的内容（即 armored key）。
+   * `-----BEGIN PGP PUBLIC KEY BLOCK-----` 与实际 key 之间必须有一空行。
+3. 将 armored key 发布到主流 key server：https://keyserver.pgp.com/
+
+## 3. 使用 SVN 更新 KEYS
+
+通过 SVN 将您的 armored 公钥追加到下面这两个 `KEYS` 文件中：
+
+   * https://dist.apache.org/repos/dist/dev/sedona/KEYS
+   * https://dist.apache.org/repos/dist/release/sedona/KEYS
+
+1. 分别 check out 两个 KEYS 文件：
+
+```bash
+svn checkout https://dist.apache.org/repos/dist/dev/sedona/ sedona-dev --depth files
+svn checkout https://dist.apache.org/repos/dist/release/sedona/ sedona-release --depth files
+```
+
+2. 使用您喜欢的文本编辑器打开 `sedona-dev/KEYS` 与 `sedona-release/KEYS`。
+3. 把 armored key 粘贴到这两个文件末尾。注意：`-----BEGIN PGP PUBLIC KEY BLOCK-----` 与实际 key 之间必须有一空行。
+4. 提交两个 KEYS。SVN 可能会要求输入您的 ASF ID 与密码——请输入，以便 SVN 在本地保存您的凭据。
+
+```bash
+svn commit -m "Update KEYS" sedona-dev/KEYS
+svn commit -m "Update KEYS" sedona-release/KEYS
+```
+
+5. 然后删除两个 svn 工作目录：
+
+```bash
+rm -rf sedona-dev
+rm -rf sedona-release
+```
+
+## 4. 添加 GPG_TTY 环境变量
+
+在 `~/.bashrc` 中加入下列内容，然后重启终端：
+
+```bash
+GPG_TTY=$(tty)
+export GPG_TTY
+```
+
+## 5. 获取 GitHub Personal Access Token（classic）
+
+您需要创建一个 GitHub Personal Access Token（classic），可参考 [GitHub 官方文档](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-personal-access-token-classic)。
+
+简要步骤：
+
+1. 在 GitHub 界面进入 Settings。
+2. 在左侧栏点击 Developer settings。
+3. 在左侧栏的 Personal access tokens 下点击 Tokens (classic)。
+4. 选择 Generate new token，然后点击 Generate new token (classic)。
+5. 给 token 起一个有描述性的名字。
+6. 设置 token 的过期时间——选择 Expiration 下拉菜单时，请设置为 `No expiration`。
+7. 选择该 token 的权限范围。要从命令行访问仓库，请勾选 `repo` 与 `admin:org`。
+8. 点击 `Generate token`。
+9. 请把 token 保存好，下一步会用到。
+
+## 6. 配置 Maven 凭据
+
+在 `~/.m2/settings.xml` 中加入以下内容；如果该文件或 `.m2` 目录不存在，请先创建。
+
+请将所有大写文本替换为您自己的 ID 与密码。
+
+```
+<settings>
+  <servers>
+    <server>
+      <id>github</id>
+      <username>YOUR_GITHUB_USERNAME</username>
+      <password>YOUR_GITHUB_TOKEN</password>
+    </server>
+    <server>
+      <id>apache.snapshots.https</id>
+      <username>YOUR_ASF_ID</username>
+      <password>YOUR_ASF_PASSWORD</password>
+    </server>
+    <server>
+      <id>apache.releases.https</id>
+      <username>YOUR_ASF_ID</username>
+      <password>YOUR_ASF_PASSWORD</password>
+    </server>
+  </servers>
+  <profiles>
+    <profile>
+      <id>gpg</id>
+      <properties>
+        <gpg.passphrase>YOUR_GPG_PASSPHRASE</gpg.passphrase>
+      </properties>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <activeProfile>gpg</activeProfile>
+  </activeProfiles>
+</settings>
+```

--- a/docs/community/rule.zh.md
+++ b/docs/community/rule.zh.md
@@ -1,0 +1,75 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# 为 Apache Sedona 贡献
+
+本项目欢迎贡献。您可以在 [Sedona GitHub 仓库](https://github.com/apache/sedona) 上提交 Pull Request 来贡献代码或文档。
+
+下面简述完成一次贡献的工作流程。
+
+## 选取/公示任务
+
+在开始贡献之前，确认贡献内容是否会被接受很重要。请先通过工单（ticket）告知社区您的意图。Sedona 同时接受 [GitHub issues](https://github.com/apache/sedona/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) 与 [JIRA](https://issues.apache.org/jira/projects/SEDONA)。新建 JIRA 工单时，会自动发送邮件通知 `dev@sedona.apache.org`。
+
+## 编写代码贡献
+
+代码贡献应包括：
+
+* 类与方法的详尽文档。
+* 用于证明代码正确性、并能在后续维护中保持的单元测试。对于 bug 修复，单元测试应能在没有该修复时复现 bug（如适用）。单元测试可以是 JUnit 测试或 Scala 测试。部分 Sedona 函数需要在 Scala 与 Java 两侧分别测试。
+* 必要时更新对应的 Sedona 文档。
+
+代码贡献必须在每个文件顶部包含 Apache 2.0 许可声明。
+
+提交 PR 前请运行 `mvn spotless:apply` 来格式化代码。如果您修改了某个特定 Spark 版本的代码（例如 `spark/spark-3.5/` 下的源文件），请追加对应的 Maven CLI 参数：`mvn spotless:apply -Dscala=2.12 -Dspark=3.5`。
+
+## 编写文档贡献
+
+文档贡献应满足以下要求：
+
+* 详细的解释与示例。
+* 把新增文档放在合适的目录下。
+* 必要时修改 ==mkdocs.yml==。
+
+!!!note
+	请阅读 [编译源码](../setup/compile.md#compile-the-documentation) 了解如何编译 Sedona 网站。
+
+## 提交 Pull Request
+
+完成贡献之后，最简单也最直观的提交方式是向 [GitHub 仓库](https://github.com/apache/sedona) 提交 Pull Request（PR）。
+
+**请在 PR 名称中使用 JIRA 工单 ID 或 GitHub issue ID，例如 "[SEDONA-1] my subject" 或 "[GH-1] my subject"。**
+
+创建 PR 时，请回答 PR 模板中的问题。
+
+提交 PR 之后，GitHub Action 会自动检查构建是否正确。请关注 PR 状态并修复其中的所有问题。
+
+## 评审 Pull Request
+
+* 每个 PR 需要满足：(1) 至少有 1 名 committer 批准；(2) 没有 committer 表示反对。任何人都欢迎参与评审，但最终决定由 committer 做出。
+* 其他评审者（包括社区成员与 committer）可以评论变更并建议修改。可以直接向同一分支推送更多 commit 来追加修改。
+* 即使最终结果可能是拒绝整个变更，社区也鼓励大家进行积极、礼貌、迅速的技术讨论。
+* 请注意：对 Sedona 关键部分（如 Sedona core、空间连接算法）的改动会接受更严格的评审，可能需要更多测试与正确性证明。
+* 有时其他变更被合并后，会与您的 PR 产生冲突。冲突解决前 PR 无法合并。请手动解决冲突，并把结果推送到您的分支。
+
+## 行为准则
+
+请阅读 [Apache 软件基金会行为准则](https://www.apache.org/foundation/policies/conduct.html)。
+
+凡正式或非正式参与 Apache 社区、声称与基金会有任何关联、参与任何与基金会相关的活动（尤其是以任何身份代表 ASF）的人员，都需遵守这一准则。

--- a/docs/community/snapshot.zh.md
+++ b/docs/community/snapshot.zh.md
@@ -1,0 +1,73 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# 发布 SNAPSHOT 版本
+
+本步骤用于将 Maven SNAPSHOT 发布到 https://repository.apache.org
+
+对于发布经理（release manager）来说，这是检验自己凭据配置的良好实践。
+
+详细要求见 [ASF Infra 网站](https://infra.apache.org/publishing-maven-artifacts.html)。
+
+!!!warning
+    本页所有脚本都应在本地 Sedona Git 仓库的 master 分支下，通过单一脚本文件运行。
+
+## 0. 准备一个空脚本文件
+
+1. 在本地 Sedona Git 仓库 master 分支下运行：
+
+```bash
+echo '#!/bin/bash' > create-release.sh
+chmod 777 create-release.sh
+```
+
+2. 用您喜欢的 GUI 文本编辑器打开 `create-release.sh`。
+3. 然后不断把本页上的脚本复制粘贴到该文件中，覆盖原内容。
+4. 不要直接将脚本复制粘贴到终端，因为 `clipboard.js` 的一个 bug 会在这种情形下产生换行符问题。
+5. 每次更新该脚本后，运行 `./create-release.sh` 执行它。
+
+## 1. 上传 snapshot 版本
+
+在您的 Sedona GitHub 仓库中运行：
+
+```bash
+#!/bin/bash
+
+git checkout master
+git pull
+
+rm -f release.*
+rm -f pom.xml.*
+
+# 校验 POM 与凭据配置
+mvn -q -B clean release:prepare -Dtag={{ sedona_create_release.current_git_tag }} -DreleaseVersion={{ sedona_create_release.current_version }} -DdevelopmentVersion={{ sedona_create_release.current_snapshot }} -Dresume=false -DdryRun=true -Penable-all-submodules -Darguments="-DskipTests"
+mvn -q -B release:clean -Penable-all-submodules
+
+# Spark 3.3 与 Scala 2.12
+mvn -q deploy -DskipTests -Dspark=3.3 -Dscala=2.12
+
+# Spark 3.3 与 Scala 2.13
+mvn -q deploy -DskipTests -Dspark=3.3 -Dscala=2.13
+
+# Spark 3.4 与 Scala 2.12
+mvn -q deploy -DskipTests -Dspark=3.4 -Dscala=2.12
+
+# Spark 3.4 与 Scala 2.13
+mvn -q deploy -DskipTests -Dspark=3.4 -Dscala=2.13
+```

--- a/docs/community/vote.zh.md
+++ b/docs/community/vote.zh.md
@@ -1,0 +1,128 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# 投票发布 Sedona 版本
+
+本页面面向 Sedona 社区，用于对 Sedona 发布版本进行投票。下面的脚本已在 macOS 上测试通过。
+
+要对 Sedona 发布版本投票，您需要在投票邮件中提供至少包含以下条目的检查清单：
+
+* 下载链接有效
+* 校验和与 PGP 签名有效
+* 已包含 DISCLAIMER 与 NOTICE
+* 源码 artifact 名称与当前发布版本一致
+* 项目能从源码成功编译
+
+为方便您完成校验，我们提供了一份基于 MyBinder 的 [在线 Jupyter Notebook](https://github.com/jiayuasu/sedona-tools)。点击下方按钮即可打开 notebook 进行校验：[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jiayuasu/sedona-tools/HEAD?labpath=binder%2Fverify-release.ipynb)。校验通过后，即可在投票邮件中投 `+1`。
+
+如果您更愿意在本机执行这些步骤，请阅读下方的步骤说明。如果能成功完成所有步骤，则上述检查清单都会得到满足，您即可在投票邮件中投 `+1` 并附上检查清单。
+
+## 安装必要软件
+
+1. GPG：在 Mac 上 `brew install gnupg gnupg2`。可在终端中通过 `gpg --version` 检查。
+2. JDK 1.8 或 1.11。Mac 上可能安装了多种 Java 版本，可以尝试当前版本，但不保证一定能通过。可在终端通过 `java --version` 检查。
+3. Apache Maven 3.3.1+。在 Mac 上 `brew install maven`。可在终端通过 `mvn -version` 检查。
+4. Python3：macOS 默认带有 Python3。可在终端通过 `python3 --version` 检查。
+
+如果您之前已安装过这些软件，可跳过本步骤。
+
+## 运行校验脚本
+
+请将 SEDONA\_CURRENT\_RC 与 SEDONA\_CURRENT\_VERSION 替换为正确的版本号，然后把内容粘贴到名为 `verify.sh` 的脚本中，并将输出重定向到文件。运行方式：
+
+```bash
+#!/bin/bash
+
+## 修改脚本权限为可执行
+chmod 777 verify.sh
+
+## 运行并把输出重定向到文件
+./verify.sh &> verify.out
+```
+
+`verify.sh` 内容如下。==如果直接复制下方内容，长行可能会被自动加上换行，请在本地脚本中将其去掉。==
+
+```bash
+#!/bin/bash
+
+SEDONA_CURRENT_RC={{ sedona_create_release.current_rc }}
+SEDONA_CURRENT_VERSION={{ sedona_create_release.current_version }}
+
+## 下载 Sedona 发布
+wget -q https://downloads.apache.org/sedona/KEYS
+wget -q https://dist.apache.org/repos/dist/dev/sedona/$SEDONA_CURRENT_RC/apache-sedona-$SEDONA_CURRENT_VERSION-src.tar.gz
+wget -q https://dist.apache.org/repos/dist/dev/sedona/$SEDONA_CURRENT_RC/apache-sedona-$SEDONA_CURRENT_VERSION-src.tar.gz.asc
+wget -q https://dist.apache.org/repos/dist/dev/sedona/$SEDONA_CURRENT_RC/apache-sedona-$SEDONA_CURRENT_VERSION-src.tar.gz.sha512
+wget -q https://dist.apache.org/repos/dist/dev/sedona/$SEDONA_CURRENT_RC/apache-sedona-$SEDONA_CURRENT_VERSION-bin.tar.gz
+wget -q https://dist.apache.org/repos/dist/dev/sedona/$SEDONA_CURRENT_RC/apache-sedona-$SEDONA_CURRENT_VERSION-bin.tar.gz.asc
+wget -q https://dist.apache.org/repos/dist/dev/sedona/$SEDONA_CURRENT_RC/apache-sedona-$SEDONA_CURRENT_VERSION-bin.tar.gz.sha512
+
+## 校验签名与校验和
+gpg --import KEYS
+gpg --verify apache-sedona-$SEDONA_CURRENT_VERSION-src.tar.gz.asc
+gpg --verify apache-sedona-$SEDONA_CURRENT_VERSION-bin.tar.gz.asc
+shasum -a 512 apache-sedona-$SEDONA_CURRENT_VERSION-src.tar.gz
+cat apache-sedona-$SEDONA_CURRENT_VERSION-src.tar.gz.sha512
+shasum -a 512 apache-sedona-$SEDONA_CURRENT_VERSION-bin.tar.gz
+cat apache-sedona-$SEDONA_CURRENT_VERSION-bin.tar.gz.sha512
+
+## 解压源码包
+tar -xvf apache-sedona-$SEDONA_CURRENT_VERSION-src.tar.gz
+
+## 从源码编译项目
+(cd apache-sedona-$SEDONA_CURRENT_VERSION-src;mvn clean install -DskipTests)
+
+```
+
+* 如果运行成功，输出文件中应能看到与下面类似的信息，并包含 `Good signature from`，最后 4 行应是两对相互匹配的校验和：
+
+```
+gpg: key 3A79A47AC26FF4CD: "Jia Yu <jiayu@apache.org>" not changed
+gpg: key 6C883CA80E7FD299: "PawelKocinski <imbruced@apache.org>" not changed
+gpg: Total number processed: 2
+gpg:              unchanged: 2
+gpg: assuming signed data in 'apache-sedona-1.2.0-incubating-src.tar.gz'
+gpg: Signature made Mon Apr  4 11:48:31 2022 PDT
+gpg:                using RSA key 949DD6275C69AB954B1872FC6C883CA80E7FD299
+gpg:                issuer "imbruced@apache.org"
+gpg: Good signature from "PawelKocinski <imbruced@apache.org>" [unknown]
+gpg: WARNING: The key's User ID is not certified with a trusted signature!
+gpg:          There is no indication that the signature belongs to the owner.
+Primary key fingerprint: 949D D627 5C69 AB95 4B18  72FC 6C88 3CA8 0E7F D299
+gpg: assuming signed data in 'apache-sedona-1.2.0-incubating-bin.tar.gz'
+gpg: Signature made Mon Apr  4 11:48:42 2022 PDT
+gpg:                using RSA key 949DD6275C69AB954B1872FC6C883CA80E7FD299
+gpg:                issuer "imbruced@apache.org"
+gpg: Good signature from "PawelKocinski <imbruced@apache.org>" [unknown]
+gpg: WARNING: The key's User ID is not certified with a trusted signature!
+gpg:          There is no indication that the signature belongs to the owner.
+Primary key fingerprint: 949D D627 5C69 AB95 4B18  72FC 6C88 3CA8 0E7F D299
+d3bdfd4d870838ebe63f21cb93634d2421ec1ac1b8184636206a5dc0d89a78a88257798b1f17371ad3cfcc3b1eb79c69e1410afdefeb4d9b52fc8bb5ea18dd2e  apache-sedona-1.2.0-incubating-src.tar.gz
+d3bdfd4d870838ebe63f21cb93634d2421ec1ac1b8184636206a5dc0d89a78a88257798b1f17371ad3cfcc3b1eb79c69e1410afdefeb4d9b52fc8bb5ea18dd2e  apache-sedona-1.2.0-incubating-src.tar.gz
+64cea38dd3ca171ee4e2a7365dbce999773862f2a11599bd0f27e9551d740659a519a9b976b3e7b0826088010967093e6acc9462f7073e9737c24b007a2df846  apache-sedona-1.2.0-incubating-bin.tar.gz
+64cea38dd3ca171ee4e2a7365dbce999773862f2a11599bd0f27e9551d740659a519a9b976b3e7b0826088010967093e6acc9462f7073e9737c24b007a2df846  apache-sedona-1.2.0-incubating-bin.tar.gz
+```
+
+* 如果源码编译成功，您还会在输出末尾看到 `BUILD SUCCESS`。如果该步骤失败，可联系 Sedona PMC 询问是否仅是您本地环境的问题。
+
+## 手动检查文件
+
+1. 检查下载的文件版本号是否正确。
+
+2. 解压源码目录后，检查 DISCLAIMER 与 NOTICE 文件是否存在且为最新。


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2912, part of EPIC #2867.

## What changes were proposed in this PR?

Phase 5 of the Chinese-documentation EPIC (#2867). Adds Chinese (`zh`) translations for the Community and Apache Software Foundation pages so `/zh/community/` and `/zh/asf/` render in Chinese.

**Translated in this PR (12 files):**

- `asf/`: `asf`, `telemetry`
- `community/`: `contact`, `publication`, `snapshot`, `rule`, `geopandas`, `vote`, `release-manager`, `develop`, `contributor`, `publish`

ASF-mandated wording (trademark notice in `asf.md`, license-related text) is preserved verbatim. Email templates inside `release-manager.md`, `contributor.md`, and `publish.md` are kept in English on purpose — these are the actual emails sent to ASF mailing lists, and translating them would mislead readers about what to send. Bash scripts, Maven commands, and version macros (`{{ sedona_create_release.* }}`) are unchanged; only the prose around them is translated.

## How was this patch tested?

Built the docs locally with `uv sync --group docs && uv run mkdocs build` and verified:

- The build succeeds with no new warnings introduced by Phase 5.
- The 12 new `*.zh.md` files render under `/zh/community/` and `/zh/asf/`.
- `pre-commit run --all-files` passes (license headers auto-added by `insert-license`, re-staged before commit).

## Did this PR include necessary documentation updates?

- Yes, this PR is itself a documentation translation. Subsequent phases (#2913-#2919) translate the remaining sections.