### PR TITLE
[GH-3084] Align GeoPandas test comparison by index (results are unordered)

### DIFF
--- a/python/tests/geopandas/test_geopandas_base.py
+++ b/python/tests/geopandas/test_geopandas_base.py
@@ -58,7 +58,10 @@ class TestGeopandasBase(TestBase):
         assert isinstance(actual, GeoSeries)
         assert isinstance(expected, gpd.GeoSeries)
         assert actual.name == expected.name, "results are of different names"
-        sgpd_result = actual.to_geopandas()
+        # Sedona's GeoPandas API does not guarantee the row ordering of results,
+        # so align both sides by index before comparing element-wise.
+        sgpd_result = actual.to_geopandas().sort_index()
+        expected = expected.sort_index()
         assert len(sgpd_result) == len(expected), "results are of different lengths"
         for a, e in zip(sgpd_result, expected):
             if a is None or e is None:
@@ -69,7 +72,7 @@ class TestGeopandasBase(TestBase):
                 continue
             cls.assert_geometry_almost_equal(a, e, tolerance)
 
-        assert_index_equal(actual.index.to_pandas(), expected.index)
+        assert_index_equal(sgpd_result.index, expected.index)
 
     @classmethod
     def check_sgpd_df_equals_gpd_df(


### PR DESCRIPTION
## Did you read the Contributor Guide?

Yes

## Is this PR related to a ticket?

Yes, resolves #3084

## What changes were proposed in this PR?

`check_sgpd_equals_gpd` in `python/tests/geopandas/test_geopandas_base.py` compared the actual `GeoSeries` against the expected `gpd.GeoSeries` element-wise by position and asserted index equality positionally. This assumed the result preserved input row order.

Sedona's GeoPandas API does not guarantee result row ordering, so operations that shuffle across Spark partitions (e.g. `GeoSeries.clip_by_rect`) can return rows in a different order, causing false test failures (`test_clip_by_rect` reports `POLYGON EMPTY` vs the expected clipped polygon even though all values are correct).

This PR aligns both sides by index before comparing, making the helper order-agnostic. It is a no-op for operations that already return ordered results.

## How was this patch tested?

Ran `test_clip_by_rect` (both `test_geoseries.py` and `test_match_geopandas_series.py`) and `test_buffer` with a multi-partition local Spark (`local[*]`); all pass with the fix and the previously-failing `clip_by_rect` cases now compare correctly.

## Did this PR include necessary documentation updates?

No, this is a test-only change.
