### PR TITLE
[GH-3051] Implement GeoSeries.translate

### DIFF
--- a/python/sedona/spark/geopandas/base.py
+++ b/python/sedona/spark/geopandas/base.py
@@ -1413,6 +1413,44 @@ class GeoFrame(metaclass=ABCMeta):
         """
         return _delegate_to_geometry_column("rotate", self, angle, origin, use_radians)
 
+    def translate(self, xoff=0.0, yoff=0.0, zoff=0.0):
+        """Return a ``GeoSeries`` with translated geometries.
+
+        See http://shapely.readthedocs.io/en/latest/manual.html#shapely.affinity.translate
+        for details.
+
+        Parameters
+        ----------
+        xoff, yoff, zoff : float, float, float
+            Amount of offset along each dimension. xoff, yoff, and zoff for
+            translation along the x, y, and z dimensions respectively.
+
+        Examples
+        --------
+        >>> from shapely.geometry import Point, LineString, Polygon
+        >>> from sedona.spark.geopandas import GeoSeries
+        >>> s = GeoSeries(
+        ...     [
+        ...         Point(1, 1),
+        ...         LineString([(1, -1), (1, 0)]),
+        ...         Polygon([(3, -1), (4, 0), (3, 1)]),
+        ...     ]
+        ... )
+        >>> s
+        0                         POINT (1 1)
+        1              LINESTRING (1 -1, 1 0)
+        2    POLYGON ((3 -1, 4 0, 3 1, 3 -1))
+        dtype: geometry
+
+        >>> s.translate(2, 3)
+        0                       POINT (3 4)
+        1            LINESTRING (3 2, 3 3)
+        2    POLYGON ((5 2, 6 3, 5 4, 5 2))
+        dtype: geometry
+
+        """
+        return _delegate_to_geometry_column("translate", self, xoff, yoff, zoff)
+
     def force_2d(self):
         """Force the dimensionality of a geometry to 2D.
 

--- a/python/sedona/spark/geopandas/geoseries.py
+++ b/python/sedona/spark/geopandas/geoseries.py
@@ -1196,7 +1196,9 @@ class GeoSeries(GeoFrame, pspd.Series):
                 raise NotImplementedError(
                     f"Array-like values for {name} are not supported yet."
                 )
-        spark_expr = stf.ST_Translate(self.spark.column, xoff, yoff, zoff)
+        spark_expr = stf.ST_Translate(
+            self.spark.column, float(xoff), float(yoff), float(zoff)
+        )
         return self._query_geometry_column(spark_expr, returns_geom=True)
 
     def force_2d(self) -> "GeoSeries":

--- a/python/sedona/spark/geopandas/geoseries.py
+++ b/python/sedona/spark/geopandas/geoseries.py
@@ -1190,6 +1190,15 @@ class GeoSeries(GeoFrame, pspd.Series):
             )
         return self._query_geometry_column(spark_expr, returns_geom=True)
 
+    def translate(self, xoff=0.0, yoff=0.0, zoff=0.0) -> "GeoSeries":
+        for name, offset in (("xoff", xoff), ("yoff", yoff), ("zoff", zoff)):
+            if not isinstance(offset, (float, int)):
+                raise NotImplementedError(
+                    f"Array-like values for {name} are not supported yet."
+                )
+        spark_expr = stf.ST_Translate(self.spark.column, xoff, yoff, zoff)
+        return self._query_geometry_column(spark_expr, returns_geom=True)
+
     def force_2d(self) -> "GeoSeries":
         spark_expr = stf.ST_Force_2D(self.spark.column)
         return self._query_geometry_column(spark_expr, returns_geom=True)

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -1918,6 +1918,44 @@ e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3
         with pytest.raises((ValueError, TypeError)):
             s.rotate(90, origin="invalid")
 
+    def test_translate(self):
+        geoms = [
+            Point(1, 1),
+            LineString([(1, -1), (1, 0)]),
+            Polygon([(3, -1), (4, 0), (3, 1)]),
+            None,
+        ]
+        s = GeoSeries(geoms)
+
+        # Docstring example: translate(2, 3)
+        result = s.translate(2, 3)
+        expected = gpd.GeoSeries(
+            [
+                Point(3, 4),
+                LineString([(3, 2), (3, 3)]),
+                Polygon([(5, 2), (6, 3), (5, 4), (5, 2)]),
+                None,
+            ]
+        )
+        self.check_sgpd_equals_gpd(result, expected)
+
+        # Identity translation
+        result = s.translate()
+        self.check_sgpd_equals_gpd(result, gpd.GeoSeries(geoms))
+
+        # Z offset on 3D geometry
+        s3d = GeoSeries([Point(1, 1, 1), Point(0, 0)])
+        result = s3d.translate(2, 3, 5)
+        expected_3d = gpd.GeoSeries([Point(3, 4, 6), Point(2, 3)])
+        self.check_sgpd_equals_gpd(result, expected_3d)
+
+        # GeoDataFrame path
+        df_result = s.to_geoframe().translate(2, 3)
+        self.check_sgpd_equals_gpd(df_result, expected)
+
+        with pytest.raises(NotImplementedError):
+            s.translate([1, 2], 3)
+
     def test_force_2d(self):
         s = sgpd.GeoSeries(
             [

--- a/python/tests/geopandas/test_match_geopandas_series.py
+++ b/python/tests/geopandas/test_match_geopandas_series.py
@@ -978,6 +978,34 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
             gpd_result = gpd.GeoSeries(non_empty).rotate(angle, **origin_kwargs)
             self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
 
+    @pytest.mark.parametrize(
+        "xoff,yoff,zoff",
+        [
+            (2, 3, 0),
+            (0, 0, 0),
+            (1.5, -2, 0),
+            (0, 0, 5),
+        ],
+    )
+    def test_translate(self, xoff, yoff, zoff):
+        for geom in self.geoms:
+            non_empty = [g for g in geom if g is not None and not g.is_empty]
+            if not non_empty:
+                continue
+
+            sgpd_result = GeoSeries(non_empty).translate(xoff, yoff, zoff)
+            gpd_result = gpd.GeoSeries(non_empty).translate(xoff, yoff, zoff)
+            self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
+
+        data = [
+            Point(0, -1, 2.5),
+            LineString([(0, 0, 1), (1, 1, 2)]),
+            Point(5, 5),
+        ]
+        sgpd_result = GeoSeries(data).translate(xoff, yoff, zoff)
+        gpd_result = gpd.GeoSeries(data).translate(xoff, yoff, zoff)
+        self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
+
     def test_force_2d(self):
         # force_2d was added from geopandas 1.0.0
         if parse_version(gpd.__version__) < parse_version("1.0.0"):


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-3051] Implement GeoSeries.translate`. Closes #3051

Contributes to #2230 (GeoPandas affine transformations).

## What changes were proposed in this PR?

Implement `GeoSeries.translate(xoff=0.0, yoff=0.0, zoff=0.0)` by wiring to the existing `ST_Translate` Spark SQL function. Also adds `GeoDataFrame.translate` via `base.py` delegation (same pattern as `rotate` in #3018).

## How was this patch tested?

Added tests in `test_geoseries.py` and `test_match_geopandas_series.py` following the `rotate` conventions.

```bash
cd python && unset VIRTUAL_ENV && uv sync --group dev --extra spark
uv run pytest -v tests/geopandas/test_geoseries.py -k translate
uv run pytest -v tests/geopandas/test_match_geopandas_series.py -k translate
```

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation (GeoPandas docstring copied into `base.py`).

cc @petern48