### PR TITLE
[GH-2617] Reorder raster function signatures

### DIFF
--- a/docs/api/sql/Raster-Band-Accessors/RS_Count.md
+++ b/docs/api/sql/Raster-Band-Accessors/RS_Count.md
@@ -30,11 +30,11 @@ Introduction: Returns the number of pixels in a given band. If band is not speci
 
 Format:
 
-`RS_Count(raster: Raster, band: Integer = 1, excludeNoDataValue: Boolean = true)`
+`RS_Count(raster: Raster)`
 
 `RS_Count(raster: Raster, band: Integer = 1)`
 
-`RS_Count(raster: Raster)`
+`RS_Count(raster: Raster, band: Integer = 1, excludeNoDataValue: Boolean = true)`
 
 Return type: `Long`
 

--- a/docs/api/sql/Raster-Band-Accessors/RS_SummaryStats.md
+++ b/docs/api/sql/Raster-Band-Accessors/RS_SummaryStats.md
@@ -36,11 +36,11 @@ Introduction: Returns summary statistic for a particular band based on the `stat
 
 Formats:
 
-`RS_SummaryStats(raster: Raster, statType: String, band: Integer = 1, excludeNoDataValue: Boolean = true)`
+`RS_SummaryStats(raster: Raster, statType: String)`
 
 `RS_SummaryStats(raster: Raster, statType: String, band: Integer = 1)`
 
-`RS_SummaryStats(raster: Raster, statType: String)`
+`RS_SummaryStats(raster: Raster, statType: String, band: Integer = 1, excludeNoDataValue: Boolean = true)`
 
 Return type: `Double`
 

--- a/docs/api/sql/Raster-Band-Accessors/RS_SummaryStatsAll.md
+++ b/docs/api/sql/Raster-Band-Accessors/RS_SummaryStatsAll.md
@@ -30,11 +30,11 @@ Introduction: Returns summary stats struct consisting of count, sum, mean, stdde
 
 Formats:
 
-`RS_SummaryStatsAll(raster: Raster, band: Integer = 1, excludeNoDataValue: Boolean = true)`
+`RS_SummaryStatsAll(raster: Raster)`
 
 `RS_SummaryStatsAll(raster: Raster, band: Integer = 1)`
 
-`RS_SummaryStatsAll(raster: Raster)`
+`RS_SummaryStatsAll(raster: Raster, band: Integer = 1, excludeNoDataValue: Boolean = true)`
 
 Return type: `Struct<count: Long, sum: Double, mean: Double, stddev: Double, min: Double, max: Double>`
 

--- a/docs/api/sql/Raster-Band-Accessors/RS_ZonalStats.md
+++ b/docs/api/sql/Raster-Band-Accessors/RS_ZonalStats.md
@@ -53,15 +53,7 @@ The `allTouched` parameter (Since `v1.7.1`) determines how pixels are selected:
 Format:
 
 ```
-RS_ZonalStats(raster: Raster, zone: Geometry, band: Integer, statType: String, allTouched: Boolean, excludeNoData: Boolean, lenient: Boolean)
-```
-
-```
-RS_ZonalStats(raster: Raster, zone: Geometry, band: Integer, statType: String, allTouched: Boolean, excludeNoData: Boolean)
-```
-
-```
-RS_ZonalStats(raster: Raster, zone: Geometry, band: Integer, statType: String, allTouched: Boolean)
+RS_ZonalStats(raster: Raster, zone: Geometry, statType: String)
 ```
 
 ```
@@ -69,7 +61,15 @@ RS_ZonalStats(raster: Raster, zone: Geometry, band: Integer, statType: String)
 ```
 
 ```
-RS_ZonalStats(raster: Raster, zone: Geometry, statType: String)
+RS_ZonalStats(raster: Raster, zone: Geometry, band: Integer, statType: String, allTouched: Boolean)
+```
+
+```
+RS_ZonalStats(raster: Raster, zone: Geometry, band: Integer, statType: String, allTouched: Boolean, excludeNoData: Boolean)
+```
+
+```
+RS_ZonalStats(raster: Raster, zone: Geometry, band: Integer, statType: String, allTouched: Boolean, excludeNoData: Boolean, lenient: Boolean)
 ```
 
 Return type: `Double`

--- a/docs/api/sql/Raster-Band-Accessors/RS_ZonalStatsAll.md
+++ b/docs/api/sql/Raster-Band-Accessors/RS_ZonalStatsAll.md
@@ -53,15 +53,7 @@ The `allTouched` parameter (Since `v1.7.1`) determines how pixels are selected:
 Format:
 
 ```
-RS_ZonalStatsAll(raster: Raster, zone: Geometry, band: Integer, allTouched: Boolean, excludeNodata: Boolean, lenient: Boolean)
-```
-
-```
-RS_ZonalStatsAll(raster: Raster, zone: Geometry, band: Integer, allTouched: Boolean, excludeNodata: Boolean)
-```
-
-```
-RS_ZonalStatsAll(raster: Raster, zone: Geometry, band: Integer, allTouched: Boolean)
+RS_ZonalStatsAll(raster: Raster, zone: Geometry)
 ```
 
 ```
@@ -69,7 +61,15 @@ RS_ZonalStatsAll(raster: Raster, zone: Geometry, band: Integer)
 ```
 
 ```
-RS_ZonalStatsAll(raster: Raster, zone: Geometry)
+RS_ZonalStatsAll(raster: Raster, zone: Geometry, band: Integer, allTouched: Boolean)
+```
+
+```
+RS_ZonalStatsAll(raster: Raster, zone: Geometry, band: Integer, allTouched: Boolean, excludeNodata: Boolean)
+```
+
+```
+RS_ZonalStatsAll(raster: Raster, zone: Geometry, band: Integer, allTouched: Boolean, excludeNodata: Boolean, lenient: Boolean)
 ```
 
 Return type: `Struct<count: Long, sum: Double, mean: Double, median: Double, mode: Double, stddev: Double, variance: Double, min: Double, max: Double>`

--- a/docs/api/sql/Raster-Operators/RS_AddBand.md
+++ b/docs/api/sql/Raster-Operators/RS_AddBand.md
@@ -32,7 +32,7 @@ If no `toRasterIndex` is provided, the new band is appended to the end of `toRas
 Format:
 
 ```
-RS_AddBand(toRaster: Raster, fromRaster: Raster, fromBand: Integer = 1, toRasterIndex: Integer = at_end)
+RS_AddBand(toRaster: Raster, fromRaster: Raster)
 ```
 
 ```
@@ -40,7 +40,7 @@ RS_AddBand(toRaster: Raster, fromRaster: Raster, fromBand: Integer = 1)
 ```
 
 ```
-RS_AddBand(toRaster: Raster, fromRaster: Raster)
+RS_AddBand(toRaster: Raster, fromRaster: Raster, fromBand: Integer = 1, toRasterIndex: Integer = at_end)
 ```
 
 Return type: `Raster`

--- a/docs/api/sql/Raster-Operators/RS_AsRaster.md
+++ b/docs/api/sql/Raster-Operators/RS_AsRaster.md
@@ -32,15 +32,7 @@ Introduction: `RS_AsRaster` converts a vector geometry into a raster dataset by 
 Format:
 
 ```
-RS_AsRaster(geom: Geometry, raster: Raster, pixelType: String, allTouched: Boolean, value: Double, noDataValue: Double, useGeometryExtent: Boolean)
-```
-
-```
-RS_AsRaster(geom: Geometry, raster: Raster, pixelType: String, allTouched: Boolean, value: Double, noDataValue: Double)
-```
-
-```
-RS_AsRaster(geom: Geometry, raster: Raster, pixelType: String, allTouched: Boolean, value: Double)
+RS_AsRaster(geom: Geometry, raster: Raster, pixelType: String)
 ```
 
 ```
@@ -48,7 +40,15 @@ RS_AsRaster(geom: Geometry, raster: Raster, pixelType: String, allTouched: Boole
 ```
 
 ```
-RS_AsRaster(geom: Geometry, raster: Raster, pixelType: String)
+RS_AsRaster(geom: Geometry, raster: Raster, pixelType: String, allTouched: Boolean, value: Double)
+```
+
+```
+RS_AsRaster(geom: Geometry, raster: Raster, pixelType: String, allTouched: Boolean, value: Double, noDataValue: Double)
+```
+
+```
+RS_AsRaster(geom: Geometry, raster: Raster, pixelType: String, allTouched: Boolean, value: Double, noDataValue: Double, useGeometryExtent: Boolean)
 ```
 
 Return type: `Raster`

--- a/docs/api/sql/Raster-Operators/RS_Clip.md
+++ b/docs/api/sql/Raster-Operators/RS_Clip.md
@@ -37,15 +37,7 @@ The `allTouched` parameter (Since `v1.7.1`) determines how pixels are selected:
 Format:
 
 ```
-RS_Clip(raster: Raster, band: Integer, geom: Geometry, allTouched: Boolean, noDataValue: Double, crop: Boolean, lenient: Boolean)
-```
-
-```
-RS_Clip(raster: Raster, band: Integer, geom: Geometry, allTouched: Boolean, noDataValue: Double, crop: Boolean)
-```
-
-```
-RS_Clip(raster: Raster, band: Integer, geom: Geometry, allTouched: Boolean, noDataValue: Double)
+RS_Clip(raster: Raster, band: Integer, geom: Geometry)
 ```
 
 ```
@@ -53,7 +45,15 @@ RS_Clip(raster: Raster, band: Integer, geom: Geometry, allTouched: Boolean)
 ```
 
 ```
-RS_Clip(raster: Raster, band: Integer, geom: Geometry)
+RS_Clip(raster: Raster, band: Integer, geom: Geometry, allTouched: Boolean, noDataValue: Double)
+```
+
+```
+RS_Clip(raster: Raster, band: Integer, geom: Geometry, allTouched: Boolean, noDataValue: Double, crop: Boolean)
+```
+
+```
+RS_Clip(raster: Raster, band: Integer, geom: Geometry, allTouched: Boolean, noDataValue: Double, crop: Boolean, lenient: Boolean)
 ```
 
 Return type: `Raster`

--- a/docs/api/sql/Raster-Operators/RS_Resample.md
+++ b/docs/api/sql/Raster-Operators/RS_Resample.md
@@ -49,7 +49,7 @@ For more information about ScaleX, ScaleY, SkewX, SkewY, please refer to the [Af
 Format:
 
 ```sql
-RS_Resample(raster: Raster, widthOrScale: Double, heightOrScale: Double, gridX: Double, gridY: Double, useScale: Boolean, algorithm: String)
+RS_Resample(raster: Raster, referenceRaster: Raster, useScale: Boolean, algorithm: String)
 ```
 
 ```sql
@@ -57,7 +57,7 @@ RS_Resample(raster: Raster, widthOrScale: Double, heightOrScale: Double, useScal
 ```
 
 ```sql
-RS_Resample(raster: Raster, referenceRaster: Raster, useScale: Boolean, algorithm: String)
+RS_Resample(raster: Raster, widthOrScale: Double, heightOrScale: Double, gridX: Double, gridY: Double, useScale: Boolean, algorithm: String)
 ```
 
 Return type: `Raster`

--- a/docs/api/sql/Raster-Operators/RS_SetBandNoDataValue.md
+++ b/docs/api/sql/Raster-Operators/RS_SetBandNoDataValue.md
@@ -33,11 +33,11 @@ Since `v1.5.1`, this function supports the ability to replace the current no-dat
 Format:
 
 ```
-RS_SetBandNoDataValue(raster: Raster, bandIndex: Integer, noDataValue: Double, replace: Boolean)
+RS_SetBandNoDataValue(raster: Raster, bandIndex: Integer = 1, noDataValue: Double)
 ```
 
 ```
-RS_SetBandNoDataValue(raster: Raster, bandIndex: Integer = 1, noDataValue: Double)
+RS_SetBandNoDataValue(raster: Raster, bandIndex: Integer, noDataValue: Double, replace: Boolean)
 ```
 
 Return type: `Raster`

--- a/docs/api/sql/Raster-Operators/RS_SetValues.md
+++ b/docs/api/sql/Raster-Operators/RS_SetValues.md
@@ -30,11 +30,11 @@ to this function.
 Format without ROI `geom`:
 
 ```
-RS_SetValues(raster: Raster, bandIndex: Integer, colX: Integer, rowY: Integer, width: Integer, height: Integer, newValues: ARRAY[Double], keepNoData: Boolean = false)
+RS_SetValues(raster: Raster, bandIndex: Integer, colX: Integer, rowY: Integer, width: Integer, height: Integer, newValues: ARRAY[Double])
 ```
 
 ```
-RS_SetValues(raster: Raster, bandIndex: Integer, colX: Integer, rowY: Integer, width: Integer, height: Integer, newValues: ARRAY[Double])
+RS_SetValues(raster: Raster, bandIndex: Integer, colX: Integer, rowY: Integer, width: Integer, height: Integer, newValues: ARRAY[Double], keepNoData: Boolean = false)
 ```
 
 Return type: `Raster`
@@ -60,7 +60,7 @@ The `allTouched` parameter (Since `v1.7.1`) determines how pixels are selected:
 Format with ROI `geom`:
 
 ```
-RS_SetValues(raster: Raster, bandIndex: Integer, geom: Geometry, newValue: Double, allTouched: Boolean = false, keepNoData: Boolean = false)
+RS_SetValues(raster: Raster, bandIndex: Integer, geom: Geometry, newValue: Double)
 ```
 
 ```
@@ -68,7 +68,7 @@ RS_SetValues(raster: Raster, bandIndex: Integer, geom: Geometry, newValue: Doubl
 ```
 
 ```
-RS_SetValues(raster: Raster, bandIndex: Integer, geom: Geometry, newValue: Double)
+RS_SetValues(raster: Raster, bandIndex: Integer, geom: Geometry, newValue: Double, allTouched: Boolean = false, keepNoData: Boolean = false)
 ```
 
 SQL Example


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2617

## What changes were proposed in this PR?

This reorders raster function format signatures from the shortest form to the longest form, so optional parameters are introduced progressively.

The patch keeps the change docs-only and updates the raster operator/band accessor pages where the reversed ordering still existed.

## How was this patch tested?

- `git diff --check`
- Static format-block check that the changed `RS_*` signatures are ordered by increasing argument count

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.

This was implemented with Codex assistance, with the final diff reviewed before posting.