### PR TITLE
[GH-3166] Resolve raster sample positions the way Java AWT does in the Python reader

### DIFF
--- a/python/sedona/spark/raster/data_buffer.py
+++ b/python/sedona/spark/raster/data_buffer.py
@@ -40,3 +40,16 @@ class DataBuffer:
         self.bank_data = bank_data
         self.size = size
         self.offsets = offsets
+
+    def bank_samples(self, bank_index: int = 0) -> np.ndarray:
+        """Return the samples of a bank as an array indexed by sample index.
+
+        The offset of the bank is applied, so index ``i`` of the returned array holds
+        the same sample as ``DataBuffer.getElem(bank_index, i)`` does in Java AWT.
+        Sample models must go through this method instead of indexing
+        :attr:`bank_data` directly, otherwise samples of banks with a non-zero offset
+        are read from the wrong positions.
+        """
+        offset = self.offsets[bank_index]
+        bank_data = self.bank_data[bank_index]
+        return bank_data[offset:] if offset else bank_data

--- a/python/sedona/spark/raster/sample_model.py
+++ b/python/sedona/spark/raster/sample_model.py
@@ -80,9 +80,9 @@ class ComponentSampleModel(SampleModel):
         if self.scanline_stride == self.width and self.pixel_stride == 1:
             # Fast path: no gaps between pixels
             band_arrs = []
-            for bank_index in self.bank_indices:
+            for k, bank_index in enumerate(self.bank_indices):
                 bank_data = data_buffer.bank_data[bank_index]
-                offset = self.band_offsets[bank_index]
+                offset = self.band_offsets[k]
                 if offset != 0:
                     bank_data = bank_data[offset : (offset + self.width * self.height)]
                 band_arr = bank_data.reshape(self.height, self.width)

--- a/python/sedona/spark/raster/sample_model.py
+++ b/python/sedona/spark/raster/sample_model.py
@@ -17,6 +17,7 @@
 
 from abc import ABC, abstractmethod
 from typing import List
+from warnings import warn
 
 import numpy as np
 
@@ -194,8 +195,7 @@ class MultiPixelPackedSampleModel(SampleModel):
         samples = data_buffer.bank_samples()
         bits_per_value = samples.dtype.itemsize * 8
 
-        # Resolve every pixel on its own, the way Java does: this sample model requires
-        # num_bits to divide the size of a data element, so no pixel spans two elements.
+        # Resolve every pixel on its own, the way Java does
         pixel_bits = self.data_bit_offset + np.arange(self.width) * self.num_bits
         cols = pixel_bits // bits_per_value
         shifts = bits_per_value - (pixel_bits % bits_per_value) - self.num_bits
@@ -210,10 +210,27 @@ class MultiPixelPackedSampleModel(SampleModel):
         # multiple of num_bits, which leaves a pixel straddling two samples and gives a
         # negative distance here, shifts the top bits of the sample down rather than
         # shifting the whole sample out, and a pixel occupying a whole 32 bit sample gets a
-        # zero mask and reads as zero.
-        values = samples[positions].astype(np.int32)
-        shifts = (shifts & 31).astype(np.int32)
+        # zero mask and reads as zero. Neither layout can hold a pixel that survives a round
+        # trip through Java, so warn about them rather than read them some other way.
         bit_mask = np.int32((1 << (self.num_bits % 32)) - 1)
-        pixels = (values >> shifts) & bit_mask
+        if bit_mask == 0:
+            warn(
+                "This raster packs one pixel per 32 bit sample. java.awt.image derives the "
+                "bit mask for it as `(1 << 32) - 1`, which is zero on an int, so Java reads "
+                "every pixel of such a raster as zero and writes to it are no-ops. "
+                "Returning zeroes to match."
+            )
+        elif (shifts < 0).any():
+            warn(
+                f"This raster's data bit offset ({self.data_bit_offset}) is not a multiple "
+                f"of its {self.num_bits} bits per pixel, so some pixels straddle two "
+                "samples. java.awt.image shifts those by a negative distance, which it "
+                "takes modulo 32, reading the top bits of the sample instead; Java's own "
+                "writes to those pixels are lossy in the same way. Returning what Java "
+                "reads."
+            )
+
+        values = samples[positions].astype(np.int32)
+        pixels = (values >> (shifts & 31).astype(np.int32)) & bit_mask
 
         return pixels.astype(samples.dtype).reshape(1, self.height, self.width)

--- a/python/sedona/spark/raster/sample_model.py
+++ b/python/sedona/spark/raster/sample_model.py
@@ -40,6 +40,7 @@ class SampleModel(ABC):
     data_type: int
     width: int
     height: int
+    scanline_stride: int
 
     def __init__(self, sample_model_type, data_type, width, height):
         self.sample_model_type = sample_model_type
@@ -52,6 +53,16 @@ class SampleModel(ABC):
         raise NotImplementedError(
             "Abstract method as_numpy was not implemented by subclass"
         )
+
+    def _pixel_positions(self, pixel_stride: int, offset: int = 0) -> np.ndarray:
+        """Sample position of every pixel, as a (height, width) array of indices.
+
+        The positions are relative to the start of a bank, so they index the arrays
+        returned by :meth:`DataBuffer.bank_samples`.
+        """
+        rows = np.arange(self.height) * self.scanline_stride + offset
+        cols = np.arange(self.width) * pixel_stride
+        return rows[:, np.newaxis] + cols[np.newaxis, :]
 
 
 class ComponentSampleModel(SampleModel):
@@ -77,33 +88,27 @@ class ComponentSampleModel(SampleModel):
         self.band_offsets = band_offsets
 
     def as_numpy(self, data_buffer: DataBuffer) -> np.ndarray:
-        if self.scanline_stride == self.width and self.pixel_stride == 1:
-            # Fast path: no gaps between pixels
-            band_arrs = []
-            for k, bank_index in enumerate(self.bank_indices):
-                bank_data = data_buffer.bank_data[bank_index]
-                offset = self.band_offsets[k]
-                if offset != 0:
-                    bank_data = bank_data[offset : (offset + self.width * self.height)]
-                band_arr = bank_data.reshape(self.height, self.width)
-                band_arrs.append(band_arr)
-            return np.array(band_arrs)
-        else:
-            # Slow path
-            band_arrs = []
-            for k in range(len(self.bank_indices)):
-                bank_index = self.bank_indices[k]
-                bank_data = data_buffer.bank_data[bank_index]
-                offset = self.band_offsets[k]
-                band_pixel_data = []
-                for y in range(self.height):
-                    for x in range(self.width):
-                        pos = offset + y * self.scanline_stride + x * self.pixel_stride
-                        band_pixel_data.append(bank_data[pos])
-                arr = np.array(band_pixel_data).reshape(self.height, self.width)
-                band_arrs.append(arr)
+        contiguous = self.scanline_stride == self.width and self.pixel_stride == 1
+        num_samples = self.width * self.height
 
-            return np.array(band_arrs)
+        band_arrs = []
+        for k, bank_index in enumerate(self.bank_indices):
+            # The band offset is relative to the offset of the bank the band lives in, and
+            # bank_indices/band_offsets are both indexed by band, not by bank.
+            samples = data_buffer.bank_samples(bank_index)
+            offset = self.band_offsets[k]
+            if contiguous:
+                # Fast path: the samples of a band follow each other. The bank may still
+                # hold more samples than the band needs, so slice a bounded window.
+                band_arr = samples[offset : (offset + num_samples)].reshape(
+                    self.height, self.width
+                )
+            else:
+                # Slow path: gaps between pixels or scanlines
+                band_arr = samples[self._pixel_positions(self.pixel_stride, offset)]
+            band_arrs.append(band_arr)
+
+        return np.array(band_arrs)
 
 
 class PixelInterleavedSampleModel(SampleModel):
@@ -121,26 +126,23 @@ class PixelInterleavedSampleModel(SampleModel):
 
     def as_numpy(self, data_buffer: DataBuffer) -> np.ndarray:
         num_bands = len(self.band_offsets)
-        bank_data = data_buffer.bank_data[0]
+        samples = data_buffer.bank_samples()
         if (
             self.pixel_stride == num_bands
             and self.scanline_stride == self.width * num_bands
             and self.band_offsets == list(range(0, num_bands))
         ):
-            # Fast path: no gapping in between band data, no band reordering
-            arr = bank_data.reshape(self.height, self.width, num_bands)
+            # Fast path: no gapping in between band data, no band reordering. The bank may
+            # still hold more samples than the image needs, so slice a bounded window.
+            num_samples = self.width * self.height * num_bands
+            arr = samples[:num_samples].reshape(self.height, self.width, num_bands)
             return np.transpose(arr, [2, 0, 1])
         else:
-            # Slow path
-            pixel_data = []
-            for y in range(self.height):
-                for x in range(self.width):
-                    begin = y * self.scanline_stride + x * self.pixel_stride
-                    end = begin + num_bands
-                    pixel = bank_data[begin:end][self.band_offsets]
-                    pixel_data.append(pixel)
-            arr = np.array(pixel_data).reshape(self.height, self.width, num_bands)
-            return np.transpose(arr, [2, 0, 1])
+            # Slow path. Band offsets are positions within a scanline, so they are not
+            # bound to the pixel they belong to and may reach past its pixel stride.
+            positions = self._pixel_positions(self.pixel_stride)
+            band_arrs = [samples[positions + offset] for offset in self.band_offsets]
+            return np.array(band_arrs)
 
 
 class SinglePixelPackedSampleModel(SampleModel):
@@ -157,21 +159,20 @@ class SinglePixelPackedSampleModel(SampleModel):
             self.bit_offsets.append((v & -v).bit_length() - 1)
 
     def as_numpy(self, data_buffer: DataBuffer) -> np.ndarray:
-        num_bands = len(self.bit_masks)
-        bank_data = data_buffer.bank_data[0]
-        pixel_data = []
-        for y in range(self.height):
-            for x in range(self.width):
-                pos = y * self.scanline_stride + x
-                value = bank_data[pos]
-                pixel = []
-                for mask, bit_offset in zip(self.bit_masks, self.bit_offsets):
-                    pixel.append((value & mask) >> bit_offset)
-                pixel_data.append(pixel)
-        arr = np.array(pixel_data, dtype=bank_data.dtype).reshape(
-            self.height, self.width, num_bands
-        )
-        return np.transpose(arr, [2, 0, 1])
+        samples = data_buffer.bank_samples()
+        # Java extracts the bands with `(value & mask) >>> bitOffset`. Read the samples as
+        # unsigned so that a mask covering the sign bit, such as the alpha mask of an ARGB
+        # raster, does not sign-extend into the band values.
+        unsigned_dtype = np.dtype(f"u{samples.dtype.itemsize}")
+        values = samples[self._pixel_positions(1)].astype(unsigned_dtype)
+        # The bit masks are deserialized as signed 32 bit integers, so masks covering the
+        # sign bit arrive negative. Take their two's complement bits.
+        value_mask = (1 << (samples.dtype.itemsize * 8)) - 1
+        band_arrs = [
+            (values & unsigned_dtype.type(mask & value_mask)) >> bit_offset
+            for mask, bit_offset in zip(self.bit_masks, self.bit_offsets)
+        ]
+        return np.array(band_arrs).astype(samples.dtype)
 
 
 class MultiPixelPackedSampleModel(SampleModel):
@@ -188,27 +189,21 @@ class MultiPixelPackedSampleModel(SampleModel):
         self.data_bit_offset = data_bit_offset
 
     def as_numpy(self, data_buffer: DataBuffer) -> np.ndarray:
-        bank_data = data_buffer.bank_data[0]
-        bits_per_value = bank_data.dtype.itemsize * 8
-        pixel_per_value = bits_per_value / self.num_bits
-        shift_right = bits_per_value - self.num_bits
-        mask = ((1 << self.num_bits) - 1) << shift_right
+        samples = data_buffer.bank_samples()
+        bits_per_value = samples.dtype.itemsize * 8
 
-        band_data = []
-        for y in range(self.height):
-            pos = y * self.scanline_stride + self.data_bit_offset // bits_per_value
-            value = bank_data[pos]
-            shift = self.data_bit_offset % bits_per_value
-            value = value << shift
-            pixels: List[int] = []
-            while len(pixels) < self.width:
-                while shift < bits_per_value and len(pixels) < self.width:
-                    pixels.append((value & mask) >> shift_right)
-                    value = value << self.num_bits
-                    shift += self.num_bits
-                pos += 1
-                value = bank_data[pos]
-                shift = 0
-            band_data.append(np.array(pixels, dtype=bank_data.dtype))
+        # Resolve every pixel on its own, the way Java does: this sample model requires
+        # num_bits to divide the size of a data element, so no pixel spans two elements.
+        pixel_bits = self.data_bit_offset + np.arange(self.width) * self.num_bits
+        cols = pixel_bits // bits_per_value
+        shifts = bits_per_value - (pixel_bits % bits_per_value) - self.num_bits
 
-        return np.array(band_data).reshape(1, self.height, self.width)
+        rows = np.arange(self.height) * self.scanline_stride
+        positions = rows[:, np.newaxis] + cols[np.newaxis, :]
+        # Shift the samples as unsigned values, otherwise pixels held in the sign bit of a
+        # signed data type would sign-extend instead of shifting in zeroes.
+        unsigned_dtype = np.dtype(f"u{samples.dtype.itemsize}")
+        values = samples[positions].astype(unsigned_dtype)
+        pixels = (values >> shifts) & ((1 << self.num_bits) - 1)
+
+        return pixels.astype(samples.dtype).reshape(1, self.height, self.width)

--- a/python/sedona/spark/raster/sample_model.py
+++ b/python/sedona/spark/raster/sample_model.py
@@ -156,7 +156,9 @@ class SinglePixelPackedSampleModel(SampleModel):
         self.bit_masks = bit_masks
         self.bit_offsets = []
         for v in self.bit_masks:
-            self.bit_offsets.append((v & -v).bit_length() - 1)
+            # Java leaves the bit offset of a zero mask at zero, and reads such a band as
+            # zero. Deriving it from the mask would give -1 for it.
+            self.bit_offsets.append((v & -v).bit_length() - 1 if v else 0)
 
     def as_numpy(self, data_buffer: DataBuffer) -> np.ndarray:
         samples = data_buffer.bank_samples()
@@ -204,6 +206,10 @@ class MultiPixelPackedSampleModel(SampleModel):
         # signed data type would sign-extend instead of shifting in zeroes.
         unsigned_dtype = np.dtype(f"u{samples.dtype.itemsize}")
         values = samples[positions].astype(unsigned_dtype)
-        pixels = (values >> shifts) & ((1 << self.num_bits) - 1)
+        # Java derives this mask as `(1 << numberOfBits) - 1` on an int, and the shift count
+        # of an int shift is taken modulo 32. A pixel occupying a whole 32 bit sample
+        # therefore ends up with a zero mask, and Java reads every such pixel as zero.
+        bit_mask = (1 << (self.num_bits % 32)) - 1
+        pixels = (values >> shifts) & bit_mask
 
         return pixels.astype(samples.dtype).reshape(1, self.height, self.width)

--- a/python/sedona/spark/raster/sample_model.py
+++ b/python/sedona/spark/raster/sample_model.py
@@ -202,14 +202,18 @@ class MultiPixelPackedSampleModel(SampleModel):
 
         rows = np.arange(self.height) * self.scanline_stride
         positions = rows[:, np.newaxis] + cols[np.newaxis, :]
-        # Shift the samples as unsigned values, otherwise pixels held in the sign bit of a
-        # signed data type would sign-extend instead of shifting in zeroes.
-        unsigned_dtype = np.dtype(f"u{samples.dtype.itemsize}")
-        values = samples[positions].astype(unsigned_dtype)
-        # Java derives this mask as `(1 << numberOfBits) - 1` on an int, and the shift count
-        # of an int shift is taken modulo 32. A pixel occupying a whole 32 bit sample
-        # therefore ends up with a zero mask, and Java reads every such pixel as zero.
-        bit_mask = (1 << (self.num_bits % 32)) - 1
+
+        # Java reads a sample through DataBuffer.getElem(), which widens it to a signed int,
+        # zero extending byte and ushort samples, and then shifts it with `>>`. Both that
+        # shift and the `1 <<` below are int operations, whose shift distance Java takes
+        # modulo 32, and `>>` propagates the sign bit. So a data bit offset that is not a
+        # multiple of num_bits, which leaves a pixel straddling two samples and gives a
+        # negative distance here, shifts the top bits of the sample down rather than
+        # shifting the whole sample out, and a pixel occupying a whole 32 bit sample gets a
+        # zero mask and reads as zero.
+        values = samples[positions].astype(np.int32)
+        shifts = (shifts & 31).astype(np.int32)
+        bit_mask = np.int32((1 << (self.num_bits % 32)) - 1)
         pixels = (values >> shifts) & bit_mask
 
         return pixels.astype(samples.dtype).reshape(1, self.height, self.width)

--- a/python/tests/raster/test_sample_model.py
+++ b/python/tests/raster/test_sample_model.py
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import numpy as np
+
+from sedona.spark.raster.data_buffer import DataBuffer
+from sedona.spark.raster.sample_model import ComponentSampleModel
+
+
+def test_component_sample_model_fast_path_uses_band_offsets() -> None:
+    sample_model = ComponentSampleModel(
+        DataBuffer.TYPE_INT,
+        2,
+        2,
+        1,
+        2,
+        [1, 0],
+        [3, 1],
+    )
+    data_buffer = DataBuffer(
+        DataBuffer.TYPE_INT,
+        [
+            np.array([10, 11, 12, 13, 14, 15, 16]),
+            np.array([20, 21, 22, 23, 24, 25, 26]),
+        ],
+        7,
+        [0, 0],
+    )
+
+    np.testing.assert_array_equal(
+        sample_model.as_numpy(data_buffer),
+        np.array([[[23, 24], [25, 26]], [[11, 12], [13, 14]]]),
+    )

--- a/python/tests/raster/test_sample_model.py
+++ b/python/tests/raster/test_sample_model.py
@@ -15,33 +15,263 @@
 # specific language governing permissions and limitations
 # under the License.
 
+"""Tests for reading rasters whose sample models use the less common layouts.
+
+The expected samples of every test were produced by handing the same sample model and data
+buffer to java.awt.image, so they record what Java AWT reads for these layouts. Each test
+names the Java layout it covers, which is enough to reproduce it.
+"""
+
+from typing import List
+
 import numpy as np
+import pytest
 
 from sedona.spark.raster.data_buffer import DataBuffer
-from sedona.spark.raster.sample_model import ComponentSampleModel
+from sedona.spark.raster.sample_model import (
+    ComponentSampleModel,
+    MultiPixelPackedSampleModel,
+    PixelInterleavedSampleModel,
+    SinglePixelPackedSampleModel,
+)
 
 
-def test_component_sample_model_fast_path_uses_band_offsets() -> None:
-    sample_model = ComponentSampleModel(
-        DataBuffer.TYPE_INT,
-        2,
-        2,
-        1,
-        2,
-        [1, 0],
-        [3, 1],
-    )
-    data_buffer = DataBuffer(
-        DataBuffer.TYPE_INT,
-        [
-            np.array([10, 11, 12, 13, 14, 15, 16]),
-            np.array([20, 21, 22, 23, 24, 25, 26]),
-        ],
-        7,
-        [0, 0],
-    )
+def ramp(start: int, length: int, dtype=np.int32) -> np.ndarray:
+    """A bank of consecutive values, so that a sample identifies its own position."""
+    return np.arange(start, start + length, dtype=dtype)
+
+
+def signed_int32(mask: int) -> int:
+    """Turn a bit mask written in its unsigned form into the value the deserializer
+    produces for it, which is negative for masks covering the top bit."""
+    return mask - (1 << 32) if mask >= (1 << 31) else mask
+
+
+def int_bank(values: List[int]) -> np.ndarray:
+    """An int32 bank holding values written in their unsigned form."""
+    return np.array(values, dtype=np.uint32).astype(np.int32)
+
+
+def test_component_fast_path_pairs_band_offsets_with_bands() -> None:
+    # ComponentSampleModel(TYPE_INT, 2, 2, 1, 2, {1, 0}, {3, 1})
+    sample_model = ComponentSampleModel(DataBuffer.TYPE_INT, 2, 2, 1, 2, [1, 0], [3, 1])
+    data_buffer = DataBuffer(DataBuffer.TYPE_INT, [ramp(10, 7), ramp(20, 7)], 7, [0, 0])
 
     np.testing.assert_array_equal(
         sample_model.as_numpy(data_buffer),
         np.array([[[23, 24], [25, 26]], [[11, 12], [13, 14]]]),
     )
+
+
+def test_component_fast_path_applies_bank_offsets() -> None:
+    # ComponentSampleModel(TYPE_INT, 2, 2, 1, 2, {1, 0}, {3, 1})
+    # over DataBufferInt(banks, 7, {2, 1})
+    sample_model = ComponentSampleModel(DataBuffer.TYPE_INT, 2, 2, 1, 2, [1, 0], [3, 1])
+    data_buffer = DataBuffer(DataBuffer.TYPE_INT, [ramp(10, 9), ramp(20, 9)], 7, [2, 1])
+
+    np.testing.assert_array_equal(
+        sample_model.as_numpy(data_buffer),
+        np.array([[[24, 25], [26, 27]], [[13, 14], [15, 16]]]),
+    )
+
+
+def test_component_fast_path_reads_a_bounded_window_of_padded_banks() -> None:
+    # ComponentSampleModel(TYPE_INT, 2, 2, 1, 2, {0, 1}, {0, 0}) over banks of 6 samples,
+    # so the band offsets alone give no reason to narrow a bank down to 4 samples
+    sample_model = ComponentSampleModel(DataBuffer.TYPE_INT, 2, 2, 1, 2, [0, 1], [0, 0])
+    data_buffer = DataBuffer(DataBuffer.TYPE_INT, [ramp(10, 6), ramp(20, 6)], 6, [0, 0])
+
+    np.testing.assert_array_equal(
+        sample_model.as_numpy(data_buffer),
+        np.array([[[10, 11], [12, 13]], [[20, 21], [22, 23]]]),
+    )
+
+
+def test_banded_sample_model_over_reordered_banks() -> None:
+    # BandedSampleModel(TYPE_INT, 2, 2, 2, {1, 0}, {1, 2}) over DataBufferInt(banks, 6, {1, 2}),
+    # which is deserialized as a component model with a unit pixel stride
+    sample_model = ComponentSampleModel(DataBuffer.TYPE_INT, 2, 2, 1, 2, [1, 0], [1, 2])
+    data_buffer = DataBuffer(DataBuffer.TYPE_INT, [ramp(10, 8), ramp(20, 8)], 6, [1, 2])
+
+    np.testing.assert_array_equal(
+        sample_model.as_numpy(data_buffer),
+        np.array([[[23, 24], [25, 26]], [[13, 14], [15, 16]]]),
+    )
+
+
+def test_component_slow_path_applies_bank_offsets() -> None:
+    # ComponentSampleModel(TYPE_INT, 3, 2, 2, 8, {1, 1, 0}, {0, 1, 4})
+    # over DataBufferInt(banks, 20, {3, 2}): two bands share a bank, and there are gaps
+    # both between the scanlines and between the pixels within them
+    sample_model = ComponentSampleModel(
+        DataBuffer.TYPE_INT, 3, 2, 2, 8, [1, 1, 0], [0, 1, 4]
+    )
+    data_buffer = DataBuffer(
+        DataBuffer.TYPE_INT, [ramp(100, 24), ramp(200, 24)], 20, [3, 2]
+    )
+
+    np.testing.assert_array_equal(
+        sample_model.as_numpy(data_buffer),
+        np.array(
+            [
+                [[202, 204, 206], [210, 212, 214]],
+                [[203, 205, 207], [211, 213, 215]],
+                [[107, 109, 111], [115, 117, 119]],
+            ]
+        ),
+    )
+
+
+def test_pixel_interleaved_fast_path_applies_bank_offset() -> None:
+    # PixelInterleavedSampleModel(TYPE_INT, 2, 2, 3, 6, {0, 1, 2})
+    # over DataBufferInt(bank of 20 samples, 17, {3})
+    sample_model = PixelInterleavedSampleModel(
+        DataBuffer.TYPE_INT, 2, 2, 3, 6, [0, 1, 2]
+    )
+    data_buffer = DataBuffer(DataBuffer.TYPE_INT, [ramp(10, 20)], 17, [3])
+
+    np.testing.assert_array_equal(
+        sample_model.as_numpy(data_buffer),
+        np.array([[[13, 16], [19, 22]], [[14, 17], [20, 23]], [[15, 18], [21, 24]]]),
+    )
+
+
+def test_pixel_interleaved_slow_path_band_offsets_may_exceed_pixel_stride() -> None:
+    # PixelInterleavedSampleModel(TYPE_INT, 2, 2, 4, 10, {3, 1, 0})
+    # over DataBufferInt(bank, 20, {2}): band 0 sits past the window the three bands of a
+    # single pixel would occupy
+    sample_model = PixelInterleavedSampleModel(
+        DataBuffer.TYPE_INT, 2, 2, 4, 10, [3, 1, 0]
+    )
+    data_buffer = DataBuffer(DataBuffer.TYPE_INT, [ramp(10, 24)], 20, [2])
+
+    np.testing.assert_array_equal(
+        sample_model.as_numpy(data_buffer),
+        np.array([[[15, 19], [25, 29]], [[13, 17], [23, 27]], [[12, 16], [22, 26]]]),
+    )
+
+
+def test_single_pixel_packed_argb_does_not_sign_extend() -> None:
+    # SinglePixelPackedSampleModel(TYPE_INT, 2, 2, 3, {0xFF000000, 0xFF0000, 0xFF00, 0xFF})
+    # over DataBufferInt(bank, 7, {1}): the alpha mask covers the sign bit of the samples
+    sample_model = SinglePixelPackedSampleModel(
+        DataBuffer.TYPE_INT,
+        2,
+        2,
+        3,
+        [signed_int32(0xFF000000), 0x00FF0000, 0x0000FF00, 0x000000FF],
+    )
+    data_buffer = DataBuffer(
+        DataBuffer.TYPE_INT,
+        [int_bank([0, 0x8090A0B0, 0x102030F0, 0, 0xFFFFFFFF, 0x01020304, 0, 0])],
+        7,
+        [1],
+    )
+
+    np.testing.assert_array_equal(
+        sample_model.as_numpy(data_buffer),
+        np.array(
+            [
+                [[128, 16], [255, 1]],
+                [[144, 32], [255, 2]],
+                [[160, 48], [255, 3]],
+                [[176, 240], [255, 4]],
+            ]
+        ),
+    )
+
+
+def test_single_pixel_packed_applies_bank_offset() -> None:
+    # SinglePixelPackedSampleModel(TYPE_USHORT, 2, 2, 4, {0xF800, 0x7E0, 0x1F}) over
+    # DataBufferUShort(bank, 8, {2}): RGB 565 pixels starting two samples into the bank
+    sample_model = SinglePixelPackedSampleModel(
+        DataBuffer.TYPE_USHORT, 2, 2, 4, [0xF800, 0x07E0, 0x001F]
+    )
+    data_buffer = DataBuffer(
+        DataBuffer.TYPE_USHORT,
+        [np.array([0, 0xF81F, 0x07E0, 0, 0, 0x1234, 0xFFFF, 0], dtype=np.uint16)],
+        8,
+        [2],
+    )
+
+    np.testing.assert_array_equal(
+        sample_model.as_numpy(data_buffer),
+        np.array([[[0, 0], [31, 0]], [[63, 0], [63, 0]], [[0, 0], [31, 0]]]),
+    )
+
+
+def test_multi_pixel_packed_applies_bit_and_bank_offsets() -> None:
+    # MultiPixelPackedSampleModel(TYPE_BYTE, 5, 2, 4, 4, 4) over DataBufferByte(bank, 9, {1}):
+    # four bits per pixel, with both the bank and the first scanline starting half a byte in
+    sample_model = MultiPixelPackedSampleModel(DataBuffer.TYPE_BYTE, 5, 2, 4, 4, 4)
+    data_buffer = DataBuffer(
+        DataBuffer.TYPE_BYTE,
+        [
+            np.array(
+                [0xFF, 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0x00],
+                dtype=np.uint8,
+            )
+        ],
+        9,
+        [1],
+    )
+
+    np.testing.assert_array_equal(
+        sample_model.as_numpy(data_buffer),
+        np.array([[[1, 2, 3, 4, 5], [9, 10, 11, 12, 13]]]),
+    )
+
+
+def test_multi_pixel_packed_stays_within_the_bank() -> None:
+    # MultiPixelPackedSampleModel(TYPE_BYTE, 8, 1, 1, 1, 0) over DataBufferByte(bank, 1, {0}):
+    # the whole image is held in a single byte, so reading beyond it is out of bounds
+    sample_model = MultiPixelPackedSampleModel(DataBuffer.TYPE_BYTE, 8, 1, 1, 1, 0)
+    data_buffer = DataBuffer(
+        DataBuffer.TYPE_BYTE, [np.array([0xA9], dtype=np.uint8)], 1, [0]
+    )
+
+    np.testing.assert_array_equal(
+        sample_model.as_numpy(data_buffer),
+        np.array([[[1, 0, 1, 0, 1, 0, 0, 1]]]),
+    )
+
+
+def test_multi_pixel_packed_scanline_spanning_several_samples() -> None:
+    # MultiPixelPackedSampleModel(TYPE_BYTE, 5, 2, 2, 3, 6) over DataBufferByte(bank, 7, {1}):
+    # scanlines of two bit pixels that start near the end of a byte
+    sample_model = MultiPixelPackedSampleModel(DataBuffer.TYPE_BYTE, 5, 2, 2, 3, 6)
+    data_buffer = DataBuffer(
+        DataBuffer.TYPE_BYTE,
+        [np.array([0x00, 0x1B, 0xE4, 0x39, 0x00, 0x4E, 0x93, 0x00], dtype=np.uint8)],
+        7,
+        [1],
+    )
+
+    np.testing.assert_array_equal(
+        sample_model.as_numpy(data_buffer),
+        np.array([[[3, 3, 2, 1, 0], [0, 1, 0, 3, 2]]]),
+    )
+
+
+@pytest.mark.parametrize(
+    "data_type,dtype",
+    [
+        (DataBuffer.TYPE_BYTE, np.uint8),
+        (DataBuffer.TYPE_SHORT, np.int16),
+        (DataBuffer.TYPE_USHORT, np.uint16),
+        (DataBuffer.TYPE_INT, np.int32),
+        (DataBuffer.TYPE_FLOAT, np.float32),
+        (DataBuffer.TYPE_DOUBLE, np.float64),
+    ],
+)
+def test_component_sample_model_keeps_the_data_type(data_type: int, dtype) -> None:
+    contiguous = ComponentSampleModel(data_type, 2, 2, 1, 2, [0], [1])
+    strided = ComponentSampleModel(data_type, 2, 2, 2, 5, [0], [1])
+
+    arr = contiguous.as_numpy(DataBuffer(data_type, [ramp(1, 6, dtype)], 5, [1]))
+    assert arr.dtype == dtype
+    np.testing.assert_array_equal(arr, np.array([[[3, 4], [5, 6]]], dtype=dtype))
+
+    arr = strided.as_numpy(DataBuffer(data_type, [ramp(1, 12, dtype)], 11, [1]))
+    assert arr.dtype == dtype
+    np.testing.assert_array_equal(arr, np.array([[[3, 5], [8, 10]]], dtype=dtype))

--- a/python/tests/raster/test_sample_model.py
+++ b/python/tests/raster/test_sample_model.py
@@ -270,6 +270,30 @@ def test_multi_pixel_packed_scanline_spanning_several_samples() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "bank,expected",
+    [
+        # the top sample has its sign bit set, so Java's arithmetic shift extends it
+        ([0x89ABCDEF, 0x12345678], [154, 188, 222, 248]),
+        # and a positive sample, where the shifted-down top bits are not sign bits
+        ([0x12345678, 0], [35, 69, 103, 1]),
+    ],
+)
+def test_multi_pixel_packed_pixel_straddling_two_samples(
+    bank: List[int], expected: List[int]
+) -> None:
+    # MultiPixelPackedSampleModel(TYPE_INT, 4, 1, 8, 1, 4): a data bit offset that is not a
+    # multiple of num_bits leaves the last pixel straddling two samples, and Java's shift
+    # distance for it goes negative. Java takes an int shift distance modulo 32, so -4 shifts
+    # right by 28 and reads the top bits of the sample rather than shifting it all out.
+    sample_model = MultiPixelPackedSampleModel(DataBuffer.TYPE_INT, 4, 1, 8, 1, 4)
+    data_buffer = DataBuffer(DataBuffer.TYPE_INT, [int_bank(bank)], 2, [0])
+
+    np.testing.assert_array_equal(
+        sample_model.as_numpy(data_buffer), np.array([[expected]])
+    )
+
+
 def test_multi_pixel_packed_whole_sample_pixels_read_zero() -> None:
     # MultiPixelPackedSampleModel(TYPE_INT, 3, 2, 32, 4, 0): Java accepts a pixel that
     # occupies a whole 32 bit sample, but derives a zero bit mask for it from

--- a/python/tests/raster/test_sample_model.py
+++ b/python/tests/raster/test_sample_model.py
@@ -181,6 +181,23 @@ def test_single_pixel_packed_argb_does_not_sign_extend() -> None:
     )
 
 
+def test_single_pixel_packed_zero_mask_reads_zero() -> None:
+    # SinglePixelPackedSampleModel(TYPE_INT, 2, 1, 2, {0xFF0000, 0xFF00, 0xFF, 0}): Java
+    # accepts a zero mask, leaves its bit offset at zero and reads the band as zero
+    sample_model = SinglePixelPackedSampleModel(
+        DataBuffer.TYPE_INT, 2, 1, 2, [0x00FF0000, 0x0000FF00, 0x000000FF, 0]
+    )
+    assert sample_model.bit_offsets == [16, 8, 0, 0]
+    data_buffer = DataBuffer(
+        DataBuffer.TYPE_INT, [int_bank([0x8090A0B0, 0xFFFFFFFF])], 2, [0]
+    )
+
+    np.testing.assert_array_equal(
+        sample_model.as_numpy(data_buffer),
+        np.array([[[144, 255]], [[160, 255]], [[176, 255]], [[0, 0]]]),
+    )
+
+
 def test_single_pixel_packed_applies_bank_offset() -> None:
     # SinglePixelPackedSampleModel(TYPE_USHORT, 2, 2, 4, {0xF800, 0x7E0, 0x1F}) over
     # DataBufferUShort(bank, 8, {2}): RGB 565 pixels starting two samples into the bank
@@ -250,6 +267,37 @@ def test_multi_pixel_packed_scanline_spanning_several_samples() -> None:
     np.testing.assert_array_equal(
         sample_model.as_numpy(data_buffer),
         np.array([[[3, 3, 2, 1, 0], [0, 1, 0, 3, 2]]]),
+    )
+
+
+def test_multi_pixel_packed_whole_sample_pixels_read_zero() -> None:
+    # MultiPixelPackedSampleModel(TYPE_INT, 3, 2, 32, 4, 0): Java accepts a pixel that
+    # occupies a whole 32 bit sample, but derives a zero bit mask for it from
+    # `(1 << 32) - 1`, so it reads every pixel of such a raster as zero
+    sample_model = MultiPixelPackedSampleModel(DataBuffer.TYPE_INT, 3, 2, 32, 4, 0)
+    data_buffer = DataBuffer(
+        DataBuffer.TYPE_INT,
+        [
+            int_bank(
+                [
+                    0x11223344,
+                    0x55667788,
+                    0x99AABBCC,
+                    0,
+                    0xDEADBEEF,
+                    0x0F0F0F0F,
+                    0x12345678,
+                    0,
+                ]
+            )
+        ],
+        8,
+        [0],
+    )
+
+    np.testing.assert_array_equal(
+        sample_model.as_numpy(data_buffer),
+        np.array([[[0, 0, 0], [0, 0, 0]]]),
     )
 
 

--- a/python/tests/raster/test_sample_model.py
+++ b/python/tests/raster/test_sample_model.py
@@ -22,6 +22,7 @@ buffer to java.awt.image, so they record what Java AWT reads for these layouts. 
 names the Java layout it covers, which is enough to reproduce it.
 """
 
+import warnings
 from typing import List
 
 import numpy as np
@@ -233,9 +234,13 @@ def test_multi_pixel_packed_applies_bit_and_bank_offsets() -> None:
         [1],
     )
 
+    # an ordinary packed layout, so reading it must not warn about Java's shift quirks
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        arr = sample_model.as_numpy(data_buffer)
+
     np.testing.assert_array_equal(
-        sample_model.as_numpy(data_buffer),
-        np.array([[[1, 2, 3, 4, 5], [9, 10, 11, 12, 13]]]),
+        arr, np.array([[[1, 2, 3, 4, 5], [9, 10, 11, 12, 13]]])
     )
 
 
@@ -289,9 +294,10 @@ def test_multi_pixel_packed_pixel_straddling_two_samples(
     sample_model = MultiPixelPackedSampleModel(DataBuffer.TYPE_INT, 4, 1, 8, 1, 4)
     data_buffer = DataBuffer(DataBuffer.TYPE_INT, [int_bank(bank)], 2, [0])
 
-    np.testing.assert_array_equal(
-        sample_model.as_numpy(data_buffer), np.array([[expected]])
-    )
+    with pytest.warns(UserWarning, match="straddle two samples"):
+        arr = sample_model.as_numpy(data_buffer)
+
+    np.testing.assert_array_equal(arr, np.array([[expected]]))
 
 
 def test_multi_pixel_packed_whole_sample_pixels_read_zero() -> None:
@@ -319,10 +325,10 @@ def test_multi_pixel_packed_whole_sample_pixels_read_zero() -> None:
         [0],
     )
 
-    np.testing.assert_array_equal(
-        sample_model.as_numpy(data_buffer),
-        np.array([[[0, 0, 0], [0, 0, 0]]]),
-    )
+    with pytest.warns(UserWarning, match="one pixel per 32 bit sample"):
+        arr = sample_model.as_numpy(data_buffer)
+
+    np.testing.assert_array_equal(arr, np.array([[[0, 0, 0], [0, 0, 0]]]))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #3166

## What changes were proposed in this PR?

The Python sample models did not resolve sample positions the way `java.awt.image` does. The band offset mix-up in `ComponentSampleModel`'s fast path was one of several defects of that kind, all of which are fixed here:

1. **Band offsets were indexed by bank instead of by band** in `ComponentSampleModel`'s fast path, so a raster whose bank mapping is not the identity returned samples from the wrong positions. The slow path already used the band position.
2. **The offsets of the `DataBuffer` were never applied**, by any of the four sample models. `DataBuffer.getElem(bank, i)` resolves to `bankdata[bank][i + offsets[bank]]` in Java, while the Python code read `bankdata[bank][i]`, so every sample of a bank with a non-zero offset came from the wrong position. `DataBuffer.bank_samples()` now applies the offset in one place, and the sample models index the array it returns.
3. **The two fast paths reshaped a whole bank** instead of a bounded `width * height` window. A bank holding more samples than the image needs, which is what a non-zero buffer offset implies, failed with `cannot reshape array of size N into shape (h,w)`.
4. **`PixelInterleavedSampleModel`'s slow path looked band offsets up within a single pixel stride** (`bank_data[begin:begin + num_bands][band_offsets]`). Band offsets are positions within a scanline and may reach past the pixel they belong to, which raised `IndexError` on such layouts.
5. **`SinglePixelPackedSampleModel` masked and shifted signed samples.** Java extracts bands with `>>>`, so a mask covering the sign bit — the alpha mask of an ARGB raster, `0xFF000000` — produced sign-extended, negative band values instead of `0..255`.
6. **`MultiPixelPackedSampleModel` always read one sample past the end of a scanline**, which is out of bounds when the last scanline ends at the end of the bank. Its running bit shift also diverged from Java for a `data_bit_offset` that is not a multiple of `num_bits`, the case where a pixel spans two data elements; for offsets that are a multiple of `num_bits` the old loop and this one agree, checked over 1323 parameter combinations.

7. **`MultiPixelPackedSampleModel` shifted samples as unsigned values, by the distance the sample model implies.** Java shifts the sample as the signed `int` that `DataBuffer.getElem()` returns, using `>>`, and takes the distance of an `int` shift modulo 32. Two consequences were missed: a `data_bit_offset` that is not a multiple of `num_bits` leaves a pixel straddling two samples and makes that distance negative, where Java shifts the sample's top bits down (`MultiPixelPackedSampleModel(TYPE_INT, 4, 1, 8, 1, 4)` over `{0x89ABCDEF, 0x12345678}` reads `[154, 188, 222, 248]`, and the last pixel came out as `0`); and the mask, derived as `(1 << numberOfBits) - 1` on an `int`, is *zero* for a pixel occupying a whole 32 bit sample, so Java reads every pixel of such a raster as zero while the port returned the backing words.
8. **`SinglePixelPackedSampleModel` derived a bit offset of `-1` for a zero bit mask,** which Java accepts and reads as a zero band. Shifting by `-1` read the band as zero by accident on numpy 1.x and raised `OverflowError: Python integer -1 out of bounds for uint32` on numpy 2.x.

Both packed models now resolve each pixel on its own, the way Java does, and the strided paths index with numpy instead of looping over every pixel in Python.

The two layouts behind defect 7 are quirks of Java's `int` arithmetic rather than sample addressing, and neither can hold a pixel that survives a round trip through Java itself — `setSample` is a no-op for a 32 bit pixel, and it truncates a straddling pixel to the bits that fit. Reading them any other way would put `as_numpy()` at odds with `RS_Value`, `RS_AsGeoTiff` and everything else that reads through `Raster.getSamples`, without recovering the value the caller wrote, so they are reproduced as Java reads them and a `UserWarning` names the layout when one is encountered.

## How was this patch tested?

New unit tests in `python/tests/raster/test_sample_model.py`: 22 cases across all four sample models. Every expected value was produced by handing the same sample model and data buffer to `java.awt.image` and reading the samples back with `Raster.getSample`, so the tests record what Java AWT reads rather than what the implementation happens to produce. 21 of the 22 fail without this change.

The warning is covered too: it fires for both quirk layouts, and reading the packed layout `RS_MakeRasterForTesting` builds today raises nothing under `warnings.simplefilter("error")`.

Both packed models were additionally swept over **7580 layouts** recorded from `java.awt.image`: every `num_bits` that divides the sample size for byte, ushort and int samples, **every `data_bit_offset` from 0 to two samples wide** so that pixels straddling two samples are covered, zero and non-zero bank offsets, and mask sets covering zero masks, whole-sample masks and masks over the sign bit. All 7580 match, under numpy 1.26 and 2.5 with numpy warnings raised as errors. 5295 of them do not match on master.

The layouts `RS_MakeRasterForTesting` builds today (`BandedSampleModel`, `PixelInterleavedSampleModel`, `PixelInterleavedSampleModelComplex`, `ComponentSampleModel`, `SinglePixelPackedSampleModel`, `MultiPixelPackedSampleModel`) were replayed through the new code with their Java-produced bank data and read back unchanged. All of them use zero buffer offsets, an identity bank mapping or in-range band offsets, which is why `tests/raster/test_serde.py` did not catch any of these defects.

Checked under numpy 1.26 and numpy 2.5.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
