### PR TITLE
Fix docs broken link report

### DIFF
--- a/docs-overrides/main.html
+++ b/docs-overrides/main.html
@@ -309,7 +309,7 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
                 {{ t.get_started_desc }}
               </div>
               <div class="btn-group">
-                <a href="/sedonadb" class="btn btn-red">
+                <a href="https://sedona.apache.org/sedonadb/" class="btn btn-red">
                      <span class="caption">
                    {{ t.install_sedonadb_cta }}
                   </span>
@@ -337,7 +337,7 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
               <h3 class="info-item__title">SedonaDB</h3>
               <div class="info-item__description editor">{{ t.sedonadb_desc }}</div>
               <div class="info-item__cta">
-                <a href="/sedonadb" class="btn-link">
+                <a href="https://sedona.apache.org/sedonadb/" class="btn-link">
                   <span class="caption">SedonaDB</span>
                   <span class="icon">
                         <svg width="19" height="19" viewBox="0 0 19 19" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/community/publish.zh.md
+++ b/docs/community/publish.zh.md
@@ -65,7 +65,7 @@ rm report.txt
 请确认以下文件中的 Sedona 版本均为 {{ sedona_create_release.current_version }}：
 
 1. https://github.com/apache/sedona/blob/master/python/sedona/version.py
-2. https://github.com/apache/sedona/blob/master/python/pyproject.toml（`[project]` 下的 `version` 字段）
+2. [python/pyproject.toml](https://github.com/apache/sedona/blob/master/python/pyproject.toml)（`[project]` 下的 `version` 字段）
 3. https://github.com/apache/sedona/blob/master/R/DESCRIPTION
 4. https://github.com/apache/sedona/blob/99239524f17389fc4ae9548ea88756f8ea538bb9/R/R/dependencies.R#L42
 5. https://github.com/apache/sedona/blob/master/zeppelin/package.json

--- a/lychee.toml
+++ b/lychee.toml
@@ -20,6 +20,7 @@ accept = ['200', '301', '401', '403', '406', '429']
 exclude = [
     '^file:///.*$',
     '^https?://localhost.*$',
+    '^https://(www\.)?datasyslab\.org/?$',
     '^https://dist\.apache\.org/repos/dist/dev/sedona/KEYS$',
     '^https://dist\.apache\.org/repos/dist/release/sedona/KEYS$'
 ]


### PR DESCRIPTION
## Summary

- Replace root-relative `/sedonadb` homepage links with the canonical SedonaDB URL.
- Exclude the historical DataSysLab URL from Lychee checks because it currently returns 522.
- Convert the Chinese `python/pyproject.toml` bare URL into a Markdown link so the trailing full-width parenthesis is not captured.

Fixes #2963.

## Verification

- git diff --check