### PR TITLE
[DOCS] Fix Makefile target `docsbuild`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,10 @@ clean:
 
 docsbuild: docsinstall
 	@echo "Building documentation..."
-	uv run mkdocs build
+	cd docs-overrides && npm ci && npx gulp build
+	cd ..
 	uv run mike deploy --update-aliases latest-snapshot -b website -p
-	uv run mike serve
+	uv run mike serve -b website
 
 docsinstall: check-install
 	@echo "Installing documentation dependencies..."


### PR DESCRIPTION
Adds the missing "npm" steps to build the new version of the site with gulp

Removes unneeded build step and fixes mike serve

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a documentation update. The PR name follows the format `[DOCS] my subject`

## What changes were proposed in this PR?

- refs #2997
- closes #1727 

Basic details are already listed in our docs.  I will do another PR to update the docs to add more information about the Makefile as an alternative and convenient way to build the docs.

https://sedona.apache.org/latest-snapshot/setup/compile/

## How was this patch tested?

- `prek run -a`
- `make docsbuild`

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
