### PR TITLE
[GH-3044] Fix aggregate function registration in sessions cloned from FunctionRegistry.builtin

### DIFF
--- a/spark/common/src/main/scala/org/apache/sedona/sql/UDF/AbstractCatalog.scala
+++ b/spark/common/src/main/scala/org/apache/sedona/sql/UDF/AbstractCatalog.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.sedona_sql.expressions.{ST_Envelope_Aggr, ST_Interse
 import org.locationtech.jts.geom.Geometry
 
 import scala.reflect.ClassTag
+import scala.util.Try
 
 abstract class AbstractCatalog {
 
@@ -89,7 +90,10 @@ abstract class AbstractCatalog {
         case Some(existingInfo) =>
           // Skip if Sedona already registered this function (e.g., SedonaContext.create called
           // twice). Overwrite if it's a Spark native function (e.g., Spark 4.1's ST_GeomFromWKB).
-          !existingInfo.getClassName.startsWith("org.apache.sedona.")
+          // Sedona expression classes live under both org.apache.sedona and
+          // org.apache.spark.sql.sedona_sql.
+          !existingInfo.getClassName.startsWith("org.apache.sedona.") &&
+          !existingInfo.getClassName.startsWith("org.apache.spark.sql.sedona_sql.")
         case None => true
       }
       if (shouldRegister) {
@@ -114,8 +118,17 @@ abstract class AbstractCatalog {
       functionName: String,
       aggregator: Aggregator[Geometry, _, _]): Unit = {
     val functionIdentifier = FunctionIdentifier(functionName)
-    if (!sparkSession.sessionState.functionRegistry.functionExists(functionIdentifier)) {
+    val registry = sparkSession.sessionState.functionRegistry
+    // A new session clones FunctionRegistry.builtin, which holds Sedona's non-invocable
+    // placeholder for this aggregate (registered below), so mere existence in the session
+    // registry does not mean the real UDAF is there (GH-3044). Probe the registered builder:
+    // the placeholder throws on any invocation, a real entry builds an expression.
+    val isInvocable = registry.functionExists(functionIdentifier) &&
+      Try(registry.lookupFunction(functionIdentifier, Seq(Literal(null)))).isSuccess
+    if (!isInvocable) {
       sparkSession.udf.register(functionName, functions.udaf(aggregator))
+    }
+    if (!FunctionRegistry.builtin.functionExists(functionIdentifier)) {
       FunctionRegistry.builtin.registerFunction(
         functionIdentifier,
         new ExpressionInfo(aggregator.getClass.getCanonicalName, null, functionName),

--- a/spark/common/src/main/scala/org/apache/sedona/sql/UDF/AbstractCatalog.scala
+++ b/spark/common/src/main/scala/org/apache/sedona/sql/UDF/AbstractCatalog.scala
@@ -90,8 +90,8 @@ abstract class AbstractCatalog {
         case Some(existingInfo) =>
           // Skip if Sedona already registered this function (e.g., SedonaContext.create called
           // twice). Overwrite if it's a Spark native function (e.g., Spark 4.1's ST_GeomFromWKB).
-          // Sedona expression classes live under both org.apache.sedona and
-          // org.apache.spark.sql.sedona_sql.
+          // All expressions registered here live under org.apache.spark.sql.sedona_sql; the
+          // org.apache.sedona prefix is kept defensively for future classes.
           !existingInfo.getClassName.startsWith("org.apache.sedona.") &&
           !existingInfo.getClassName.startsWith("org.apache.spark.sql.sedona_sql.")
         case None => true

--- a/spark/common/src/main/scala/org/apache/sedona/sql/UDF/AbstractCatalog.scala
+++ b/spark/common/src/main/scala/org/apache/sedona/sql/UDF/AbstractCatalog.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry.FunctionBuilder
 import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression, ExpressionInfo, Literal}
-import org.apache.spark.sql.expressions.Aggregator
+import org.apache.spark.sql.expressions.{Aggregator, UserDefinedFunction}
 import org.apache.spark.sql.sedona_sql.expressions.{ST_Envelope_Aggr, ST_Intersection_Aggr, ST_Union_Aggr}
 import org.locationtech.jts.geom.Geometry
 
@@ -113,28 +113,64 @@ abstract class AbstractCatalog {
     registerAggregateFunction(sparkSession, "ST_Union_Agg", new ST_Union_Aggr())
   }
 
+  // Builds the catalyst aggregate for a UDAF so the FunctionRegistry.builtin entry can be the
+  // real implementation rather than a non-invocable placeholder. The required Spark API is
+  // package-private in Scala (public in bytecode) and moved between versions, hence reflection:
+  // Spark 3.4/3.5 expose UserDefinedAggregator.scalaAggregator(children), Spark 4.x the
+  // ScalaAggregator companion's apply(udaf, children).
+  private lazy val builtinAggregateBuilder
+      : Option[(UserDefinedFunction, Seq[Expression]) => Expression] = {
+    val spark3Builder = Try {
+      val method = Class
+        .forName("org.apache.spark.sql.expressions.UserDefinedAggregator")
+        .getMethod("scalaAggregator", classOf[Seq[Expression]])
+      (udaf: UserDefinedFunction, children: Seq[Expression]) =>
+        method.invoke(udaf, children).asInstanceOf[Expression]
+    }
+    val spark4Builder = Try {
+      val companionClass =
+        Class.forName("org.apache.spark.sql.execution.aggregate.ScalaAggregator$")
+      val companion = companionClass.getField("MODULE$").get(null)
+      val method = companionClass.getMethods
+        .find(m =>
+          m.getName == "apply" && m.getParameterCount == 2 &&
+            m.getParameterTypes()(0).getSimpleName == "UserDefinedAggregator")
+        .get
+      (udaf: UserDefinedFunction, children: Seq[Expression]) =>
+        method.invoke(companion, udaf, children).asInstanceOf[Expression]
+    }
+    spark3Builder.orElse(spark4Builder).toOption
+  }
+
   private def registerAggregateFunction(
       sparkSession: SparkSession,
       functionName: String,
       aggregator: Aggregator[Geometry, _, _]): Unit = {
     val functionIdentifier = FunctionIdentifier(functionName)
     val registry = sparkSession.sessionState.functionRegistry
-    // A new session clones FunctionRegistry.builtin, which holds Sedona's non-invocable
-    // placeholder for this aggregate (registered below), so mere existence in the session
-    // registry does not mean the real UDAF is there (GH-3044). Probe the registered builder:
-    // the placeholder throws on any invocation, a real entry builds an expression.
+    val udaf = functions.udaf(aggregator)
+    // A session created before this JVM's first SedonaContext.create cloned
+    // FunctionRegistry.builtin while it still held the non-invocable placeholder for this
+    // aggregate, so mere existence in the session registry does not mean the real UDAF is
+    // there (GH-3044). Probe the registered builder: the placeholder throws on any
+    // invocation, a real entry builds an expression.
     val isInvocable = registry.functionExists(functionIdentifier) &&
       Try(registry.lookupFunction(functionIdentifier, Seq(Literal(null)))).isSuccess
     if (!isInvocable) {
-      sparkSession.udf.register(functionName, functions.udaf(aggregator))
+      sparkSession.udf.register(functionName, udaf)
     }
     if (!FunctionRegistry.builtin.functionExists(functionIdentifier)) {
+      val builtinBuilder: FunctionBuilder = builtinAggregateBuilder match {
+        case Some(build) => children => build(udaf, children)
+        case None =>
+          _ =>
+            throw new UnsupportedOperationException(
+              s"Aggregate function $functionName cannot be used as a regular function")
+      }
       FunctionRegistry.builtin.registerFunction(
         functionIdentifier,
         new ExpressionInfo(aggregator.getClass.getCanonicalName, null, functionName),
-        (_: Seq[Expression]) =>
-          throw new UnsupportedOperationException(
-            s"Aggregate function $functionName cannot be used as a regular function"))
+        builtinBuilder)
     }
   }
 

--- a/spark/common/src/test/scala/org/apache/sedona/sql/aggregateFunctionTestScala.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/aggregateFunctionTestScala.scala
@@ -19,6 +19,7 @@
 package org.apache.sedona.sql
 
 import org.apache.sedona.common.geometryObjects.Box2D
+import org.apache.sedona.spark.SedonaContext
 import org.apache.spark.sql.DataFrame
 import org.locationtech.jts.geom.{Coordinate, Geometry, GeometryFactory, Polygon}
 
@@ -507,6 +508,20 @@ class aggregateFunctionTestScala extends TestBaseScala {
       val result = envelopeDF.take(1)(0).get(0)
 
       assert(result == null)
+    }
+
+    it("Passed aggregate functions in a new session") {
+      // GH-3044: a new session clones FunctionRegistry.builtin, which holds Sedona's
+      // non-invocable placeholder for aggregate functions. SedonaContext.create must still
+      // install the real UDAF in the new session's registry instead of skipping it because
+      // the name already exists.
+      val newSession = sparkSession.newSession()
+      SedonaContext.create(newSession)
+      Seq("ST_Envelope_Aggr", "ST_Envelope_Agg", "ST_Union_Aggr").foreach { func =>
+        val result = newSession.sql(
+          s"SELECT $func(geom) FROM (SELECT ST_GeomFromWKT('POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))') AS geom)")
+        assert(result.take(1)(0).get(0) != null, s"$func returned null in a new session")
+      }
     }
   }
 

--- a/spark/common/src/test/scala/org/apache/sedona/sql/aggregateFunctionTestScala.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/aggregateFunctionTestScala.scala
@@ -523,6 +523,16 @@ class aggregateFunctionTestScala extends TestBaseScala {
         assert(result.take(1)(0).get(0) != null, s"$func returned null in a new session")
       }
     }
+
+    it("Passed aggregate functions in a new session without SedonaContext.create") {
+      // The FunctionRegistry.builtin entry registered by an earlier SedonaContext.create must
+      // be the real aggregate builder, so a session that never ran create can still resolve
+      // the aggregate from its cloned registry.
+      val newSession = sparkSession.newSession()
+      val result = newSession.sql(
+        "SELECT ST_Envelope_Aggr(geom) FROM (SELECT ST_GeomFromWKT('POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))') AS geom)")
+      assert(result.take(1)(0).get(0) != null)
+    }
   }
 
   def generateRandomPolygon(index: Int): String = {


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #3044

## What changes were proposed in this PR?

Sedona registers aggregate functions in two places: the real UDAF via `udf.register` in the session registry, and an entry in the global `FunctionRegistry.builtin` that throws `UnsupportedOperationException` on invocation (added in #2420 for permanent VIEW support). Every new SparkSession clones `FunctionRegistry.builtin` into its session registry, so any session created after the first `SedonaContext.create()` in the JVM starts out holding the throwing placeholder under the aggregate names.

The `functionExists()` guard added in #2642 mistook that cloned placeholder for a real registration and skipped `udf.register`, so the real UDAF was never installed and the session failed with `Aggregate function ST_Envelope_Aggr cannot be used as a regular function`. Spark Connect creates a new server-side session per client session, which is why the reported repro fails on the second session (1.8.1 re-registered unconditionally, which silently overwrote the cloned placeholder).

Two commits:

1. **Re-register over the placeholder.** `registerAggregateFunction` now probes the existing entry by invoking its builder: the placeholder throws, a real entry builds an expression. The real UDAF is re-registered only when the entry is not invocable, so the GH-2640 behavior (no re-registration noise on repeated `create()`) is preserved. Also extends the scalar skip check to cover Sedona expression classes under `org.apache.spark.sql.sedona_sql`, which the `org.apache.sedona` prefix never matched.
2. **Back the builtin entry with the real builder.** `FunctionRegistry.builtin` now receives the actual `ScalaAggregator` builder instead of a throwing placeholder, so cloned registries resolve Sedona aggregates by construction (even in sessions that never ran `SedonaContext.create`). The required Spark API is package-private and moved between versions, so it is loaded reflectively: `UserDefinedAggregator.scalaAggregator` on Spark 3.4/3.5, the `ScalaAggregator` companion apply on Spark 4.x. If neither is found, the previous placeholder behavior is kept and the probe from commit 1 still applies.

The first commit is intentionally minimal and self-contained so it can be cherry-picked to a 1.9.1 patch release on its own.

## How was this patch tested?

Two new tests in `aggregateFunctionTestScala`:

- `ST_Envelope_Aggr`, `ST_Envelope_Agg`, and `ST_Union_Aggr` in a `newSession()` after `SedonaContext.create` — reproduces #3044 without Spark Connect; fails on current master with the exact exception from the report.
- `ST_Envelope_Aggr` in a `newSession()` that never ran `SedonaContext.create` — verifies the builtin entry is the real builder.

Full suite run locally on Spark 3.4 / Scala 2.12 / JDK 11 and Spark 4.0 / Scala 2.13 / JDK 17 (30/30 passing), covering both reflection paths.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.