### PR TITLE
[GH-3075] Add geography support to SedonaFlink spatial predicates

### DIFF
--- a/flink/src/main/java/org/apache/sedona/flink/expressions/Predicates.java
+++ b/flink/src/main/java/org/apache/sedona/flink/expressions/Predicates.java
@@ -193,6 +193,7 @@ public class Predicates {
                 rawSerializer = GeometryTypeSerializer.class,
                 bridgedTo = Geometry.class)
             Object o2) {
+      if (o1 == null || o2 == null) return null;
       Geometry geom1 = (Geometry) o1;
       Geometry geom2 = (Geometry) o2;
       return org.apache.sedona.common.Predicates.within(geom1, geom2);
@@ -323,6 +324,7 @@ public class Predicates {
                 rawSerializer = GeometryTypeSerializer.class,
                 bridgedTo = Geometry.class)
             Object o2) {
+      if (o1 == null || o2 == null) return null;
       Geometry geom1 = (Geometry) o1;
       Geometry geom2 = (Geometry) o2;
       return org.apache.sedona.common.Predicates.equals(geom1, geom2);

--- a/flink/src/main/java/org/apache/sedona/flink/expressions/Predicates.java
+++ b/flink/src/main/java/org/apache/sedona/flink/expressions/Predicates.java
@@ -24,6 +24,7 @@ import org.apache.sedona.common.geometryObjects.Box2D;
 import org.apache.sedona.common.geometryObjects.Box3D;
 import org.apache.sedona.flink.Box2DTypeSerializer;
 import org.apache.sedona.flink.Box3DTypeSerializer;
+import org.apache.sedona.flink.GeographyTypeSerializer;
 import org.apache.sedona.flink.GeometryTypeSerializer;
 import org.locationtech.jts.geom.Geometry;
 
@@ -84,6 +85,22 @@ public class Predicates {
       if (a == null || b == null) return null;
       return org.apache.sedona.common.Predicates.box3dIntersects(a, b);
     }
+
+    @DataTypeHint("Boolean")
+    public Boolean eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = GeographyTypeSerializer.class,
+                bridgedTo = org.apache.sedona.common.S2Geography.Geography.class)
+            org.apache.sedona.common.S2Geography.Geography g1,
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = GeographyTypeSerializer.class,
+                bridgedTo = org.apache.sedona.common.S2Geography.Geography.class)
+            org.apache.sedona.common.S2Geography.Geography g2) {
+      if (g1 == null || g2 == null) return null;
+      return org.apache.sedona.common.geography.Functions.intersects(g1, g2);
+    }
   }
 
   public static class ST_Contains extends ScalarFunction {
@@ -142,6 +159,22 @@ public class Predicates {
       if (a == null || b == null) return null;
       return org.apache.sedona.common.Predicates.box3dContains(a, b);
     }
+
+    @DataTypeHint("Boolean")
+    public Boolean eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = GeographyTypeSerializer.class,
+                bridgedTo = org.apache.sedona.common.S2Geography.Geography.class)
+            org.apache.sedona.common.S2Geography.Geography g1,
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = GeographyTypeSerializer.class,
+                bridgedTo = org.apache.sedona.common.S2Geography.Geography.class)
+            org.apache.sedona.common.S2Geography.Geography g2) {
+      if (g1 == null || g2 == null) return null;
+      return org.apache.sedona.common.geography.Functions.contains(g1, g2);
+    }
   }
 
   public static class ST_Within extends ScalarFunction {
@@ -163,6 +196,22 @@ public class Predicates {
       Geometry geom1 = (Geometry) o1;
       Geometry geom2 = (Geometry) o2;
       return org.apache.sedona.common.Predicates.within(geom1, geom2);
+    }
+
+    @DataTypeHint("Boolean")
+    public Boolean eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = GeographyTypeSerializer.class,
+                bridgedTo = org.apache.sedona.common.S2Geography.Geography.class)
+            org.apache.sedona.common.S2Geography.Geography g1,
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = GeographyTypeSerializer.class,
+                bridgedTo = org.apache.sedona.common.S2Geography.Geography.class)
+            org.apache.sedona.common.S2Geography.Geography g2) {
+      if (g1 == null || g2 == null) return null;
+      return org.apache.sedona.common.geography.Functions.within(g1, g2);
     }
   }
 
@@ -277,6 +326,22 @@ public class Predicates {
       Geometry geom1 = (Geometry) o1;
       Geometry geom2 = (Geometry) o2;
       return org.apache.sedona.common.Predicates.equals(geom1, geom2);
+    }
+
+    @DataTypeHint("Boolean")
+    public Boolean eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = GeographyTypeSerializer.class,
+                bridgedTo = org.apache.sedona.common.S2Geography.Geography.class)
+            org.apache.sedona.common.S2Geography.Geography g1,
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = GeographyTypeSerializer.class,
+                bridgedTo = org.apache.sedona.common.S2Geography.Geography.class)
+            org.apache.sedona.common.S2Geography.Geography g2) {
+      if (g1 == null || g2 == null) return null;
+      return org.apache.sedona.common.geography.Functions.equals(g1, g2);
     }
   }
 
@@ -444,6 +509,23 @@ public class Predicates {
       Geometry geom1 = (Geometry) o1;
       Geometry geom2 = (Geometry) o2;
       return org.apache.sedona.common.Predicates.dWithin(geom1, geom2, distance, useSphere);
+    }
+
+    @DataTypeHint("Boolean")
+    public Boolean eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = GeographyTypeSerializer.class,
+                bridgedTo = org.apache.sedona.common.S2Geography.Geography.class)
+            org.apache.sedona.common.S2Geography.Geography g1,
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = GeographyTypeSerializer.class,
+                bridgedTo = org.apache.sedona.common.S2Geography.Geography.class)
+            org.apache.sedona.common.S2Geography.Geography g2,
+        @DataTypeHint("Double") Double distance) {
+      if (g1 == null || g2 == null || distance == null) return null;
+      return org.apache.sedona.common.geography.Functions.dWithin(g1, g2, distance);
     }
   }
 

--- a/flink/src/test/java/org/apache/sedona/flink/GeographyPredicateTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/GeographyPredicateTest.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.flink;
+
+import static org.apache.flink.table.api.Expressions.$;
+import static org.apache.flink.table.api.Expressions.call;
+import static org.apache.flink.table.api.Expressions.lit;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.table.api.ApiExpression;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.types.Row;
+import org.apache.sedona.flink.expressions.Predicates;
+import org.apache.sedona.flink.expressions.geography.GeographyConstructors;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class GeographyPredicateTest extends TestBase {
+
+  // Geography polygons follow the spherical right-hand rule: a CCW ring's interior is the enclosed
+  // region. The polygons below are CCW so containment matches the intuitive (planar) expectation; a
+  // CW ring would denote the complementary region on the sphere.
+
+  @BeforeClass
+  public static void onceExecutedBeforeAll() {
+    initialize();
+  }
+
+  /** Evaluate a predicate call over two geography columns built from {@code wktA}/{@code wktB}. */
+  private Object eval(String wktA, String wktB, PredicateFactory factory) {
+    RowTypeInfo ti =
+        new RowTypeInfo(
+            new TypeInformation<?>[] {
+              BasicTypeInfo.STRING_TYPE_INFO, BasicTypeInfo.STRING_TYPE_INFO
+            },
+            new String[] {"a", "b"});
+    DataStream<Row> ds =
+        env.fromCollection(Collections.singletonList(Row.of(wktA, wktB))).returns(ti);
+    Table t =
+        tableEnv
+            .fromDataStream(ds)
+            .select(
+                call(GeographyConstructors.ST_GeogFromWKT.class.getSimpleName(), $("a"), lit(4326))
+                    .as("ga"),
+                call(GeographyConstructors.ST_GeogFromWKT.class.getSimpleName(), $("b"), lit(4326))
+                    .as("gb"));
+    return first(t.select(factory.build($("ga"), $("gb")).as("o"))).getFieldAs("o");
+  }
+
+  private interface PredicateFactory {
+    ApiExpression build(ApiExpression a, ApiExpression b);
+  }
+
+  @Test
+  public void testIntersects() {
+    String poly = "POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))";
+    assertTrue(
+        (Boolean)
+            eval(
+                poly,
+                "POINT (1 1)",
+                (a, b) -> call(Predicates.ST_Intersects.class.getSimpleName(), a, b)));
+    assertFalse(
+        (Boolean)
+            eval(
+                poly,
+                "POINT (5 5)",
+                (a, b) -> call(Predicates.ST_Intersects.class.getSimpleName(), a, b)));
+  }
+
+  @Test
+  public void testContains() {
+    assertTrue(
+        (Boolean)
+            eval(
+                "POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))",
+                "POINT (1 1)",
+                (a, b) -> call(Predicates.ST_Contains.class.getSimpleName(), a, b)));
+  }
+
+  @Test
+  public void testWithin() {
+    assertTrue(
+        (Boolean)
+            eval(
+                "POINT (1 1)",
+                "POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))",
+                (a, b) -> call(Predicates.ST_Within.class.getSimpleName(), a, b)));
+  }
+
+  @Test
+  public void testEquals() {
+    assertTrue(
+        (Boolean)
+            eval(
+                "POINT (1 1)",
+                "POINT (1 1)",
+                (a, b) -> call(Predicates.ST_Equals.class.getSimpleName(), a, b)));
+    assertFalse(
+        (Boolean)
+            eval(
+                "POINT (1 1)",
+                "POINT (2 2)",
+                (a, b) -> call(Predicates.ST_Equals.class.getSimpleName(), a, b)));
+  }
+
+  @Test
+  public void testDWithin() {
+    // Two points ~111 km apart (1 degree of latitude near the equator).
+    assertTrue(
+        (Boolean)
+            eval(
+                "POINT (0 0)",
+                "POINT (0 1)",
+                (a, b) -> call(Predicates.ST_DWithin.class.getSimpleName(), a, b, lit(200000.0))));
+    assertFalse(
+        (Boolean)
+            eval(
+                "POINT (0 0)",
+                "POINT (0 1)",
+                (a, b) -> call(Predicates.ST_DWithin.class.getSimpleName(), a, b, lit(50000.0))));
+  }
+
+  @Test
+  public void testGeometryStillWorks() {
+    // The geometry overload must remain selectable on the same predicate.
+    RowTypeInfo ti =
+        new RowTypeInfo(
+            new TypeInformation<?>[] {
+              BasicTypeInfo.STRING_TYPE_INFO, BasicTypeInfo.STRING_TYPE_INFO
+            },
+            new String[] {"a", "b"});
+    DataStream<Row> ds =
+        env.fromCollection(
+                Collections.singletonList(
+                    Row.of("POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))", "POINT (1 1)")))
+            .returns(ti);
+    String geom =
+        org.apache.sedona.flink.expressions.Constructors.ST_GeomFromWKT.class.getSimpleName();
+    Table t =
+        tableEnv
+            .fromDataStream(ds)
+            .select(call(geom, $("a")).as("ga"), call(geom, $("b")).as("gb"));
+    Object out =
+        first(
+                t.select(
+                    call(Predicates.ST_Contains.class.getSimpleName(), $("ga"), $("gb")).as("o")))
+            .getFieldAs("o");
+    assertEquals(true, out);
+  }
+}


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #3075.

## What changes were proposed in this PR?

Part of the geography parity effort for SedonaFlink (#3054), building on the type serializer (#3058), constructors (#3061), and functions (#3073).

This adds `Geography` support to the SedonaFlink spatial predicates, so geography columns can be compared, not just constructed and measured. Each of the following gains a `Geography` `eval` overload in `flink/.../expressions/Predicates.java`, delegating to `org.apache.sedona.common.geography.Functions`:

- `ST_Intersects` (geog, geog)
- `ST_Contains` (geog, geog)
- `ST_Within` (geog, geog)
- `ST_Equals` (geog, geog)
- `ST_DWithin` (geog, geog, distanceMeters)

Each overload uses `@DataTypeHint(value = "RAW", rawSerializer = GeographyTypeSerializer.class, bridgedTo = Geography.class)` and propagates SQL NULL the same way the existing geometry overloads do. Flink resolves geometry vs geography by the RAW `bridgedTo` type, so a single registered name serves both types and no new `Catalog` entries are required.

This mirrors Spark, where these predicates accept either `Geometry` or `Geography`.

Note on semantics: geography polygons follow the spherical right-hand rule — a CCW ring's interior is the enclosed region; a CW ring denotes the complementary region on the sphere. This is inherited from the `common` S2 layer and matches Spark.

## How was this patch tested?

Added `GeographyPredicateTest` (6 tests) exercising each predicate end-to-end through the Flink Table API (true and false cases for `ST_Intersects`/`ST_Equals`/`ST_DWithin`), plus `testGeometryStillWorks` confirming the geometry overload still resolves on the shared predicate. No regressions: the geometry `PredicateTest` (22 tests) and `ModuleTest` pass.

## Did this PR include necessary documentation updates?

- No. The SedonaFlink geography API docs (covering constructors, functions, and predicates together) are tracked as a separate sub-task of #3054.
