### PR TITLE
[GH-2939] Box2D spatial join: ST_BoxIntersects / ST_BoxContains

### DIFF
--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/BroadcastIndexJoinExec.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/BroadcastIndexJoinExec.scala
@@ -323,11 +323,10 @@ case class BroadcastIndexJoinExec(
         })
       case Some(distanceExpression) =>
         streamResultsRaw.map(row => {
-          val geom = boundStreamShape.eval(row).asInstanceOf[Array[Byte]]
-          if (geom == null) {
+          val geometry = TraitJoinQueryBase.shapeToGeometry(boundStreamShape, row)
+          if (geometry == null) {
             (null, row)
           } else {
-            val geometry = GeometrySerializer.deserialize(geom)
             val radius = BindReferences
               .bindReference(distanceExpression, streamed.output)
               .eval(row)
@@ -351,23 +350,21 @@ case class BroadcastIndexJoinExec(
         })
       case _ =>
         streamResultsRaw.map(row => {
-          val serializedObject = boundStreamShape.eval(row).asInstanceOf[Array[Byte]]
-          if (serializedObject == null) {
-            (null, row)
-          } else {
-            val shape = if (isRasterPredicate) {
-              if (boundStreamShape.dataType.isInstanceOf[RasterUDT]) {
-                val raster = RasterSerializer.deserialize(serializedObject)
-                JoinedGeometryRaster.rasterToWGS84Envelope(raster)
-              } else {
-                val geom = GeometrySerializer.deserialize(serializedObject)
-                JoinedGeometryRaster.geometryToWGS84Envelope(geom)
-              }
+          val shape = if (isRasterPredicate) {
+            // Raster path keeps the legacy bytes-only handling — Box2D doesn't apply here.
+            val serializedObject = boundStreamShape.eval(row).asInstanceOf[Array[Byte]]
+            if (serializedObject == null) null
+            else if (boundStreamShape.dataType.isInstanceOf[RasterUDT]) {
+              val raster = RasterSerializer.deserialize(serializedObject)
+              JoinedGeometryRaster.rasterToWGS84Envelope(raster)
             } else {
-              GeometrySerializer.deserialize(serializedObject)
+              val geom = GeometrySerializer.deserialize(serializedObject)
+              JoinedGeometryRaster.geometryToWGS84Envelope(geom)
             }
-            (shape, row)
+          } else {
+            TraitJoinQueryBase.shapeToGeometry(boundStreamShape, row)
           }
+          (shape, row)
         })
     }
   }

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/JoinQueryDetector.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/JoinQueryDetector.scala
@@ -291,6 +291,31 @@ class JoinQueryDetector(sparkSession: SparkSession) extends SparkStrategy {
                 rightShape,
                 SpatialPredicate.EQUALS,
                 extraCondition)
+            // Box2D predicates. Both shape expressions resolve to Box2DUDT; the executors
+            // materialise each Box2D as a rectangular Polygon so the existing partitioner /
+            // R-tree / refine machinery applies unchanged. ST_BoxContains is closed-interval
+            // containment, so it maps to SpatialPredicate.COVERS (JTS `contains` would reject
+            // edge-touching cases).
+            case ST_BoxIntersects(Seq(leftShape, rightShape)) =>
+              Some(
+                JoinQueryDetection(
+                  left,
+                  right,
+                  leftShape,
+                  rightShape,
+                  SpatialPredicate.INTERSECTS,
+                  isGeography = false,
+                  extraCondition))
+            case ST_BoxContains(Seq(leftShape, rightShape)) =>
+              Some(
+                JoinQueryDetection(
+                  left,
+                  right,
+                  leftShape,
+                  rightShape,
+                  SpatialPredicate.COVERS,
+                  isGeography = false,
+                  extraCondition))
             case pred: ST_Predicate =>
               getJoinDetection(left, right, pred, extraCondition)
             case pred: RS_Predicate =>

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/OptimizableJoinCondition.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/OptimizableJoinCondition.scala
@@ -63,7 +63,7 @@ case class OptimizableJoinCondition(left: LogicalPlan, right: LogicalPlan) {
     expression match {
       case _: ST_Intersects | _: ST_Contains | _: ST_Covers | _: ST_Within | _: ST_CoveredBy |
           _: ST_Overlaps | _: ST_Touches | _: ST_Equals | _: ST_Crosses | _: ST_KNN |
-          _: RS_Predicate =>
+          _: ST_BoxIntersects | _: ST_BoxContains | _: RS_Predicate =>
         val leftShape = expression.children.head
         val rightShape = expression.children(1)
         ExpressionUtils.matchExpressionsToPlans(leftShape, rightShape, left, right).isDefined

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/TraitJoinQueryBase.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/TraitJoinQueryBase.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Expression, UnsafeRow}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.sedona_sql.UDT.{Box2DUDT, RasterUDT}
-import org.locationtech.jts.geom.Geometry
+import org.locationtech.jts.geom.{Geometry, GeometryFactory}
 
 trait TraitJoinQueryBase {
   self: SparkPlan =>
@@ -51,7 +51,10 @@ trait TraitJoinQueryBase {
     spatialRdd.setRawSpatialRDD(
       rdd
         .map { x =>
-          val shape = TraitJoinQueryBase.shapeToGeometry(shapeExpression, x)
+          // Null shape rows materialise as an empty geometry collection so they carry the row
+          // payload through the partitioner / index without participating in any spatial match
+          // — mirrors the pre-existing `GeometrySerializer.deserialize(null)` fallback.
+          val shape = TraitJoinQueryBase.shapeToGeometryOrEmpty(shapeExpression, x)
           shape.setUserData(x.copy)
           shape
         }
@@ -124,7 +127,7 @@ trait TraitJoinQueryBase {
     spatialRdd.setRawSpatialRDD(
       rdd
         .map { x =>
-          val shape = TraitJoinQueryBase.shapeToGeometry(shapeExpression, x)
+          val shape = TraitJoinQueryBase.shapeToGeometryOrEmpty(shapeExpression, x)
           val distance = boundRadius.eval(x).asInstanceOf[Double]
           val expandedEnvelope =
             JoinedGeometry.geometryToExpandedEnvelope(shape, distance, isGeography)
@@ -191,6 +194,15 @@ object TraitJoinQueryBase {
    * rectangle-rectangle predicates (`Polygon.isRectangle` triggers `RectangleIntersects` /
    * `RectangleContains`), so a `ST_BoxIntersects` join naturally pays only the four-double
    * envelope comparison at refine time.
+   *
+   * Inverted Box2D bounds (`xmin > xmax` / `ymin > ymax`) are rejected with the same
+   * `IllegalArgumentException` raised by `Predicates.boxIntersects` / `boxContains`. Inverted
+   * bounds have no defined planar meaning today (they are reserved for future
+   * antimeridian-wraparound semantics on Geography bboxes) and would silently mis-prune the
+   * R-tree if accepted here.
+   *
+   * Returns `null` when the shape column evaluates to NULL; the caller is expected to either skip
+   * the row or substitute an empty geometry.
    */
   def shapeToGeometry(shapeExpression: Expression, row: InternalRow): Geometry = {
     val evaluated = shapeExpression.eval(row)
@@ -200,14 +212,30 @@ object TraitJoinQueryBase {
       shapeExpression.dataType match {
         case _: Box2DUDT =>
           val box = evaluated.asInstanceOf[InternalRow]
-          Constructors
-            .polygonFromEnvelope(
-              box.getDouble(0),
-              box.getDouble(1),
-              box.getDouble(2),
-              box.getDouble(3))
+          val xmin = box.getDouble(0)
+          val ymin = box.getDouble(1)
+          val xmax = box.getDouble(2)
+          val ymax = box.getDouble(3)
+          if (xmin > xmax || ymin > ymax) {
+            throw new IllegalArgumentException(
+              "Box2D join input has inverted bounds (xmin > xmax or ymin > ymax). " +
+                "Planar Box2D predicates require ordered intervals; inverted bounds are " +
+                "reserved for future antimeridian wraparound semantics.")
+          }
+          Constructors.polygonFromEnvelope(xmin, ymin, xmax, ymax)
         case _ =>
           GeometrySerializer.deserialize(evaluated.asInstanceOf[Array[Byte]])
       }
+  }
+
+  /**
+   * Convenience wrapper that substitutes an empty geometry collection for NULL shapes. Used by
+   * the partitioned-RDD path where each row must carry a non-null geometry so the original
+   * `UnsafeRow` survives to outer-join output; spatial predicates against the empty geometry
+   * produce no matches, matching the legacy `GeometrySerializer.deserialize(null)` behaviour.
+   */
+  def shapeToGeometryOrEmpty(shapeExpression: Expression, row: InternalRow): Geometry = {
+    val shape = shapeToGeometry(shapeExpression, row)
+    if (shape == null) new GeometryFactory().createGeometryCollection() else shape
   }
 }

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/TraitJoinQueryBase.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/TraitJoinQueryBase.scala
@@ -18,14 +18,16 @@
  */
 package org.apache.spark.sql.sedona_sql.strategy.join
 
+import org.apache.sedona.common.Constructors
 import org.apache.sedona.common.S2Geography.GeographyWKBSerializer
 import org.apache.sedona.core.spatialRDD.SpatialRDD
 import org.apache.sedona.core.utils.SedonaConf
 import org.apache.sedona.sql.utils.{GeometrySerializer, RasterSerializer}
 import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Expression, UnsafeRow}
 import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.sedona_sql.UDT.RasterUDT
+import org.apache.spark.sql.sedona_sql.UDT.{Box2DUDT, RasterUDT}
 import org.locationtech.jts.geom.Geometry
 
 trait TraitJoinQueryBase {
@@ -49,8 +51,7 @@ trait TraitJoinQueryBase {
     spatialRdd.setRawSpatialRDD(
       rdd
         .map { x =>
-          val shape =
-            GeometrySerializer.deserialize(shapeExpression.eval(x).asInstanceOf[Array[Byte]])
+          val shape = TraitJoinQueryBase.shapeToGeometry(shapeExpression, x)
           shape.setUserData(x.copy)
           shape
         }
@@ -123,8 +124,7 @@ trait TraitJoinQueryBase {
     spatialRdd.setRawSpatialRDD(
       rdd
         .map { x =>
-          val shape =
-            GeometrySerializer.deserialize(shapeExpression.eval(x).asInstanceOf[Array[Byte]])
+          val shape = TraitJoinQueryBase.shapeToGeometry(shapeExpression, x)
           val distance = boundRadius.eval(x).asInstanceOf[Double]
           val expandedEnvelope =
             JoinedGeometry.geometryToExpandedEnvelope(shape, distance, isGeography)
@@ -176,5 +176,38 @@ trait TraitJoinQueryBase {
       dominantShapes.spatialPartitioning(sedonaConf.getJoinGridType, numPartitions)
       followerShapes.spatialPartitioning(dominantShapes.getPartitioner)
     }
+  }
+}
+
+object TraitJoinQueryBase {
+
+  /**
+   * Materialise a shape column value as a JTS [[Geometry]]. Box2D-typed columns are turned into
+   * the closed rectangular polygon implied by their `(xmin, ymin, xmax, ymax)` bounds; all other
+   * shape columns are deserialised from the Sedona geometry binary form.
+   *
+   * Producing a JTS rectangle here lets the rest of the join machinery — partitioner, R-tree
+   * `IndexBuilder`, refine evaluator — stay shape-agnostic. JTS already short-circuits
+   * rectangle-rectangle predicates (`Polygon.isRectangle` triggers `RectangleIntersects` /
+   * `RectangleContains`), so a `ST_BoxIntersects` join naturally pays only the four-double
+   * envelope comparison at refine time.
+   */
+  def shapeToGeometry(shapeExpression: Expression, row: InternalRow): Geometry = {
+    val evaluated = shapeExpression.eval(row)
+    if (evaluated == null) {
+      null
+    } else
+      shapeExpression.dataType match {
+        case _: Box2DUDT =>
+          val box = evaluated.asInstanceOf[InternalRow]
+          Constructors
+            .polygonFromEnvelope(
+              box.getDouble(0),
+              box.getDouble(1),
+              box.getDouble(2),
+              box.getDouble(3))
+        case _ =>
+          GeometrySerializer.deserialize(evaluated.asInstanceOf[Array[Byte]])
+      }
   }
 }

--- a/spark/common/src/test/scala/org/apache/sedona/sql/Box2DJoinSuite.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/Box2DJoinSuite.scala
@@ -138,12 +138,17 @@ class Box2DJoinSuite extends TestBaseScala {
       val invertedLeft =
         Seq((1, new org.apache.sedona.common.geometryObjects.Box2D(10.0, 0.0, 0.0, 10.0)))
           .toDF("id", "box")
-      val ex = intercept[org.apache.spark.SparkException] {
-        invertedLeft
-          .alias("L")
-          .join(broadcast(rightBoxes.alias("R")), expr("ST_BoxIntersects(L.box, R.box)"))
-          .collect()
-      }
+      val df = invertedLeft
+        .alias("L")
+        .join(broadcast(rightBoxes.alias("R")), expr("ST_BoxIntersects(L.box, R.box)"))
+      // Confirm the join is actually planned as BroadcastIndexJoinExec so the throw originates
+      // from the join-side `shapeToGeometry` validation, not from a row-by-row fallback that
+      // also happens to throw via `Predicates.boxIntersects`.
+      assert(
+        df.queryExecution.sparkPlan.collect { case b: BroadcastIndexJoinExec => b }.size == 1,
+        "Expected BroadcastIndexJoinExec — without it the test could pass via row-by-row " +
+          "predicate evaluation, hiding a regression in join optimization")
+      val ex = intercept[org.apache.spark.SparkException](df.collect())
       val cause = Iterator
         .iterate(ex: Throwable)(_.getCause)
         .takeWhile(_ != null)

--- a/spark/common/src/test/scala/org/apache/sedona/sql/Box2DJoinSuite.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/Box2DJoinSuite.scala
@@ -112,6 +112,46 @@ class Box2DJoinSuite extends TestBaseScala {
       assert(df.count() == 4)
     }
 
+    it("Null Box2D rows are safe and produce no matches") {
+      // A null shape on either side must not crash the executor and must not contribute matches
+      // (mirrors the existing GeometrySerializer.deserialize(null) → empty-collection fallback).
+      import sparkSession.implicits._
+      val withNullLeft = leftBoxes
+        .selectExpr("id", "box AS box")
+        .union(Seq((99, null.asInstanceOf[org.apache.sedona.common.geometryObjects.Box2D]))
+          .toDF("id", "box"))
+      val df = withNullLeft
+        .alias("L")
+        .join(broadcast(rightBoxes.alias("R")), expr("ST_BoxIntersects(L.box, R.box)"))
+      assert(df.count() == 4) // unchanged from the non-null fixture
+      // Range join path (no broadcast) also tolerates nulls.
+      val rangeDf = withNullLeft
+        .alias("L")
+        .join(rightBoxes.alias("R"), expr("ST_BoxIntersects(L.box, R.box)"))
+      assert(rangeDf.count() == 4)
+    }
+
+    it("Inverted Box2D bounds in a join throw IllegalArgumentException") {
+      import sparkSession.implicits._
+      // Construct an inverted Box2D directly via the Java constructor (the SQL ST_MakeBox2D
+      // doesn't validate, so this is how a stored column with inverted bounds would look).
+      val invertedLeft =
+        Seq((1, new org.apache.sedona.common.geometryObjects.Box2D(10.0, 0.0, 0.0, 10.0)))
+          .toDF("id", "box")
+      val ex = intercept[org.apache.spark.SparkException] {
+        invertedLeft
+          .alias("L")
+          .join(broadcast(rightBoxes.alias("R")), expr("ST_BoxIntersects(L.box, R.box)"))
+          .collect()
+      }
+      val cause = Iterator
+        .iterate(ex: Throwable)(_.getCause)
+        .takeWhile(_ != null)
+        .find(_.isInstanceOf[IllegalArgumentException])
+      assert(cause.isDefined, s"Expected IllegalArgumentException in cause chain, got: $ex")
+      assert(cause.get.getMessage.contains("inverted bounds"))
+    }
+
     it("Result is equivalent to ST_Intersects on the Box2D-as-polygon envelopes") {
       val viaBox = leftBoxes
         .alias("L")

--- a/spark/common/src/test/scala/org/apache/sedona/sql/Box2DJoinSuite.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/Box2DJoinSuite.scala
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.sql
+
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.functions.{broadcast, expr}
+import org.apache.spark.sql.sedona_sql.strategy.join.{BroadcastIndexJoinExec, RangeJoinExec}
+
+class Box2DJoinSuite extends TestBaseScala {
+
+  import Box2DJoinSuite.TestBox
+
+  /**
+   * Three left-side boxes and three right-side boxes wired so we can predict exact result sizes:
+   *
+   *   - L1=(0,0,10,10) R1=(5,5,15,15) — overlapping
+   *   - L1=(0,0,10,10) R2=(2,2,8,8) — R2 fully inside L1
+   *   - L2=(0,0,10,10) R1=(5,5,15,15) — overlapping
+   *   - L2=(0,0,10,10) R2=(2,2,8,8) — R2 fully inside L2
+   *   - L3 and R3 are disjoint from everything else; (L3,R3) is itself disjoint.
+   *
+   * Intersection-pair count: 4. Containment-pair count: 2 (L1⊇R2, L2⊇R2).
+   */
+  private def leftBoxes: DataFrame = {
+    import sparkSession.implicits._
+    Seq(TestBox(1, 0, 0, 10, 10), TestBox(2, 0, 0, 10, 10), TestBox(3, 20, 20, 30, 30))
+      .toDF("id", "xmin", "ymin", "xmax", "ymax")
+      .selectExpr("id", "ST_MakeBox2D(ST_Point(xmin, ymin), ST_Point(xmax, ymax)) AS box")
+  }
+
+  private def rightBoxes: DataFrame = {
+    import sparkSession.implicits._
+    Seq(TestBox(11, 5, 5, 15, 15), TestBox(12, 2, 2, 8, 8), TestBox(13, 40, 40, 50, 50))
+      .toDF("id", "xmin", "ymin", "xmax", "ymax")
+      .selectExpr("id", "ST_MakeBox2D(ST_Point(xmin, ymin), ST_Point(xmax, ymax)) AS box")
+  }
+
+  describe("Box2D spatial join") {
+
+    it("ST_BoxIntersects: broadcast index join produces correct pairs") {
+      val df = leftBoxes
+        .alias("L")
+        .join(broadcast(rightBoxes.alias("R")), expr("ST_BoxIntersects(L.box, R.box)"))
+      val plan = df.queryExecution.sparkPlan
+      assert(
+        plan.collect { case b: BroadcastIndexJoinExec => b }.size == 1,
+        "Expected BroadcastIndexJoinExec in the plan")
+      assert(df.count() == 4)
+    }
+
+    it("ST_BoxIntersects: argument order is symmetric") {
+      val swapped = leftBoxes
+        .alias("L")
+        .join(broadcast(rightBoxes.alias("R")), expr("ST_BoxIntersects(R.box, L.box)"))
+      assert(swapped.count() == 4)
+      assert(swapped.queryExecution.sparkPlan.collect { case b: BroadcastIndexJoinExec =>
+        b
+      }.size == 1)
+    }
+
+    it("ST_BoxContains: broadcast index join uses COVERS semantics") {
+      val df = leftBoxes
+        .alias("L")
+        .join(broadcast(rightBoxes.alias("R")), expr("ST_BoxContains(L.box, R.box)"))
+      assert(df.queryExecution.sparkPlan.collect { case b: BroadcastIndexJoinExec =>
+        b
+      }.size == 1)
+      assert(df.count() == 2)
+    }
+
+    it("ST_BoxContains: edge-touching boxes count (closed-interval semantics)") {
+      // R contained in L sharing an edge: ST_BoxContains is closed-interval, so this matches.
+      // JTS Polygon.contains would reject (strict-interior), JTS Polygon.covers accepts; the
+      // detector maps ST_BoxContains → SpatialPredicate.COVERS specifically for this case.
+      import sparkSession.implicits._
+      val outer = Seq(TestBox(1, 0, 0, 10, 10))
+        .toDF("id", "xmin", "ymin", "xmax", "ymax")
+        .selectExpr("id", "ST_MakeBox2D(ST_Point(xmin, ymin), ST_Point(xmax, ymax)) AS box")
+      // edge-sharing box: same xmax, shares the right edge with outer.
+      val inner = Seq(TestBox(11, 5, 5, 10, 10))
+        .toDF("id", "xmin", "ymin", "xmax", "ymax")
+        .selectExpr("id", "ST_MakeBox2D(ST_Point(xmin, ymin), ST_Point(xmax, ymax)) AS box")
+      val df = outer
+        .alias("O")
+        .join(broadcast(inner.alias("I")), expr("ST_BoxContains(O.box, I.box)"))
+      assert(df.count() == 1, "Closed-interval containment must include edge-touching boxes")
+    }
+
+    it("ST_BoxIntersects: non-broadcast range join produces the same count") {
+      val df = leftBoxes
+        .alias("L")
+        .join(rightBoxes.alias("R"), expr("ST_BoxIntersects(L.box, R.box)"))
+      assert(
+        df.queryExecution.sparkPlan.collect { case r: RangeJoinExec => r }.size == 1,
+        "Expected RangeJoinExec in the plan")
+      assert(df.count() == 4)
+    }
+
+    it("Result is equivalent to ST_Intersects on the Box2D-as-polygon envelopes") {
+      val viaBox = leftBoxes
+        .alias("L")
+        .join(broadcast(rightBoxes.alias("R")), expr("ST_BoxIntersects(L.box, R.box)"))
+        .selectExpr("L.id AS l", "R.id AS r")
+        .orderBy("l", "r")
+        .collect()
+        .toSeq
+
+      // ST_GeomFromBox2D is the function-form equivalent of `CAST(box AS geometry)`. The cast
+      // syntax requires the Sedona SQL parser extension; this suite runs under the common test
+      // base, which doesn't wire that extension, so we go through the function form here.
+      val asPolygons = leftBoxes
+        .selectExpr("id", "ST_GeomFromBox2D(box) AS g")
+        .alias("L")
+        .join(
+          broadcast(rightBoxes.selectExpr("id", "ST_GeomFromBox2D(box) AS g").alias("R")),
+          expr("ST_Intersects(L.g, R.g)"))
+        .selectExpr("L.id AS l", "R.id AS r")
+        .orderBy("l", "r")
+        .collect()
+        .toSeq
+
+      assert(viaBox == asPolygons)
+    }
+  }
+
+}
+
+object Box2DJoinSuite {
+  // Top-level case class so Spark's encoder doesn't need an outer-class reference.
+  case class TestBox(id: Int, xmin: Double, ymin: Double, xmax: Double, ymax: Double)
+}


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2939.

## What changes were proposed in this PR?

Teaches Sedona's spatial join planner about the Box2D predicates from #2926. After this PR, both broadcast index joins and distributed range joins handle:

- `ST_BoxIntersects(box_a, box_b)`
- `ST_BoxContains(box_a, box_b)` (both argument orders)

…using the same machinery (partitioner, R-tree, refine evaluator) that already powers `ST_Intersects` / `ST_Contains` joins. No new physical operator, no new index implementation, no new partitioning code.

### How it works

At every executor boundary where a shape column is materialised — `TraitJoinQueryBase.toSpatialRDD`, `TraitJoinQueryBase.toExpandedEnvelopeRDD`, and `BroadcastIndexJoinExec.createStreamShapes` — dispatch on the shape expression's `dataType`. If it is `Box2DUDT`, read the four doubles out of the serialized `InternalRow` and materialise the implied closed rectangular Polygon via `Constructors.polygonFromEnvelope`. Geometry columns continue through `GeometrySerializer.deserialize` as before.

The materialised Polygon flows through `SpatialRDD<T extends Geometry>`, the spatial partitioner's sample step, `IndexBuilder`'s R-tree, and `SpatialPredicateEvaluators` unchanged. JTS already short-circuits axis-aligned rectangle predicates via `RectangleIntersects` / `RectangleContains` (gated on `Polygon.isRectangle()`), which `polygonFromEnvelope` produces exactly. The refine step therefore pays only a four-double envelope comparison per pair — the savings the user expects from "we know the data is a box".

### Predicate-kind mapping

| Source predicate | `SpatialPredicate` |
| ---------------- | ------------------ |
| `ST_BoxIntersects(a, b)` | `INTERSECTS` |
| `ST_BoxContains(a, b)`   | `COVERS` |

`ST_BoxContains` deliberately maps to `COVERS`, not `CONTAINS`. PostGIS-style closed-interval containment counts edge-touching pairs as contained; JTS `Geometry.contains` excludes shared-edge pairs (strict interior), whereas `Geometry.covers` accepts them — which is what we want.

### What's left untouched

- The `Box2D` class hierarchy (still a value class).
- Storage / on-wire layout (still a struct of four doubles via `Box2DUDT`).
- `SpatialRDD`, the partitioners, the R-tree, the refine evaluator.
- The raster join path and all Geography join paths.

### Scope notes

`ST_DWithin` (distance join) only has `(Geometry, Geometry, distance)` and `(Geography, Geography, distance)` overloads today, so Box2D × Box2D distance joins are out of scope for this PR. Adding a `(Box2D, Box2D, distance)` overload is a follow-up.

## How was this patch tested?

New `Box2DJoinSuite` under `spark/common/src/test/scala/org/apache/sedona/sql/`:

- `ST_BoxIntersects` broadcast index join produces the expected 4 pairs from a 3×3 fixture, with `BroadcastIndexJoinExec` in the plan.
- `ST_BoxIntersects(R, L)` produces the same 4 pairs (argument order symmetric).
- `ST_BoxContains` broadcast index join produces the expected 2 closed-interval containment pairs.
- Edge-touching containment (closed-interval) is counted — locks in the `COVERS`-not-`CONTAINS` mapping.
- Non-broadcast range join produces the same 4 pairs with `RangeJoinExec` in the plan.
- Result is equivalent (same ordered row pairs) to `ST_Intersects` on the same data materialised as polygons via `ST_GeomFromBox2D`.

Run locally against Spark 3.5 / Scala 2.12. Regression runs: `BroadcastIndexJoinSuite` 65/65, `SpatialJoinSuite` 160/160, `Box2DUDTSuite` 5/5, `Box2DCastResolutionRuleSuite` 3/3, `GeoParquetSpatialFilterPushDownSuite` 25/25 — all still pass.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public SQL API documentation surface in isolation. The new spatial-join behavior for `ST_BoxIntersects` / `ST_BoxContains` is covered by the consolidated Phase 1+2+3 Box2D docs update.
