### PR TITLE
[SEDONA-753] feat: add eo:cloud_cover and eo:snow_cover STAC extensions to reader

### DIFF
--- a/docs/tutorial/files/stac-sedona-spark.md
+++ b/docs/tutorial/files/stac-sedona-spark.md
@@ -78,6 +78,8 @@ root
  |-- constellation: string (nullable = true)
  |-- mission: string (nullable = true)
  |-- grid:code: string (nullable = true)
+ |-- eo:cloud_cover: double (nullable = true)
+ |-- eo:snow_cover: double (nullable = true)
  |-- gsd: double (nullable = true)
  |-- collection: string (nullable = true)
  |-- links: array (nullable = true)
@@ -152,6 +154,16 @@ In this example, the data source will push down the temporal filter to the under
 ```
 
 In this example, the data source will push down the spatial filter to the underlying data source.
+
+### SQL Select With EO Extension Filter
+
+```sql
+  SELECT id, datetime, geometry, `eo:cloud_cover`
+  FROM STAC_TABLE
+  WHERE `eo:cloud_cover` < 20.0
+```
+
+This example filters items by cloud cover percentage from the [EO extension](https://github.com/stac-extensions/eo). The `eo:cloud_cover` and `eo:snow_cover` fields are automatically extracted when present in the STAC item properties.
 
 ### Sedona Configuration for STAC Reader
 

--- a/docs/tutorial/files/stac-sedona-spark.zh.md
+++ b/docs/tutorial/files/stac-sedona-spark.zh.md
@@ -78,6 +78,8 @@ root
  |-- constellation: string (nullable = true)
  |-- mission: string (nullable = true)
  |-- grid:code: string (nullable = true)
+ |-- eo:cloud_cover: double (nullable = true)
+ |-- eo:snow_cover: double (nullable = true)
  |-- gsd: double (nullable = true)
  |-- collection: string (nullable = true)
  |-- links: array (nullable = true)
@@ -152,6 +154,16 @@ SELECT id, datetime as dt, geometry, bbox FROM STAC_TABLE
 ```
 
 该例中，数据源会把空间过滤下推到底层数据源。
+
+### 带 EO 扩展过滤的 SQL Select
+
+```sql
+  SELECT id, datetime, geometry, `eo:cloud_cover`
+  FROM STAC_TABLE
+  WHERE `eo:cloud_cover` < 20.0
+```
+
+该例按 [EO 扩展](https://github.com/stac-extensions/eo) 中的云覆盖百分比进行过滤。当 STAC item properties 中包含 `eo:cloud_cover` 和 `eo:snow_cover` 字段时，会被自动提取。
 
 ### Sedona 的 STAC 读取器配置
 

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacExtension.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacExtension.scala
@@ -18,7 +18,7 @@
  */
 package org.apache.spark.sql.sedona_sql.io.stac
 
-import org.apache.spark.sql.types.{StringType, StructField, StructType}
+import org.apache.spark.sql.types.{DoubleType, StringType, StructField, StructType}
 
 /**
  * Defines a STAC extension with its schema and property mappings
@@ -49,9 +49,14 @@ object StacExtension {
       StacExtension(
         name = "grid",
         // Schema for the grid extension, add all required fields here
-        schema = StructType(Seq(StructField("grid:code", StringType, nullable = true))))
+        schema = StructType(Seq(StructField("grid:code", StringType, nullable = true)))),
 
       // Add other extensions here...
-    )
+      StacExtension(
+        name = "eo",
+        schema = StructType(Seq(StructField("eo:cloud_cover", DoubleType, nullable = true)))),
+      StacExtension(
+        name = "eo",
+        schema = StructType(Seq(StructField("eo:snow_cover", DoubleType, nullable = true)))))
   }
 }

--- a/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacDataSourceTest.scala
+++ b/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacDataSourceTest.scala
@@ -44,8 +44,18 @@ class StacDataSourceTest extends TestBaseScala {
   it("basic df load from local file with extensions should work") {
     val dfStac = sparkSession.read.format("stac").load(STAC_COLLECTION_LOCAL)
     // Filter rows where grid:code equals "MSIN-2506"
-    val filteredDf = dfStac.filter(dfStac.col("grid:code") === "MSIN-2506")
-    val rowCount = filteredDf.count()
+    var filteredDf = dfStac.filter(dfStac.col("grid:code") === "MSIN-2506")
+    var rowCount = filteredDf.count()
+    assert(rowCount > 0)
+
+    // Filter rows where eo:cloud_cover equals 1.2
+    filteredDf = dfStac.filter(dfStac.col("eo:cloud_cover") === 1.2)
+    rowCount = filteredDf.count()
+    assert(rowCount > 0)
+
+    // Filter rows where eo:snow_cover equals 0.0
+    filteredDf = dfStac.filter(dfStac.col("eo:snow_cover") === 0.0)
+    rowCount = filteredDf.count()
     assert(rowCount > 0)
   }
 
@@ -347,9 +357,10 @@ class StacDataSourceTest extends TestBaseScala {
     // Extension fields that may be present
     val extensionFields = Seq(
       // Grid extension fields
-      StructField("grid:code", StringType, nullable = true)
+      StructField("grid:code", StringType, nullable = true),
       // Add other extension fields as needed
-    )
+      StructField("eo:cloud_cover", DoubleType, nullable = true),
+      StructField("eo:snow_cover", DoubleType, nullable = true))
 
     // Check that all base fields are present with correct types
     baseFields.foreach { expectedField =>


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

- Adds `eo:cloud_cover` and `eo:snow_cover` STAC extension fields (from the [EO extension](https://stac-extensions.github.io/eo/v2.0.0-beta.1/schema.json)) to the STAC reader output schema when present in the source data. These are promoted as top-level `DoubleType` columns alongside the existing `grid:code` extension field.

## How was this patch tested?

- Extended existing extension test to filter on `eo:cloud_cover` and `eo:snow_cover` values from the local test STAC collection
- Updated schema validation test to include the new extension fields

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.