### PR TITLE
[CI] Remove deprecated hook `check-docstring-first`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -417,9 +417,6 @@ repos:
       - id: check-case-conflict
         name: run check-case-conflict
         description: check for case conflicts in file names
-      - id: check-docstring-first
-        name: run check-docstring-first
-        description: check that docstrings are at the start of functions
       - id: check-executables-have-shebangs
         name: run check-executables-have-shebangs
         description: check that executable scripts have shebang lines


### PR DESCRIPTION
https://github.com/pre-commit/pre-commit-hooks#deprecated--replaced-hooks

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

As described above.

## How was this patch tested?

`prek run -a`

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
