### PR TITLE
[CI] Fix pre-commit black-jupyter failure and drop stale First Interaction badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@
 [![Docker image build](https://github.com/apache/sedona/actions/workflows/docker-build.yml/badge.svg)](https://github.com/apache/sedona/actions/workflows/docker-build.yml)
 [![Docs build](https://github.com/apache/sedona/actions/workflows/docs.yml/badge.svg)](https://github.com/apache/sedona/actions/workflows/docs.yml)
 [![Example project build](https://github.com/apache/sedona/actions/workflows/example.yml/badge.svg)](https://github.com/apache/sedona/actions/workflows/example.yml)
-[![First Interaction Workflow Status](https://github.com/apache/sedona/actions/workflows/first-interaction.yml/badge.svg)](https://github.com/apache/sedona/actions/workflows/first-interaction.yml)
 [![Manual Hooks Workflow Status](https://github.com/apache/sedona/actions/workflows/pre-commit-manual.yml/badge.svg)](https://github.com/apache/sedona/actions/workflows/pre-commit-manual.yml)
 [![Pre-commit Workflow Status](https://github.com/apache/sedona/actions/workflows/pre-commit.yml/badge.svg)](https://github.com/apache/sedona/actions/workflows/pre-commit.yml)
 [![Python build](https://github.com/apache/sedona/actions/workflows/python.yml/badge.svg)](https://github.com/apache/sedona/actions/workflows/python.yml)

--- a/python/sedona/spark/raster/sedona_raster.py
+++ b/python/sedona/spark/raster/sedona_raster.py
@@ -258,9 +258,7 @@ class SedonaRaster(ABC):
 
         Only supported on InDbSedonaRaster.
         """
-        raise TypeError(
-            f"with_bands() is not supported on {type(self).__name__}."
-        )
+        raise TypeError(f"with_bands() is not supported on {type(self).__name__}.")
 
     def __enter__(self):
         return self


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

- Reformat `python/sedona/spark/raster/sedona_raster.py:258` so the `raise TypeError(...)` call fits on a single line. The previous multi-line form was rejected by `black-jupyter`, which broke the `pre-commit` workflow on `master` after #2956 ([failing run](https://github.com/apache/sedona/actions/runs/26051825101)).
- Remove the `First Interaction Workflow Status` badge from `README.md`. The underlying workflow was deleted in #2965, so the badge is broken.

## How was this patch tested?

- `pre-commit run --files python/sedona/spark/raster/sedona_raster.py README.md` passes locally.
- CI on this PR re-runs the `pre-commit` workflow.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.