### PR TITLE
[DOCS] Update homepage banner to announce SedonaDB 0.4.0 release

### DIFF
--- a/docs-overrides/main.html
+++ b/docs-overrides/main.html
@@ -29,11 +29,11 @@
 
 {% block header %}
   {%- set announcement = {
-      'en': 'Apache Sedona 1.9.0 is out now, featuring Spark 4.1 support, proj4sedona CRS transformation, Bing Tile functions, and more!',
-      'zh': 'Apache Sedona 1.9.0 已正式发布，新增 Spark 4.1 支持、proj4sedona 坐标系转换、Bing Tile 函数等众多特性！'
+            'en': '🎉 SedonaDB 0.4.0 is out now! 🗺️ Python DataFrame API, R dplyr, Geography support & GPU-accelerated spatial joins. Read the release blog →',
+            'zh': '🎉 SedonaDB 0.4.0 已正式发布！🗺️ 新增 Python DataFrame API、R dplyr 接口、Geography 支持及 GPU 加速空间连接。阅读发布博客 →'
   } -%}
   <div style="background: #CA463A; color: white; text-align: center; padding: 0.5rem;">
-    <a href="{{ 'setup/release-notes/' | url }}" title="Announcement">{{ announcement[cur_lang] }}</a>
+        <a href="{{ 'blog/2026/06/19/sedonadb-040-release/' | url }}" title="Announcement">{{ announcement[cur_lang] }}</a>
   </div>
   {{ super() }} {# This renders the original header below your test bar #}
 {% endblock %}


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a documentation update. The PR name follows the format `[DOCS] my subject`

## What changes were proposed in this PR?

This updates the announcement banner in `docs-overrides/main.html` to promote the SedonaDB 0.4.0 release (released June 19, 2026) instead of the previous Apache Sedona 1.9.0 announcement.\n\n- Updated the English (`en`) and Chinese (`zh`) banner text to highlight SedonaDB 0.4.0 features: Python DataFrame API, R dplyr interface, Geography support, and GPU-accelerated spatial joins.\n- Pointed the banner link to the SedonaDB 0.4.0 release blog post (`blog/2026/06/19/sedonadb-040-release/`).\n

## How was this patch tested?

Documentation/template-only change. Verified the rendered banner text and link locally; no code paths affected.\n

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.
