### PR TITLE
[DOCS] Add trademark attribution to root redirect footer for Whimsy (GH-3033)

### DIFF
--- a/docs-overrides/redirect.html
+++ b/docs-overrides/redirect.html
@@ -48,6 +48,11 @@ under the License.
         <a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy</a> |
         <a href="https://www.apache.org/foundation/marks/">Trademarks</a>
       </p>
+      <p>
+        Apache Sedona, Sedona, Apache, the Apache feather logo, and the Apache Sedona project logo
+        are either registered trademarks or trademarks of The Apache Software Foundation
+        in the United States and other countries.
+      </p>
     </footer>
   </body>
 </html>


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #3033

## What changes were proposed in this PR?

Apache Whimsy's Trademarks site-check scans page **text** for the attribution sentence `trademarks of The Apache Software Foundation` (`CHECK_VALIDATE`), not for a link. The mike-generated site root (`sedona.apache.org/`) only exposed a `Trademarks` link via the redirect template added in #3065, so the Whimsy Trademarks check stayed red while every other ASF footer check went green.

This PR adds the trademark attribution sentence to the redirect template footer (`docs-overrides/redirect.html`) so the regenerated root satisfies the check.

## How was this patch tested?

Verified the new footer text matches Whimsy's regexes in `lib/whimsy/sitestandards.rb`:
- `CHECK_TEXT => /\btrademarks\b/` ✅
- `CHECK_VALIDATE => /trademarks of [Tt]he Apache Software Foundation/` ✅

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
