### PR TITLE
[DOCS] Add excerpt separator to SedonaDB 0.4.0 release blog post

### DIFF
--- a/docs/blog/posts/intro-sedonadb-0-4.md
+++ b/docs/blog/posts/intro-sedonadb-0-4.md
@@ -20,6 +20,8 @@ SedonaDB is the first open-source, single-node analytical database engine that t
 
 Apache Sedona powers large-scale geospatial processing on distributed engines like Spark (SedonaSpark), Flink (SedonaFlink), and Snowflake (SedonaSnow). SedonaDB extends the Sedona ecosystem with a single-node engine optimized for small-to-medium data analytics, delivering the simplicity and speed that distributed systems often cannot.
 
+<!-- more -->
+
 ## Release Highlights
 
 We're excited to have so many things to highlight in this release!


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)
## Is this PR related to a ticket?

- No: this is a documentation update. The PR name follows the format `[DOCS] my subject`
## What changes were proposed in this PR?

The SedonaDB 0.4.0 release blog post (`docs/blog/posts/intro-sedonadb-0-4.md`) was missing the `<!-- more -->` excerpt separator. As a result, the entire post (the full ~11 min read, including all code samples and output tables) rendered inline on the blog index page, pushing all older posts far down the page.

This PR adds the `<!-- more -->` marker right after the introductory paragraphs (before `## Release Highlights`), so the blog index shows only a short digest with a "Continue reading" link. This matches the convention already used in the 0.2 and 0.3 release posts.

## How was this patch tested?

Documentation-only change. Verified that the 0.2 and 0.3 posts use the same `<!-- more -->` marker in the same position.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.