### PR TITLE
[CI] Clean up pre-commit config and Makefile

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@
 default_stages: [pre-commit, pre-push]
 default_language_version:
   python: python3
-  node: 24.13.0
+  node: 24.16.0
 minimum_pre_commit_version: '3.2.0'
 repos:
   - repo: meta
@@ -54,20 +54,16 @@ repos:
         entry: prettier --write '**/*.js' '**/*.yaml' '**/*.yml'
         files: \.(js|ya?ml)$
         language: node
-        additional_dependencies: ['prettier@3.8.1']
+        additional_dependencies: ['prettier@3.8.3']
         pass_filenames: false
       - id: maven-spotless-apply
         name: maven spotless apply
         description: automatically formats Java and Scala code using mvn spotless:apply.
         entry: mvn spotless:apply
-        language: system # Indicates that the 'entry' command should be run directly as a system command.
-        types: [java, scala] # Specifies that this hook should run on Java and Scala files.
-        pass_filenames:
-          false # Crucial: tells pre-commit NOT to pass filenames as arguments to 'mvn spotless:apply'.
-          # Spotless typically scans the whole project based on its configuration.
-        always_run:
-          true # Ensures this hook runs even if no Java files are changed.
-          # This is useful for spotless:apply which might affect files not staged.
+        language: system
+        types: [java, scala]
+        pass_filenames: false # Crucial: tells pre-commit NOT to pass filenames as arguments to 'mvn spotless:apply'. Spotless typically scans the whole project based on its configuration.
+        always_run: true # Ensures this hook runs even if no Java files are changed. This is useful for spotless:apply which might affect files not staged.
         stages: [manual]
       - id: check-zip-file-is-not-committed
         name: check no zip files are committed
@@ -80,7 +76,7 @@ repos:
       - id: check-makefiles-tabs
         name: check Makefiles files for tabs
         description: ensures that Makefiles are indented with tabs
-        entry: ./scripts/pre-commit/check_makefiles_for_tabs.sh # Path to your script
+        entry: ./scripts/pre-commit/check_makefiles_for_tabs.sh
         language: system
         files: '(?i)makefile$'
         pass_filenames: true # <-- Crucial change: pass filenames to the script
@@ -301,12 +297,28 @@ repos:
       - id: forbid-tabs
         name: run forbid-tabs
         description: check the codebase for tabs
-        exclude: ^python/sedona/doc/make\.bat$|^spark/common/src/test/resources/.*$|(^|/)Makefile$|\.csv$|\.md$|\.tsv$
+        exclude: |
+          (?x)(
+            ^python/sedona/doc/make\.bat|
+            ^spark/common/src/test/resources/.*|
+            (^|/)Makefile|
+            \.csv|
+            \.md|
+            \.tsv
+          )$
       - id: remove-tabs
         name: run remove-tabs
         description: find and convert tabs to spaces
         args: [--whitespaces-count, '2']
-        exclude: ^python/sedona/doc/make\.bat$|^spark/common/src/test/resources/.*$|(^|/)Makefile$|\.csv$|\.md$|\.tsv$
+        exclude: |
+          (?x)(
+            ^python/sedona/doc/make\.bat|
+            ^spark/common/src/test/resources/.*|
+            (^|/)Makefile|
+            \.csv|
+            \.md|
+            \.tsv
+          )$
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.21.2
     hooks:
@@ -538,7 +550,12 @@ repos:
       - id: editorconfig-checker
         name: run editorconfig-checker
         description: a tool to verify that your files are in harmony with your .editorconfig
-        exclude: ^docs/image/.*$|^R/man/.*\.Rd$|^spark/common/src/test/resources/.*$
+        exclude: |
+          (?x)^(
+            docs/image/.*|
+            R/man/.*\.Rd|
+            spark/common/src/test/resources/.*
+          )$
         alias: ec
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.12

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ docsinstall: check-install
 
 install: check-install ## Sync all dependencies (including development) using uv
 	uv sync --all-groups
+	prek install
 
 run-docs:
 	docker build -f docker/docs/Dockerfile -t mkdocs-sedona .


### PR DESCRIPTION
Added `prek install` to the Makefile target `install` commands to install the hooks in the repo root.

This ensures that `prek` will always run on `git commit`.

Catching more issues locally before pushing up to GitHub exactly how git hooks are designed to work

Also updated the default node language version and the additional dependency prettier

https://nodejs.org/en/download

https://www.npmjs.com/package/prettier

The pre-commit config changes also included removing some unneeded comments, using easy to read multiline regexs and some minor cleanups in spacing/lines

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

As described

## How was this patch tested?

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
