### PR TITLE
[DOCS] Document SedonaFlink geography functions

### DIFF
--- a/docs/api/flink/Geography-Constructors/ST_GeogCollFromText.md
+++ b/docs/api/flink/Geography-Constructors/ST_GeogCollFromText.md
@@ -1,0 +1,44 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_GeogCollFromText
+
+Introduction: Constructs a GeometryCollection geography from the WKT with the given SRID. If SRID is not provided then it defaults to 0. It returns `null` if the WKT is not a `GEOMETRYCOLLECTION`.
+
+Format:
+
+`ST_GeogCollFromText (Wkt: String)`
+
+`ST_GeogCollFromText (Wkt: String, srid: Integer)`
+
+Return type: `Geography`
+
+Since: `v1.9.1`
+
+Example:
+
+```sql
+SELECT ST_GeogCollFromText('GEOMETRYCOLLECTION (POINT (1 2), LINESTRING (0 0, 1 1))')
+```
+
+Output:
+
+```
+GEOMETRYCOLLECTION (POINT (1 2), LINESTRING (0 0, 1 1))
+```

--- a/docs/api/flink/Geography-Constructors/ST_GeogFromEWKB.md
+++ b/docs/api/flink/Geography-Constructors/ST_GeogFromEWKB.md
@@ -1,0 +1,44 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_GeogFromEWKB
+
+Introduction: Construct a Geography from EWKB Binary. This function is an alias of [ST_GeogFromWKB](ST_GeogFromWKB.md). The SRID embedded in the EWKB is attached to the resulting geography.
+
+Format:
+
+`ST_GeogFromEWKB (EWkb: Bytes)`
+
+Return type: `Geography`
+
+Since: `v1.9.1`
+
+Example:
+
+```sql
+SELECT ST_GeogFromEWKB([01 02 00 00 20 E6 10 00 00 02 00 00 00 00 00 00 00 84 D6 00 C0 00 00 00 00 80 B5 D6 BF 00 00 00 60 E1 EF F7 BF 00 00 00 80 07 5D E5 BF])
+```
+
+Output:
+
+```
+LINESTRING (-2.1 -0.4, -1.5 -0.7)
+```
+
+The EWKB above embeds SRID `4326`, which is carried over to the resulting geography.

--- a/docs/api/flink/Geography-Constructors/ST_GeogFromEWKT.md
+++ b/docs/api/flink/Geography-Constructors/ST_GeogFromEWKT.md
@@ -1,0 +1,44 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_GeogFromEWKT
+
+Introduction: Construct a Geography from OGC Extended WKT.
+
+Format:
+
+`ST_GeogFromEWKT (EWkt: String)`
+
+Return type: `Geography`
+
+Since: `v1.9.1`
+
+Example:
+
+```sql
+SELECT ST_GeogFromEWKT('SRID=4326;LINESTRING (0 0, 3 3, 4 4)')
+```
+
+Output:
+
+```
+LINESTRING (0 0, 3 3, 4 4)
+```
+
+The SRID parsed from the EWKT string (here `4326`) is attached to the resulting geography.

--- a/docs/api/flink/Geography-Constructors/ST_GeogFromGeoHash.md
+++ b/docs/api/flink/Geography-Constructors/ST_GeogFromGeoHash.md
@@ -1,0 +1,44 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_GeogFromGeoHash
+
+Introduction: Create Geography from geohash string and optional precision. When precision is omitted, the full precision of the geohash string is used.
+
+Format:
+
+`ST_GeogFromGeoHash (geohash: String)`
+
+`ST_GeogFromGeoHash (geohash: String, precision: Integer)`
+
+Return type: `Geography`
+
+Since: `v1.9.1`
+
+Example:
+
+```sql
+SELECT ST_GeogFromGeoHash('s00twy01mt', 4)
+```
+
+Output:
+
+```
+POLYGON ((0.7 0.9, 1.1 0.9, 1.1 1.1, 0.7 1.1, 0.7 0.9))
+```

--- a/docs/api/flink/Geography-Constructors/ST_GeogFromText.md
+++ b/docs/api/flink/Geography-Constructors/ST_GeogFromText.md
@@ -1,0 +1,44 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_GeogFromText
+
+Introduction: Construct a Geography from WKT. If SRID is not set, it defaults to 0 (unknown). Alias of [ST_GeogFromWKT](ST_GeogFromWKT.md).
+
+Format:
+
+`ST_GeogFromText (Wkt: String)`
+
+`ST_GeogFromText (Wkt: String, srid: Integer)`
+
+Return type: `Geography`
+
+Since: `v1.9.1`
+
+Example:
+
+```sql
+SELECT ST_GeogFromText('LINESTRING (1 2, 3 4, 5 6)')
+```
+
+Output:
+
+```
+LINESTRING (1 2, 3 4, 5 6)
+```

--- a/docs/api/flink/Geography-Constructors/ST_GeogFromWKB.md
+++ b/docs/api/flink/Geography-Constructors/ST_GeogFromWKB.md
@@ -1,0 +1,44 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_GeogFromWKB
+
+Introduction: Construct a Geography from WKB Binary. This function also supports EWKB format. If SRID is not provided then it defaults to 0.
+
+Format:
+
+`ST_GeogFromWKB (Wkb: Bytes)`
+
+`ST_GeogFromWKB (Wkb: Bytes, srid: Integer)`
+
+Return type: `Geography`
+
+Since: `v1.9.1`
+
+Example:
+
+```sql
+SELECT ST_GeogFromWKB([01 02 00 00 00 02 00 00 00 00 00 00 00 84 D6 00 C0 00 00 00 00 80 B5 D6 BF 00 00 00 60 E1 EF F7 BF 00 00 00 80 07 5D E5 BF])
+```
+
+Output:
+
+```
+LINESTRING (-2.1 -0.4, -1.5 -0.7)
+```

--- a/docs/api/flink/Geography-Constructors/ST_GeogFromWKT.md
+++ b/docs/api/flink/Geography-Constructors/ST_GeogFromWKT.md
@@ -1,0 +1,56 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_GeogFromWKT
+
+Introduction: Construct a Geography from WKT. If SRID is not set, it defaults to 0 (unknown).
+
+Format:
+
+`ST_GeogFromWKT (Wkt: String)`
+
+`ST_GeogFromWKT (Wkt: String, srid: Integer)`
+
+Return type: `Geography`
+
+Since: `v1.9.1`
+
+Example:
+
+```sql
+SELECT ST_GeogFromWKT('LINESTRING (1 2, 3 4, 5 6)')
+```
+
+Output:
+
+```
+LINESTRING (1 2, 3 4, 5 6)
+```
+
+Example with SRID:
+
+```sql
+SELECT ST_GeogFromWKT('LINESTRING (1 2, 3 4, 5 6)', 4326)
+```
+
+Output:
+
+```
+LINESTRING (1 2, 3 4, 5 6)
+```

--- a/docs/api/flink/Geography-Constructors/ST_GeogToGeometry.md
+++ b/docs/api/flink/Geography-Constructors/ST_GeogToGeometry.md
@@ -1,0 +1,51 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_GeogToGeometry
+
+Introduction:
+
+This function constructs a planar Geometry object from a Geography. While Sedona makes every effort to preserve the original spatial object, the conversion is not always exact because Geography and Geometry have different underlying models:
+
+* Geography represents shapes on the Earth's surface (spherical).
+* Geometry represents shapes on a flat, Euclidean plane.
+
+Because geography vertices are stored as points on the sphere, converting back to planar coordinates can introduce small floating-point differences. Wrap the result with [ST_ReducePrecision](../Geometry-Processing/ST_ReducePrecision.md) if you need a fixed number of decimals.
+
+Sedona does not validate or enforce the SRID of the input Geography. Whatever SRID is attached to the Geography will be carried over to the resulting Geometry.
+
+Format:
+
+`ST_GeogToGeometry (geog: Geography)`
+
+Return type: `Geometry`
+
+Since: `v1.9.1`
+
+Example:
+
+```sql
+SELECT ST_ReducePrecision(ST_GeogToGeometry(ST_GeogFromWKT('MULTILINESTRING ((90 90, 20 20, 10 40), (40 40, 30 30, 40 20, 30 10))', 4326)), 6)
+```
+
+Output:
+
+```
+MULTILINESTRING ((90 90, 20 20, 10 40), (40 40, 30 30, 40 20, 30 10))
+```

--- a/docs/api/flink/Geography-Constructors/ST_GeomToGeography.md
+++ b/docs/api/flink/Geography-Constructors/ST_GeomToGeography.md
@@ -1,0 +1,48 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_GeomToGeography
+
+Introduction:
+
+This function constructs a Geography object from a planar Geometry. It is intended for geometries defined in a Geographic Coordinate Reference System (CRS), most commonly WGS84 (EPSG:4326), where coordinates are expressed in degrees in longitude/latitude order.
+
+If the input Geometry is defined in a projected CRS (e.g., Web Mercator EPSG:3857, UTM zones), the conversion may succeed syntactically, but the resulting Geography will not be meaningful. This is because Geography interprets coordinates on the surface of a sphere, not a flat plane.
+
+Sedona does not validate or enforce the SRID of the input Geometry. Whatever SRID is attached to the Geometry will simply be carried over to the Geography, even if it is inappropriate for spherical interpretation. It is the user's responsibility to ensure the input Geometry uses a Geographic CRS.
+
+Format:
+
+`ST_GeomToGeography (geom: Geometry)`
+
+Return type: `Geography`
+
+Since: `v1.9.1`
+
+Example:
+
+```sql
+SELECT ST_GeomToGeography(ST_GeomFromWKT('POINT (1 2)'))
+```
+
+Output:
+
+```
+POINT (1 2)
+```

--- a/docs/api/flink/Geography-Functions.md
+++ b/docs/api/flink/Geography-Functions.md
@@ -1,0 +1,70 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# Geography Functions
+
+The `Geography` type in Sedona represents spatial objects on a spherical (geodesic) model of the Earth. Unlike the planar [Geometry](Geometry-Functions.md) type, distance, area, and other measurements performed on `Geography` objects account for the curvature of the Earth and return results in real-world units (e.g., meters).
+
+SedonaFlink exposes geography constructors, measurement and output functions, and spatial predicates. Constructors build `Geography` values and convert between `Geometry` and `Geography`; the functions and predicates operate on `Geography` columns directly. These functions share the same names as their `Geometry` counterparts — SedonaFlink resolves the geography variant from the column type.
+
+## Geography Constructors
+
+These functions create geography objects from various formats, or convert between geometry and geography.
+
+| Function | Return type | Description | Since |
+| :--- | :--- | :--- | :--- |
+| [ST_GeogCollFromText](Geography-Constructors/ST_GeogCollFromText.md) | Geography | Constructs a GeometryCollection geography from the WKT with the given SRID. If SRID is not provided then it defaults to 0. It returns `null` if the WKT is not a `GEOMETRYCOLLECTION`. | v1.9.1 |
+| [ST_GeogFromEWKB](Geography-Constructors/ST_GeogFromEWKB.md) | Geography | Construct a Geography from EWKB Binary. This function is an alias of [ST_GeogFromWKB](Geography-Constructors/ST_GeogFromWKB.md). | v1.9.1 |
+| [ST_GeogFromEWKT](Geography-Constructors/ST_GeogFromEWKT.md) | Geography | Construct a Geography from OGC Extended WKT. | v1.9.1 |
+| [ST_GeogFromGeoHash](Geography-Constructors/ST_GeogFromGeoHash.md) | Geography | Create Geography from geohash string and optional precision. | v1.9.1 |
+| [ST_GeogFromText](Geography-Constructors/ST_GeogFromText.md) | Geography | Construct a Geography from WKT. If SRID is not set, it defaults to 0 (unknown). Alias of [ST_GeogFromWKT](Geography-Constructors/ST_GeogFromWKT.md). | v1.9.1 |
+| [ST_GeogFromWKB](Geography-Constructors/ST_GeogFromWKB.md) | Geography | Construct a Geography from WKB Binary. | v1.9.1 |
+| [ST_GeogFromWKT](Geography-Constructors/ST_GeogFromWKT.md) | Geography | Construct a Geography from WKT. If SRID is not set, it defaults to 0 (unknown). | v1.9.1 |
+| [ST_GeogToGeometry](Geography-Constructors/ST_GeogToGeometry.md) | Geometry | Construct a planar Geometry from a Geography. | v1.9.1 |
+| [ST_GeomToGeography](Geography-Constructors/ST_GeomToGeography.md) | Geography | Construct a Geography from a planar Geometry. | v1.9.1 |
+
+## Geography Functions
+
+These functions measure or format geography objects. Measurements are computed on a spherical model of the Earth (radius `R = 6 371 008 m`, the authalic Earth radius), not the WGS84 ellipsoid — areas in square meters and lengths/distances in meters. (`ST_Buffer` is the exception: it is computed on the WGS84 spheroid.)
+
+| Function | Return type | Description | Since |
+| :--- | :--- | :--- | :--- |
+| [ST_Area](Geography-Functions/ST_Area.md) | Double | Return the geodesic area of a geography in square meters. | v1.9.1 |
+| [ST_AsEWKT](Geography-Functions/ST_AsEWKT.md) | String | Return the EWKT representation of a geography, including its SRID. | v1.9.1 |
+| [ST_AsText](Geography-Functions/ST_AsText.md) | String | Return the WKT representation of a geography. | v1.9.1 |
+| [ST_Buffer](Geography-Functions/ST_Buffer.md) | Geography | Return the geodesic buffer of a geography (distance in meters). | v1.9.1 |
+| [ST_Centroid](Geography-Functions/ST_Centroid.md) | Geography | Return the centroid of a geography as a Geography point. | v1.9.1 |
+| [ST_Distance](Geography-Functions/ST_Distance.md) | Double | Return the minimum geodesic distance between two geographies in meters. | v1.9.1 |
+| [ST_Envelope](Geography-Functions/ST_Envelope.md) | Geography | Return the bounding box of a geography. Supports antimeridian splitting. | v1.9.1 |
+| [ST_GeometryType](Geography-Functions/ST_GeometryType.md) | String | Return the type of a geography as a string. | v1.9.1 |
+| [ST_Length](Geography-Functions/ST_Length.md) | Double | Return the spherical length of a geography in meters. | v1.9.1 |
+| [ST_NPoints](Geography-Functions/ST_NPoints.md) | Integer | Return the number of points (vertices) in a geography. | v1.9.1 |
+| [ST_NumGeometries](Geography-Functions/ST_NumGeometries.md) | Integer | Return the number of sub-geometries in a geography. | v1.9.1 |
+
+## Geography Predicates
+
+These functions test spatial relationships between two geographies on the sphere.
+
+| Function | Return type | Description | Since |
+| :--- | :--- | :--- | :--- |
+| [ST_Contains](Geography-Predicates/ST_Contains.md) | Boolean | Test whether geography A fully contains geography B. | v1.9.1 |
+| [ST_DWithin](Geography-Predicates/ST_DWithin.md) | Boolean | Test whether two geographies are within a given geodesic distance (in meters) of each other. | v1.9.1 |
+| [ST_Equals](Geography-Predicates/ST_Equals.md) | Boolean | Test whether two geographies are spatially equal. | v1.9.1 |
+| [ST_Intersects](Geography-Predicates/ST_Intersects.md) | Boolean | Test whether two geographies intersect. | v1.9.1 |
+| [ST_Within](Geography-Predicates/ST_Within.md) | Boolean | Test whether geography A is fully within geography B. | v1.9.1 |

--- a/docs/api/flink/Geography-Functions/ST_Area.md
+++ b/docs/api/flink/Geography-Functions/ST_Area.md
@@ -1,0 +1,46 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_Area
+
+Introduction: Return the spherical area of a geography in square meters, calculated on the sphere. The Earth is modeled as a sphere of radius `R = 6 371 008 m` (the authalic Earth radius), not the WGS84 ellipsoid; the result is the area of the polygon's interior on that sphere. Multi-polygons sum the children's areas and geography collections recurse. Returns `0.0` for non-areal geographies (points, linestrings) and for `NULL`.
+
+![ST_Area on a Geography (sphere-native)](../../../image/ST_Area_geography/ST_Area_geography.svg "ST_Area on a Geography (sphere-native)")
+
+If the input ring is wound in the orientation that would describe the rest of the planet, Sedona returns the smaller of the two regions, so the answer is always bounded by half the surface of the Earth. If you specifically want the WGS84 ellipsoidal value, convert via `ST_GeogToGeometry` first and use the geometry overload.
+
+Format:
+
+`ST_Area (geog: Geography)`
+
+Return type: `Double`
+
+Since: `v1.9.1`
+
+SQL Example:
+
+```sql
+SELECT ST_Area(ST_GeogFromWKT('POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))', 4326))
+```
+
+Output:
+
+```
+4.945234327988249E10
+```

--- a/docs/api/flink/Geography-Functions/ST_AsEWKT.md
+++ b/docs/api/flink/Geography-Functions/ST_AsEWKT.md
@@ -1,0 +1,42 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_AsEWKT
+
+Introduction: Return the Extended Well-Known Text (EWKT) representation of a geography, including its SRID.
+
+Format:
+
+`ST_AsEWKT (geog: Geography)`
+
+Return type: `String`
+
+Since: `v1.9.1`
+
+SQL Example:
+
+```sql
+SELECT ST_AsEWKT(ST_GeogFromWKT('POINT (1 2)', 4326))
+```
+
+Output:
+
+```
+SRID=4326; POINT (1 2)
+```

--- a/docs/api/flink/Geography-Functions/ST_AsText.md
+++ b/docs/api/flink/Geography-Functions/ST_AsText.md
@@ -1,0 +1,42 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_AsText
+
+Introduction: Return the Well-Known Text (WKT) representation of a geography.
+
+Format:
+
+`ST_AsText (geog: Geography)`
+
+Return type: `String`
+
+Since: `v1.9.1`
+
+SQL Example:
+
+```sql
+SELECT ST_AsText(ST_GeogFromWKT('POINT (0 0)', 4326))
+```
+
+Output:
+
+```
+POINT (0 0)
+```

--- a/docs/api/flink/Geography-Functions/ST_Buffer.md
+++ b/docs/api/flink/Geography-Functions/ST_Buffer.md
@@ -1,0 +1,48 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_Buffer
+
+Introduction: Return the geodesic buffer of a geography. The distance is always interpreted as meters on the spheroid. The result is a polygon approximating the buffer.
+
+![ST_Buffer of a Geography point: a geodesic buffer on the sphere](../../../image/ST_Buffer_geography/ST_Buffer_geography_point.svg "ST_Buffer of a Geography point: a geodesic buffer on the sphere")
+
+Format:
+
+`ST_Buffer (geog: Geography, distanceMeters: Double)`
+
+`ST_Buffer (geog: Geography, distanceMeters: Double, parameters: String)`
+
+Return type: `Geography`
+
+Since: `v1.9.1`
+
+Geography is always spheroidal, so the boolean `useSpheroid` argument accepted by the geometry `ST_Buffer` is not supported for geography inputs: `ST_Buffer(geog, distance, useSpheroid)` throws a clear error. Use `ST_Buffer(geog, distance)` or `ST_Buffer(geog, distance, parameters)` instead.
+
+SQL Example:
+
+```sql
+SELECT ST_Buffer(ST_GeogFromWKT('POINT (10 10)', 4326), 100000)
+```
+
+Output:
+
+```
+POLYGON ((10.9 10.2, 10.8 10.3, 10.8 10.5, 10.6 10.6, ...))
+```

--- a/docs/api/flink/Geography-Functions/ST_Centroid.md
+++ b/docs/api/flink/Geography-Functions/ST_Centroid.md
@@ -1,0 +1,42 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_Centroid
+
+Introduction: Return the centroid of a geography as a Geography point.
+
+Format:
+
+`ST_Centroid (geog: Geography)`
+
+Return type: `Geography`
+
+Since: `v1.9.1`
+
+SQL Example:
+
+```sql
+SELECT ST_Centroid(ST_GeogFromWKT('POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))', 4326))
+```
+
+Output:
+
+```
+POINT (1 1)
+```

--- a/docs/api/flink/Geography-Functions/ST_Distance.md
+++ b/docs/api/flink/Geography-Functions/ST_Distance.md
@@ -1,0 +1,44 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_Distance
+
+Introduction: Return the minimum geodesic distance between two geographies in meters.
+
+![ST_Distance on a sphere: great-circle distance between two geographies](../../../image/ST_Distance_geography/ST_Distance_geography.svg "ST_Distance on a sphere: great-circle distance between two geographies")
+
+Format:
+
+`ST_Distance (geogA: Geography, geogB: Geography)`
+
+Return type: `Double`
+
+Since: `v1.9.1`
+
+SQL Example:
+
+```sql
+SELECT ST_Distance(ST_GeogFromWKT('POINT (0 0)', 4326), ST_GeogFromWKT('POINT (0 1)', 4326))
+```
+
+Output:
+
+```
+111195.0662708989
+```

--- a/docs/api/flink/Geography-Functions/ST_Envelope.md
+++ b/docs/api/flink/Geography-Functions/ST_Envelope.md
@@ -1,0 +1,42 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_Envelope
+
+Introduction: Return the bounding box (envelope) of a geography. When `splitAtAntiMeridian` is true, an envelope crossing the antimeridian is split into a MultiPolygon.
+
+Format:
+
+`ST_Envelope (geog: Geography, splitAtAntiMeridian: Boolean)`
+
+Return type: `Geography`
+
+Since: `v1.9.1`
+
+SQL Example:
+
+```sql
+SELECT ST_Envelope(ST_GeogFromWKT('LINESTRING (1 1, 2 3)', 4326), false)
+```
+
+Output:
+
+```
+POLYGON ((1 1, 2 1, 2 3, 1 3, 1 1))
+```

--- a/docs/api/flink/Geography-Functions/ST_GeometryType.md
+++ b/docs/api/flink/Geography-Functions/ST_GeometryType.md
@@ -1,0 +1,42 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_GeometryType
+
+Introduction: Return the type of a geography as a string (for example, "ST_Point" or "ST_Polygon").
+
+Format:
+
+`ST_GeometryType (geog: Geography)`
+
+Return type: `String`
+
+Since: `v1.9.1`
+
+SQL Example:
+
+```sql
+SELECT ST_GeometryType(ST_GeogFromWKT('POINT (1 2)', 4326))
+```
+
+Output:
+
+```
+ST_Point
+```

--- a/docs/api/flink/Geography-Functions/ST_Length.md
+++ b/docs/api/flink/Geography-Functions/ST_Length.md
@@ -1,0 +1,44 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_Length
+
+Introduction: Return the spherical length of a geography in meters, summed along great-circle edges.
+
+![ST_Length on a sphere: great-circle length](../../../image/ST_Length_geography/ST_Length_geography.svg "ST_Length on a sphere: great-circle length")
+
+Format:
+
+`ST_Length (geog: Geography)`
+
+Return type: `Double`
+
+Since: `v1.9.1`
+
+SQL Example:
+
+```sql
+SELECT ST_Length(ST_GeogFromWKT('LINESTRING (0 0, 0 1)', 4326))
+```
+
+Output:
+
+```
+111195.0662708989
+```

--- a/docs/api/flink/Geography-Functions/ST_NPoints.md
+++ b/docs/api/flink/Geography-Functions/ST_NPoints.md
@@ -1,0 +1,44 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_NPoints
+
+Introduction: Return the number of points (vertices) in a geography.
+
+![ST_NPoints counts the vertices of a Geography](../../../image/ST_NPoints_geography/ST_NPoints_geography.svg "ST_NPoints counts the vertices of a Geography")
+
+Format:
+
+`ST_NPoints (geog: Geography)`
+
+Return type: `Integer`
+
+Since: `v1.9.1`
+
+SQL Example:
+
+```sql
+SELECT ST_NPoints(ST_GeogFromWKT('LINESTRING (0 0, 1 1, 2 2)', 4326))
+```
+
+Output:
+
+```
+3
+```

--- a/docs/api/flink/Geography-Functions/ST_NumGeometries.md
+++ b/docs/api/flink/Geography-Functions/ST_NumGeometries.md
@@ -1,0 +1,42 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_NumGeometries
+
+Introduction: Return the number of sub-geometries in a geography (1 for single geometries).
+
+Format:
+
+`ST_NumGeometries (geog: Geography)`
+
+Return type: `Integer`
+
+Since: `v1.9.1`
+
+SQL Example:
+
+```sql
+SELECT ST_NumGeometries(ST_GeogFromWKT('MULTIPOINT ((0 0), (1 1))', 4326))
+```
+
+Output:
+
+```
+2
+```

--- a/docs/api/flink/Geography-Predicates/ST_Contains.md
+++ b/docs/api/flink/Geography-Predicates/ST_Contains.md
@@ -1,0 +1,46 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_Contains
+
+Introduction: Return true if geography A fully contains geography B.
+
+![ST_Contains on the sphere: A contains B](../../../image/ST_Contains_geography/ST_Contains_geography_true.svg "ST_Contains on the sphere: A contains B")
+
+Format:
+
+`ST_Contains (geogA: Geography, geogB: Geography)`
+
+Return type: `Boolean`
+
+Since: `v1.9.1`
+
+Geography polygons follow the spherical right-hand rule: a counter-clockwise ring's interior is the enclosed region, so the polygon below is counter-clockwise. A clockwise ring would denote the complementary region on the sphere.
+
+SQL Example:
+
+```sql
+SELECT ST_Contains(ST_GeogFromWKT('POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))', 4326), ST_GeogFromWKT('POINT (1 1)', 4326))
+```
+
+Output:
+
+```
+true
+```

--- a/docs/api/flink/Geography-Predicates/ST_DWithin.md
+++ b/docs/api/flink/Geography-Predicates/ST_DWithin.md
@@ -1,0 +1,44 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_DWithin
+
+Introduction: Return true if two geographies are within a given geodesic distance (in meters) of each other.
+
+![ST_DWithin on the sphere: two geographies within a distance](../../../image/ST_DWithin_geography/ST_DWithin_geography_true.svg "ST_DWithin on the sphere: two geographies within a distance")
+
+Format:
+
+`ST_DWithin (geogA: Geography, geogB: Geography, distanceMeters: Double)`
+
+Return type: `Boolean`
+
+Since: `v1.9.1`
+
+SQL Example:
+
+```sql
+SELECT ST_DWithin(ST_GeogFromWKT('POINT (0 0)', 4326), ST_GeogFromWKT('POINT (0 1)', 4326), 200000)
+```
+
+Output:
+
+```
+true
+```

--- a/docs/api/flink/Geography-Predicates/ST_Equals.md
+++ b/docs/api/flink/Geography-Predicates/ST_Equals.md
@@ -1,0 +1,42 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_Equals
+
+Introduction: Return true if two geographies are spatially equal.
+
+Format:
+
+`ST_Equals (geogA: Geography, geogB: Geography)`
+
+Return type: `Boolean`
+
+Since: `v1.9.1`
+
+SQL Example:
+
+```sql
+SELECT ST_Equals(ST_GeogFromWKT('POINT (1 1)', 4326), ST_GeogFromWKT('POINT (1 1)', 4326))
+```
+
+Output:
+
+```
+true
+```

--- a/docs/api/flink/Geography-Predicates/ST_Intersects.md
+++ b/docs/api/flink/Geography-Predicates/ST_Intersects.md
@@ -1,0 +1,46 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_Intersects
+
+Introduction: Return true if two geographies share any portion of space.
+
+![ST_Intersects on the sphere: two geographies intersect](../../../image/ST_Intersects_geography/ST_Intersects_geography_true.svg "ST_Intersects on the sphere: two geographies intersect")
+
+Format:
+
+`ST_Intersects (geogA: Geography, geogB: Geography)`
+
+Return type: `Boolean`
+
+Since: `v1.9.1`
+
+Geography polygons follow the spherical right-hand rule: a counter-clockwise ring's interior is the enclosed region, so the polygon below is counter-clockwise. A clockwise ring would denote the complementary region on the sphere.
+
+SQL Example:
+
+```sql
+SELECT ST_Intersects(ST_GeogFromWKT('POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))', 4326), ST_GeogFromWKT('POINT (1 1)', 4326))
+```
+
+Output:
+
+```
+true
+```

--- a/docs/api/flink/Geography-Predicates/ST_Within.md
+++ b/docs/api/flink/Geography-Predicates/ST_Within.md
@@ -1,0 +1,46 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_Within
+
+Introduction: Return true if geography A is fully within geography B.
+
+![ST_Within on the sphere: A within B](../../../image/ST_Within_geography/ST_Within_geography_true.svg "ST_Within on the sphere: A within B")
+
+Format:
+
+`ST_Within (geogA: Geography, geogB: Geography)`
+
+Return type: `Boolean`
+
+Since: `v1.9.1`
+
+Geography polygons follow the spherical right-hand rule: a counter-clockwise ring's interior is the enclosed region, so the polygon below is counter-clockwise. A clockwise ring would denote the complementary region on the sphere.
+
+SQL Example:
+
+```sql
+SELECT ST_Within(ST_GeogFromWKT('POINT (1 1)', 4326), ST_GeogFromWKT('POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))', 4326))
+```
+
+Output:
+
+```
+true
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,6 +121,7 @@ nav:
           - SQL:
               - Overview (Flink): api/flink/Overview.md
               - Geometry Functions: api/flink/Geometry-Functions.md
+              - Geography Functions: api/flink/Geography-Functions.md
       - Release notes: setup/release-notes.md
 
   - SedonaSnow:


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, this is a documentation update. The PR name follows the format `[DOCS] my subject`. Closes #3069.

## What changes were proposed in this PR?

Final piece of the SedonaFlink geography support effort (#3054): documents the geography API now exposed by SedonaFlink, mirroring the structure of the existing SedonaFlink geometry docs and the Spark geography docs.

- `docs/api/flink/Geography-Functions.md` — overview page with three sections: **Geography Constructors**, **Geography Functions**, and **Geography Predicates**.
- `docs/api/flink/Geography-Constructors/` — 9 per-function pages (constructors/conversions).
- `docs/api/flink/Geography-Functions/` — 11 per-function pages (`ST_Area`, `ST_Length`, `ST_Distance`, `ST_Buffer`, `ST_Centroid`, `ST_Envelope`, `ST_NPoints`, `ST_NumGeometries`, `ST_GeometryType`, `ST_AsText`, `ST_AsEWKT`).
- `docs/api/flink/Geography-Predicates/` — 5 per-function pages (`ST_Contains`, `ST_Intersects`, `ST_Within`, `ST_Equals`, `ST_DWithin`).
- `mkdocs.yml` — adds the Geography Functions page to the SedonaFlink API nav.

All SQL examples and their outputs were captured by running the functions end-to-end through the Flink Table API, so the documented outputs match real behavior (including geodesic units and the spherical right-hand rule for polygon orientation). The 9 concepts that have illustrations (`ST_Area`, `ST_Length`, `ST_Distance`, `ST_NPoints`, `ST_Buffer`, `ST_Contains`, `ST_Intersects`, `ST_Within`, `ST_DWithin`) reuse the existing engine-agnostic geography SVGs under `docs/image/`, matching the Spark geography docs.

## How was this patch tested?

`mkdocs build` succeeds with no warnings for the new pages, and all internal links and embedded SVG paths resolve.

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation. The new geography functions are documented as `Since: v1.9.1`, the current SNAPSHOT version.
