### PR TITLE
[CI] Pin remaining actions to SHA for supply chain security

### DIFF
--- a/.github/linters/zizmor.yml
+++ b/.github/linters/zizmor.yml
@@ -15,10 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-rules:
-  unpinned-uses:
-    config:
-      policies:
-        r-lib/actions/check-r-package: any
-        r-lib/actions/setup-r: any
-        r-lib/actions/setup-r-dependencies: any
+rules: {}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -75,12 +75,12 @@ jobs:
       - name: Sync doc environment
         run: uv sync --group docs
       - run: sudo apt update
-      - uses: r-lib/actions/setup-r@v2.12.0
+      - uses: r-lib/actions/setup-r@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2.12.0
         with:
           r-version: release
           use-public-rspm: true
       - name: Query R dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2.12.0
+        uses: r-lib/actions/setup-r-dependencies@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2.12.0
         with:
           cache: true
           extra-packages: |

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -89,12 +89,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: r-lib/actions/setup-r@v2.12.0
+      - uses: r-lib/actions/setup-r@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2.12.0
         with:
           r-version: ${{ matrix.r }}
           use-public-rspm: true
       - name: Query R dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2.12.0
+        uses: r-lib/actions/setup-r-dependencies@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2.12.0
         with:
           cache: true
           extra-packages: |
@@ -102,7 +102,7 @@ jobs:
             any::rcmdcheck
           working-directory: './R'
       - name: Build and check R package
-        uses: r-lib/actions/check-r-package@v2.12.0
+        uses: r-lib/actions/check-r-package@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2.12.0
         with:
           build_args: 'c("--no-build-vignettes", "--no-manual")'
           args: 'c("--no-build-vignettes", "--no-manual", "--no-tests")'


### PR DESCRIPTION
Cleans up the zizmor.yml linter file.

https://github.com/apache/infrastructure-actions/blob/25ab499ef9c241b64a56860245e57c195baddec6/approved_patterns.yml#L279

https://github.com/r-lib/actions/commit/a51a8012b0aab7c32ef9d19bf54da93f3254335e

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

Pinning GitHub Actions to a specific commit SHA is the primary method to prevent supply-chain attacks. It guarantees that your continuous integration (CI) workflows execute the exact, unalterable version of code you have verified

## How was this patch tested?

`prek run -a`

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
