### PR TITLE
[DOCS] Add `alt` text to showcase homepage images

### DIFF
--- a/docs-overrides/main.html
+++ b/docs-overrides/main.html
@@ -485,63 +485,63 @@ docker run -d -p 8888:8888 -p 8085:8085 apache/sedona:latest
                 <div data-tab="Mobility" class="industries-tabs__body-item active">
                   <div class="industries-grid">
                     <div class="grid-item">
-                      <img src="{{ "image/home/industries/bmw.svg" | url }}" alt="" class="">
+                      <img src="{{ "image/home/industries/bmw.svg" | url }}" alt="BMW" class="">
                     </div>
                     <div class="grid-item">
-                      <img src="{{ "image/home/industries/gm.svg" | url }}" alt="" class="">
+                      <img src="{{ "image/home/industries/gm.svg" | url }}" alt="General Motors" class="">
                     </div>
                     <div class="grid-item">
-                      <img src="{{ "image/home/industries/placer-ai.svg" | url }}" alt="" class="">
+                      <img src="{{ "image/home/industries/placer-ai.svg" | url }}" alt="Placer.ai" class="">
                     </div>
                     <div class="grid-item">
-                      <img src="{{ "image/home/industries/arity.svg" | url }}" alt="" class="">
+                      <img src="{{ "image/home/industries/arity.svg" | url }}" alt="Arity" class="">
                     </div>
                   </div>
                 </div>
 
                 <div data-tab="Telecom" class="industries-tabs__body-item">
                   <div class="industries-grid">
-                    <div class="grid-item"><img src="{{ "image/home/industries/comcast.svg" | url }}" alt="" class=""></div>
-                    <div class="grid-item"><img src="{{ "image/home/industries/at&t.svg" | url }}" alt="" class=""></div>
-                    <div class="grid-item"><img src="{{ "image/home/industries/telus.svg" | url }}" alt="" class=""></div>
-                    <div class="grid-item"><img src="{{ "image/home/industries/t-mobile.svg" | url }}" alt="" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/comcast.svg" | url }}" alt="Comcast" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/at&t.svg" | url }}" alt="AT&T" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/telus.svg" | url }}" alt="Telus" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/t-mobile.svg" | url }}" alt="T-Mobile" class=""></div>
                   </div>
                 </div>
 
                 <div data-tab="Data and map production" class="industries-tabs__body-item">
                   <div class="industries-grid">
-                    <div class="grid-item"><img src="{{ "image/home/industries/space-x.svg" | url }}" alt="" class=""></div>
-                    <div class="grid-item"><img src="{{ "image/home/industries/maxar.svg" | url }}" alt="" class=""></div>
-                    <div class="grid-item"><img src="{{ "image/home/industries/mapbox.svg" | url }}" alt="" class=""></div>
-                    <div class="grid-item"><img src="{{ "image/home/industries/tom-tom.svg" | url }}" alt="" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/space-x.svg" | url }}" alt="SpaceX" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/maxar.svg" | url }}" alt="Maxar" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/mapbox.svg" | url }}" alt="Mapbox" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/tom-tom.svg" | url }}" alt="TomTom" class=""></div>
                   </div>
                 </div>
 
                 <div data-tab="Logistics" class="industries-tabs__body-item">
                   <div class="industries-grid">
-                    <div class="grid-item"><img src="{{ "image/home/industries/instacart.svg" | url }}" alt="" class=""></div>
-                    <div class="grid-item"><img src="{{ "image/home/industries/uber.svg" | url }}" alt="" class=""></div>
-                    <div class="grid-item"><img src="{{ "image/home/industries/UnitedAirlines.svg" | url }}" alt="" class=""></div>
-                    <div class="grid-item"><img src="{{ "image/home/industries/Boeing.svg" | url }}" alt="" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/instacart.svg" | url }}" alt="Instacart" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/uber.svg" | url }}" alt="Uber" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/UnitedAirlines.svg" | url }}" alt="United Airlines" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/Boeing.svg" | url }}" alt="Boeing" class=""></div>
                   </div>
                 </div>
 
                 <div data-tab="Energy" class="industries-tabs__body-item">
                   <div class="industries-grid">
-                    <div class="grid-item"><img src="{{ "image/home/industries/shell.svg" | url }}" alt="" class=""></div>
-                    <div class="grid-item"><img src="{{ "image/home/industries/DukeEnergy.svg" | url }}" alt="" class=""></div>
-                    <div class="grid-item"><img src="{{ "image/home/industries/PG&E.svg" | url }}" alt="" class=""></div>
-                    <div class="grid-item"><img src="{{ "image/home/industries/Southern_Company.svg" | url }}" alt="" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/shell.svg" | url }}" alt="Shell" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/DukeEnergy.svg" | url }}" alt="Duke Energy" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/PG&E.svg" | url }}" alt="PG&E" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/Southern_Company.svg" | url }}" alt="Southern Company" class=""></div>
                   </div>
                 </div>
 
                 <div data-tab="Finance" class="industries-tabs__body-item">
                   <div class="industries-grid">
-                    <div class="grid-item"><img src="{{ "image/home/industries/Allstate.svg" | url }}" alt="" class=""></div>
-                    <div class="grid-item"><img src="{{ "image/home/industries/CapitalOne.svg" | url }}" alt="" class=""></div>
-                    <div class="grid-item"><img src="{{ "image/home/industries/cigna.svg" | url }}" alt="" class=""></div>
-                    <div class="grid-item"><img src="{{ "image/home/industries/JPMorganChase.svg" | url }}" alt="" class=""></div>
-                    <div class="grid-item"><img src="{{ "image/home/industries/StateFarm.svg" | url }}" alt="" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/Allstate.svg" | url }}" alt="Allstate" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/CapitalOne.svg" | url }}" alt="Capital One" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/cigna.svg" | url }}" alt="Cigna" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/JPMorganChase.svg" | url }}" alt="JPMorgan Chase" class=""></div>
+                    <div class="grid-item"><img src="{{ "image/home/industries/StateFarm.svg" | url }}" alt="State Farm" class=""></div>
                   </div>
                 </div>
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a documentation update. The PR name follows the format `[DOCS] my subject`

## What changes were proposed in this PR?

### Key Benefits

* **Ensures Accessibility**: Screen readers speak alt text aloud to visually impaired visitors.
* **Improves SEO**: Search engines index alt text to rank images in search results.
* **Provides a Fallback**: Text displays if images fail to load due to slow internet.
* **Ensures Legal Compliance**: Meets web accessibility standards like WCAG to reduce legal risks.

## How was this patch tested?


## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
