### PR TITLE
[GH-3039] Flink Box3D accessors, ST_AsText, and ST_3DExtent

### DIFF
--- a/flink/src/main/java/org/apache/sedona/flink/Catalog.java
+++ b/flink/src/main/java/org/apache/sedona/flink/Catalog.java
@@ -26,6 +26,7 @@ public class Catalog {
     return new UserDefinedFunction[] {
       new Aggregators.ST_Envelope_Aggr(),
       new Aggregators.ST_Extent(),
+      new Aggregators.ST_3DExtent(),
       new Aggregators.ST_Intersection_Aggr(),
       new Aggregators.ST_Union_Aggr(),
       // Aliases for *_Aggr functions with *_Agg suffix

--- a/flink/src/main/java/org/apache/sedona/flink/expressions/Accumulators.java
+++ b/flink/src/main/java/org/apache/sedona/flink/expressions/Accumulators.java
@@ -39,6 +39,24 @@ public class Accumulators {
     }
   }
 
+  public static class Envelope3D {
+    public double minX = Double.MAX_VALUE;
+    public double minY = Double.MAX_VALUE;
+    public double minZ = Double.MAX_VALUE;
+    public double maxX = -Double.MAX_VALUE;
+    public double maxY = -Double.MAX_VALUE;
+    public double maxZ = -Double.MAX_VALUE;
+
+    void reset() {
+      minX = Double.MAX_VALUE;
+      minY = Double.MAX_VALUE;
+      minZ = Double.MAX_VALUE;
+      maxX = -Double.MAX_VALUE;
+      maxY = -Double.MAX_VALUE;
+      maxZ = -Double.MAX_VALUE;
+    }
+  }
+
   public static class AccGeometry {
     @DataTypeHint(
         value = "RAW",

--- a/flink/src/main/java/org/apache/sedona/flink/expressions/Aggregators.java
+++ b/flink/src/main/java/org/apache/sedona/flink/expressions/Aggregators.java
@@ -21,7 +21,9 @@ package org.apache.sedona.flink.expressions;
 import org.apache.flink.table.annotation.DataTypeHint;
 import org.apache.flink.table.functions.AggregateFunction;
 import org.apache.sedona.common.geometryObjects.Box2D;
+import org.apache.sedona.common.geometryObjects.Box3D;
 import org.apache.sedona.flink.Box2DTypeSerializer;
+import org.apache.sedona.flink.Box3DTypeSerializer;
 import org.apache.sedona.flink.GeometryTypeSerializer;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
@@ -164,6 +166,69 @@ public class Aggregators {
     }
 
     public void resetAccumulator(Accumulators.Envelope acc) {
+      acc.reset();
+    }
+  }
+
+  // Aggregate the 3D bounding box of all input geometries as a Box3D. Mirrors PostGIS
+  // ST_3DExtent. Geometries without a Z dimension fold into z = 0 per coordinate (via
+  // Functions.box3D). Returns null when there are no rows or all inputs are null/empty.
+  @DataTypeHint(value = "RAW", rawSerializer = Box3DTypeSerializer.class, bridgedTo = Box3D.class)
+  public static class ST_3DExtent extends AggregateFunction<Box3D, Accumulators.Envelope3D> {
+
+    @Override
+    public Accumulators.Envelope3D createAccumulator() {
+      return new Accumulators.Envelope3D();
+    }
+
+    @Override
+    @DataTypeHint(value = "RAW", rawSerializer = Box3DTypeSerializer.class, bridgedTo = Box3D.class)
+    public Box3D getValue(Accumulators.Envelope3D acc) {
+      if (acc.minX > acc.maxX) return null;
+      return new Box3D(acc.minX, acc.minY, acc.minZ, acc.maxX, acc.maxY, acc.maxZ);
+    }
+
+    public void accumulate(
+        Accumulators.Envelope3D acc,
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = GeometryTypeSerializer.class,
+                bridgedTo = Geometry.class)
+            Object o) {
+      if (o == null) return;
+      // Functions.box3D folds missing Z to 0 and returns null for empty geometries.
+      Box3D box = org.apache.sedona.common.Functions.box3D((Geometry) o);
+      if (box == null) return;
+      acc.minX = Math.min(acc.minX, box.getXMin());
+      acc.minY = Math.min(acc.minY, box.getYMin());
+      acc.minZ = Math.min(acc.minZ, box.getZMin());
+      acc.maxX = Math.max(acc.maxX, box.getXMax());
+      acc.maxY = Math.max(acc.maxY, box.getYMax());
+      acc.maxZ = Math.max(acc.maxZ, box.getZMax());
+    }
+
+    public void retract(
+        Accumulators.Envelope3D acc,
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = GeometryTypeSerializer.class,
+                bridgedTo = Geometry.class)
+            Object o) {
+      assert (false);
+    }
+
+    public void merge(Accumulators.Envelope3D acc, Iterable<Accumulators.Envelope3D> it) {
+      for (Accumulators.Envelope3D a : it) {
+        acc.minX = Math.min(acc.minX, a.minX);
+        acc.minY = Math.min(acc.minY, a.minY);
+        acc.minZ = Math.min(acc.minZ, a.minZ);
+        acc.maxX = Math.max(acc.maxX, a.maxX);
+        acc.maxY = Math.max(acc.maxY, a.maxY);
+        acc.maxZ = Math.max(acc.maxZ, a.maxZ);
+      }
+    }
+
+    public void resetAccumulator(Accumulators.Envelope3D acc) {
       acc.reset();
     }
   }

--- a/flink/src/main/java/org/apache/sedona/flink/expressions/Functions.java
+++ b/flink/src/main/java/org/apache/sedona/flink/expressions/Functions.java
@@ -984,6 +984,16 @@ public class Functions {
             Box2D box) {
       return org.apache.sedona.common.Functions.yMin(box);
     }
+
+    @DataTypeHint("Double")
+    public Double eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = Box3DTypeSerializer.class,
+                bridgedTo = Box3D.class)
+            Box3D box) {
+      return org.apache.sedona.common.Functions.yMin(box);
+    }
   }
 
   public static class ST_YMax extends ScalarFunction {
@@ -1007,6 +1017,16 @@ public class Functions {
             Box2D box) {
       return org.apache.sedona.common.Functions.yMax(box);
     }
+
+    @DataTypeHint("Double")
+    public Double eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = Box3DTypeSerializer.class,
+                bridgedTo = Box3D.class)
+            Box3D box) {
+      return org.apache.sedona.common.Functions.yMax(box);
+    }
   }
 
   public static class ST_ZMax extends ScalarFunction {
@@ -1020,6 +1040,16 @@ public class Functions {
       Geometry geom = (Geometry) o;
       return org.apache.sedona.common.Functions.zMax(geom);
     }
+
+    @DataTypeHint("Double")
+    public Double eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = Box3DTypeSerializer.class,
+                bridgedTo = Box3D.class)
+            Box3D box) {
+      return org.apache.sedona.common.Functions.zMax(box);
+    }
   }
 
   public static class ST_ZMin extends ScalarFunction {
@@ -1032,6 +1062,16 @@ public class Functions {
             Object o) {
       Geometry geom = (Geometry) o;
       return org.apache.sedona.common.Functions.zMin(geom);
+    }
+
+    @DataTypeHint("Double")
+    public Double eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = Box3DTypeSerializer.class,
+                bridgedTo = Box3D.class)
+            Box3D box) {
+      return org.apache.sedona.common.Functions.zMin(box);
     }
   }
 
@@ -1370,6 +1410,16 @@ public class Functions {
             Box2D box) {
       return org.apache.sedona.common.Functions.box2dAsText(box);
     }
+
+    @DataTypeHint("String")
+    public String eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = Box3DTypeSerializer.class,
+                bridgedTo = Box3D.class)
+            Box3D box) {
+      return org.apache.sedona.common.Functions.box3dAsText(box);
+    }
   }
 
   public static class ST_AsEWKB extends ScalarFunction {
@@ -1592,6 +1642,16 @@ public class Functions {
             Box2D box) {
       return org.apache.sedona.common.Functions.xMax(box);
     }
+
+    @DataTypeHint("Double")
+    public Double eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = Box3DTypeSerializer.class,
+                bridgedTo = Box3D.class)
+            Box3D box) {
+      return org.apache.sedona.common.Functions.xMax(box);
+    }
   }
 
   public static class ST_XMin extends ScalarFunction {
@@ -1613,6 +1673,16 @@ public class Functions {
                 rawSerializer = Box2DTypeSerializer.class,
                 bridgedTo = Box2D.class)
             Box2D box) {
+      return org.apache.sedona.common.Functions.xMin(box);
+    }
+
+    @DataTypeHint("Double")
+    public Double eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = Box3DTypeSerializer.class,
+                bridgedTo = Box3D.class)
+            Box3D box) {
       return org.apache.sedona.common.Functions.xMin(box);
     }
   }

--- a/flink/src/test/java/org/apache/sedona/flink/AggregatorTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/AggregatorTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertNull;
 import org.apache.flink.table.api.*;
 import org.apache.flink.types.Row;
 import org.apache.sedona.common.geometryObjects.Box2D;
+import org.apache.sedona.common.geometryObjects.Box3D;
 import org.apache.sedona.flink.expressions.Functions;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -62,6 +63,38 @@ public class AggregatorTest extends TestBase {
     assertEquals(0.0, bbox.getYMin(), 0.0);
     assertEquals(4.0, bbox.getXMax(), 0.0);
     assertEquals(5.0, bbox.getYMax(), 0.0);
+  }
+
+  @Test
+  public void test3DExtent() {
+    tableEnv.executeSql(
+        "CREATE OR REPLACE TEMPORARY VIEW extent3d_view AS "
+            + "SELECT ST_GeomFromWKT(wkt) as geom FROM ("
+            + "VALUES ('POINT Z (1 2 3)'), ('POINT Z (4 5 -1)'), ('LINESTRING (-3 0, 0 0)')"
+            + ") AS t(wkt)");
+    Table result = tableEnv.sqlQuery("SELECT ST_3DExtent(geom) FROM extent3d_view");
+    Row last = last(result);
+    Box3D bbox = (Box3D) last.getField(0);
+    assertEquals(-3.0, bbox.getXMin(), 0.0);
+    assertEquals(0.0, bbox.getYMin(), 0.0);
+    // z-min is -1.0 from POINT Z (4 5 -1); the XY-only linestring folds to z = 0, which sits
+    // between the -1 and 3 of the two POINT Z rows and so does not move either Z bound.
+    assertEquals(-1.0, bbox.getZMin(), 0.0);
+    assertEquals(4.0, bbox.getXMax(), 0.0);
+    assertEquals(5.0, bbox.getYMax(), 0.0);
+    assertEquals(3.0, bbox.getZMax(), 0.0);
+  }
+
+  @Test
+  public void test3DExtent_EmptyAndNullGeometries() {
+    tableEnv.executeSql(
+        "CREATE OR REPLACE TEMPORARY VIEW null_extent3d_view AS "
+            + "SELECT ST_GeomFromWKT(wkt) as geom FROM ("
+            + "VALUES (CAST(NULL AS STRING)), ('POINT EMPTY'), ('POLYGON EMPTY')"
+            + ") AS t(wkt)");
+    Table result = tableEnv.sqlQuery("SELECT ST_3DExtent(geom) FROM null_extent3d_view");
+    Row last = last(result);
+    assertNull(last.getField(0));
   }
 
   @Test

--- a/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
@@ -507,6 +507,24 @@ public class FunctionTest extends TestBase {
   }
 
   @Test
+  public void testBox3DAsTextAndAccessors() {
+    Table t =
+        tableEnv.sqlQuery(
+            "WITH bx AS ("
+                + " SELECT ST_Box3D(ST_GeomFromText('LINESTRING Z(0 0 -3, 5 10 7)')) AS b)"
+                + " SELECT ST_AsText(b), ST_XMin(b), ST_YMin(b), ST_ZMin(b),"
+                + " ST_XMax(b), ST_YMax(b), ST_ZMax(b) FROM bx");
+    Row row = first(t);
+    assertEquals("BOX3D(0.0 0.0 -3.0, 5.0 10.0 7.0)", row.getField(0));
+    assertEquals(0.0, row.getField(1));
+    assertEquals(0.0, row.getField(2));
+    assertEquals(-3.0, row.getField(3));
+    assertEquals(5.0, row.getField(4));
+    assertEquals(10.0, row.getField(5));
+    assertEquals(7.0, row.getField(6));
+  }
+
+  @Test
   public void testEnvelope() {
     Table linestringTable = createLineStringTable(1);
     linestringTable =


### PR DESCRIPTION
## Did you read the Contributor Guide?

- [x] Yes

## Is this PR related to a ticket?

- [x] Yes — closes [#3039](https://github.com/apache/sedona/issues/3039); follow-up to the Box3D EPIC ([#2973](https://github.com/apache/sedona/issues/2973)) and the Flink foundation slice #3037.

## What changes were proposed in this PR?

Second Flink Box3D slice. With `Box3DTypeSerializer` + `ST_Box3D` / `ST_3DMakeBox` already merged in #3037, this adds the accessor surface, the text form, and the aggregate — mirroring the Box2D Flink functions.

- **Accessors**: Box3D `eval` overloads on `ST_XMin` / `ST_YMin` / `ST_ZMin` / `ST_XMax` / `ST_YMax` / `ST_ZMax`. `ST_ZMin` / `ST_ZMax` previously had only the Geometry overload.
- **Text**: `ST_AsText(box3d)` → `box3dAsText` (PostGIS-style `BOX3D(...)`).
- **Aggregate**: `Aggregators.ST_3DExtent` — `AggregateFunction<Box3D, Envelope3D>` mirroring `ST_Extent`. Per-row folding via `Functions.box3D` (missing Z → 0, empty → skipped); returns null on an all-empty/null input. New `Accumulators.Envelope3D` six-double accumulator. Registered in `Catalog`.

**`ST_Expand` is intentionally not given a Box3D overload** — the common layer has no `expand(Box3D, ...)`, and the Spark Box3D surface doesn't expose it either.

## How was this patch tested?

- `FunctionTest.testBox3DAsTextAndAccessors` — `BOX3D` text + all six accessors over a Box3D. Full `FunctionTest`: 205 pass.
- `AggregatorTest.test3DExtent` (mixed XYZ / XY-fold-to-0 rows) and `test3DExtent_EmptyAndNullGeometries` (all-empty/null → NULL). Full `AggregatorTest` + `Box3DTypeSerializerTest`: 20 pass.

## Did this PR include necessary documentation updates?

- [x] No — Box3D documentation is tracked separately under the Box3D EPIC.

## Out of scope (final Flink slice)

- Box3D overloads on `ST_Intersects` / `ST_Contains`; `ST_3DDWithin`.