### PR TITLE
[GH-3073] Add geography support to SedonaFlink measurement and output functions

### DIFF
--- a/flink/src/main/java/org/apache/sedona/flink/expressions/Functions.java
+++ b/flink/src/main/java/org/apache/sedona/flink/expressions/Functions.java
@@ -27,6 +27,7 @@ import org.apache.sedona.common.geometryObjects.Box2D;
 import org.apache.sedona.common.geometryObjects.Box3D;
 import org.apache.sedona.flink.Box2DTypeSerializer;
 import org.apache.sedona.flink.Box3DTypeSerializer;
+import org.apache.sedona.flink.GeographyTypeSerializer;
 import org.apache.sedona.flink.GeometryArrayTypeSerializer;
 import org.apache.sedona.flink.GeometryTypeSerializer;
 import org.geotools.api.referencing.FactoryException;
@@ -105,6 +106,16 @@ public class Functions {
             Object o) {
       Geometry geom = (Geometry) o;
       return org.apache.sedona.common.Functions.area(geom);
+    }
+
+    @DataTypeHint("Double")
+    public Double eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = GeographyTypeSerializer.class,
+                bridgedTo = org.apache.sedona.common.S2Geography.Geography.class)
+            org.apache.sedona.common.S2Geography.Geography geog) {
+      return org.apache.sedona.common.geography.Functions.area(geog);
     }
   }
 
@@ -238,6 +249,50 @@ public class Functions {
       Geometry geom = (Geometry) o;
       return org.apache.sedona.common.Functions.buffer(geom, radius, useSpheroid, params);
     }
+
+    @DataTypeHint(
+        value = "RAW",
+        rawSerializer = GeographyTypeSerializer.class,
+        bridgedTo = org.apache.sedona.common.S2Geography.Geography.class)
+    public org.apache.sedona.common.S2Geography.Geography eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = GeographyTypeSerializer.class,
+                bridgedTo = org.apache.sedona.common.S2Geography.Geography.class)
+            org.apache.sedona.common.S2Geography.Geography geog,
+        @DataTypeHint("Double") Double radius) {
+      return org.apache.sedona.common.geography.Functions.buffer(geog, radius);
+    }
+
+    @DataTypeHint(
+        value = "RAW",
+        rawSerializer = GeographyTypeSerializer.class,
+        bridgedTo = org.apache.sedona.common.S2Geography.Geography.class)
+    public org.apache.sedona.common.S2Geography.Geography eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = GeographyTypeSerializer.class,
+                bridgedTo = org.apache.sedona.common.S2Geography.Geography.class)
+            org.apache.sedona.common.S2Geography.Geography geog,
+        @DataTypeHint("Double") Double radius,
+        @DataTypeHint("Boolean") Boolean useSpheroid) {
+      return org.apache.sedona.common.geography.Functions.buffer(geog, radius, useSpheroid);
+    }
+
+    @DataTypeHint(
+        value = "RAW",
+        rawSerializer = GeographyTypeSerializer.class,
+        bridgedTo = org.apache.sedona.common.S2Geography.Geography.class)
+    public org.apache.sedona.common.S2Geography.Geography eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = GeographyTypeSerializer.class,
+                bridgedTo = org.apache.sedona.common.S2Geography.Geography.class)
+            org.apache.sedona.common.S2Geography.Geography geog,
+        @DataTypeHint("Double") Double radius,
+        @DataTypeHint("String") String parameters) {
+      return org.apache.sedona.common.geography.Functions.buffer(geog, radius, parameters);
+    }
   }
 
   public static class ST_BestSRID extends ScalarFunction {
@@ -359,6 +414,19 @@ public class Functions {
             Object o) {
       Geometry geom = (Geometry) o;
       return org.apache.sedona.common.Functions.getCentroid(geom);
+    }
+
+    @DataTypeHint(
+        value = "RAW",
+        rawSerializer = GeographyTypeSerializer.class,
+        bridgedTo = org.apache.sedona.common.S2Geography.Geography.class)
+    public org.apache.sedona.common.S2Geography.Geography eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = GeographyTypeSerializer.class,
+                bridgedTo = org.apache.sedona.common.S2Geography.Geography.class)
+            org.apache.sedona.common.S2Geography.Geography geog) {
+      return org.apache.sedona.common.geography.Functions.centroid(geog);
     }
   }
 
@@ -503,6 +571,20 @@ public class Functions {
             Object o) {
       Geometry geom = (Geometry) o;
       return org.apache.sedona.common.Functions.envelope(geom);
+    }
+
+    @DataTypeHint(
+        value = "RAW",
+        rawSerializer = GeographyTypeSerializer.class,
+        bridgedTo = org.apache.sedona.common.S2Geography.Geography.class)
+    public org.apache.sedona.common.S2Geography.Geography eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = GeographyTypeSerializer.class,
+                bridgedTo = org.apache.sedona.common.S2Geography.Geography.class)
+            org.apache.sedona.common.S2Geography.Geography geog,
+        @DataTypeHint("Boolean") Boolean splitAtAntiMeridian) {
+      return org.apache.sedona.common.geography.Functions.getEnvelope(geog, splitAtAntiMeridian);
     }
   }
 
@@ -673,6 +755,21 @@ public class Functions {
       Geometry geom2 = (Geometry) o2;
       return org.apache.sedona.common.Functions.distance(geom1, geom2);
     }
+
+    @DataTypeHint("Double")
+    public Double eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = GeographyTypeSerializer.class,
+                bridgedTo = org.apache.sedona.common.S2Geography.Geography.class)
+            org.apache.sedona.common.S2Geography.Geography g1,
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = GeographyTypeSerializer.class,
+                bridgedTo = org.apache.sedona.common.S2Geography.Geography.class)
+            org.apache.sedona.common.S2Geography.Geography g2) {
+      return org.apache.sedona.common.geography.Functions.distance(g1, g2);
+    }
   }
 
   public static class ST_DistanceSphere extends ScalarFunction {
@@ -809,6 +906,16 @@ public class Functions {
       Geometry geom = (Geometry) o;
       return org.apache.sedona.common.Functions.geometryType(geom);
     }
+
+    @DataTypeHint("String")
+    public String eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = GeographyTypeSerializer.class,
+                bridgedTo = org.apache.sedona.common.S2Geography.Geography.class)
+            org.apache.sedona.common.S2Geography.Geography geog) {
+      return org.apache.sedona.common.geography.Functions.geometryType(geog);
+    }
   }
 
   public static class ST_Intersection extends ScalarFunction {
@@ -843,6 +950,16 @@ public class Functions {
             Object o) {
       Geometry geom = (Geometry) o;
       return org.apache.sedona.common.Functions.length(geom);
+    }
+
+    @DataTypeHint("Double")
+    public Double eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = GeographyTypeSerializer.class,
+                bridgedTo = org.apache.sedona.common.S2Geography.Geography.class)
+            org.apache.sedona.common.S2Geography.Geography geog) {
+      return org.apache.sedona.common.geography.Functions.length(geog);
     }
   }
 
@@ -1319,6 +1436,16 @@ public class Functions {
       Geometry geom = (Geometry) o;
       return org.apache.sedona.common.Functions.nPoints(geom);
     }
+
+    @DataTypeHint("Integer")
+    public Integer eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = GeographyTypeSerializer.class,
+                bridgedTo = org.apache.sedona.common.S2Geography.Geography.class)
+            org.apache.sedona.common.S2Geography.Geography geog) {
+      return org.apache.sedona.common.geography.Functions.nPoints(geog);
+    }
   }
 
   public static class ST_NumGeometries extends ScalarFunction {
@@ -1331,6 +1458,16 @@ public class Functions {
             Object o) {
       Geometry geom = (Geometry) o;
       return org.apache.sedona.common.Functions.numGeometries(geom);
+    }
+
+    @DataTypeHint("Integer")
+    public Integer eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = GeographyTypeSerializer.class,
+                bridgedTo = org.apache.sedona.common.S2Geography.Geography.class)
+            org.apache.sedona.common.S2Geography.Geography geog) {
+      return org.apache.sedona.common.geography.Functions.numGeometries(geog);
     }
   }
 
@@ -1387,6 +1524,16 @@ public class Functions {
       Geometry geom = (Geometry) o;
       return org.apache.sedona.common.Functions.asEWKT(geom);
     }
+
+    @DataTypeHint("String")
+    public String eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = GeographyTypeSerializer.class,
+                bridgedTo = org.apache.sedona.common.S2Geography.Geography.class)
+            org.apache.sedona.common.S2Geography.Geography geog) {
+      return org.apache.sedona.common.geography.Functions.asEWKT(geog);
+    }
   }
 
   public static class ST_AsText extends ScalarFunction {
@@ -1419,6 +1566,16 @@ public class Functions {
                 bridgedTo = Box3D.class)
             Box3D box) {
       return org.apache.sedona.common.Functions.box3dAsText(box);
+    }
+
+    @DataTypeHint("String")
+    public String eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = GeographyTypeSerializer.class,
+                bridgedTo = org.apache.sedona.common.S2Geography.Geography.class)
+            org.apache.sedona.common.S2Geography.Geography geog) {
+      return org.apache.sedona.common.geography.Functions.asText(geog);
     }
   }
 

--- a/flink/src/test/java/org/apache/sedona/flink/GeographyFunctionTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/GeographyFunctionTest.java
@@ -23,6 +23,7 @@ import static org.apache.flink.table.api.Expressions.call;
 import static org.apache.flink.table.api.Expressions.lit;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.Collections;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
@@ -178,6 +179,19 @@ public class GeographyFunctionTest extends TestBase {
   }
 
   @Test
+  public void testEnvelopeSplitAtAntiMeridian() throws Exception {
+    // An antimeridian-crossing line: with splitAtAntiMeridian=true the envelope is split into a
+    // MultiPolygon, exercising a different code path than the false branch above.
+    String wkt = "LINESTRING (170 10, -170 20)";
+    Object out = eval(wkt, call(Functions.ST_Envelope.class.getSimpleName(), $("geog"), lit(true)));
+    Geography expected =
+        org.apache.sedona.common.geography.Functions.getEnvelope(
+            Constructors.geogFromWKT(wkt, 4326), true);
+    assertEquals(expected.toEWKT(), ((Geography) out).toEWKT());
+    assertTrue(expected.toEWKT().contains("MULTIPOLYGON"));
+  }
+
+  @Test
   public void testBuffer() throws Exception {
     String wkt = "POINT (0 0)";
     Object out = eval(wkt, call(Functions.ST_Buffer.class.getSimpleName(), $("geog"), lit(1000.0)));
@@ -185,6 +199,47 @@ public class GeographyFunctionTest extends TestBase {
         org.apache.sedona.common.geography.Functions.buffer(
             Constructors.geogFromWKT(wkt, 4326), 1000.0);
     assertEquals(expected.toEWKT(), ((Geography) out).toEWKT());
+  }
+
+  @Test
+  public void testBufferWithParameters() throws Exception {
+    String wkt = "POINT (0 0)";
+    String params = "quad_segs=2";
+    Object out =
+        eval(
+            wkt,
+            call(Functions.ST_Buffer.class.getSimpleName(), $("geog"), lit(1000.0), lit(params)));
+    Geography expected =
+        org.apache.sedona.common.geography.Functions.buffer(
+            Constructors.geogFromWKT(wkt, 4326), 1000.0, params);
+    assertEquals(expected.toEWKT(), ((Geography) out).toEWKT());
+  }
+
+  @Test
+  public void testBufferUseSpheroidThrows() {
+    // The (Geography, radius, boolean) overload exists for parity with Spark and intentionally
+    // throws a clear error: Geography is always spheroidal, so useSpheroid is not accepted. This
+    // also confirms Flink resolves the boolean argument to this overload rather than coercing it to
+    // the (Geography, radius, String) parameters overload.
+    try {
+      eval(
+          "POINT (0 0)",
+          call(Functions.ST_Buffer.class.getSimpleName(), $("geog"), lit(1000.0), lit(true)));
+      fail("Expected ST_Buffer(geog, radius, useSpheroid) to throw");
+    } catch (Exception e) {
+      assertTrue(
+          "Expected a clear useSpheroid error, got: " + messageChain(e),
+          messageChain(e).contains("does not accept a useSpheroid argument"));
+    }
+  }
+
+  /** Concatenate the messages of an exception and all its causes, for robust assertion. */
+  private static String messageChain(Throwable t) {
+    StringBuilder sb = new StringBuilder();
+    for (Throwable c = t; c != null; c = c.getCause()) {
+      sb.append(c.getMessage()).append(" | ");
+    }
+    return sb.toString();
   }
 
   @Test

--- a/flink/src/test/java/org/apache/sedona/flink/GeographyFunctionTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/GeographyFunctionTest.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.flink;
+
+import static org.apache.flink.table.api.Expressions.$;
+import static org.apache.flink.table.api.Expressions.call;
+import static org.apache.flink.table.api.Expressions.lit;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.table.api.ApiExpression;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.types.Row;
+import org.apache.sedona.common.S2Geography.Geography;
+import org.apache.sedona.common.geography.Constructors;
+import org.apache.sedona.flink.expressions.Functions;
+import org.apache.sedona.flink.expressions.geography.GeographyConstructors;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class GeographyFunctionTest extends TestBase {
+
+  @BeforeClass
+  public static void onceExecutedBeforeAll() {
+    initialize();
+  }
+
+  /**
+   * A single-row table whose column "geog" is the geography parsed from {@code wkt} (SRID 4326).
+   */
+  private Table geogTable(String wkt) {
+    RowTypeInfo ti =
+        new RowTypeInfo(
+            new TypeInformation<?>[] {BasicTypeInfo.STRING_TYPE_INFO}, new String[] {"v"});
+    DataStream<Row> ds = env.fromCollection(Collections.singletonList(Row.of(wkt))).returns(ti);
+    return tableEnv
+        .fromDataStream(ds)
+        .select(
+            call(GeographyConstructors.ST_GeogFromWKT.class.getSimpleName(), $("v"), lit(4326))
+                .as("geog"));
+  }
+
+  private Object eval(String wkt, ApiExpression call) {
+    return first(geogTable(wkt).select(call.as("o"))).getFieldAs("o");
+  }
+
+  @Test
+  public void testArea() throws Exception {
+    String wkt = "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))";
+    Object out = eval(wkt, call(Functions.ST_Area.class.getSimpleName(), $("geog")));
+    double expected =
+        org.apache.sedona.common.geography.Functions.area(Constructors.geogFromWKT(wkt, 4326));
+    assertEquals(expected, (Double) out, 1e-6);
+    // sanity: geodesic area of a ~1deg box near the equator is on the order of 1e10 m^2
+    assertTrue((Double) out > 1e9);
+  }
+
+  @Test
+  public void testLength() throws Exception {
+    String wkt = "LINESTRING (0 0, 0 1)";
+    Object out = eval(wkt, call(Functions.ST_Length.class.getSimpleName(), $("geog")));
+    double expected =
+        org.apache.sedona.common.geography.Functions.length(Constructors.geogFromWKT(wkt, 4326));
+    assertEquals(expected, (Double) out, 1e-6);
+  }
+
+  @Test
+  public void testDistance() throws Exception {
+    String wktA = "POINT (0 0)";
+    String wktB = "POINT (0 1)";
+    RowTypeInfo ti =
+        new RowTypeInfo(
+            new TypeInformation<?>[] {
+              BasicTypeInfo.STRING_TYPE_INFO, BasicTypeInfo.STRING_TYPE_INFO
+            },
+            new String[] {"a", "b"});
+    DataStream<Row> ds =
+        env.fromCollection(Collections.singletonList(Row.of(wktA, wktB))).returns(ti);
+    Table t =
+        tableEnv
+            .fromDataStream(ds)
+            .select(
+                call(GeographyConstructors.ST_GeogFromWKT.class.getSimpleName(), $("a"), lit(4326))
+                    .as("ga"),
+                call(GeographyConstructors.ST_GeogFromWKT.class.getSimpleName(), $("b"), lit(4326))
+                    .as("gb"));
+    Object out =
+        first(t.select(call(Functions.ST_Distance.class.getSimpleName(), $("ga"), $("gb")).as("o")))
+            .getFieldAs("o");
+    double expected =
+        org.apache.sedona.common.geography.Functions.distance(
+            Constructors.geogFromWKT(wktA, 4326), Constructors.geogFromWKT(wktB, 4326));
+    assertEquals(expected, (Double) out, 1e-6);
+  }
+
+  @Test
+  public void testNPoints() {
+    Object out =
+        eval(
+            "LINESTRING (0 0, 1 1, 2 2)",
+            call(Functions.ST_NPoints.class.getSimpleName(), $("geog")));
+    assertEquals(3, ((Integer) out).intValue());
+  }
+
+  @Test
+  public void testNumGeometries() {
+    Object out =
+        eval(
+            "MULTIPOINT ((0 0), (1 1))",
+            call(Functions.ST_NumGeometries.class.getSimpleName(), $("geog")));
+    assertEquals(2, ((Integer) out).intValue());
+  }
+
+  @Test
+  public void testGeometryType() {
+    Object out =
+        eval("POINT (1 2)", call(Functions.ST_GeometryType.class.getSimpleName(), $("geog")));
+    assertEquals("ST_Point", out.toString());
+  }
+
+  @Test
+  public void testAsText() throws Exception {
+    String wkt = "POINT (1 2)";
+    Object out = eval(wkt, call(Functions.ST_AsText.class.getSimpleName(), $("geog")));
+    assertEquals(
+        org.apache.sedona.common.geography.Functions.asText(Constructors.geogFromWKT(wkt, 4326)),
+        out.toString());
+  }
+
+  @Test
+  public void testAsEWKT() throws Exception {
+    String wkt = "POINT (1 2)";
+    Object out = eval(wkt, call(Functions.ST_AsEWKT.class.getSimpleName(), $("geog")));
+    assertEquals(
+        org.apache.sedona.common.geography.Functions.asEWKT(Constructors.geogFromWKT(wkt, 4326)),
+        out.toString());
+  }
+
+  @Test
+  public void testCentroid() throws Exception {
+    String wkt = "POLYGON ((0 0, 0 2, 2 2, 2 0, 0 0))";
+    Object out = eval(wkt, call(Functions.ST_Centroid.class.getSimpleName(), $("geog")));
+    Geography expected =
+        org.apache.sedona.common.geography.Functions.centroid(Constructors.geogFromWKT(wkt, 4326));
+    assertEquals(expected.toEWKT(), ((Geography) out).toEWKT());
+  }
+
+  @Test
+  public void testEnvelope() throws Exception {
+    String wkt = "LINESTRING (0 0, 2 3)";
+    Object out =
+        eval(wkt, call(Functions.ST_Envelope.class.getSimpleName(), $("geog"), lit(false)));
+    Geography expected =
+        org.apache.sedona.common.geography.Functions.getEnvelope(
+            Constructors.geogFromWKT(wkt, 4326), false);
+    assertEquals(expected.toEWKT(), ((Geography) out).toEWKT());
+  }
+
+  @Test
+  public void testBuffer() throws Exception {
+    String wkt = "POINT (0 0)";
+    Object out = eval(wkt, call(Functions.ST_Buffer.class.getSimpleName(), $("geog"), lit(1000.0)));
+    Geography expected =
+        org.apache.sedona.common.geography.Functions.buffer(
+            Constructors.geogFromWKT(wkt, 4326), 1000.0);
+    assertEquals(expected.toEWKT(), ((Geography) out).toEWKT());
+  }
+
+  @Test
+  public void testGeometryStillWorks() throws Exception {
+    // The geometry overload must remain selectable on the same function.
+    RowTypeInfo ti =
+        new RowTypeInfo(
+            new TypeInformation<?>[] {BasicTypeInfo.STRING_TYPE_INFO}, new String[] {"v"});
+    DataStream<Row> ds =
+        env.fromCollection(Collections.singletonList(Row.of("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))")))
+            .returns(ti);
+    Table geom =
+        tableEnv
+            .fromDataStream(ds)
+            .select(
+                call(
+                        org.apache.sedona.flink.expressions.Constructors.ST_GeomFromWKT.class
+                            .getSimpleName(),
+                        $("v"))
+                    .as("g"));
+    Object out =
+        first(geom.select(call(Functions.ST_Area.class.getSimpleName(), $("g")).as("o")))
+            .getFieldAs("o");
+    assertEquals(1.0, (Double) out, 1e-9);
+  }
+}


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #3073.

## What changes were proposed in this PR?

Part of the geography parity effort for SedonaFlink (#3054), building on the type serializer (#3058) and constructors (#3061).

This adds `Geography` support to the SedonaFlink measurement and output functions, so geography columns can be measured and formatted, not just constructed. Each of the following gains a `Geography` `eval` overload in `flink/.../expressions/Functions.java`, delegating to `org.apache.sedona.common.geography.Functions`:

- `ST_Area` (geodesic, m²)
- `ST_Length` (geodesic, m)
- `ST_Distance` (geodesic, m)
- `ST_Buffer` (geog, radius[, useSpheroid | parameters] — 3 overloads)
- `ST_Centroid`
- `ST_Envelope` (geog, splitAtAntiMeridian)
- `ST_NPoints`
- `ST_NumGeometries`
- `ST_GeometryType`
- `ST_AsText`
- `ST_AsEWKT`

Each overload uses `@DataTypeHint(value = "RAW", rawSerializer = GeographyTypeSerializer.class, bridgedTo = Geography.class)`. Flink resolves geometry vs geography by the RAW `bridgedTo` type — the same mechanism `ST_AsText` already uses to support `Box2D`/`Box3D` — so a single registered function name serves both types and no new `Catalog` entries are required.

This mirrors Spark, where these functions accept either `Geometry` or `Geography`. Geography predicates (`ST_Contains`, `ST_Intersects`, `ST_Within`, `ST_Equals`, `ST_DWithin`) are tracked as a follow-up.

## How was this patch tested?

Added `GeographyFunctionTest` (12 tests) exercising each function end-to-end through the Flink Table API, asserting against the `common.geography.Functions` reference values, plus `testGeometryStillWorks` confirming the geometry overload still resolves on the shared function. No regressions: `FunctionTest` (205 geometry tests), `GeographyConstructorTest`, `GeographyTypeSerializerTest`, and `ModuleTest` all pass.

## Did this PR include necessary documentation updates?

- No. The SedonaFlink geography API docs (covering constructors, functions, and predicates together) are tracked as a separate sub-task of #3054.
