### PR TITLE
[CI] Add pre-commit hook to test that the docs can `npm install`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,15 @@ repos:
         files: ^README\.md$
   - repo: local
     hooks:
-      - id: npm-install
+      - id: docs-overrides-install
+        name: Install docs-overrides Node dependencies
+        entry: bash -c "cd docs-overrides && npm install"
+        language: system
+        pass_filenames: false
+        files: ^docs-overrides/(package\.json|package-lock\.json)$
+        description: Ensures local node_modules match the lockfile
+        stages: [manual]
+      - id: zeppelin-install
         name: Install Zeppelin Node dependencies
         entry: bash -c "cd zeppelin && npm install"
         language: system


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

Added another basic check or test to our pre-commit framework.

Set as manual hook since it runs bash by default not available on Windows

refs #2718 

## How was this patch tested?

Ran:

- `prek run docs-overrides-install -a`
- `prek run zeppelin-install -a`
- `prek run -a` 

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
