### PR TITLE
[DOCS] Correct geography area/length radius wording: spherical mean radius, not authalic or WGS84 spheroid

### DIFF
--- a/docs/api/flink/Geography-Functions.md
+++ b/docs/api/flink/Geography-Functions.md
@@ -41,7 +41,7 @@ These functions create geography objects from various formats, or convert betwee
 
 ## Geography Functions
 
-These functions measure or format geography objects. Measurements are computed on a spherical model of the Earth (radius `R = 6 371 008 m`, the authalic Earth radius), not the WGS84 ellipsoid — areas in square meters and lengths/distances in meters. (`ST_Buffer` is the exception: it is computed on the WGS84 spheroid.)
+These functions measure or format geography objects. Measurements are computed on a spherical model of the Earth (radius `R = 6 371 008 m`, the mean Earth radius), not the WGS84 ellipsoid — areas in square meters and lengths/distances in meters. (`ST_Buffer` is the exception: it is computed on the WGS84 spheroid.)
 
 | Function | Return type | Description | Since |
 | :--- | :--- | :--- | :--- |

--- a/docs/api/flink/Geography-Functions/ST_Area.md
+++ b/docs/api/flink/Geography-Functions/ST_Area.md
@@ -19,7 +19,7 @@
 
 # ST_Area
 
-Introduction: Return the spherical area of a geography in square meters, calculated on the sphere. The Earth is modeled as a sphere of radius `R = 6 371 008 m` (the authalic Earth radius), not the WGS84 ellipsoid; the result is the area of the polygon's interior on that sphere. Multi-polygons sum the children's areas and geography collections recurse. Returns `0.0` for non-areal geographies (points, linestrings) and for `NULL`.
+Introduction: Return the spherical area of a geography in square meters, calculated on the sphere. The Earth is modeled as a sphere of radius `R = 6 371 008 m` (the mean Earth radius), not the WGS84 ellipsoid; the result is the area of the polygon's interior on that sphere. Multi-polygons sum the children's areas and geography collections recurse. Returns `0.0` for non-areal geographies (points, linestrings) and for `NULL`.
 
 ![ST_Area on a Geography (sphere-native)](../../../image/ST_Area_geography/ST_Area_geography.svg "ST_Area on a Geography (sphere-native)")
 

--- a/docs/api/sql/geography/Geography-Functions.md
+++ b/docs/api/sql/geography/Geography-Functions.md
@@ -41,7 +41,7 @@ These functions operate on geography type objects.
 
 | Function | Return type | Description | Since |
 | :--- | :--- | :--- | :--- |
-| [ST_Area](Geography-Functions/ST_Area.md) | Double | Return the geodesic area of a geography in square meters (WGS84 spheroid). | v1.9.1 |
+| [ST_Area](Geography-Functions/ST_Area.md) | Double | Return the spherical area of a geography in square meters, computed on a sphere of mean Earth radius (`R = 6 371 008 m`), not the WGS84 ellipsoid. | v1.9.1 |
 | [ST_AsEWKT](Geography-Functions/ST_AsEWKT.md) | String | Return the Extended Well-Known Text representation of a geography. | v1.8.0 |
 | [ST_AsText](Geography-Functions/ST_AsText.md) | String | Return the Well-Known Text (WKT) representation of a geography. | v1.9.1 |
 | [ST_Centroid](Geography-Functions/ST_Centroid.md) | Geography | Return the planar centroid of a geography as a Geography point (computed in projected lon/lat space). | v1.9.1 |

--- a/docs/api/sql/geography/Geography-Functions/ST_Area.md
+++ b/docs/api/sql/geography/Geography-Functions/ST_Area.md
@@ -19,7 +19,7 @@
 
 # ST_Area
 
-Introduction: Returns the spherical area of a geography in square meters, calculated on the sphere. The Earth is modeled as a sphere of radius `R = 6 371 008 m` (the authalic Earth radius); the result is the area of the polygon's interior on that sphere. Returns `0.0` for non-areal geographies (points, linestrings) and for `NULL`.
+Introduction: Returns the spherical area of a geography in square meters, calculated on the sphere. The Earth is modeled as a sphere of radius `R = 6 371 008 m` (the mean Earth radius); the result is the area of the polygon's interior on that sphere. Returns `0.0` for non-areal geographies (points, linestrings) and for `NULL`.
 
 Multi-polygons sum the children's areas; geography collections recurse into their members.
 

--- a/docs/api/sql/geography/Geography-Functions/ST_Length.md
+++ b/docs/api/sql/geography/Geography-Functions/ST_Length.md
@@ -19,7 +19,7 @@
 
 # ST_Length
 
-Introduction: Returns the spherical length of a geography in meters, calculated on the sphere. The Earth is modeled as a sphere of radius `R = 6 371 008 m` (the authalic Earth radius). Each edge between successive vertices is interpreted as a great-circle arc; the per-edge arc-angles are summed and scaled by `R`.
+Introduction: Returns the spherical length of a geography in meters, calculated on the sphere. The Earth is modeled as a sphere of radius `R = 6 371 008 m` (the mean Earth radius). Each edge between successive vertices is interpreted as a great-circle arc; the per-edge arc-angles are summed and scaled by `R`.
 
 Multi-linestrings sum the children's lengths; geography collections recurse and add up the lengths of their linear members. Returns `0.0` for non-linear geographies (points, polygons) and for `NULL`.
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a documentation update. The PR name follows the format `[DOCS] my subject`

## What changes were proposed in this PR?

Corrects the radius wording in the geography area/length docs to match the implementation.

`common/src/main/java/org/apache/sedona/common/geography/Functions.java` computes `ST_Area` and `ST_Length` on a sphere, scaling by `org.apache.sedona.common.sphere.Haversine.AVG_EARTH_RADIUS`, which is defined as `6371008.0` meters. That value is the **mean** Earth radius (IUGG R1 = (2a + b) / 3 ≈ 6 371 008.8 m), and the constant is named `AVG_EARTH_RADIUS` accordingly. It is not the WGS84 ellipsoid, and it is not the authalic radius (R2 ≈ 6 371 007.2 m).

Two inaccuracies are fixed:

- The `ST_Area` overview row in `docs/api/sql/geography/Geography-Functions.md` said "WGS84 spheroid" — the computation is spherical, not ellipsoidal.
- Several pages labeled `R = 6 371 008 m` as the "authalic Earth radius" — that value is the mean radius. Reworded to "mean Earth radius" in the Spark `ST_Area`/`ST_Length` pages and the SedonaFlink geography overview and `ST_Area` page.

## How was this patch tested?

`mkdocs build` succeeds; the changed pages have no new warnings and all links resolve.

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.
