### PR TITLE
[CI] Clean up and update the CODEOWNERS files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,7 +20,6 @@
 /.github/workflows/license-templates/LICENSE.txt    @jbampton @jiayuasu
 /.github/workflows/pre-commit.yml                   @jbampton @jiayuasu
 /.github/workflows/pre-commit-manual.yml            @jbampton @jiayuasu
-/.github/workflows/pre-commit-reusable.yml          @jbampton @jiayuasu
 /.github/dependabot.yml                             @jbampton @jiayuasu
 /python/sedona/doc/checkmake.ini                    @jbampton @jiayuasu
 /python/sedona/doc/Makefile                         @jbampton @jiayuasu
@@ -30,4 +29,5 @@
 .prettierignore                                     @jbampton @jiayuasu
 .prettierrc                                         @jbampton @jiayuasu
 checkmake.ini                                       @jbampton @jiayuasu
+lychee.toml                                         @jbampton @jiayuasu
 Makefile                                            @jbampton @jiayuasu


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

Removed one file that no longer exists.

Added `lychee.toml` to the list

## How was this patch tested?

With prek. 

The CODEOWNERS are requested for review so this runs on GitHub pull requests.

I can see it says the CODEOWNERS file is valid

<img width="1256" height="670" alt="Screenshot 2026-05-27 at 6 58 57 pm" src="https://github.com/user-attachments/assets/3d86aded-eb97-430e-b045-8663de36c7af" />


## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
