### PR TITLE
[CI] Clean up link checker workflow

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -24,8 +24,6 @@ on:
   repository_dispatch:
   workflow_dispatch:
   pull_request:
-  schedule:
-    - cron: '7 1 * * 0' # At 01:07 on Sunday.
 
 jobs:
   check-links:
@@ -42,21 +40,3 @@ jobs:
         with:
           args: --config lychee.toml .
           fail: false
-
-      - name: Broken Links Report
-        if: steps.lychee.outputs.exit_code != 0 && github.event_name == 'schedule'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          script: |
-            const fs = require('fs');
-
-            // Read the markdown file
-            // Ensure the path is correct relative to the workspace root
-            const reportBody = fs.readFileSync('./lychee/out.md', 'utf8');
-
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: 'Broken Links Report',
-              body: reportBody
-            });


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

The cron job has been removed since we don't need a report every week filling our issue list.

I removed the report as well.  Just using the standard lychee action

https://github.com/lycheeverse/lychee-action

## How was this patch tested?

Runs on the CI but I did run basic checks with pre-commit

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
