### PR TITLE
[DOCS] Expose ASF footer links on site root for Whimsy via mike redirect template (GH-3033)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -118,6 +118,7 @@ jobs:
             git fetch origin website --depth=1
             version="${GITHUB_REF##*/branch-}"
             uv run mike deploy --update-aliases "$version" latest -b website -p
+            uv run mike set-default latest -T docs-overrides/redirect.html -b website -p
           fi
       - run: mkdir staging
       - run: cp -r site/* staging/

--- a/docs-overrides/partials/copyright.html
+++ b/docs-overrides/partials/copyright.html
@@ -4,7 +4,6 @@
   <div class="md-copyright__highlight">{{ config.copyright }}</div>
   {% endif %}
   <div class="md-copyright__asf-links">
-    <a href="https://www.apache.org/">Copyright &copy; The Apache Software Foundation</a> |
     <a href="https://www.apache.org/licenses/">License</a> |
     <a href="https://www.apache.org/events/current-event">Events</a> |
     <a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a> |

--- a/docs-overrides/redirect.html
+++ b/docs-overrides/redirect.html
@@ -39,6 +39,7 @@ under the License.
     -->
     <footer>
       <p>
+        <a href="https://www.apache.org/">Copyright &copy; The Apache Software Foundation</a> |
         <a href="https://www.apache.org/licenses/">License</a> |
         <a href="https://www.apache.org/events/current-event">Events</a> |
         <a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a> |
@@ -47,7 +48,6 @@ under the License.
         <a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy</a> |
         <a href="https://www.apache.org/foundation/marks/">Trademarks</a>
       </p>
-      <p>Copyright &copy; The Apache Software Foundation</p>
     </footer>
   </body>
 </html>

--- a/docs-overrides/redirect.html
+++ b/docs-overrides/redirect.html
@@ -1,0 +1,53 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Redirecting&hellip;</title>
+    <link rel="canonical" href="{{ href }}" />
+    <noscript>
+      <meta http-equiv="refresh" content="1; url={{ href }}" />
+    </noscript>
+    <script>
+      var target = "{{ href }}" + window.location.hash;
+      window.location.replace(target);
+    </script>
+  </head>
+  <body>
+    <p>Redirecting to <a href="{{ href }}">{{ href }}</a>&hellip;</p>
+    <!--
+      The links below are not shown to human visitors (who are redirected
+      immediately to {{ href }}), but they ensure the site root exposes the
+      ASF-required footer links to crawlers such as Apache Whimsy.
+    -->
+    <footer>
+      <p>
+        <a href="https://www.apache.org/licenses/">License</a> |
+        <a href="https://www.apache.org/events/current-event">Events</a> |
+        <a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a> |
+        <a href="https://www.apache.org/foundation/thanks.html">Thanks</a> |
+        <a href="https://www.apache.org/security/">Security</a> |
+        <a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy</a> |
+        <a href="https://www.apache.org/foundation/marks/">Trademarks</a>
+      </p>
+      <p>Copyright &copy; The Apache Software Foundation</p>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
## Is this PR related to a ticket?

Yes. Closes #3033 (partially — see below).

## What changes were proposed in this PR?

This addresses the remaining red link-checks in the [Whimsy site report](https://whimsy.apache.org/site/project/sedona) for the ASF-required footer links (License, Events, Sponsorship, Thanks, Security, Privacy, Trademarks).

### Background / root cause

The deployed footer on the actual docs pages (e.g. `/latest/`) already contains all required links. However, Whimsy crawls the bare site root `https://sedona.apache.org/`, which is the `mike`-generated redirect stub. That stub is a client-side `window.location.replace(...)` (plus a `<noscript>` meta-refresh) and contains none of the footer links. Whimsy does not execute JavaScript and does not follow the client-side redirect, so it reads the stub and reports the links as missing.

### Changes

1. **`docs-overrides/redirect.html`** — a custom `mike` redirect template. It keeps the existing redirect behaviour (canonical link, `<noscript>` meta-refresh, and JS `location.replace`) so real users are still sent to `{{ href }}` instantly, and adds a `<footer>` containing the ASF-required links so crawlers see them at the root.
2. **`.github/workflows/docs.yml`** — adds a `mike set-default latest -T docs-overrides/redirect.html` step after the release deploy, so the root redirect is regenerated from the new template. The workflow previously never ran `set-default`, which is why the root stub had not been regenerated since 2023.

### Notes

- These footer links are not shown to human visitors (they are redirected away immediately); they exist so the site root exposes the ASF-required links to crawlers such as Whimsy.
- The root is only regenerated on release branch (`branch-*`) deploys, since that is when the `latest` alias is updated. The Whimsy report will therefore go green after the next release deploy rather than immediately.

## How was this patch tested?

Template rendering reviewed manually; redirect logic and link set verified against the existing root stub and the `mike set-default --template` contract (`{{ href }}` substitution).

## Did you read the Contributor Guide?

Yes — [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/).