### PR TITLE
[GH-3033] [DOCS] Fix Whimsy site-check failures: ASF footer links, nav URLs, and external GitHub API call (GH-3033)

### DIFF
--- a/docs-overrides/partials/copyright.html
+++ b/docs-overrides/partials/copyright.html
@@ -1,14 +1,20 @@
-{#-
-  This file was automatically generated - do not edit
--#}
+{#- Site footer copyright and ASF-required links. -#}
 <div class="md-copyright">
   {% if config.copyright %}
-      {{ config.copyright }}
+  <div class="md-copyright__highlight">{{ config.copyright }}</div>
   {% endif %}
+  <div class="md-copyright__asf-links">
+    <a href="https://www.apache.org/">Copyright &copy; The Apache Software Foundation</a> |
+    <a href="https://www.apache.org/licenses/">License</a> |
+    <a href="https://www.apache.org/events/current-event">Events</a> |
+    <a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a> |
+    <a href="https://www.apache.org/foundation/thanks.html">Thanks</a> |
+    <a href="https://www.apache.org/security/">Security</a> |
+    <a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy</a> |
+    <a href="https://www.apache.org/foundation/marks/">Trademarks</a>
+  </div>
   {% if not config.extra.generator == false %}
-    Made with
-    <a href="https://squidfunk.github.io/mkdocs-material/" target="_blank" rel="noopener">
-      Material for MkDocs
-    </a>
+  <div class="md-copyright__generator">Made with <a href="https://squidfunk.github.io/mkdocs-material/" target="_blank" rel="noopener">Material for MkDocs</a>
+  </div>
   {% endif %}
 </div>

--- a/docs-overrides/partials/source.html
+++ b/docs-overrides/partials/source.html
@@ -1,0 +1,9 @@
+{% if config.repo_url %}
+<a href="{{ config.repo_url }}" title="{{ config.repo_name }}" class="md-source" target="_blank" rel="noopener">
+  <div class="md-source__icon md-icon">
+  {% set icon = config.theme.icon.repo or "fontawesome/brands/git-alt" %}
+  {% include ".icons/" ~ icon ~ ".svg" %}
+  </div>
+  <div class="md-source__repository">{{ config.repo_name }}</div>
+  </a>
+  {% endif %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -154,12 +154,12 @@ nav:
       - Publications: community/publication.md
   - Apache Software Foundation:
       - Foundation: asf/asf.md
-      - License: https://www.apache.org/licenses/" target="_blank
-      - Events: https://www.apache.org/events/current-event" target="_blank
-      - Sponsorship: https://www.apache.org/foundation/sponsorship.html" target="_blank
-      - Thanks: https://www.apache.org/foundation/thanks.html" target="_blank
-      - Security: https://www.apache.org/security/" target="_blank
-      - Privacy: https://privacy.apache.org/policies/privacy-policy-public.html" target="_blank
+      - License: https://www.apache.org/licenses/
+      - Events: https://www.apache.org/events/current-event
+      - Sponsorship: https://www.apache.org/foundation/sponsorship.html
+      - Thanks: https://www.apache.org/foundation/thanks.html
+      - Security: https://www.apache.org/security/
+      - Privacy: https://privacy.apache.org/policies/privacy-policy-public.html
       - Telemetry: asf/telemetry.md
 repo_url: https://github.com/apache/sedona
 repo_name: apache/sedona


### PR DESCRIPTION
## What this PR does

Fixes the Whimsy project website checks for Sedona (https://whimsy.apache.org/site/project/sedona), which were failing nearly every required-content check. Three changes:

1. **`docs-overrides/partials/copyright.html`** — Adds the ASF-required links to the rendered site footer so they appear on the homepage where Whimsy looks: License, Events, Sponsorship, Thanks, Security, Privacy, and Trademarks. Also makes the copyright notice itself a link (Whimsy's Copyright check expects a link matching `(©|Copyright).*apache`). Previously these links only existed as `nav:` entries in `mkdocs.yml` and never rendered in the footer.

2. **`mkdocs.yml`** — Removes the stray `" target="_blank` that had been appended to the License, Events, Sponsorship, Thanks, Security, and Privacy nav URLs, which produced malformed hrefs.

3. **`docs-overrides/partials/source.html`** (new) — Overrides the Material for MkDocs source partial to render the repo link without `data-md-component="source"`, so the theme no longer fetches stars/forks/version from `api.github.com`. Those calls were being refused by the site CSP and showed up as failed external resources in the Whimsy "Resources" check. The ASF-sanctioned Scarf and Matomo pixels are unaffected.

## Did you read the Contributor Guide?

- Yes.

## Is this PR related to a ticket?

- Yes, the PR name follows the format `[GH-XXX] my subject`. Closes #3033