### PR TITLE
[SEDONA-751] RS_Interpolate band index and noDataValue handling

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/raster/RasterEditors.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterEditors.java
@@ -840,7 +840,9 @@ public class RasterEditors {
                       maxRadiusOrMinPoints);
               interpolatedValue =
                   (Double.isNaN(interpolatedValue)) ? noDataValue : interpolatedValue;
-              if (interpolatedValue != noDataValue) {
+              // Only decrement if interpolation actually succeeded (returned a valid value)
+              if (!Double.isNaN(interpolatedValue)
+                  && (Double.isNaN(noDataValue) || interpolatedValue != noDataValue)) {
                 countNoDataValues--;
               }
               raster.setSample(x, y, bandIndex, interpolatedValue);
@@ -861,9 +863,9 @@ public class RasterEditors {
             0,
             raster.getWidth(),
             raster.getHeight(),
-            band,
+            bandIndex,
             rasterData.getSamples(
-                0, 0, raster.getWidth(), raster.getHeight(), band, (double[]) null));
+                0, 0, raster.getWidth(), raster.getHeight(), bandIndex, (double[]) null));
       }
     }
 

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterEditorsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterEditorsTest.java
@@ -19,6 +19,7 @@
 package org.apache.sedona.common.raster;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 
 import java.awt.image.DataBuffer;
@@ -3575,6 +3576,39 @@ public class RasterEditorsTest extends RasterTestBase {
     assertEquals(
         Double.NaN, RasterUtils.getNoDataValue(modifiedRaster6.getSampleDimension(0)), 0.01d);
     assertEquals(0.0, RasterUtils.getNoDataValue(modifiedRaster6.getSampleDimension(1)), 0.01d);
+  }
+
+  /**
+   * Test that when interpolating a single band in a multi-band raster, the other bands are
+   * preserved unchanged.
+   */
+  @Test
+  public void testInterpolatePreservesOtherBands() throws FactoryException {
+    double[] band1Values =
+        new double[] {1, Double.NaN, 3, Double.NaN, 5, Double.NaN, 7, Double.NaN, 9};
+    double[] band2Values = new double[] {1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+    GridCoverage2D raster = RasterConstructors.makeEmptyRaster(2, 3, 3, 0, 0, 1);
+    // Use -9999 as noDataValue so 0 is preserved as a valid value
+    raster = MapAlgebra.addBandFromArray(raster, band1Values, 1, -9999.0);
+    raster = MapAlgebra.addBandFromArray(raster, band2Values, 2, -9999.0);
+
+    // Interpolate only band 1 (specify band=1), leaving band 2 unchanged
+    GridCoverage2D result = RasterEditors.interpolate(raster, 2.0, "Fixed", 3.0, 1.0, 1);
+
+    // Verify band 1 was interpolated (NaN values should be filled)
+    double[] resultBand1 = MapAlgebra.bandAsArray(result, 1);
+    for (int i = 0; i < resultBand1.length; i++) {
+      // Band 1 should not have any NaN values after interpolation
+      assertFalse("Band 1 should not have NaN at index " + i, Double.isNaN(resultBand1[i]));
+    }
+
+    // Verify band 2 is EXACTLY the same as original
+    double[] resultBand2 = MapAlgebra.bandAsArray(result, 2);
+    assertEquals(
+        "Band 2 should be preserved unchanged",
+        Arrays.toString(band2Values),
+        Arrays.toString(resultBand2));
   }
 
   @Test


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[SEDONA-XXX] my subject`.

## What changes were proposed in this PR?

Fixes two bugs in `RS_Interpolate`:

1. **Band index bug**: When interpolating a specific band in a multi-band raster, non-interpolated bands were copied using the wrong index variable (`band` instead of `bandIndex`), causing incorrect data in the output raster.

2. **noDataValue NaN comparison bug**: When `noDataValue` is `NaN`, the comparison `interpolatedValue != noDataValue` always returns `true` (since `NaN != NaN` in IEEE 754), causing `countNoDataValues` to be incorrectly decremented even when interpolation didn't produce a valid value. Fixed by using proper `Double.isNaN()` checks.

## How was this patch tested?

Added `testInterpolatePreservesOtherBands` test that creates a 2-band raster, interpolates only band 1, and verifies band 2 is preserved unchanged. Existing interpolation tests continue to pass.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.