### PR TITLE
[GH-2973] Box3D accessors + ST_AsText overload

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/Functions.java
+++ b/common/src/main/java/org/apache/sedona/common/Functions.java
@@ -730,6 +730,10 @@ public class Functions {
     return box == null ? null : box.getXMin();
   }
 
+  public static Double xMin(Box3D box) {
+    return box == null ? null : box.getXMin();
+  }
+
   public static Double xMax(Geometry geometry) {
     Coordinate[] points = geometry.getCoordinates();
     double max = -Double.MAX_VALUE;
@@ -740,6 +744,10 @@ public class Functions {
   }
 
   public static Double xMax(Box2D box) {
+    return box == null ? null : box.getXMax();
+  }
+
+  public static Double xMax(Box3D box) {
     return box == null ? null : box.getXMax();
   }
 
@@ -756,6 +764,10 @@ public class Functions {
     return box == null ? null : box.getYMin();
   }
 
+  public static Double yMin(Box3D box) {
+    return box == null ? null : box.getYMin();
+  }
+
   public static Double yMax(Geometry geometry) {
     Coordinate[] points = geometry.getCoordinates();
     double max = -Double.MAX_VALUE;
@@ -769,6 +781,10 @@ public class Functions {
     return box == null ? null : box.getYMax();
   }
 
+  public static Double yMax(Box3D box) {
+    return box == null ? null : box.getYMax();
+  }
+
   public static Double zMax(Geometry geometry) {
     Coordinate[] points = geometry.getCoordinates();
     double max = -Double.MAX_VALUE;
@@ -779,6 +795,10 @@ public class Functions {
     return max == -Double.MAX_VALUE ? null : max;
   }
 
+  public static Double zMax(Box3D box) {
+    return box == null ? null : box.getZMax();
+  }
+
   public static Double zMin(Geometry geometry) {
     Coordinate[] points = geometry.getCoordinates();
     double min = Double.MAX_VALUE;
@@ -787,6 +807,10 @@ public class Functions {
       min = Math.min(points[i].getZ(), min);
     }
     return min == Double.MAX_VALUE ? null : min;
+  }
+
+  public static Double zMin(Box3D box) {
+    return box == null ? null : box.getZMin();
   }
 
   public static boolean hasM(Geometry geom) {
@@ -919,6 +943,38 @@ public class Functions {
         + box.getXMax()
         + " "
         + box.getYMax()
+        + ")";
+  }
+
+  /**
+   * PostGIS-format text for a Box3D: {@code BOX3D(xmin ymin zmin, xmax ymax zmax)}. NULL on null
+   * input.
+   *
+   * <p>Values are emitted exactly as stored on the Box3D — this method does not normalize the
+   * corners. Sedona's Box3D allows inverted bounds (e.g. {@code xmin > xmax}); that ordering is
+   * reserved for the same future antimeridian-wraparound semantics noted on {@link
+   * #box2dAsText(Box2D)}. The text faithfully reflects what {@code ST_XMin} / {@code ST_XMax} /
+   * etc. would return.
+   *
+   * <p>Not WKT (WKT has no {@code BOX3D} type), so like {@link #box2dAsText(Box2D)} this lives
+   * outside the {@code asWKT} family to keep that API a true geometry serializer.
+   */
+  public static String box3dAsText(Box3D box) {
+    if (box == null) {
+      return null;
+    }
+    return "BOX3D("
+        + box.getXMin()
+        + " "
+        + box.getYMin()
+        + " "
+        + box.getZMin()
+        + ", "
+        + box.getXMax()
+        + " "
+        + box.getYMax()
+        + " "
+        + box.getZMax()
         + ")";
   }
 

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
@@ -72,7 +72,8 @@ private[apache] case class ST_Distance(inputExpressions: Seq[Expression])
 private[apache] case class ST_YMax(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction1((g: Geometry) => Functions.yMax(g)),
-      inferrableFunction1((b: Box2D) => Functions.yMax(b))) {
+      inferrableFunction1((b: Box2D) => Functions.yMax(b)),
+      inferrableFunction1((b: Box3D) => Functions.yMax(b))) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
@@ -82,7 +83,8 @@ private[apache] case class ST_YMax(inputExpressions: Seq[Expression])
 private[apache] case class ST_YMin(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction1((g: Geometry) => Functions.yMin(g)),
-      inferrableFunction1((b: Box2D) => Functions.yMin(b))) {
+      inferrableFunction1((b: Box2D) => Functions.yMin(b)),
+      inferrableFunction1((b: Box3D) => Functions.yMin(b))) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
@@ -90,13 +92,16 @@ private[apache] case class ST_YMin(inputExpressions: Seq[Expression])
 }
 
 /**
- * Return the Z maxima of the geometry.
+ * Return the Z maxima of a Geometry or a Box3D.
  *
  * @param inputExpressions
- *   This function takes a geometry and returns the maximum of all Z-coordinate values.
+ *   For a Geometry, returns the maximum of all Z-coordinate values. For a Box3D, returns the
+ *   stored {@code zmax} bound verbatim (no corner normalization).
  */
 private[apache] case class ST_ZMax(inputExpressions: Seq[Expression])
-    extends InferredExpression(Functions.zMax _) {
+    extends InferredExpression(
+      inferrableFunction1((g: Geometry) => Functions.zMax(g)),
+      inferrableFunction1((b: Box3D) => Functions.zMax(b))) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
@@ -104,13 +109,16 @@ private[apache] case class ST_ZMax(inputExpressions: Seq[Expression])
 }
 
 /**
- * Return the Z minima of the geometry.
+ * Return the Z minima of a Geometry or a Box3D.
  *
  * @param inputExpressions
- *   This function takes a geometry and returns the minimum of all Z-coordinate values.
+ *   For a Geometry, returns the minimum of all Z-coordinate values. For a Box3D, returns the
+ *   stored {@code zmin} bound verbatim (no corner normalization).
  */
 private[apache] case class ST_ZMin(inputExpressions: Seq[Expression])
-    extends InferredExpression(Functions.zMin _) {
+    extends InferredExpression(
+      inferrableFunction1((g: Geometry) => Functions.zMin(g)),
+      inferrableFunction1((b: Box3D) => Functions.zMin(b))) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
@@ -633,7 +641,8 @@ private[apache] case class ST_AsText(inputExpressions: Seq[Expression])
       inferrableFunction1((g: Geometry) => Functions.asWKT(g)),
       inferrableFunction1((g: Geography) =>
         org.apache.sedona.common.geography.Functions.asText(g)),
-      inferrableFunction1((b: Box2D) => Functions.box2dAsText(b))) {
+      inferrableFunction1((b: Box2D) => Functions.box2dAsText(b)),
+      inferrableFunction1((b: Box3D) => Functions.box3dAsText(b))) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
@@ -1516,7 +1525,8 @@ private[apache] case class ST_IsEmpty(inputExpressions: Seq[Expression])
 private[apache] case class ST_XMax(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction1((g: Geometry) => Functions.xMax(g)),
-      inferrableFunction1((b: Box2D) => Functions.xMax(b))) {
+      inferrableFunction1((b: Box2D) => Functions.xMax(b)),
+      inferrableFunction1((b: Box3D) => Functions.xMax(b))) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
@@ -1531,7 +1541,8 @@ private[apache] case class ST_XMax(inputExpressions: Seq[Expression])
 private[apache] case class ST_XMin(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction1((g: Geometry) => Functions.xMin(g)),
-      inferrableFunction1((b: Box2D) => Functions.xMin(b))) {
+      inferrableFunction1((b: Box2D) => Functions.xMin(b)),
+      inferrableFunction1((b: Box3D) => Functions.xMin(b))) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)

--- a/spark/common/src/test/scala/org/apache/sedona/sql/Box3DAccessorSuite.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/Box3DAccessorSuite.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.sql
+
+class Box3DAccessorSuite extends TestBaseScala {
+
+  describe("Box3D accessors + ST_AsText") {
+
+    it("ST_XMin/YMin/ZMin/XMax/YMax/ZMax accept Box3D") {
+      val row = sparkSession
+        .sql("""
+          WITH t AS (
+            SELECT ST_3DMakeBox(ST_PointZ(1, 2, 3), ST_PointZ(4, 5, 6)) AS b
+          )
+          SELECT
+            ST_XMin(b), ST_YMin(b), ST_ZMin(b),
+            ST_XMax(b), ST_YMax(b), ST_ZMax(b)
+          FROM t
+        """)
+        .collect()(0)
+      assert(row.getDouble(0) == 1.0)
+      assert(row.getDouble(1) == 2.0)
+      assert(row.getDouble(2) == 3.0)
+      assert(row.getDouble(3) == 4.0)
+      assert(row.getDouble(4) == 5.0)
+      assert(row.getDouble(5) == 6.0)
+    }
+
+    it("Accessors propagate NULL on a NULL Box3D input") {
+      val row = sparkSession
+        .sql(
+          "SELECT ST_XMin(b), ST_YMin(b), ST_ZMin(b), " +
+            "ST_XMax(b), ST_YMax(b), ST_ZMax(b) " +
+            "FROM (SELECT ST_3DMakeBox(ST_GeomFromText(NULL), ST_PointZ(1,1,1)) AS b)")
+        .collect()(0)
+      (0 until 6).foreach(i => assert(row.isNullAt(i), s"column $i should be NULL"))
+    }
+
+    it("ST_AsText(box3d) returns BOX3D(...) text") {
+      val str = sparkSession
+        .sql("SELECT ST_AsText(ST_3DMakeBox(ST_PointZ(0, 0, 0), ST_PointZ(10, 20, 30))) AS s")
+        .collect()(0)
+        .getString(0)
+      assert(str == "BOX3D(0.0 0.0 0.0, 10.0 20.0 30.0)")
+    }
+
+    it("ST_AsText(box3d) returns NULL for NULL input") {
+      val row = sparkSession
+        .sql("SELECT ST_AsText(ST_3DMakeBox(ST_GeomFromText(NULL), ST_PointZ(1,1,1))) AS s")
+        .collect()(0)
+      assert(row.isNullAt(0))
+    }
+  }
+}


### PR DESCRIPTION
## Did you read the Contributor Guide?

- [x] Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

## Is this PR related to a ticket?

- [x] Yes, and the PR title follows the format `[GH-XXX] my subject`.

## What changes were proposed in this PR?

Third slice of the Box3D Phase 1 epic ([#2973](https://github.com/apache/sedona/issues/2973)). Builds on the type + constructors merged in #2978 and #2984.

- `Functions.{xMin, yMin, zMin, xMax, yMax, zMax}(Box3D)` Java overloads — each returns the corresponding bound from the Box3D struct.
- `Functions.box3dAsText(Box3D)` — PostGIS-format text form `BOX3D(xmin ymin zmin, xmax ymax zmax)`. Not WKT; lives alongside the existing Box2D `BOX(...)` text form rather than inside the `asWKT` family.
- Catalyst dispatch wired through `InferredExpression`: `ST_XMin/YMin/ZMin/XMax/YMax/ZMax` gain `inferrableFunction1((b: Box3D) => ...)` branches; `ST_AsText` is extended with a Box3D overload so the same accessor names work for geometry, Box2D, and Box3D.
- `Box3DAccessorSuite`: covers all six accessors, NULL-input propagation, ST_AsText output format, and ST_AsText NULL propagation.

Remaining Phase 1 slices: predicates (ST_3DBoxIntersects / ST_3DBoxContains) and the ST_3DExtent aggregate.

## How was this patch tested?

- New ScalaTest suite `Box3DAccessorSuite` (4 tests, all green locally).
- `mvn -pl spark/common -Dspark=3.5 -Dscala=2.12 test` covering the affected expression layer.

## Did this PR include necessary documentation updates?

- [x] No, docs will land alongside the final Phase 1 slice once the full surface (accessors + predicates + aggregate) is in place.