### PR TITLE
[GH-3095] Exclude the entire Scala toolchain from shaded jars

### DIFF
--- a/flink-shaded/pom.xml
+++ b/flink-shaded/pom.xml
@@ -85,7 +85,12 @@
                             </transformers>
                             <artifactSet>
                                 <excludes>
-                                    <exclude>org.scala-lang:scala-library</exclude>
+                                    <!-- Never bundle the Scala toolchain (scala-library, scala-reflect,
+                                         scala-compiler): the runtime provides its own, and an unrelocated
+                                         copy shadows it, breaking Scala-compiler users such as
+                                         almond/Ammonite kernels. The groupId match is exact, so
+                                         org.scala-lang.modules artifacts are still bundled. -->
+                                    <exclude>org.scala-lang:*</exclude>
                                 </excludes>
                             </artifactSet>
                             <relocations>

--- a/snowflake/pom.xml
+++ b/snowflake/pom.xml
@@ -133,7 +133,12 @@
                             </transformers>
                             <artifactSet>
                                 <excludes>
-                                    <exclude>org.scala-lang:scala-library</exclude>
+                                    <!-- Never bundle the Scala toolchain (scala-library, scala-reflect,
+                                         scala-compiler): the runtime provides its own, and an unrelocated
+                                         copy shadows it, breaking Scala-compiler users such as
+                                         almond/Ammonite kernels. The groupId match is exact, so
+                                         org.scala-lang.modules artifacts are still bundled. -->
+                                    <exclude>org.scala-lang:*</exclude>
                                 </excludes>
                             </artifactSet>
                             <relocations>

--- a/spark-shaded/pom.xml
+++ b/spark-shaded/pom.xml
@@ -233,7 +233,12 @@
                             </transformers>
                             <artifactSet>
                                 <excludes>
-                                    <exclude>org.scala-lang:scala-library</exclude>
+                                    <!-- Never bundle the Scala toolchain (scala-library, scala-reflect,
+                                         scala-compiler): the runtime provides its own, and an unrelocated
+                                         copy shadows it, breaking Scala-compiler users such as
+                                         almond/Ammonite kernels. The groupId match is exact, so
+                                         org.scala-lang.modules artifacts are still bundled. -->
+                                    <exclude>org.scala-lang:*</exclude>
                                     <exclude>org.apache.commons:commons-*</exclude>
                                     <exclude>commons-pool:commons-pool</exclude>
                                     <exclude>commons-io:commons-io</exclude>


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #3095

## What changes were proposed in this PR?

Change the shade-plugin exclude in `spark-shaded`, `flink-shaded`, and `snowflake` from `org.scala-lang:scala-library` to `org.scala-lang:*`, so `scala-reflect`/`scala-compiler` can never be bundled unrelocated into the fat jars and shadow the runtime's Scala toolchain. See #3095 for details. The groupId match is exact, so `org.scala-lang.modules:scala-collection-compat` stays bundled.

## How was this patch tested?

Verified on a downstream build hit by this that the shaded jar goes from containing an unrelocated `scala-reflect` 2.13.8 to zero `scala/reflect/` or `scala/tools/` entries, with `scala/collection/compat/` still bundled.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.