### PR TITLE
[GH-3103] Bump proj4sedona to 0.1.1 and re-enable RS_CRS round-trip tests

### DIFF
--- a/common/src/test/java/org/apache/sedona/common/raster/CrsRoundTripComplianceTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/CrsRoundTripComplianceTest.java
@@ -24,7 +24,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.coverage.grid.GridCoverage2D;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -86,19 +85,11 @@ public class CrsRoundTripComplianceTest extends RasterTestBase {
   }
 
   @Test
-  @Ignore(
-      "apache/sedona#3103: RS_CRS PROJ-string export is not idempotent for this CRS "
-          + "due to a raster CRS-bridge path divergence (surfaced by the proj4sedona 0.1.0 "
-          + "serialization changes; transforms are unaffected).")
   public void testProjRoundTrip_AlbersEqualArea_5070() throws FactoryException {
     assertProjRoundTrip(5070);
   }
 
   @Test
-  @Ignore(
-      "apache/sedona#3103: RS_CRS PROJ-string export is not idempotent for this CRS "
-          + "due to a raster CRS-bridge path divergence (surfaced by the proj4sedona 0.1.0 "
-          + "serialization changes; transforms are unaffected).")
   public void testProjRoundTrip_ObliqueStereographic_28992() throws FactoryException {
     assertProjRoundTrip(28992);
   }
@@ -129,28 +120,16 @@ public class CrsRoundTripComplianceTest extends RasterTestBase {
   }
 
   @Test
-  @Ignore(
-      "apache/sedona#3103: RS_CRS PROJ-string export is not idempotent for this CRS "
-          + "due to a raster CRS-bridge path divergence (surfaced by the proj4sedona 0.1.0 "
-          + "serialization changes; transforms are unaffected).")
   public void testProjRoundTrip_TransverseMercator_OSGB_27700() throws FactoryException {
     assertProjRoundTrip(27700);
   }
 
   @Test
-  @Ignore(
-      "apache/sedona#3103: RS_CRS PROJ-string export is not idempotent for this CRS "
-          + "due to a raster CRS-bridge path divergence (surfaced by the proj4sedona 0.1.0 "
-          + "serialization changes; transforms are unaffected).")
   public void testProjRoundTrip_AlbersEqualArea_Australian_3577() throws FactoryException {
     assertProjRoundTrip(3577);
   }
 
   @Test
-  @Ignore(
-      "apache/sedona#3103: RS_CRS PROJ-string export is not idempotent for this CRS "
-          + "due to a raster CRS-bridge path divergence (surfaced by the proj4sedona 0.1.0 "
-          + "serialization changes; transforms are unaffected).")
   public void testProjRoundTrip_LambertConformalConic2SP_Vicgrid_3111() throws FactoryException {
     assertProjRoundTrip(3111);
   }

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <scala-collection-compat.version>2.5.0</scala-collection-compat.version>
         <geoglib.version>1.52</geoglib.version>
         <caffeine.version>2.9.2</caffeine.version>
-        <proj4sedona.version>0.1.0</proj4sedona.version>
+        <proj4sedona.version>0.1.1</proj4sedona.version>
 
         <geotools.scope>provided</geotools.scope>
         <!-- Because it's not in Maven central, make it provided by default -->


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #3103

## What changes were proposed in this PR?

Bumps the `proj4sedona` dependency **0.1.0 → 0.1.1** and re-enables the 5 `CrsRoundTripComplianceTest` cases that were `@Ignore`'d against #3103.

proj4sedona 0.1.1 fixes the CRS-serialization interop issues that made `RS_CRS` PROJ-string export non-idempotent for several projected CRSs:
- WKT1 emits `TOWGS84` in human units (arc-seconds / ppm)
- WKT / GeoTools method names are normalized to PROJ short codes on export (e.g. `Polar_Stereographic` → `stere`)
- Canonical PROJ short codes are registry-owned
- Polar Stereographic variant A/B selection is consistent across proj-string / WKT1 / WKT2

Re-enabled cases: `EPSG:5070` (Albers), `EPSG:28992` (Oblique Stereographic), `EPSG:27700` (OSGB TM), `EPSG:3577` (Australian Albers), `EPSG:3111` (Vicgrid LCC 2SP). Transforms were never affected — this was export idempotency only.

## How was this patch tested?

Built the `common` module and the Spark CRS path against proj4sedona 0.1.1:
- `common` full suite: **1145** tests, 0 failures / 0 errors / 0 skipped — including `CrsRoundTripComplianceTest` (**81**, all cases active, 0 skipped)
- `CRSTransformProj4Test` (Spark `ST_Transform` → proj4sedona): **36**, 0 failures
- `CRSTransformationTest` (Spark core CRS): **1**, 0 failures

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
