### PR TITLE
[GH-2867] Strip mike canonical-version prefix from language switcher links

### DIFF
--- a/docs-overrides/partials/alternate.html
+++ b/docs-overrides/partials/alternate.html
@@ -5,16 +5,27 @@
   </summary>
   <ul class="sd-lang-switch__menu">
     {#-
-      mkdocs-static-i18n stores `alt.link` as a server-absolute path like
-      `/zh/sedonaspark/`. Passing that directly to `| url` keeps the leading
-      slash, so the link bypasses any deployment prefix added by mike (e.g.
-      `/latest-snapshot/`) and lands at the wrong version. Strip the leading
-      slash so `| url` resolves against the docs root and stays inside the
-      current mike version.
+      mkdocs-static-i18n derives `alt.link` from `urlsplit(site_url).path`, so
+      when mike rewrites site_url to include its canonical_version (e.g.
+      `https://sedona.apache.org/latest`) the alt links get that prefix baked
+      in — yielding paths like `/latest/zh/sedonaspark/`. Feeding that through
+      `| url` from a different mike alias (`/latest-snapshot/`) produces
+      broken targets like `/latest-snapshot/latest/zh/`. Strip the mike
+      canonical prefix, then any remaining leading slash, so `| url`
+      resolves against the docs root of the version actually being served.
     -#}
+    {%- set mike_prefix = '' -%}
+    {%- if 'mike' in config.plugins and config.plugins.mike.config.canonical_version -%}
+      {%- set mike_prefix = '/' ~ config.plugins.mike.config.canonical_version ~ '/' -%}
+    {%- endif -%}
     {% for alt in config.extra.alternate %}
       {%- set is_active = (alt.lang == config.theme.language) -%}
-      {%- set alt_link = alt.link[1:] if alt.link.startswith('/') else alt.link -%}
+      {%- set alt_link = alt.link -%}
+      {%- if mike_prefix and alt_link.startswith(mike_prefix) -%}
+        {%- set alt_link = alt_link[mike_prefix|length:] -%}
+      {%- elif alt_link.startswith('/') -%}
+        {%- set alt_link = alt_link[1:] -%}
+      {%- endif -%}
       <li>
         <a
           href="{{ alt_link | url }}"


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Part of #2867.

## What changes were proposed in this PR?

Follow-up to #2936. The 文A language switcher was still producing broken URLs when the deployed mike alias was not `latest` — for example on `https://sedona.apache.org/latest-snapshot/` clicking 中文 navigated to `https://sedona.apache.org/latest-snapshot/latest/zh/`, which 404s.

Root cause: `mkdocs-static-i18n` derives `alt.link` from `urlsplit(config.site_url).path`. The mike plugin rewrites `config.site_url` to include `canonical_version` (configured as `latest` in this site), so every alt link ends up prefixed with `/latest/` at build time, regardless of which alias the build is actually being deployed under. `#2936` only stripped the leading slash, which is not enough — the `/latest/` segment then resolves relative to the current alias's path and produces `/latest-snapshot/latest/zh/…`.

This PR reads `canonical_version` from the mike plugin config in `docs-overrides/partials/alternate.html` and strips that `/<canonical_version>/` prefix from `alt.link` before piping through the `| url` filter. The remaining path resolves against the docs root of whichever alias is actually being served.

## How was this patch tested?

Locally with `mike deploy --branch <test> latest-snapshot` followed by a threaded static server, verifying the rendered `<a class=\"sd-lang-switch__link\">` hrefs across several pages:

| Page | English link | 中文 link |
|---|---|---|
| `/latest-snapshot/` | `.` | `zh/` |
| `/latest-snapshot/zh/` | `..` | `./` |
| `/latest-snapshot/sedonaspark/` | `./` | `../zh/sedonaspark/` |
| `/latest-snapshot/zh/sedonaspark/` | `../../sedonaspark/` | `./` |

All resolve to the correct path inside the deployed alias.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.