### PR TITLE
[CI] Pin codeql actions to hash

### DIFF
--- a/.github/linters/zizmor.yml
+++ b/.github/linters/zizmor.yml
@@ -19,7 +19,6 @@ rules:
   unpinned-uses:
     config:
       policies:
-        github/*: any
         r-lib/actions/check-r-package: any
         r-lib/actions/setup-r: any
         r-lib/actions/setup-r-dependencies: any

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,12 +45,12 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           languages: ${{ matrix.language }}
           build-mode: none
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           category: 'Security'


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

refs #2821 

## How was this patch tested?

With zizmor with pre-commit.  We will see the CodeQL action running on the GitHub CI.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
