### PR TITLE
[GH-3042] Flink Box3D predicates: ST_Intersects / ST_Contains + ST_3DDWithin

### DIFF
--- a/flink/src/main/java/org/apache/sedona/flink/Catalog.java
+++ b/flink/src/main/java/org/apache/sedona/flink/Catalog.java
@@ -263,7 +263,8 @@ public class Catalog {
       new Predicates.ST_Touches(),
       new Predicates.ST_Relate(),
       new Predicates.ST_RelateMatch(),
-      new Predicates.ST_DWithin()
+      new Predicates.ST_DWithin(),
+      new Predicates.ST_3DDWithin()
     };
   }
 }

--- a/flink/src/main/java/org/apache/sedona/flink/expressions/Predicates.java
+++ b/flink/src/main/java/org/apache/sedona/flink/expressions/Predicates.java
@@ -21,7 +21,9 @@ package org.apache.sedona.flink.expressions;
 import org.apache.flink.table.annotation.DataTypeHint;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.sedona.common.geometryObjects.Box2D;
+import org.apache.sedona.common.geometryObjects.Box3D;
 import org.apache.sedona.flink.Box2DTypeSerializer;
+import org.apache.sedona.flink.Box3DTypeSerializer;
 import org.apache.sedona.flink.GeometryTypeSerializer;
 import org.locationtech.jts.geom.Geometry;
 
@@ -65,6 +67,23 @@ public class Predicates {
       if (a == null || b == null) return null;
       return org.apache.sedona.common.Predicates.boxIntersects(a, b);
     }
+
+    /** Box3D-on-Box3D bbox intersection on all three axes (closed interval). */
+    @DataTypeHint("Boolean")
+    public Boolean eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = Box3DTypeSerializer.class,
+                bridgedTo = Box3D.class)
+            Box3D a,
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = Box3DTypeSerializer.class,
+                bridgedTo = Box3D.class)
+            Box3D b) {
+      if (a == null || b == null) return null;
+      return org.apache.sedona.common.Predicates.box3dIntersects(a, b);
+    }
   }
 
   public static class ST_Contains extends ScalarFunction {
@@ -105,6 +124,23 @@ public class Predicates {
             Box2D b) {
       if (a == null || b == null) return null;
       return org.apache.sedona.common.Predicates.boxContains(a, b);
+    }
+
+    /** Box3D-on-Box3D bbox containment on all three axes (closed interval). */
+    @DataTypeHint("Boolean")
+    public Boolean eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = Box3DTypeSerializer.class,
+                bridgedTo = Box3D.class)
+            Box3D a,
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = Box3DTypeSerializer.class,
+                bridgedTo = Box3D.class)
+            Box3D b) {
+      if (a == null || b == null) return null;
+      return org.apache.sedona.common.Predicates.box3dContains(a, b);
     }
   }
 
@@ -403,6 +439,51 @@ public class Predicates {
       Geometry geom1 = (Geometry) o1;
       Geometry geom2 = (Geometry) o2;
       return org.apache.sedona.common.Predicates.dWithin(geom1, geom2, distance, useSphere);
+    }
+  }
+
+  public static class ST_3DDWithin extends ScalarFunction {
+
+    public ST_3DDWithin() {}
+
+    /** 3D Euclidean distance-within over two geometries (missing Z folds to 0). */
+    @DataTypeHint("Boolean")
+    public Boolean eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = GeometryTypeSerializer.class,
+                bridgedTo = Geometry.class)
+            Object o1,
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = GeometryTypeSerializer.class,
+                bridgedTo = Geometry.class)
+            Object o2,
+        @DataTypeHint("Double") Double distance) {
+      // Guard distance too: the common-layer dWithin3D takes a primitive double, so a SQL NULL
+      // distance would autounbox to an NPE rather than propagating NULL.
+      if (o1 == null || o2 == null || distance == null) return null;
+      Geometry geom1 = (Geometry) o1;
+      Geometry geom2 = (Geometry) o2;
+      return org.apache.sedona.common.Predicates.dWithin3D(geom1, geom2, distance);
+    }
+
+    /** Closed-interval 3D distance test over two Box3D values. */
+    @DataTypeHint("Boolean")
+    public Boolean eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = Box3DTypeSerializer.class,
+                bridgedTo = Box3D.class)
+            Box3D a,
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = Box3DTypeSerializer.class,
+                bridgedTo = Box3D.class)
+            Box3D b,
+        @DataTypeHint("Double") Double distance) {
+      if (a == null || b == null || distance == null) return null;
+      return org.apache.sedona.common.Predicates.dWithin3D(a, b, distance);
     }
   }
 }

--- a/flink/src/test/java/org/apache/sedona/flink/PredicateTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/PredicateTest.java
@@ -21,6 +21,7 @@ package org.apache.sedona.flink;
 import static org.apache.flink.table.api.Expressions.$;
 import static org.apache.flink.table.api.Expressions.call;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import org.apache.flink.table.api.Table;
 import org.apache.sedona.flink.expressions.Predicates;
@@ -60,6 +61,75 @@ public class PredicateTest extends TestBase {
     org.apache.flink.types.Row row = first(t);
     assertEquals(true, row.getField(0));
     assertEquals(false, row.getField(1));
+  }
+
+  @Test
+  public void testIntersectsOnBox3D() {
+    Table t =
+        tableEnv.sqlQuery(
+            "WITH boxes AS ("
+                + " SELECT ST_3DMakeBox(ST_PointZ(0, 0, 0), ST_PointZ(5, 5, 5)) AS a,"
+                + " ST_3DMakeBox(ST_PointZ(3, 3, 3), ST_PointZ(7, 7, 7)) AS overlap,"
+                + " ST_3DMakeBox(ST_PointZ(0, 0, 10), ST_PointZ(5, 5, 11)) AS zdisjoint,"
+                + " ST_3DMakeBox(ST_PointZ(6, 6, 6), ST_PointZ(7, 7, 7)) AS disjoint)"
+                + " SELECT ST_Intersects(a, overlap), ST_Intersects(a, zdisjoint),"
+                + " ST_Intersects(a, disjoint) FROM boxes");
+    org.apache.flink.types.Row row = first(t);
+    assertEquals(true, row.getField(0));
+    // Overlaps in XY but separated in Z — Box3D intersection must reject it.
+    assertEquals(false, row.getField(1));
+    assertEquals(false, row.getField(2));
+  }
+
+  @Test
+  public void testContainsOnBox3D() {
+    Table t =
+        tableEnv.sqlQuery(
+            "WITH boxes AS ("
+                + " SELECT ST_3DMakeBox(ST_PointZ(0, 0, 0), ST_PointZ(10, 10, 10)) AS outer_box,"
+                + " ST_3DMakeBox(ST_PointZ(2, 2, 2), ST_PointZ(5, 5, 5)) AS inner_box,"
+                + " ST_3DMakeBox(ST_PointZ(2, 2, 2), ST_PointZ(5, 5, 99)) AS zout)"
+                + " SELECT ST_Contains(outer_box, inner_box), ST_Contains(outer_box, zout)"
+                + " FROM boxes");
+    org.apache.flink.types.Row row = first(t);
+    assertEquals(true, row.getField(0));
+    // Contained in XY but pokes out of the Z range — not contained in 3D.
+    assertEquals(false, row.getField(1));
+  }
+
+  @Test
+  public void test3DDWithin() {
+    // Two POINT Z 3 units apart in Z only.
+    Table within =
+        tableEnv.sqlQuery(
+            "SELECT ST_3DDWithin(ST_PointZ(0, 0, 0), ST_PointZ(0, 0, 3), 3.0),"
+                + " ST_3DDWithin(ST_PointZ(0, 0, 0), ST_PointZ(0, 0, 3), 2.9)");
+    org.apache.flink.types.Row row = first(within);
+    assertEquals(true, row.getField(0));
+    assertEquals(false, row.getField(1));
+
+    // Box3D-on-Box3D: faces 4 units apart in Z.
+    Table boxes =
+        tableEnv.sqlQuery(
+            "WITH b AS ("
+                + " SELECT ST_3DMakeBox(ST_PointZ(0, 0, 0), ST_PointZ(1, 1, 1)) AS a,"
+                + " ST_3DMakeBox(ST_PointZ(0, 0, 5), ST_PointZ(1, 1, 6)) AS far)"
+                + " SELECT ST_3DDWithin(a, far, 4.0), ST_3DDWithin(a, far, 3.9) FROM b");
+    org.apache.flink.types.Row boxRow = first(boxes);
+    assertEquals(true, boxRow.getField(0));
+    assertEquals(false, boxRow.getField(1));
+
+    // NULL distance propagates to NULL rather than throwing on autounbox.
+    Table nullDist =
+        tableEnv.sqlQuery(
+            "SELECT ST_3DDWithin(ST_PointZ(0, 0, 0), ST_PointZ(0, 0, 3),"
+                + " CAST(NULL AS DOUBLE)) AS geom_null,"
+                + " ST_3DDWithin(ST_3DMakeBox(ST_PointZ(0, 0, 0), ST_PointZ(1, 1, 1)),"
+                + " ST_3DMakeBox(ST_PointZ(0, 0, 5), ST_PointZ(1, 1, 6)),"
+                + " CAST(NULL AS DOUBLE)) AS box_null");
+    org.apache.flink.types.Row nullRow = first(nullDist);
+    assertNull(nullRow.getField(0));
+    assertNull(nullRow.getField(1));
   }
 
   @Test


### PR DESCRIPTION
## Did you read the Contributor Guide?

- [x] Yes

## Is this PR related to a ticket?

- [x] Yes — closes [#3042](https://github.com/apache/sedona/issues/3042); follow-up to the Box3D EPIC ([#2973](https://github.com/apache/sedona/issues/2973)) and the Flink slices #3037 (foundation) and #3040 (accessors / ST_3DExtent).

## What changes were proposed in this PR?

Final Flink Box3D slice. Brings the Flink predicate surface to parity with Spark's Box3D predicates (consolidated into `ST_Intersects` / `ST_Contains` plus the standalone `ST_3DDWithin`).

- **`ST_Intersects` / `ST_Contains`**: Box3D `eval` overloads wrapping `Predicates.box3dIntersects` / `box3dContains`. Mirrors the Box2D overloads already on these classes.
- **`ST_3DDWithin`**: new scalar function with two overloads — `(Geometry, Geometry, Double)` → `dWithin3D` (missing Z folds to 0), and `(Box3D, Box3D, Double)` → `dWithin3D`. NULL-guarded like the Box overloads. Registered in `Catalog`.

## How was this patch tested?

- `PredicateTest.testIntersectsOnBox3D` / `testContainsOnBox3D` — XY-overlapping-but-Z-disjoint rows confirm the Z axis is enforced (not just an XY-footprint check).
- `PredicateTest.test3DDWithin` — Geometry POINT Z within / just-outside the threshold, plus Box3D-on-Box3D faces-apart-in-Z within / just-outside.
- Full `PredicateTest`: 21 pass.

## Did this PR include necessary documentation updates?

- [x] No — Box3D documentation is tracked separately under the Box3D EPIC.

## Completion

This completes Flink Box3D parity with the shipped Spark surface: type + serializer, constructors, accessors, `ST_AsText`, `ST_3DExtent`, and predicates.