### PR TITLE
[GH-2979] ST_Split: support puntal input (Point, MultiPoint)

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/utils/GeometrySplitter.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/GeometrySplitter.java
@@ -68,9 +68,74 @@ public final class GeometrySplitter {
       result = splitLines(input, blade);
     } else if (GeomUtils.geometryIsPolygonal(input)) {
       result = splitPolygons(input, blade);
+    } else if (GeomUtils.geometryIsPuntal(input)) {
+      result = splitPoints(input, blade);
     }
 
     return result;
+  }
+
+  /**
+   * Split puntal input geometry by the blade geometry. Mirrors the PostGIS 3.2+ behaviour:
+   *
+   * <ul>
+   *   <li>When the blade is polygonal, partition the input points into those inside (covered by)
+   *       the polygon and those outside, and return both groups as MULTIPOINTs wrapped in a
+   *       GEOMETRYCOLLECTION.
+   *   <li>When the blade is puntal, return a MULTIPOINT with the blade points removed from the
+   *       input (set-difference of coordinates).
+   * </ul>
+   *
+   * @param input puntal input geometry (Point or MultiPoint)
+   * @param blade blade geometry — polygonal or puntal
+   * @return result of the split, or {@code null} if the blade type is unsupported
+   */
+  public GeometryCollection splitPoints(Geometry input, Geometry blade) {
+    if (GeomUtils.geometryIsPolygonal(blade)) {
+      return splitPointsByPolygon(input, blade);
+    } else if (GeomUtils.geometryIsPuntal(blade)) {
+      return splitPointsByPoints(input, blade);
+    }
+    return null;
+  }
+
+  private GeometryCollection splitPointsByPolygon(Geometry points, Geometry polygons) {
+    List<Point> inside = new ArrayList<>();
+    List<Point> outside = new ArrayList<>();
+
+    for (int i = 0; i < points.getNumGeometries(); i++) {
+      Point p = (Point) points.getGeometryN(i);
+      if (polygons.covers(p)) {
+        inside.add(p);
+      } else {
+        outside.add(p);
+      }
+    }
+
+    List<Geometry> parts = new ArrayList<>();
+    if (!inside.isEmpty()) {
+      parts.add(geometryFactory.createMultiPoint(inside.toArray(new Point[0])));
+    }
+    if (!outside.isEmpty()) {
+      parts.add(geometryFactory.createMultiPoint(outside.toArray(new Point[0])));
+    }
+    return geometryFactory.createGeometryCollection(parts.toArray(new Geometry[0]));
+  }
+
+  private MultiPoint splitPointsByPoints(Geometry input, Geometry blade) {
+    java.util.Set<Coordinate> bladeCoords = new java.util.HashSet<>();
+    for (Coordinate c : blade.getCoordinates()) {
+      bladeCoords.add(c);
+    }
+
+    List<Point> remaining = new ArrayList<>();
+    for (int i = 0; i < input.getNumGeometries(); i++) {
+      Point p = (Point) input.getGeometryN(i);
+      if (!bladeCoords.contains(p.getCoordinate())) {
+        remaining.add(p);
+      }
+    }
+    return geometryFactory.createMultiPoint(remaining.toArray(new Point[0]));
   }
 
   /**

--- a/common/src/main/java/org/apache/sedona/common/utils/GeometrySplitter.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/GeometrySplitter.java
@@ -47,15 +47,16 @@ public final class GeometrySplitter {
 
   /**
    * Split input geometry by the blade geometry. Input geometry can be lineal (LineString or
-   * MultiLineString) or polygonal (Polygon or MultiPolygon). A GeometryCollection can also be used
-   * as an input, but it must be homogeneous. For lineal geometry refer to the {@link
-   * splitLines(Geometry, Geometry) splitLines} method for restrictions on the blade. Refer to
-   * {@link splitPolygons(Geometry, Geometry) splitPolygons} for restrictions on the blade for
-   * polygonal input geometry.
+   * MultiLineString), polygonal (Polygon or MultiPolygon), or puntal (Point or MultiPoint). A
+   * GeometryCollection can also be used as an input, but it must be homogeneous. For lineal
+   * geometry refer to the {@link splitLines(Geometry, Geometry) splitLines} method for restrictions
+   * on the blade. Refer to {@link splitPolygons(Geometry, Geometry) splitPolygons} for restrictions
+   * on the blade for polygonal input geometry. Puntal input is partitioned by polygon coverage —
+   * see {@link splitPoints(Geometry, Geometry) splitPoints}.
    *
    * <p>The result will be null if the input geometry and blade are either invalid in general or in
-   * relation to each other. Otherwise, the result will always be a MultiLineString or MultiPolygon
-   * depending on the input, and even if the result is a single geometry.
+   * relation to each other. Otherwise the result is a MultiLineString for lineal input, a
+   * MultiPolygon for polygonal input, or a GeometryCollection of MultiPoints for puntal input.
    *
    * @param input input geometry
    * @param blade geometry to use as a blade

--- a/common/src/main/java/org/apache/sedona/common/utils/GeometrySplitter.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/GeometrySplitter.java
@@ -76,35 +76,33 @@ public final class GeometrySplitter {
   }
 
   /**
-   * Split puntal input geometry by the blade geometry. Mirrors the PostGIS 3.2+ behaviour:
+   * Split puntal input geometry by the blade geometry. Sedona-specific extension on top of the
+   * lineal/polygonal cases described in the PostGIS docs: partition the input points into those
+   * covered by the polygonal blade and those that are not, and return both groups as MULTIPOINTs
+   * wrapped in a GEOMETRYCOLLECTION. The union of the two MULTIPOINTs reconstructs the input.
    *
-   * <ul>
-   *   <li>When the blade is polygonal, partition the input points into those inside (covered by)
-   *       the polygon and those outside, and return both groups as MULTIPOINTs wrapped in a
-   *       GEOMETRYCOLLECTION.
-   *   <li>When the blade is puntal, return a MULTIPOINT with the blade points removed from the
-   *       input (set-difference of coordinates).
-   * </ul>
+   * <p>Only polygonal blades are supported. The input may be a Point, MultiPoint, or a homogeneous
+   * GeometryCollection of points — nested puntal collections are flattened by walking coordinates.
    *
-   * @param input puntal input geometry (Point or MultiPoint)
-   * @param blade blade geometry — polygonal or puntal
+   * @param input puntal input geometry
+   * @param blade blade geometry; must be polygonal
    * @return result of the split, or {@code null} if the blade type is unsupported
    */
   public GeometryCollection splitPoints(Geometry input, Geometry blade) {
-    if (GeomUtils.geometryIsPolygonal(blade)) {
-      return splitPointsByPolygon(input, blade);
-    } else if (GeomUtils.geometryIsPuntal(blade)) {
-      return splitPointsByPoints(input, blade);
+    if (!GeomUtils.geometryIsPolygonal(blade)) {
+      return null;
     }
-    return null;
+    return splitPointsByPolygon(input, blade);
   }
 
   private GeometryCollection splitPointsByPolygon(Geometry points, Geometry polygons) {
     List<Point> inside = new ArrayList<>();
     List<Point> outside = new ArrayList<>();
 
-    for (int i = 0; i < points.getNumGeometries(); i++) {
-      Point p = (Point) points.getGeometryN(i);
+    // Walk coordinates so homogeneous puntal collections (including nested ones like
+    // GEOMETRYCOLLECTION(MULTIPOINT(...), POINT(...))) are flattened without a class cast.
+    for (Coordinate c : points.getCoordinates()) {
+      Point p = geometryFactory.createPoint(c);
       if (polygons.covers(p)) {
         inside.add(p);
       } else {
@@ -120,22 +118,6 @@ public final class GeometrySplitter {
       parts.add(geometryFactory.createMultiPoint(outside.toArray(new Point[0])));
     }
     return geometryFactory.createGeometryCollection(parts.toArray(new Geometry[0]));
-  }
-
-  private MultiPoint splitPointsByPoints(Geometry input, Geometry blade) {
-    java.util.Set<Coordinate> bladeCoords = new java.util.HashSet<>();
-    for (Coordinate c : blade.getCoordinates()) {
-      bladeCoords.add(c);
-    }
-
-    List<Point> remaining = new ArrayList<>();
-    for (int i = 0; i < input.getNumGeometries(); i++) {
-      Point p = (Point) input.getGeometryN(i);
-      if (!bladeCoords.contains(p.getCoordinate())) {
-        remaining.add(p);
-      }
-    }
-    return geometryFactory.createMultiPoint(remaining.toArray(new Point[0]));
   }
 
   /**

--- a/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
@@ -570,6 +570,103 @@ public class FunctionsTest extends TestBase {
   }
 
   @Test
+  public void splitMultiPointByPolygon() {
+    // PostGIS 3.2+ parity: partition a MultiPoint into points inside and outside the polygon.
+    MultiPoint multiPoint =
+        GEOMETRY_FACTORY.createMultiPointFromCoords(coordArray(1.0, 1.0, 5.0, 5.0, 15.0, 15.0));
+    Polygon polygon =
+        GEOMETRY_FACTORY.createPolygon(
+            coordArray(0.0, 0.0, 10.0, 0.0, 10.0, 10.0, 0.0, 10.0, 0.0, 0.0));
+
+    String actualResult = Functions.split(multiPoint, polygon).norm().toText();
+    String expectedResult = "GEOMETRYCOLLECTION (MULTIPOINT ((1 1), (5 5)), MULTIPOINT ((15 15)))";
+
+    assertEquals(expectedResult, actualResult);
+  }
+
+  @Test
+  public void splitMultiPointAllInsidePolygon() {
+    MultiPoint multiPoint =
+        GEOMETRY_FACTORY.createMultiPointFromCoords(coordArray(1.0, 1.0, 5.0, 5.0));
+    Polygon polygon =
+        GEOMETRY_FACTORY.createPolygon(
+            coordArray(0.0, 0.0, 10.0, 0.0, 10.0, 10.0, 0.0, 10.0, 0.0, 0.0));
+
+    String actualResult = Functions.split(multiPoint, polygon).norm().toText();
+    // Only the inside group is present — the outside group is omitted because it is empty.
+    String expectedResult = "GEOMETRYCOLLECTION (MULTIPOINT ((1 1), (5 5)))";
+
+    assertEquals(expectedResult, actualResult);
+  }
+
+  @Test
+  public void splitMultiPointAllOutsidePolygon() {
+    MultiPoint multiPoint =
+        GEOMETRY_FACTORY.createMultiPointFromCoords(coordArray(20.0, 20.0, 30.0, 30.0));
+    Polygon polygon =
+        GEOMETRY_FACTORY.createPolygon(
+            coordArray(0.0, 0.0, 10.0, 0.0, 10.0, 10.0, 0.0, 10.0, 0.0, 0.0));
+
+    String actualResult = Functions.split(multiPoint, polygon).norm().toText();
+    String expectedResult = "GEOMETRYCOLLECTION (MULTIPOINT ((20 20), (30 30)))";
+
+    assertEquals(expectedResult, actualResult);
+  }
+
+  @Test
+  public void splitMultiPointOnPolygonBoundaryGoesToInside() {
+    // Points on the polygon boundary are covered by it, so they fall in the "inside" group.
+    MultiPoint multiPoint =
+        GEOMETRY_FACTORY.createMultiPointFromCoords(coordArray(0.0, 5.0, 5.0, 5.0, 20.0, 20.0));
+    Polygon polygon =
+        GEOMETRY_FACTORY.createPolygon(
+            coordArray(0.0, 0.0, 10.0, 0.0, 10.0, 10.0, 0.0, 10.0, 0.0, 0.0));
+
+    String actualResult = Functions.split(multiPoint, polygon).norm().toText();
+    String expectedResult = "GEOMETRYCOLLECTION (MULTIPOINT ((0 5), (5 5)), MULTIPOINT ((20 20)))";
+
+    assertEquals(expectedResult, actualResult);
+  }
+
+  @Test
+  public void splitPointByPolygon() {
+    // A single Point input is treated as a one-element MultiPoint.
+    Point point = GEOMETRY_FACTORY.createPoint(new Coordinate(5.0, 5.0));
+    Polygon polygon =
+        GEOMETRY_FACTORY.createPolygon(
+            coordArray(0.0, 0.0, 10.0, 0.0, 10.0, 10.0, 0.0, 10.0, 0.0, 0.0));
+
+    String actualResult = Functions.split(point, polygon).norm().toText();
+    String expectedResult = "GEOMETRYCOLLECTION (MULTIPOINT ((5 5)))";
+
+    assertEquals(expectedResult, actualResult);
+  }
+
+  @Test
+  public void splitMultiPointByMultiPoint() {
+    // PostGIS 3.2+ parity: remove coordinates present in the blade from the input.
+    MultiPoint input =
+        GEOMETRY_FACTORY.createMultiPointFromCoords(coordArray(1.0, 1.0, 2.0, 2.0, 3.0, 3.0));
+    MultiPoint blade = GEOMETRY_FACTORY.createMultiPointFromCoords(coordArray(2.0, 2.0));
+
+    String actualResult = Functions.split(input, blade).norm().toText();
+    String expectedResult = "MULTIPOINT ((1 1), (3 3))";
+
+    assertEquals(expectedResult, actualResult);
+  }
+
+  @Test
+  public void splitPointByUnsupportedBladeReturnsNull() {
+    // Puntal input with a lineal blade has no PostGIS-defined behavior — return null.
+    Point point = GEOMETRY_FACTORY.createPoint(new Coordinate(5.0, 5.0));
+    LineString blade = GEOMETRY_FACTORY.createLineString(coordArray(0.0, 0.0, 10.0, 10.0));
+
+    Geometry actualResult = Functions.split(point, blade);
+
+    assertNull(actualResult);
+  }
+
+  @Test
   public void splitCircleInto2SemiCircles() throws ParseException {
     String polygonWkt =
         "POLYGON ((-117.76405581088967 34.111876749328026, -117.76407506132291 34.11170068822483, "

--- a/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
@@ -571,7 +571,8 @@ public class FunctionsTest extends TestBase {
 
   @Test
   public void splitMultiPointByPolygon() {
-    // PostGIS 3.2+ parity: partition a MultiPoint into points inside and outside the polygon.
+    // Partition a MultiPoint into points inside and outside the polygon. The union of the two
+    // MultiPoints reconstructs the original input.
     MultiPoint multiPoint =
         GEOMETRY_FACTORY.createMultiPointFromCoords(coordArray(1.0, 1.0, 5.0, 5.0, 15.0, 15.0));
     Polygon polygon =
@@ -579,6 +580,27 @@ public class FunctionsTest extends TestBase {
             coordArray(0.0, 0.0, 10.0, 0.0, 10.0, 10.0, 0.0, 10.0, 0.0, 0.0));
 
     String actualResult = Functions.split(multiPoint, polygon).norm().toText();
+    String expectedResult = "GEOMETRYCOLLECTION (MULTIPOINT ((1 1), (5 5)), MULTIPOINT ((15 15)))";
+
+    assertEquals(expectedResult, actualResult);
+  }
+
+  @Test
+  public void splitHomogeneousPuntalGeometryCollectionByPolygon() {
+    // Nested puntal collection: GeometryCollection of a MultiPoint and a Point. Must be flattened
+    // by walking coordinates rather than casting children to Point (which would ClassCastException
+    // on the MultiPoint child).
+    Geometry collection =
+        GEOMETRY_FACTORY.createGeometryCollection(
+            new Geometry[] {
+              GEOMETRY_FACTORY.createMultiPointFromCoords(coordArray(1.0, 1.0, 5.0, 5.0)),
+              GEOMETRY_FACTORY.createPoint(new Coordinate(15.0, 15.0))
+            });
+    Polygon polygon =
+        GEOMETRY_FACTORY.createPolygon(
+            coordArray(0.0, 0.0, 10.0, 0.0, 10.0, 10.0, 0.0, 10.0, 0.0, 0.0));
+
+    String actualResult = Functions.split(collection, polygon).norm().toText();
     String expectedResult = "GEOMETRYCOLLECTION (MULTIPOINT ((1 1), (5 5)), MULTIPOINT ((15 15)))";
 
     assertEquals(expectedResult, actualResult);
@@ -643,27 +665,14 @@ public class FunctionsTest extends TestBase {
   }
 
   @Test
-  public void splitMultiPointByMultiPoint() {
-    // PostGIS 3.2+ parity: remove coordinates present in the blade from the input.
-    MultiPoint input =
-        GEOMETRY_FACTORY.createMultiPointFromCoords(coordArray(1.0, 1.0, 2.0, 2.0, 3.0, 3.0));
-    MultiPoint blade = GEOMETRY_FACTORY.createMultiPointFromCoords(coordArray(2.0, 2.0));
-
-    String actualResult = Functions.split(input, blade).norm().toText();
-    String expectedResult = "MULTIPOINT ((1 1), (3 3))";
-
-    assertEquals(expectedResult, actualResult);
-  }
-
-  @Test
-  public void splitPointByUnsupportedBladeReturnsNull() {
-    // Puntal input with a lineal blade has no PostGIS-defined behavior — return null.
+  public void splitPuntalByNonPolygonalBladeReturnsNull() {
+    // Only polygonal blades are supported for puntal input. Lineal and puntal blades return null.
     Point point = GEOMETRY_FACTORY.createPoint(new Coordinate(5.0, 5.0));
-    LineString blade = GEOMETRY_FACTORY.createLineString(coordArray(0.0, 0.0, 10.0, 10.0));
+    LineString lineBlade = GEOMETRY_FACTORY.createLineString(coordArray(0.0, 0.0, 10.0, 10.0));
+    MultiPoint pointBlade = GEOMETRY_FACTORY.createMultiPointFromCoords(coordArray(5.0, 5.0));
 
-    Geometry actualResult = Functions.split(point, blade);
-
-    assertNull(actualResult);
+    assertNull(Functions.split(point, lineBlade));
+    assertNull(Functions.split(point, pointBlade));
   }
 
   @Test

--- a/docs/api/flink/Overlay-Functions/ST_Split.md
+++ b/docs/api/flink/Overlay-Functions/ST_Split.md
@@ -23,7 +23,7 @@ Introduction: Split an input geometry by another geometry (called the blade).
 Linear (LineString or MultiLineString) geometry can be split by a Point, MultiPoint, LineString, MultiLineString, Polygon, or MultiPolygon.
 Polygonal (Polygon or MultiPolygon) geometry can be split by a LineString, MultiLineString, Polygon, or MultiPolygon.
 As a Sedona-specific extension, puntal (Point or MultiPoint) input may be split by a Polygon or MultiPolygon: the points are partitioned into those covered by the blade and those that are not, and the union of the result reconstructs the input.
-In either case, when a polygonal blade is used then the boundary of the blade is what is actually split by.
+For lineal and polygonal inputs, when the blade is polygonal then the boundary of the blade is what is actually split by. For puntal inputs, the polygon's interior is used to partition points by coverage rather than its boundary.
 ST_Split returns a MultiLineString when the input is lineal, a MultiPolygon when the input is polygonal, and a GeometryCollection of MultiPoints when the input is puntal.
 Homogeneous GeometryCollections are treated as a multi-geometry of the type they contain.
 For example, if a GeometryCollection of only Point geometries is passed as a blade it is the same as passing a MultiPoint of the same geometries.

--- a/docs/api/flink/Overlay-Functions/ST_Split.md
+++ b/docs/api/flink/Overlay-Functions/ST_Split.md
@@ -1,0 +1,63 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_Split
+
+Introduction: Split an input geometry by another geometry (called the blade).
+Linear (LineString or MultiLineString) geometry can be split by a Point, MultiPoint, LineString, MultiLineString, Polygon, or MultiPolygon.
+Polygonal (Polygon or MultiPolygon) geometry can be split by a LineString, MultiLineString, Polygon, or MultiPolygon.
+As a Sedona-specific extension, puntal (Point or MultiPoint) input may be split by a Polygon or MultiPolygon: the points are partitioned into those covered by the blade and those that are not, and the union of the result reconstructs the input.
+In either case, when a polygonal blade is used then the boundary of the blade is what is actually split by.
+ST_Split returns a MultiLineString when the input is lineal, a MultiPolygon when the input is polygonal, and a GeometryCollection of MultiPoints when the input is puntal.
+Homogeneous GeometryCollections are treated as a multi-geometry of the type they contain.
+For example, if a GeometryCollection of only Point geometries is passed as a blade it is the same as passing a MultiPoint of the same geometries.
+
+![ST_Split](../../../image/ST_Split/ST_Split.svg "ST_Split")
+
+Format: `ST_Split (input: Geometry, blade: Geometry)`
+
+Return type: `Geometry`
+
+Example:
+
+```sql
+SELECT ST_Split(
+    ST_GeomFromWKT('LINESTRING (0 0, 1.5 1.5, 2 2)'),
+    ST_GeomFromWKT('MULTIPOINT (0.5 0.5, 1 1)'))
+```
+
+Result:
+
+```
+MULTILINESTRING ((0 0, 0.5 0.5), (0.5 0.5, 1 1), (1 1, 1.5 1.5, 2 2))
+```
+
+Example — partition a MultiPoint by a Polygon:
+
+```sql
+SELECT ST_Split(
+    ST_GeomFromWKT('MULTIPOINT ((1 1), (5 5), (15 15))'),
+    ST_GeomFromWKT('POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))'))
+```
+
+Result:
+
+```
+GEOMETRYCOLLECTION (MULTIPOINT ((1 1), (5 5)), MULTIPOINT ((15 15)))
+```

--- a/docs/api/snowflake/vector-data/Overlay-Functions/ST_Split.md
+++ b/docs/api/snowflake/vector-data/Overlay-Functions/ST_Split.md
@@ -23,7 +23,7 @@ Introduction: Split an input geometry by another geometry (called the blade).
 Linear (LineString or MultiLineString) geometry can be split by a Point, MultiPoint, LineString, MultiLineString, Polygon, or MultiPolygon.
 Polygonal (Polygon or MultiPolygon) geometry can be split by a LineString, MultiLineString, Polygon, or MultiPolygon.
 As a Sedona-specific extension, puntal (Point or MultiPoint) input may be split by a Polygon or MultiPolygon: the points are partitioned into those covered by the blade and those that are not, and the union of the result reconstructs the input.
-In either case, when a polygonal blade is used then the boundary of the blade is what is actually split by.
+For lineal and polygonal inputs, when the blade is polygonal then the boundary of the blade is what is actually split by. For puntal inputs, the polygon's interior is used to partition points by coverage rather than its boundary.
 ST_Split returns a MultiLineString when the input is lineal, a MultiPolygon when the input is polygonal, and a GeometryCollection of MultiPoints when the input is puntal.
 Homogeneous GeometryCollections are treated as a multi-geometry of the type they contain.
 For example, if a GeometryCollection of only Point geometries is passed as a blade it is the same as passing a MultiPoint of the same geometries.

--- a/docs/api/snowflake/vector-data/Overlay-Functions/ST_Split.md
+++ b/docs/api/snowflake/vector-data/Overlay-Functions/ST_Split.md
@@ -22,8 +22,10 @@
 Introduction: Split an input geometry by another geometry (called the blade).
 Linear (LineString or MultiLineString) geometry can be split by a Point, MultiPoint, LineString, MultiLineString, Polygon, or MultiPolygon.
 Polygonal (Polygon or MultiPolygon) geometry can be split by a LineString, MultiLineString, Polygon, or MultiPolygon.
+Puntal (Point or MultiPoint) geometry can be split by a Polygon, MultiPolygon, Point, or MultiPoint.
 In either case, when a polygonal blade is used then the boundary of the blade is what is actually split by.
-ST_Split will always return either a MultiLineString or MultiPolygon even if they only contain a single geometry.
+ST_Split returns a MultiLineString when the input is lineal, a MultiPolygon when the input is polygonal, and a GeometryCollection of MultiPoints when the input is puntal and the blade is polygonal.
+When both input and blade are puntal, ST_Split returns a MultiPoint with the blade coordinates removed from the input.
 Homogeneous GeometryCollections are treated as a multi-geometry of the type it contains.
 For example, if a GeometryCollection of only Point geometries is passed as a blade it is the same as passing a MultiPoint of the same geometries.
 
@@ -42,3 +44,13 @@ SELECT ST_Split(
 ```
 
 Output: `MULTILINESTRING ((0 0, 0.5 0.5), (0.5 0.5, 1 1), (1 1, 1.5 1.5, 2 2))`
+
+SQL Example — partition a MultiPoint by a Polygon:
+
+```sql
+SELECT ST_Split(
+    ST_GeomFromWKT('MULTIPOINT ((1 1), (5 5), (15 15))'),
+    ST_GeomFromWKT('POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))'))
+```
+
+Output: `GEOMETRYCOLLECTION (MULTIPOINT ((1 1), (5 5)), MULTIPOINT ((15 15)))`

--- a/docs/api/snowflake/vector-data/Overlay-Functions/ST_Split.md
+++ b/docs/api/snowflake/vector-data/Overlay-Functions/ST_Split.md
@@ -22,11 +22,10 @@
 Introduction: Split an input geometry by another geometry (called the blade).
 Linear (LineString or MultiLineString) geometry can be split by a Point, MultiPoint, LineString, MultiLineString, Polygon, or MultiPolygon.
 Polygonal (Polygon or MultiPolygon) geometry can be split by a LineString, MultiLineString, Polygon, or MultiPolygon.
-Puntal (Point or MultiPoint) geometry can be split by a Polygon, MultiPolygon, Point, or MultiPoint.
+As a Sedona-specific extension, puntal (Point or MultiPoint) input may be split by a Polygon or MultiPolygon: the points are partitioned into those covered by the blade and those that are not, and the union of the result reconstructs the input.
 In either case, when a polygonal blade is used then the boundary of the blade is what is actually split by.
-ST_Split returns a MultiLineString when the input is lineal, a MultiPolygon when the input is polygonal, and a GeometryCollection of MultiPoints when the input is puntal and the blade is polygonal.
-When both input and blade are puntal, ST_Split returns a MultiPoint with the blade coordinates removed from the input.
-Homogeneous GeometryCollections are treated as a multi-geometry of the type it contains.
+ST_Split returns a MultiLineString when the input is lineal, a MultiPolygon when the input is polygonal, and a GeometryCollection of MultiPoints when the input is puntal.
+Homogeneous GeometryCollections are treated as a multi-geometry of the type they contain.
 For example, if a GeometryCollection of only Point geometries is passed as a blade it is the same as passing a MultiPoint of the same geometries.
 
 ![ST_Split](../../../../image/ST_Split/ST_Split.svg "ST_Split")

--- a/docs/api/sql/Overlay-Functions/ST_Split.md
+++ b/docs/api/sql/Overlay-Functions/ST_Split.md
@@ -22,11 +22,10 @@
 Introduction: Split an input geometry by another geometry (called the blade).
 Linear (LineString or MultiLineString) geometry can be split by a Point, MultiPoint, LineString, MultiLineString, Polygon, or MultiPolygon.
 Polygonal (Polygon or MultiPolygon) geometry can be split by a LineString, MultiLineString, Polygon, or MultiPolygon.
-Puntal (Point or MultiPoint) geometry can be split by a Polygon, MultiPolygon, Point, or MultiPoint.
+As a Sedona-specific extension, puntal (Point or MultiPoint) input may be split by a Polygon or MultiPolygon: the points are partitioned into those covered by the blade and those that are not, and the union of the result reconstructs the input.
 In either case, when a polygonal blade is used then the boundary of the blade is what is actually split by.
-ST_Split returns a MultiLineString when the input is lineal, a MultiPolygon when the input is polygonal, and a GeometryCollection of MultiPoints when the input is puntal and the blade is polygonal.
-When both input and blade are puntal, ST_Split returns a MultiPoint with the blade coordinates removed from the input.
-Homogeneous GeometryCollections are treated as a multi-geometry of the type it contains.
+ST_Split returns a MultiLineString when the input is lineal, a MultiPolygon when the input is polygonal, and a GeometryCollection of MultiPoints when the input is puntal.
+Homogeneous GeometryCollections are treated as a multi-geometry of the type they contain.
 For example, if a GeometryCollection of only Point geometries is passed as a blade it is the same as passing a MultiPoint of the same geometries.
 
 ![ST_Split](../../../image/ST_Split/ST_Split.svg "ST_Split")

--- a/docs/api/sql/Overlay-Functions/ST_Split.md
+++ b/docs/api/sql/Overlay-Functions/ST_Split.md
@@ -23,7 +23,7 @@ Introduction: Split an input geometry by another geometry (called the blade).
 Linear (LineString or MultiLineString) geometry can be split by a Point, MultiPoint, LineString, MultiLineString, Polygon, or MultiPolygon.
 Polygonal (Polygon or MultiPolygon) geometry can be split by a LineString, MultiLineString, Polygon, or MultiPolygon.
 As a Sedona-specific extension, puntal (Point or MultiPoint) input may be split by a Polygon or MultiPolygon: the points are partitioned into those covered by the blade and those that are not, and the union of the result reconstructs the input.
-In either case, when a polygonal blade is used then the boundary of the blade is what is actually split by.
+For lineal and polygonal inputs, when the blade is polygonal then the boundary of the blade is what is actually split by. For puntal inputs, the polygon's interior is used to partition points by coverage rather than its boundary.
 ST_Split returns a MultiLineString when the input is lineal, a MultiPolygon when the input is polygonal, and a GeometryCollection of MultiPoints when the input is puntal.
 Homogeneous GeometryCollections are treated as a multi-geometry of the type they contain.
 For example, if a GeometryCollection of only Point geometries is passed as a blade it is the same as passing a MultiPoint of the same geometries.

--- a/docs/api/sql/Overlay-Functions/ST_Split.md
+++ b/docs/api/sql/Overlay-Functions/ST_Split.md
@@ -22,8 +22,10 @@
 Introduction: Split an input geometry by another geometry (called the blade).
 Linear (LineString or MultiLineString) geometry can be split by a Point, MultiPoint, LineString, MultiLineString, Polygon, or MultiPolygon.
 Polygonal (Polygon or MultiPolygon) geometry can be split by a LineString, MultiLineString, Polygon, or MultiPolygon.
+Puntal (Point or MultiPoint) geometry can be split by a Polygon, MultiPolygon, Point, or MultiPoint.
 In either case, when a polygonal blade is used then the boundary of the blade is what is actually split by.
-ST_Split will always return either a MultiLineString or MultiPolygon even if they only contain a single geometry.
+ST_Split returns a MultiLineString when the input is lineal, a MultiPolygon when the input is polygonal, and a GeometryCollection of MultiPoints when the input is puntal and the blade is polygonal.
+When both input and blade are puntal, ST_Split returns a MultiPoint with the blade coordinates removed from the input.
 Homogeneous GeometryCollections are treated as a multi-geometry of the type it contains.
 For example, if a GeometryCollection of only Point geometries is passed as a blade it is the same as passing a MultiPoint of the same geometries.
 
@@ -47,4 +49,18 @@ Output:
 
 ```
 MULTILINESTRING ((0 0, 0.5 0.5), (0.5 0.5, 1 1), (1 1, 1.5 1.5, 2 2))
+```
+
+SQL Example — partition a MultiPoint by a Polygon
+
+```sql
+SELECT ST_Split(
+    ST_GeomFromWKT('MULTIPOINT ((1 1), (5 5), (15 15))'),
+    ST_GeomFromWKT('POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))'))
+```
+
+Output:
+
+```
+GEOMETRYCOLLECTION (MULTIPOINT ((1 1), (5 5)), MULTIPOINT ((15 15)))
 ```

--- a/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
@@ -2089,7 +2089,7 @@ public class FunctionTest extends TestBase {
 
   @Test
   public void testSplitMultiPointByPolygon() {
-    // PostGIS 3.2+ parity: ST_Split on a MultiPoint by a Polygon partitions points by coverage.
+    // ST_Split on a MultiPoint by a Polygon partitions points by polygon coverage.
     Table table =
         tableEnv.sqlQuery(
             "SELECT ST_Split(ST_GeomFromWKT('MULTIPOINT ((1 1), (5 5), (15 15))'),"
@@ -2097,17 +2097,6 @@ public class FunctionTest extends TestBase {
     assertEquals(
         "GEOMETRYCOLLECTION (MULTIPOINT ((1 1), (5 5)), MULTIPOINT ((15 15)))",
         ((Geometry) first(table).getField(0)).norm().toText());
-  }
-
-  @Test
-  public void testSplitMultiPointByMultiPoint() {
-    // PostGIS 3.2+ parity: subtract blade coordinates from a puntal input.
-    Table table =
-        tableEnv.sqlQuery(
-            "SELECT ST_Split(ST_GeomFromWKT('MULTIPOINT ((1 1), (2 2), (3 3))'),"
-                + " ST_GeomFromWKT('MULTIPOINT ((2 2))'))");
-    assertEquals(
-        "MULTIPOINT ((1 1), (3 3))", ((Geometry) first(table).getField(0)).norm().toText());
   }
 
   @Test

--- a/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
@@ -2088,6 +2088,29 @@ public class FunctionTest extends TestBase {
   }
 
   @Test
+  public void testSplitMultiPointByPolygon() {
+    // PostGIS 3.2+ parity: ST_Split on a MultiPoint by a Polygon partitions points by coverage.
+    Table table =
+        tableEnv.sqlQuery(
+            "SELECT ST_Split(ST_GeomFromWKT('MULTIPOINT ((1 1), (5 5), (15 15))'),"
+                + " ST_GeomFromWKT('POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))'))");
+    assertEquals(
+        "GEOMETRYCOLLECTION (MULTIPOINT ((1 1), (5 5)), MULTIPOINT ((15 15)))",
+        ((Geometry) first(table).getField(0)).norm().toText());
+  }
+
+  @Test
+  public void testSplitMultiPointByMultiPoint() {
+    // PostGIS 3.2+ parity: subtract blade coordinates from a puntal input.
+    Table table =
+        tableEnv.sqlQuery(
+            "SELECT ST_Split(ST_GeomFromWKT('MULTIPOINT ((1 1), (2 2), (3 3))'),"
+                + " ST_GeomFromWKT('MULTIPOINT ((2 2))'))");
+    assertEquals(
+        "MULTIPOINT ((1 1), (3 3))", ((Geometry) first(table).getField(0)).norm().toText());
+  }
+
+  @Test
   public void testSubdivide() {
     Table table =
         tableEnv.sqlQuery(

--- a/spark/common/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
@@ -3020,6 +3020,12 @@ class functionTestScala
     val geomTestCases = Map(
       ("'LINESTRING (0 0, 1.5 1.5, 2 2)'", "'MULTIPOINT (0.5 0.5, 1 1)'")
         -> "MULTILINESTRING ((0 0, 0.5 0.5), (0.5 0.5, 1 1), (1 1, 1.5 1.5, 2 2))",
+      // Puntal input by polygonal blade (PostGIS 3.2+ parity): partition points by the polygon.
+      ("'MULTIPOINT ((1 1), (5 5), (15 15))'", "'POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))'")
+        -> "GEOMETRYCOLLECTION (MULTIPOINT ((1 1), (5 5)), MULTIPOINT ((15 15)))",
+      // Puntal input by puntal blade: subtract blade coordinates from the input.
+      ("'MULTIPOINT ((1 1), (2 2), (3 3))'", "'MULTIPOINT ((2 2))'")
+        -> "MULTIPOINT ((1 1), (3 3))",
       ("null", "'MULTIPOINT (0.5 0.5, 1 1)'")
         -> null,
       ("'LINESTRING (0 0, 1.5 1.5, 2 2)'", "null")
@@ -3028,7 +3034,7 @@ class functionTestScala
       var df =
         sparkSession.sql(s"SELECT ST_Split(ST_GeomFromText($target), ST_GeomFromText($blade))")
       var result = df.take(1)(0).get(0).asInstanceOf[Geometry]
-      var textResult = if (result == null) null else result.toText
+      var textResult = if (result == null) null else result.norm().toText
       assert(textResult == expected)
     }
   }

--- a/spark/common/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
@@ -3020,12 +3020,9 @@ class functionTestScala
     val geomTestCases = Map(
       ("'LINESTRING (0 0, 1.5 1.5, 2 2)'", "'MULTIPOINT (0.5 0.5, 1 1)'")
         -> "MULTILINESTRING ((0 0, 0.5 0.5), (0.5 0.5, 1 1), (1 1, 1.5 1.5, 2 2))",
-      // Puntal input by polygonal blade (PostGIS 3.2+ parity): partition points by the polygon.
+      // Puntal input by polygonal blade: partition points covered by the polygon vs not.
       ("'MULTIPOINT ((1 1), (5 5), (15 15))'", "'POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))'")
         -> "GEOMETRYCOLLECTION (MULTIPOINT ((1 1), (5 5)), MULTIPOINT ((15 15)))",
-      // Puntal input by puntal blade: subtract blade coordinates from the input.
-      ("'MULTIPOINT ((1 1), (2 2), (3 3))'", "'MULTIPOINT ((2 2))'")
-        -> "MULTIPOINT ((1 1), (3 3))",
       ("null", "'MULTIPOINT (0.5 0.5, 1 1)'")
         -> null,
       ("'LINESTRING (0 0, 1.5 1.5, 2 2)'", "null")


### PR DESCRIPTION
## Did you read the Contributor Guide?

- [x] Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Docs](https://sedona.apache.org/latest/community/develop/) before making this pull request.

## Is this PR related to a JIRA ticket?

- [x] Yes. Resolves #2979.

## What changes were proposed in this PR?

`ST_Split` returned `null` when the input geometry was a `Point` or `MultiPoint`, because `GeometrySplitter.split()` only dispatched lineal and polygonal inputs. PostGIS 3.2+ supports splitting puntal inputs, which is the most likely scenario behind the empty result reported in #2979.

This PR adds parity with PostGIS:

- **Puntal input by polygonal blade** → `GEOMETRYCOLLECTION(MULTIPOINT(<inside>), MULTIPOINT(<outside>))`. Points covered by the polygon land in the first MultiPoint, the rest in the second. An empty group is omitted.
- **Puntal input by puntal blade** → `MULTIPOINT` with the blade coordinates removed from the input (set-difference of coordinates).
- A single `Point` is treated as a one-element MultiPoint and handled by the same code path.
- `Point` / `MultiPoint` with an unsupported blade type (e.g. `LineString`) continues to return `null`, matching PostGIS's no-op behaviour for that case.

Example matching the PostGIS docs:

```sql
SELECT ST_Split(
    ST_GeomFromWKT('MULTIPOINT ((1 1), (5 5), (15 15))'),
    ST_GeomFromWKT('POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))'))
-- GEOMETRYCOLLECTION (MULTIPOINT ((1 1), (5 5)), MULTIPOINT ((15 15)))
```

## How was this patch tested?

- 7 new unit tests in `sedona-common` (`FunctionsTest`) covering MultiPoint-by-Polygon, all-inside / all-outside partitions, boundary semantics, single-Point input, MultiPoint-by-MultiPoint, and the unsupported-blade null case. All 26 split-related tests pass.
- Extended the table-driven `ST_Split` test in Spark `functionTestScala` with the two new cases. Full suite (233 tests) passes.
- Added `testSplitMultiPointByPolygon` and `testSplitMultiPointByMultiPoint` to Flink `FunctionTest`. All 3 split tests pass.

## Did this PR include necessary documentation updates?

- [x] Yes, I have updated the documentation. Both `docs/api/sql/Overlay-Functions/ST_Split.md` and `docs/api/snowflake/vector-data/Overlay-Functions/ST_Split.md` describe the new puntal-input behaviour and include a MultiPoint-by-Polygon SQL example.