### PR TITLE
[GH-3046] Flink ST_DWithin: propagate NULL arguments instead of NPE

### DIFF
--- a/flink/src/main/java/org/apache/sedona/flink/expressions/Predicates.java
+++ b/flink/src/main/java/org/apache/sedona/flink/expressions/Predicates.java
@@ -417,6 +417,9 @@ public class Predicates {
                 bridgedTo = Geometry.class)
             Object o2,
         @DataTypeHint("Double") Double distance) {
+      // The common-layer dWithin takes a primitive double, so a SQL NULL distance would
+      // autounbox to an NPE; any NULL argument propagates to a NULL result instead.
+      if (o1 == null || o2 == null || distance == null) return null;
       Geometry geom1 = (Geometry) o1;
       Geometry geom2 = (Geometry) o2;
       return org.apache.sedona.common.Predicates.dWithin(geom1, geom2, distance);
@@ -436,6 +439,8 @@ public class Predicates {
             Object o2,
         @DataTypeHint("Double") Double distance,
         @DataTypeHint("Boolean") Boolean useSphere) {
+      // distance and useSphere both autounbox to primitives in the common layer; guard all four.
+      if (o1 == null || o2 == null || distance == null || useSphere == null) return null;
       Geometry geom1 = (Geometry) o1;
       Geometry geom2 = (Geometry) o2;
       return org.apache.sedona.common.Predicates.dWithin(geom1, geom2, distance, useSphere);

--- a/flink/src/test/java/org/apache/sedona/flink/PredicateTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/PredicateTest.java
@@ -284,6 +284,23 @@ public class PredicateTest extends TestBase {
   }
 
   @Test
+  public void testDWithinNullArguments() {
+    // Any NULL argument propagates to NULL rather than NPE-ing on autounbox / null geometry.
+    Table t =
+        tableEnv.sqlQuery(
+            "SELECT ST_DWithin(ST_GeomFromWKT('POINT (0 0)'), ST_GeomFromWKT('POINT (1 0)'),"
+                + " CAST(NULL AS DOUBLE)) AS null_dist,"
+                + " ST_DWithin(ST_GeomFromWKT(CAST(NULL AS STRING)),"
+                + " ST_GeomFromWKT('POINT (1 0)'), 1.0) AS null_geom,"
+                + " ST_DWithin(ST_GeomFromWKT('POINT (0 0)'), ST_GeomFromWKT('POINT (1 0)'), 1.0,"
+                + " CAST(NULL AS BOOLEAN)) AS null_sphere");
+    org.apache.flink.types.Row row = first(t);
+    assertNull(row.getField(0));
+    assertNull(row.getField(1));
+    assertNull(row.getField(2));
+  }
+
+  @Test
   public void testDWithinFailure() {
     Table table =
         tableEnv.sqlQuery(


### PR DESCRIPTION
## Did you read the Contributor Guide?

- [x] Yes

## Is this PR related to a ticket?

- [x] Yes — closes [#3046](https://github.com/apache/sedona/issues/3046). Surfaced reviewing #3043.

## What changes were proposed in this PR?

The Flink `ST_DWithin` overloads passed their arguments straight to the common-layer `dWithin`, which takes primitive `double` / `boolean`. A SQL `NULL` distance (or `useSphere`) autounboxed to a `NullPointerException`, and a `NULL` geometry NPE'd inside the predicate — instead of propagating to a `NULL` result as SQL semantics require.

- **3-arg overload**: guard `o1` / `o2` / `distance`.
- **4-arg overload**: additionally guard `useSphere`.

This brings `ST_DWithin` up to the NULL-safe contract that `ST_3DDWithin` already has (added in #3043).

**Audit of the rest of the Flink predicate surface:** `ST_DWithin` and `ST_3DDWithin` are the only predicates with boxed-primitive arguments (`distance` / `useSphere`); every other predicate takes geometry RAW arguments only, so there is no further autounbox hazard. `ST_3DDWithin` was already guarded.

## How was this patch tested?

- `PredicateTest.testDWithinNullArguments` asserts NULL propagation for a NULL distance, a NULL geometry, and a NULL `useSphere`.
- Full `PredicateTest`: 22 pass.

## Did this PR include necessary documentation updates?

- [x] No — behavior fix; no API surface change.