### PR TITLE
[GH-3089] Fix empty-envelope false candidate and RS_DWithin EXPLAIN label in raster distance join

### DIFF
--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/BroadcastIndexJoinExec.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/BroadcastIndexJoinExec.scala
@@ -122,7 +122,7 @@ case class BroadcastIndexJoinExec(
     case (None, _, false) => s"ST_$spatialPredicate($windowExpression, $objectExpression)"
     case (None, _, true) => s"RS_$spatialPredicate($windowExpression, $objectExpression)"
     case (Some(r), _, true) =>
-      s"RS_Distance($windowExpression, $objectExpression) < $r"
+      s"RS_DWithin($windowExpression, $objectExpression, $r)"
   }
 
   override def simpleString(maxFields: Int): String =

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/TraitJoinQueryBase.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/strategy/join/TraitJoinQueryBase.scala
@@ -188,6 +188,12 @@ trait TraitJoinQueryBase {
   private[join] def expandRasterFilterEnvelope(
       baseShape: Geometry,
       distance: Double): Geometry = {
+    // An empty shape (e.g. the empty GeometryCollection substituted for a NULL raster/geometry)
+    // must stay empty: expanding its degenerate envelope by `distance` would yield a non-empty
+    // filter geometry that spuriously matches rows the predicate should never join.
+    if (baseShape.isEmpty) {
+      return baseShape
+    }
     val envelope = baseShape.getEnvelopeInternal
     val touchesPole = envelope.getMaxY >= 90.0 || envelope.getMinY <= -90.0
     val tooWide = envelope.getWidth > 180.0


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #3089

## What changes were proposed in this PR?

Two issues in the raster distance-join machinery built around `RS_DWithin`, reported in #3089. Both changes are confined to `spark/common`.

1. **Empty-envelope false candidate.** When a raster or geometry input is `NULL`, the join substitutes an empty `GeometryCollection`. `expandRasterFilterEnvelope` then expanded that geometry's degenerate envelope by `distance`, producing a non-empty R-tree filter envelope that pulls the row in as a coarse-filter candidate (and can produce a `NaN`-bounded envelope from the null `Envelope`). It now returns the empty shape unchanged so the coarse filter excludes it.

2. **Misleading EXPLAIN output.** The raster distance branch of `BroadcastIndexJoinExec.simpleString` printed `RS_Distance(left, right) < r` — a function that does not exist in Sedona. It now prints `RS_DWithin(left, right, r)`, naming the actual predicate that drives the join.

## How was this patch tested?

`sedona-spark-common` compiles cleanly with the changes. Both are minimal changes within existing code paths exercised by `RasterJoinSuite` and `BroadcastIndexJoinSuite`.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
