### PR TITLE
[DOCS] Remove broken `Star History` image from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@
 - [Docker image](#docker-image)
 - [Building Sedona](#building-sedona)
 - [Documentation](#documentation)
-- [Star History](#star-history)
 - [Powered by](#powered-by)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -226,10 +225,6 @@ We provide a Docker image for Apache Sedona with Python JupyterLab and a single-
 * [Sedona Python API Documentation](https://sedona.apache.org/latest/api/pydocs/)
 
 Please visit [Apache Sedona website](https://sedona.apache.org/) for detailed information
-
-## Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=apache/sedona&type=Date)](https://www.star-history.com/#apache/sedona&Date)
 
 ## Powered by
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a documentation update. The PR name follows the format `[DOCS] my subject`

## What changes were proposed in this PR?

Removes the Star History section since the image is broken 

## How was this patch tested?

<img width="717" height="161" alt="Screenshot 2026-07-15 at 3 50 05 am" src="https://github.com/user-attachments/assets/ff9ad86f-e686-427c-8750-8753ba4d715c" />
<img width="711" height="1001" alt="Screenshot 2026-07-15 at 3 48 48 am" src="https://github.com/user-attachments/assets/06a5edac-29f0-409c-a829-7ae8b30be526" />

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.