### PR TITLE
[DOCS] Add blog post: spatial joins over STAC catalogs

### DIFF
--- a/docs-overrides/hooks/blog_star_cta.py
+++ b/docs-overrides/hooks/blog_star_cta.py
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Appends a "Star us on GitHub" call-to-action to the end of every blog post.
+# Implemented as an on_page_markdown hook so it applies to all current and
+# future posts automatically, with no per-file edits.
+
+from mkdocs import plugins
+
+STAR_CTA = """
+
+<div class="sedona-star-cta" style="margin-top:3rem;padding:1.5rem 1.5rem 1.75rem;border:1px solid var(--md-default-fg-color--lightest);border-radius:.6rem;background:var(--md-default-fg-color--lightest)">
+  <p style="font-weight:700;font-size:1.1rem;margin:0 0 .25rem">&#11088; Enjoyed this? Star Apache Sedona on GitHub</p>
+  <p style="margin:0 0 1rem;color:var(--md-default-fg-color--light)">A star takes two seconds and helps others discover the projects.</p>
+  <a class="md-button md-button--primary" href="https://github.com/apache/sedona" target="_blank" rel="noopener">&#11088; apache/sedona</a>
+  <a class="md-button" href="https://github.com/apache/sedona-db" target="_blank" rel="noopener">&#11088; apache/sedona-db</a>
+  <a class="md-button" href="https://github.com/apache/sedona-spatialbench" target="_blank" rel="noopener">&#11088; apache/sedona-spatialbench</a>
+</div>
+"""
+
+
+@plugins.event_priority(-50)
+def on_page_markdown(markdown, page, config, files, **kwargs):
+    src = page.file.src_uri
+    if src.startswith("blog/posts/") and src.endswith(".md"):
+        return markdown + STAR_CTA
+    return markdown

--- a/docs-overrides/hooks/blog_star_cta.py
+++ b/docs-overrides/hooks/blog_star_cta.py
@@ -18,18 +18,23 @@
 # Appends a "Star us on GitHub" call-to-action to the end of every blog post.
 # Implemented as an on_page_markdown hook so it applies to all current and
 # future posts automatically, with no per-file edits.
+#
+# The CTA is emitted as Markdown (an admonition plus attr_list buttons) rather
+# than raw HTML, so it inherits the Material theme's styling and stays robust
+# across theme changes. Requires the `admonition` and `attr_list` extensions,
+# which are already enabled in mkdocs.yml.
 
 from mkdocs import plugins
 
 STAR_CTA = """
 
-<div class="sedona-star-cta" style="margin-top:3rem;padding:1.5rem 1.5rem 1.75rem;border:1px solid var(--md-default-fg-color--lightest);border-radius:.6rem;background:var(--md-default-fg-color--lightest)">
-  <p style="font-weight:700;font-size:1.1rem;margin:0 0 .25rem">&#11088; Enjoyed this? Star Apache Sedona on GitHub</p>
-  <p style="margin:0 0 1rem;color:var(--md-default-fg-color--light)">A star takes two seconds and helps others discover the projects.</p>
-  <a class="md-button md-button--primary" href="https://github.com/apache/sedona" target="_blank" rel="noopener">&#11088; apache/sedona</a>
-  <a class="md-button" href="https://github.com/apache/sedona-db" target="_blank" rel="noopener">&#11088; apache/sedona-db</a>
-  <a class="md-button" href="https://github.com/apache/sedona-spatialbench" target="_blank" rel="noopener">&#11088; apache/sedona-spatialbench</a>
-</div>
+!!! tip "Star Apache Sedona on GitHub"
+
+    A star takes two seconds and helps others discover the projects.
+
+    [apache/sedona](https://github.com/apache/sedona){ .md-button .md-button--primary target="_blank" rel="noopener" }
+    [apache/sedona-db](https://github.com/apache/sedona-db){ .md-button target="_blank" rel="noopener" }
+    [apache/sedona-spatialbench](https://github.com/apache/sedona-spatialbench){ .md-button target="_blank" rel="noopener" }
 """
 
 

--- a/docs/blog/posts/stac-catalog-reader-cover.svg
+++ b/docs/blog/posts/stac-catalog-reader-cover.svg
@@ -1,0 +1,80 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720" role="img" aria-label="Apache Sedona STAC reader: multispectral satellite imagery footprints spatially joined to a vector area of interest above the curved limb of the Earth">
+<defs>
+<linearGradient id="space" x1="0" y1="0" x2="0.35" y2="1"><stop offset="0" stop-color="#0b0a26"/><stop offset="0.5" stop-color="#1a0f30"/><stop offset="1" stop-color="#2c1430"/></linearGradient>
+<radialGradient id="atmoGlow" cx="0.5" cy="1" r="0.75"><stop offset="0" stop-color="#35c9d8" stop-opacity="0.28"/><stop offset="0.5" stop-color="#6f8ff0" stop-opacity="0.1"/><stop offset="1" stop-color="#6f8ff0" stop-opacity="0"/></radialGradient>
+<linearGradient id="ocean" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#123a52"/><stop offset="1" stop-color="#081426"/></linearGradient>
+<filter id="soft" x="-20%" y="-20%" width="140%" height="140%"><feGaussianBlur stdDeviation="6"/></filter>
+</defs>
+
+<rect width="1280" height="720" fill="url(#space)"/>
+<rect x="0" y="360" width="1280" height="360" fill="url(#atmoGlow)"/>
+
+<!-- stars -->
+<g fill="#e9ecff"><circle cx="120" cy="90" r="1.3" opacity=".7"/><circle cx="300" cy="150" r="1" opacity=".5"/><circle cx="520" cy="70" r="1.4" opacity=".8"/><circle cx="980" cy="60" r="1.1" opacity=".6"/><circle cx="1180" cy="120" r="1.4" opacity=".75"/><circle cx="1240" cy="240" r="1" opacity=".5"/><circle cx="60" cy="300" r="1.1" opacity=".55"/><circle cx="1210" cy="360" r="1.2" opacity=".5"/><circle cx="430" cy="110" r="1" opacity=".5"/><circle cx="760" cy="95" r="1.2" opacity=".6"/></g>
+
+<!-- faint sky graticule -->
+<g stroke="#7d84c8" stroke-opacity="0.08" stroke-width="1">
+<line x1="640" y1="0" x2="640" y2="470"/><line x1="760" y1="0" x2="760" y2="470"/><line x1="880" y1="0" x2="880" y2="470"/><line x1="1000" y1="0" x2="1000" y2="470"/><line x1="1120" y1="0" x2="1120" y2="470"/><line x1="1240" y1="0" x2="1240" y2="470"/>
+<line x1="600" y1="120" x2="1280" y2="120"/><line x1="600" y1="220" x2="1280" y2="220"/><line x1="600" y1="320" x2="1280" y2="320"/></g>
+
+<!-- ===== Earth limb + full-spectrum atmosphere ===== -->
+<g filter="url(#soft)">
+<circle cx="640" cy="1272" r="800" fill="none" stroke="#35c9d8" stroke-width="16" opacity="0.20"/>
+<circle cx="640" cy="1272" r="786" fill="none" stroke="#6f8ff0" stroke-width="14" opacity="0.26"/>
+<circle cx="640" cy="1272" r="773" fill="none" stroke="#c86ff0" stroke-width="12" opacity="0.30"/>
+<circle cx="640" cy="1272" r="762" fill="none" stroke="#ff6a9a" stroke-width="11" opacity="0.34"/>
+<circle cx="640" cy="1272" r="752" fill="none" stroke="#ff8a4d" stroke-width="10" opacity="0.40"/>
+<circle cx="640" cy="1272" r="744" fill="none" stroke="#ffd27f" stroke-width="8" opacity="0.5"/>
+</g>
+<circle cx="640" cy="1272" r="740" fill="url(#ocean)"/>
+<!-- faint continents + latitude arcs on the globe cap -->
+<g fill="#1d5a54" opacity="0.55"><path d="M300,600 q90,-46 190,-16 q70,22 40,70 q-50,60 -150,44 q-120,-20 -80,-98 Z"/><path d="M760,640 q120,-40 220,4 q60,30 8,74 q-90,54 -200,20 q-96,-40 -28,-98 Z"/></g>
+<g stroke="#5fd8e0" stroke-opacity="0.12" stroke-width="1.3" fill="none"><path d="M40,588 Q640,540 1240,588"/><path d="M120,656 Q640,612 1160,656"/></g>
+
+<!-- ===== satellite + sensor rays to the swath ===== -->
+<g stroke="#7fe6ff" stroke-opacity="0.26" stroke-width="1">
+<line x1="1128" y1="118" x2="660" y2="270"/><line x1="1128" y1="118" x2="800" y2="330"/><line x1="1128" y1="118" x2="960" y2="300"/><line x1="1128" y1="118" x2="900" y2="420"/><line x1="1128" y1="118" x2="1090" y2="300"/></g>
+<path d="M660,180 Q900,84 1200,150" fill="none" stroke="#7fe6ff" stroke-width="1.4" stroke-dasharray="2 8" opacity="0.6"/>
+<g transform="translate(1128,118) rotate(20)">
+<rect x="-12" y="-9" width="24" height="18" rx="2.5" fill="#f7efe7"/>
+<rect x="-40" y="-6" width="24" height="12" rx="2" fill="#35c9d8"/>
+<rect x="18" y="-6" width="24" height="12" rx="2" fill="#35c9d8"/>
+<line x1="0" y1="9" x2="0" y2="27" stroke="#ff7a45" stroke-width="2"/>
+</g>
+<text x="1002" y="96" font-family="ui-monospace, 'SF Mono', Menlo, monospace" font-size="14" fill="#a9b3e0">SENTINEL-2 · descending node</text>
+
+<!-- ===== multispectral footprint tiles ===== -->
+<g stroke-width="2">
+<polygon points="646,214 762,230 744,330 628,314" fill="#8a6ff0" fill-opacity="0.42" stroke="#8a6ff0"/>
+<polygon points="762,230 878,246 860,346 744,330" fill="#4d8ff5" fill-opacity="0.42" stroke="#4d8ff5"/>
+<polygon points="878,246 994,262 976,362 860,346" fill="#35c9d8" fill-opacity="0.42" stroke="#35c9d8"/>
+<polygon points="994,262 1110,278 1092,378 976,362" fill="#2fd2a8" fill-opacity="0.42" stroke="#2fd2a8"/>
+<polygon points="700,318 816,334 798,434 682,418" fill="#7ed957" fill-opacity="0.42" stroke="#7ed957"/>
+<polygon points="816,334 932,350 914,450 798,434" fill="#f5c542" fill-opacity="0.42" stroke="#f5c542"/>
+<polygon points="932,350 1048,366 1030,466 914,450" fill="#f2913a" fill-opacity="0.42" stroke="#f2913a"/>
+</g>
+<text x="646" y="204" font-family="ui-monospace, 'SF Mono', Menlo, monospace" font-size="13" fill="#a9b3e0">multispectral footprints · tile 10SEG …</text>
+
+<!-- AOI polygon over the swath; body = the match -->
+<polygon points="838,300 966,318 986,404 846,430 796,368" fill="#ffffff" fill-opacity="0.14" stroke="#ff7a45" stroke-width="2.8" stroke-dasharray="7 5"/>
+<circle cx="898" cy="366" r="7" fill="#ff7a45"/>
+<text x="742" y="474" font-family="Inter, 'Helvetica Neue', Arial, sans-serif" font-size="18" font-weight="700" fill="#f7efe7">your AOI <tspan fill="#ff9a5c">&#8745;</tspan> footprint = match</text>
+
+<!-- ===== LEFT: title block ===== -->
+<text x="72" y="150" font-family="Inter, 'Helvetica Neue', Arial, sans-serif" font-size="20" font-weight="700" letter-spacing="4" fill="#f0a94e">APACHE SEDONA · STAC READER</text>
+<text x="70" y="236" font-family="Inter, 'Helvetica Neue', Arial, sans-serif" font-size="72" font-weight="800" fill="#f7efe7">Join the <tspan fill="#35c9d8">sky</tspan></text>
+<text x="70" y="316" font-family="Inter, 'Helvetica Neue', Arial, sans-serif" font-size="72" font-weight="800" fill="#f7efe7">to the <tspan fill="#ff7a45">ground</tspan>.</text>
+<text x="72" y="382" font-family="Inter, 'Helvetica Neue', Arial, sans-serif" font-size="23" font-weight="500" fill="#b6acc9">Read a planetary imagery catalog as a Sedona DataFrame,</text>
+<text x="72" y="414" font-family="Inter, 'Helvetica Neue', Arial, sans-serif" font-size="23" font-weight="500" fill="#b6acc9">then spatially join footprints to your vector shapes.</text>
+
+<rect x="72" y="470" width="452" height="52" rx="10" fill="#140f28" stroke="#3c3268" stroke-width="1.5"/>
+<text x="94" y="503" font-family="ui-monospace, 'SF Mono', Menlo, monospace" font-size="19" fill="#8fe6d0">sedona.read.<tspan fill="#f7efe7">format</tspan>(<tspan fill="#f5c542">"stac"</tspan>).<tspan fill="#f7efe7">load</tspan>(url)</text>
+
+<g font-family="Inter, 'Helvetica Neue', Arial, sans-serif" font-size="15">
+<rect x="72" y="560" width="150" height="34" rx="17" fill="none" stroke="#35c9d8" stroke-opacity="0.6" stroke-width="1.3"/><text x="147" y="582" text-anchor="middle" fill="#5fd8e0">geometry column</text>
+<rect x="234" y="560" width="150" height="34" rx="17" fill="none" stroke="#7ed957" stroke-opacity="0.6" stroke-width="1.3"/><text x="309" y="582" text-anchor="middle" fill="#98e07a">filter pushdown</text>
+<rect x="396" y="560" width="120" height="34" rx="17" fill="none" stroke="#ff7a45" stroke-opacity="0.6" stroke-width="1.3"/><text x="456" y="582" text-anchor="middle" fill="#ff9a5c">ST_Intersects</text>
+</g>
+
+<text x="72" y="662" font-family="Inter, 'Helvetica Neue', Arial, sans-serif" font-size="15" fill="#9086a8">A field guide to the STAC catalog reader</text>
+</svg>

--- a/docs/blog/posts/stac-catalog-reader-coverage.svg
+++ b/docs/blog/posts/stac-catalog-reader-coverage.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1180" height="240" viewBox="0 0 1180 240" role="img" aria-label="AOI coverage bars: Kanton Reef 80.2 percent, Offshore Buoy 29.4 percent, Null Island Park no coverage">
+<defs>
+<linearGradient id="cbg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#1c1022"/><stop offset="0.55" stop-color="#2a1420"/><stop offset="1" stop-color="#3a1e1b"/></linearGradient>
+<linearGradient id="barfill" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#f5c542"/><stop offset="1" stop-color="#f2913a"/></linearGradient>
+</defs>
+<rect width="1180" height="240" rx="18" fill="url(#cbg)"/>
+
+<text x="40" y="46" font-family="Inter, 'Helvetica Neue', Arial, sans-serif" font-size="15" font-weight="700" fill="#f7efe7">AOI coverage — share of each area inside a scene footprint</text>
+
+<text x="40" y="94" font-family="ui-monospace, Menlo, monospace" font-size="13" fill="#f0d3b8">Kanton Reef</text>
+<rect x="250" y="82" width="820" height="18" rx="9" fill="#3a231d"/>
+<rect x="250" y="82" width="658" height="18" rx="9" fill="url(#barfill)"/>
+<circle cx="908" cy="91" r="7" fill="#ff5a2e"/>
+<text x="1140" y="95" text-anchor="end" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700" fill="#f7efe7">80.2%</text>
+
+<text x="40" y="142" font-family="ui-monospace, Menlo, monospace" font-size="13" fill="#f0d3b8">Offshore Buoy</text>
+<rect x="250" y="130" width="820" height="18" rx="9" fill="#3a231d"/>
+<rect x="250" y="130" width="241" height="18" rx="9" fill="url(#barfill)"/>
+<circle cx="491" cy="139" r="7" fill="#ff5a2e"/>
+<text x="1140" y="143" text-anchor="end" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700" fill="#f7efe7">29.4%</text>
+
+<text x="40" y="190" font-family="ui-monospace, Menlo, monospace" font-size="13" fill="#f0d3b8">Null Island Park</text>
+<rect x="250" y="178" width="820" height="18" rx="9" fill="#3a231d"/>
+<rect x="250" y="178" width="820" height="18" rx="9" fill="none" stroke="#ff5a2e" stroke-width="1.4" stroke-dasharray="5 4"/>
+<text x="262" y="191" font-family="ui-monospace, Menlo, monospace" font-size="11" fill="#ff9a6e">no coverage — surfaced by the LEFT ANTI JOIN</text>
+<text x="1140" y="191" text-anchor="end" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700" fill="#ff8f5c">0%</text>
+
+<text x="40" y="224" font-family="ui-monospace, Menlo, monospace" font-size="11" fill="#a8897a">bar = ST_Area(ST_Intersection(aoi, footprint)) / ST_Area(aoi)</text>
+</svg>

--- a/docs/blog/posts/stac-catalog-reader-join.svg
+++ b/docs/blog/posts/stac-catalog-reader-join.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1180" height="430" viewBox="0 0 1180 430" role="img" aria-label="Three mini-maps: vector areas of interest join to raster footprints via ST_Intersects, producing the overlap as the result">
+<defs>
+<linearGradient id="jbg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#1c1022"/><stop offset="0.55" stop-color="#2a1420"/><stop offset="1" stop-color="#3a1e1b"/></linearGradient>
+<radialGradient id="jglow" cx="0.5" cy="0.1" r="0.7"><stop offset="0" stop-color="#e8672a" stop-opacity="0.16"/><stop offset="1" stop-color="#e8672a" stop-opacity="0"/></radialGradient>
+</defs>
+<rect width="1180" height="430" rx="18" fill="url(#jbg)"/>
+<rect width="1180" height="430" rx="18" fill="url(#jglow)"/>
+
+<text x="590" y="42" text-anchor="middle" font-family="ui-monospace, 'SF Mono', Menlo, monospace" font-size="18" fill="#f0d3b8">aoi <tspan fill="#ff6a3d" font-size="20">&#8904;</tspan> scenes  <tspan fill="#a8897a">ON</tspan>  <tspan fill="#f5b74e">ST_Intersects</tspan>(aoi.geom, scene.geometry)</text>
+
+<!-- ===== CARD A: vectors (gold) ===== -->
+<g font-family="Inter, 'Helvetica Neue', Arial, sans-serif">
+<rect x="30" y="72" width="300" height="300" rx="14" fill="#2a181c" stroke="#6e3a24" stroke-width="1.5"/>
+<rect x="30" y="72" width="300" height="40" rx="14" fill="#3a2119"/><rect x="30" y="92" width="300" height="20" fill="#3a2119"/>
+<text x="50" y="98" font-family="ui-monospace, Menlo, monospace" font-size="13" font-weight="600" fill="#f5c542">VECTOR — areas of interest</text>
+<g stroke="#8a5a3a" stroke-opacity="0.35" stroke-width="1"><line x1="30" y1="182" x2="330" y2="182"/><line x1="30" y1="252" x2="330" y2="252"/><line x1="30" y1="322" x2="330" y2="322"/><line x1="110" y1="112" x2="110" y2="372"/><line x1="190" y1="112" x2="190" y2="372"/><line x1="270" y1="112" x2="270" y2="372"/></g>
+<polygon points="90,150 170,140 200,215 120,245 70,195" fill="#f5c542" fill-opacity="0.16" stroke="#f5c542" stroke-width="2.2"/>
+<polygon points="205,265 285,275 275,340 195,330" fill="#f5c542" fill-opacity="0.16" stroke="#f5c542" stroke-width="2.2"/>
+<text x="118" y="200" font-family="ui-monospace, Menlo, monospace" font-size="11" fill="#f0d08a">AOI-1</text>
+<text x="228" y="308" font-family="ui-monospace, Menlo, monospace" font-size="11" fill="#f0d08a">AOI-2</text>
+</g>
+
+<text x="365" y="232" text-anchor="middle" font-size="34" fill="#ff6a3d" font-weight="700" font-family="Inter, Arial, sans-serif">&#8904;</text>
+
+<!-- ===== CARD B: footprints (orange) ===== -->
+<g font-family="Inter, 'Helvetica Neue', Arial, sans-serif">
+<rect x="400" y="72" width="300" height="300" rx="14" fill="#2a181c" stroke="#6e3a24" stroke-width="1.5"/>
+<rect x="400" y="72" width="300" height="40" rx="14" fill="#3a2119"/><rect x="400" y="92" width="300" height="20" fill="#3a2119"/>
+<text x="420" y="98" font-family="ui-monospace, Menlo, monospace" font-size="13" font-weight="600" fill="#5fd8e0">RASTER — STAC footprints</text>
+<g stroke="#8a5a3a" stroke-opacity="0.35" stroke-width="1"><line x1="400" y1="182" x2="700" y2="182"/><line x1="400" y1="252" x2="700" y2="252"/><line x1="400" y1="322" x2="700" y2="322"/><line x1="480" y1="112" x2="480" y2="372"/><line x1="560" y1="112" x2="560" y2="372"/><line x1="640" y1="112" x2="640" y2="372"/></g>
+<polygon points="435,145 540,157 528,255 420,243" fill="#4d8ff5" fill-opacity="0.42" stroke="#4d8ff5" stroke-width="1.8"/>
+<polygon points="540,157 645,169 633,268 528,255" fill="#35c9d8" fill-opacity="0.42" stroke="#35c9d8" stroke-width="1.8"/>
+<polygon points="470,250 575,262 565,352 460,340" fill="#7ed957" fill-opacity="0.42" stroke="#7ed957" stroke-width="1.8"/>
+<text x="452" y="168" font-family="ui-monospace, Menlo, monospace" font-size="11" fill="#a9c8ff">scene A</text>
+<text x="560" y="190" font-family="ui-monospace, Menlo, monospace" font-size="11" fill="#8fe6ef">scene B</text>
+<text x="492" y="300" font-family="ui-monospace, Menlo, monospace" font-size="11" fill="#b6ec96">scene C</text>
+</g>
+
+<text x="735" y="228" text-anchor="middle" font-size="30" fill="#c6ab9c" font-weight="700" font-family="Inter, Arial, sans-serif">=</text>
+
+<!-- ===== CARD C: result overlap (red) ===== -->
+<g font-family="Inter, 'Helvetica Neue', Arial, sans-serif">
+<rect x="770" y="72" width="380" height="300" rx="14" fill="#2a181c" stroke="#ff5a2e" stroke-width="1.8"/>
+<rect x="770" y="72" width="380" height="40" rx="14" fill="#4a1e15"/><rect x="770" y="92" width="380" height="20" fill="#4a1e15"/>
+<text x="790" y="98" font-family="ui-monospace, Menlo, monospace" font-size="13" font-weight="600" fill="#ff8f5c">MATCHES — where they overlap</text>
+<g stroke="#8a5a3a" stroke-opacity="0.3" stroke-width="1"><line x1="770" y1="182" x2="1150" y2="182"/><line x1="770" y1="252" x2="1150" y2="252"/><line x1="770" y1="322" x2="1150" y2="322"/><line x1="880" y1="112" x2="880" y2="372"/><line x1="990" y1="112" x2="990" y2="372"/><line x1="1100" y1="112" x2="1100" y2="372"/></g>
+<g fill="none" stroke-width="1.3" opacity="0.65">
+<polygon points="815,150 930,163 918,262 803,250" stroke="#35c9d8"/>
+<polygon points="865,255 980,268 968,360 853,348" stroke="#7ed957"/>
+</g>
+<g stroke="#f5c542" fill="none" stroke-width="1.6" stroke-dasharray="4 3" opacity="0.85">
+<polygon points="832,160 915,150 945,225 862,258 812,208"/>
+<polygon points="890,264 975,276 963,352 878,340"/>
+</g>
+<polygon points="832,162 915,158 918,225 862,248 815,208" fill="#ff5a2e" fill-opacity="0.9"/>
+<polygon points="890,266 975,272 968,352 888,344" fill="#ff5a2e" fill-opacity="0.9"/>
+<text x="960" y="358" text-anchor="middle" font-family="ui-monospace, Menlo, monospace" font-size="12" font-weight="600" fill="#ff9a6e">&#8745; = the answer</text>
+</g>
+</svg>

--- a/docs/blog/posts/stac-catalog-reader-pushdown.svg
+++ b/docs/blog/posts/stac-catalog-reader-pushdown.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1180" height="300" viewBox="0 0 1180 300" role="img" aria-label="Predicate pushdown funnel: the full Sentinel-2 archive filtered by spatial, temporal and cloud predicates down to a few hundred matching scenes">
+<defs>
+<linearGradient id="pbg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#1c1022"/><stop offset="0.55" stop-color="#2a1420"/><stop offset="1" stop-color="#3a1e1b"/></linearGradient>
+<linearGradient id="fun" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#f5c542" stop-opacity="0.22"/><stop offset="0.5" stop-color="#f2913a" stop-opacity="0.28"/><stop offset="1" stop-color="#ff5a2e" stop-opacity="0.34"/></linearGradient>
+</defs>
+<rect width="1180" height="300" rx="18" fill="url(#pbg)"/>
+
+<rect x="40" y="60" width="330" height="180" rx="12" fill="#2a181c" stroke="#6e3a24" stroke-width="1.5"/>
+<text x="205" y="46" text-anchor="middle" font-family="ui-monospace, Menlo, monospace" font-size="13" font-weight="600" fill="#f2913a">sentinel-2-l2a — whole archive</text>
+<g fill="#f2913a" opacity="0.6">
+<circle cx="80" cy="92" r="3.2"/><circle cx="122" cy="92" r="3.2"/><circle cx="164" cy="92" r="3.2"/><circle cx="206" cy="92" r="3.2"/><circle cx="248" cy="92" r="3.2"/><circle cx="290" cy="92" r="3.2"/><circle cx="332" cy="92" r="3.2" opacity="0.4"/>
+<circle cx="80" cy="128" r="3.2"/><circle cx="122" cy="128" r="3.2"/><circle cx="164" cy="128" r="3.2"/><circle cx="206" cy="128" r="3.2"/><circle cx="248" cy="128" r="3.2"/><circle cx="290" cy="128" r="3.2"/><circle cx="332" cy="128" r="3.2" opacity="0.4"/>
+<circle cx="80" cy="164" r="3.2"/><circle cx="122" cy="164" r="3.2"/><circle cx="164" cy="164" r="3.2"/><circle cx="206" cy="164" r="3.2"/><circle cx="248" cy="164" r="3.2"/><circle cx="290" cy="164" r="3.2"/><circle cx="332" cy="164" r="3.2" opacity="0.4"/>
+<circle cx="80" cy="200" r="3.2"/><circle cx="122" cy="200" r="3.2"/><circle cx="164" cy="200" r="3.2"/><circle cx="206" cy="200" r="3.2"/><circle cx="248" cy="200" r="3.2"/><circle cx="290" cy="200" r="3.2"/><circle cx="332" cy="200" r="3.2" opacity="0.4"/>
+</g>
+<text x="205" y="262" text-anchor="middle" font-family="Inter, 'Helvetica Neue', Arial, sans-serif" font-size="12" fill="#a8897a">tens of millions of scenes</text>
+
+<polygon points="420,72 630,72 535,158 535,222 420,222" fill="url(#fun)" stroke="#8a4a2c" stroke-width="1.3"/>
+<text x="525" y="60" text-anchor="middle" font-family="Inter, 'Helvetica Neue', Arial, sans-serif" font-size="13" font-weight="700" fill="#f7efe7">predicate pushdown</text>
+<g font-family="ui-monospace, Menlo, monospace" font-size="12" fill="#f0d3b8">
+<text x="446" y="112">ST_Intersects(aoi)</text>
+<text x="446" y="140">datetime BETWEEN …</text>
+<text x="446" y="168">eo:cloud_cover &lt; 20</text>
+</g>
+<path d="M630,147 L712,147" stroke="#ff5a2e" stroke-width="2.2" marker-end="url(#pa)"/>
+
+<rect x="720" y="86" width="230" height="120" rx="12" fill="#2a181c" stroke="#ff5a2e" stroke-width="1.8"/>
+<g fill="#ff5a2e"><rect x="748" y="110" width="24" height="24" rx="3" opacity="0.92"/><rect x="780" y="110" width="24" height="24" rx="3" opacity="0.74"/><rect x="812" y="110" width="24" height="24" rx="3" opacity="0.56"/></g>
+<text x="835" y="176" text-anchor="middle" font-family="Inter, 'Helvetica Neue', Arial, sans-serif" font-size="30" font-weight="800" fill="#f7efe7">304</text>
+<text x="835" y="196" text-anchor="middle" font-family="Inter, 'Helvetica Neue', Arial, sans-serif" font-size="12" fill="#c6ab9c">clear scenes over SF</text>
+
+<text x="1050" y="140" text-anchor="middle" font-family="Inter, 'Helvetica Neue', Arial, sans-serif" font-size="13" fill="#f0a94e">only these</text>
+<text x="1050" y="160" text-anchor="middle" font-family="Inter, 'Helvetica Neue', Arial, sans-serif" font-size="13" fill="#f0a94e">bytes move</text>
+<path d="M962,147 L1000,147" stroke="#f5b74e" stroke-width="1.6" stroke-dasharray="4 3"/>
+
+<defs><marker id="pa" markerWidth="9" markerHeight="9" refX="6" refY="3" orient="auto"><path d="M0,0 L6,3 L0,6 Z" fill="#ff5a2e"/></marker></defs>
+</svg>

--- a/docs/blog/posts/stac-catalog-reader.md
+++ b/docs/blog/posts/stac-catalog-reader.md
@@ -90,8 +90,9 @@ sf = (
 sf_scenes = (
     sedona.read.format("stac")
     .load(f"{base}/collections/sentinel-2-l2a")
-    # pushed to the STAC /search API as a bbox query
+    # spatial + temporal + cloud predicates, all pushed to the STAC /search API
     .filter(f"ST_Intersects(ST_GeomFromText('{sf}'), geometry)")
+    .filter("datetime BETWEEN '2026-05-01' AND '2026-06-30'")
     .filter("`eo:cloud_cover` < 20")
 )
 
@@ -109,7 +110,6 @@ Only tile `10SEG` — the one covering San Francisco — comes back, at sub-1% c
 |S2C_10SEG_20260513_0_L2A  |2026-05-13  |0.9   |
 |S2A_10SEG_20260515_0_L2A  |2026-05-15  |0.1   |
 |S2B_10SEG_20260518_0_L2A  |2026-05-18  |0.7   |
-|S2A_10SEG_20260604_0_L2A  |2026-06-04  |0.2   |
 +--------------------------+------------+------+
 ```
 
@@ -121,11 +121,13 @@ This is the payoff. Because `geometry` is a real geometry column, the catalog is
 
 ![Vector areas of interest joined to raster footprints with ST_Intersects, producing the overlapping region as the result](stac-catalog-reader-join.svg)
 
-Let's make it concrete and reproducible. Sedona ships a tiny sample STAC collection in its test resources, so you can run this offline, verbatim. We load those scene footprints, define three analyst-drawn AOIs as a vector layer, and ask: **which scenes cover each AOI, and how much of the AOI do they cover?**
+Let's make it concrete. The Apache Sedona source tree ships a tiny sample STAC collection under `spark/common/src/test/resources/datasource_stac/` — clone the repo and point at it, or swap in any `collection.json` of your own. We load those scene footprints, define three analyst-drawn AOIs as a vector layer, and ask: **which scenes cover each AOI, and how much of the AOI do they cover?**
 
 ```python
-# 1 — the imagery layer (Sedona's bundled sample STAC collection)
-scenes = sedona.read.format("stac").load("datasource_stac/collection.json")
+# 1 — the imagery layer (Sedona's sample STAC collection, from the source tree)
+scenes = sedona.read.format("stac").load(
+    "spark/common/src/test/resources/datasource_stac/collection.json"
+)
 scenes.createOrReplaceTempView("scenes")
 
 # 2 — the vector layer: your areas of interest (load from GeoParquet /
@@ -141,7 +143,7 @@ aoi.createOrReplaceTempView("aoi")
 
 # 3 — the spatial join + how much of each AOI is covered
 sedona.sql("""
-    SELECT a.aoi_name, s.id AS scene_id,
+    SELECT DISTINCT a.aoi_name, s.id AS scene_id,
            ROUND(ST_Area(ST_Intersection(a.geom, s.geometry))
                  / ST_Area(a.geom) * 100, 1) AS aoi_covered_pct
     FROM   aoi a

--- a/docs/blog/posts/stac-catalog-reader.md
+++ b/docs/blog/posts/stac-catalog-reader.md
@@ -1,0 +1,214 @@
+---
+date:
+  created: 2026-07-17
+links:
+  - STAC reader tutorial: https://sedona.apache.org/latest/tutorial/files/stac-sedona-spark/
+  - STAC specification: https://stacspec.org/
+  - earth-search (public Sentinel-2 STAC): https://earth-search.aws.element84.com/v1
+authors:
+  - jia
+title: "Join the Sky to the Ground: Spatial Joins over STAC Catalogs"
+---
+
+# Join the Sky to the Ground: Spatial Joins over STAC Catalogs
+
+You have the shapes. Somewhere in a petabyte of satellite imagery are exactly the scenes that cover them. The hard part was never the analysis — it was the plumbing in between.
+
+![Apache Sedona's STAC reader turns a satellite imagery catalog into a Sedona DataFrame and spatially joins scene footprints to your vector areas of interest](stac-catalog-reader-cover.svg)
+
+<!-- more -->
+
+Every few days, satellites re-photograph the entire planet. A [**STAC catalog**](https://stacspec.org/) (SpatioTemporal Asset Catalog) is how that firehose is published — Sentinel-2, Landsat, NAIP, Maxar, and Microsoft's Planetary Computer all speak it. Each *item* in a catalog describes one captured scene: its footprint geometry, its timestamp, its cloud cover, and links to the actual pixels.
+
+SedonaSpark's STAC reader parses all of that into a Sedona DataFrame whose `geometry` column is a real Sedona geometry — which means the catalog drops straight into a spatial join with the vector shapes you already have. This post walks the whole path, from a live catalog read to the spatial join, with real output throughout.
+
+## One line to a Sedona DataFrame
+
+Point the `stac` format at any STAC endpoint — a public API, an `s3a://` object, or a local `collection.json`. Here we open Element 84's public `earth-search` catalog and pull the live Sentinel-2 archive:
+
+```python
+from sedona.spark import SedonaContext
+
+sedona = SedonaContext.create(SedonaContext.builder().master("local[*]").getOrCreate())
+
+base = "https://earth-search.aws.element84.com/v1"
+scenes = sedona.read.format("stac").load(f"{base}/collections/sentinel-2-l2a")
+
+scenes.printSchema()
+```
+
+The reader gives every STAC field a typed column. The important ones: `geometry` arrives as a native geometry, `datetime` as a timestamp, and the [EO extension](https://github.com/stac-extensions/eo)'s `eo:cloud_cover` is lifted to a top-level double.
+
+```
+ |-- id: string
+ |-- bbox: array<double>
+ |-- geometry: geometry          <- a real Sedona geometry
+ |-- datetime: timestamp
+ |-- eo:cloud_cover: double
+ |-- eo:snow_cover: double
+ |-- platform: string
+ |-- constellation: string
+ |-- collection: string
+ |-- assets: map<string, struct<href, type, title, roles>>
+```
+
+A peek at the rows — a live descending pass captured the day this ran:
+
+```python
+scenes.selectExpr(
+    "id",
+    "datetime",
+    "`eo:cloud_cover` AS cloud",
+    "ST_GeometryType(geometry) AS shape",
+).show(3, truncate=False)
+```
+
+```
++--------------------------+-------------------------+------+-----------+
+|id                        |datetime                 |cloud |shape      |
++--------------------------+-------------------------+------+-----------+
+|S2B_50LQK_20260717_0_L2A  |2026-07-17 02:31:27.091  |0.0   |ST_Polygon |
+|S2B_50LPJ_20260717_0_L2A  |2026-07-17 02:31:39.810  |1.55  |ST_Polygon |
+|S2B_50LQL_20260717_0_L2A  |2026-07-17 02:31:16.128  |6.95  |ST_Polygon |
++--------------------------+-------------------------+------+-----------+
+```
+
+Real footprints, real cloud cover, real timestamps — with nothing more than a format string.
+
+## The API does the filtering
+
+The Sentinel-2 archive is tens of millions of scenes. You never want all of them. When you filter on **space**, **time**, or **cloud cover**, Sedona pushes those predicates *down to the STAC API itself* — only the matching tiles ever cross the network. Apply the spatial predicate *on the read* (not buried in a join) and it becomes an API-side bounding query.
+
+![The full Sentinel-2 archive filtered by spatial, temporal and cloud predicates that are pushed down to the STAC API, leaving only a few hundred matching scenes](stac-catalog-reader-pushdown.svg)
+
+```python
+sf = (
+    "POLYGON((-122.52 37.70, -122.36 37.70, "
+    "-122.36 37.83, -122.52 37.83, -122.52 37.70))"
+)
+
+sf_scenes = (
+    sedona.read.format("stac")
+    .load(f"{base}/collections/sentinel-2-l2a")
+    # pushed to the STAC /search API as a bbox query
+    .filter(f"ST_Intersects(ST_GeomFromText('{sf}'), geometry)")
+    .filter("`eo:cloud_cover` < 20")
+)
+
+sf_scenes.selectExpr(
+    "id", "date(datetime) AS day", "round(`eo:cloud_cover`, 1) AS cloud"
+).orderBy("day").show(4)
+```
+
+Only tile `10SEG` — the one covering San Francisco — comes back, at sub-1% cloud:
+
+```
++--------------------------+------------+------+
+|id                        |day         |cloud |
++--------------------------+------------+------+
+|S2C_10SEG_20260513_0_L2A  |2026-05-13  |0.9   |
+|S2A_10SEG_20260515_0_L2A  |2026-05-15  |0.1   |
+|S2B_10SEG_20260518_0_L2A  |2026-05-18  |0.7   |
+|S2A_10SEG_20260604_0_L2A  |2026-06-04  |0.2   |
++--------------------------+------------+------+
+```
+
+The archive's other tens of millions of scenes never touched the wire.
+
+## Join footprints to your vectors
+
+This is the payoff. Because `geometry` is a real geometry column, the catalog is just another spatial table — and it joins against your vector layer with the same `ST_Intersects` predicate you'd use anywhere else in Sedona. Your areas of interest on the left, the imagery footprints on the right, and the join is the overlap.
+
+![Vector areas of interest joined to raster footprints with ST_Intersects, producing the overlapping region as the result](stac-catalog-reader-join.svg)
+
+Let's make it concrete and reproducible. Sedona ships a tiny sample STAC collection in its test resources, so you can run this offline, verbatim. We load those scene footprints, define three analyst-drawn AOIs as a vector layer, and ask: **which scenes cover each AOI, and how much of the AOI do they cover?**
+
+```python
+# 1 — the imagery layer (Sedona's bundled sample STAC collection)
+scenes = sedona.read.format("stac").load("datasource_stac/collection.json")
+scenes.createOrReplaceTempView("scenes")
+
+# 2 — the vector layer: your areas of interest (load from GeoParquet /
+#     Shapefile in production; inline WKT here so the example is self-contained)
+aoi = sedona.sql("""
+    SELECT aoi_name, ST_GeomFromText(wkt) AS geom FROM VALUES
+      ('Kanton Reef',      'POLYGON((172.91 1.34, 172.95 1.34, 172.95 1.37, 172.91 1.37, 172.91 1.34))'),
+      ('Offshore Buoy',    'POLYGON((172.93 1.35, 172.97 1.35, 172.97 1.39, 172.93 1.39, 172.93 1.35))'),
+      ('Null Island Park', 'POLYGON((-0.01 -0.01, 0.01 -0.01, 0.01 0.01, -0.01 0.01, -0.01 -0.01))')
+    AS t(aoi_name, wkt)
+""")
+aoi.createOrReplaceTempView("aoi")
+
+# 3 — the spatial join + how much of each AOI is covered
+sedona.sql("""
+    SELECT a.aoi_name, s.id AS scene_id,
+           ROUND(ST_Area(ST_Intersection(a.geom, s.geometry))
+                 / ST_Area(a.geom) * 100, 1) AS aoi_covered_pct
+    FROM   aoi a
+    JOIN   scenes s ON ST_Intersects(a.geom, s.geometry)
+    ORDER BY aoi_covered_pct DESC
+""").show(truncate=False)
+```
+
+```
++--------------+---------------------+-----------------+
+|aoi_name      |scene_id             |aoi_covered_pct  |
++--------------+---------------------+-----------------+
+|Kanton Reef   |20201211_223832_CS2  |80.2             |
+|Offshore Buoy |20201211_223832_CS2  |29.4             |
++--------------+---------------------+-----------------+
+```
+
+Kanton Reef is 80.2% inside the scene footprint; Offshore Buoy only 29.4%. Null Island didn't match at all — and that's the point of the inverse query. **Which AOIs have no coverage?** is a `LEFT ANTI JOIN` on the same predicate — perfect for *"where are the gaps, and where do we need to task a new capture?"*
+
+```python
+sedona.sql("""
+    SELECT a.aoi_name
+    FROM   aoi a
+    LEFT ANTI JOIN scenes s ON ST_Intersects(a.geom, s.geometry)
+""").show(truncate=False)
+```
+
+```
++------------------+
+|aoi_name          |
++------------------+
+|Null Island Park  |
++------------------+
+```
+
+The same three AOIs, read as a coverage report:
+
+![Coverage bars showing Kanton Reef at 80.2 percent, Offshore Buoy at 29.4 percent, and Null Island Park with no coverage flagged by the anti-join](stac-catalog-reader-coverage.svg)
+
+And it scales without changing shape. Swap the bundled path for the live `earth-search` endpoint, push a spatial + temporal filter, and the identical join runs over only the tiles that survive the pushdown. In one live run over San Francisco (May–June 2026), the AOI matched **5** scenes, **3** of them under 20% cloud, the clearest at **0.06%** — from the same join.
+
+## Or skip the URLs entirely
+
+For interactive work there's a Pythonic client that wraps the reader — open a catalog, search a collection with a bbox and a time range, get a Sedona DataFrame back. Same engine underneath, so the result drops into the exact same join:
+
+```python
+from sedona.spark.stac import Client
+
+df = Client.open("https://planetarycomputer.microsoft.com/api/stac/v1").search(
+    collection_id="aster-l1t",
+    bbox=[-122.6, 37.6, -122.3, 37.9],
+    datetime="2020",  # a whole year
+    max_items=50,
+)
+df.show()  # -> a Sedona DataFrame, ready to join
+```
+
+The client also supports `with_bearer_token()` and `with_basic_auth()` for private catalogs.
+
+## From match to pixels
+
+Once the join hands you the matching items, the `assets` map holds the links to the actual imagery. From there:
+
+- **Persist the catalog** — `save_to_geoparquet()` writes the filtered items to GeoParquet so you never re-hit the API.
+- **Rank per AOI** — a window function over `eo:cloud_cover` and `datetime` picks the single best scene for each shape.
+- **Go to raster** — feed `assets['visual'].href` into Sedona's raster functions and clip to the AOI for analysis-ready pixels.
+
+The through-line is simple: the STAC reader makes a planetary imagery archive behave like a spatial table. And a spatial table is something Sedona already knows how to join, filter, and aggregate at scale. The sky becomes just another layer in your query.
+
+*See the [STAC reader tutorial](https://sedona.apache.org/latest/tutorial/files/stac-sedona-spark/) for the full reader and Python client reference.*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -380,6 +380,7 @@ plugins:
       canonical_version: 'latest'
 hooks:
   - docs-overrides/hooks/i18n_blog_passthrough.py
+  - docs-overrides/hooks/blog_star_cta.py
 extra_css:
   - assets/stylesheets/extra.min.css
 extra_javascript:


### PR DESCRIPTION
## What

A new blog post introducing SedonaSpark's **STAC catalog reader** through a worked spatial-join example.

- Read a STAC catalog (the public Element 84 `earth-search` Sentinel-2 API) into a Sedona DataFrame with `sedona.read.format("stac")`
- Spatial + temporal + cloud-cover **filter pushdown** to the STAC API
- An **`ST_Intersects` join** of scene footprints against a vector AOI layer — plus coverage percentage via `ST_Area(ST_Intersection(...))` and a `LEFT ANTI JOIN` to surface coverage gaps
- The reproducible join example uses Sedona's bundled sample STAC collection (`datasource_stac/collection.json`) so readers can run it offline, verbatim
- Four self-contained SVG figures (cover, join, pushdown, coverage)

Uses the existing `jia` author entry; blog `.md` is license-exempt per `.pre-commit-config.yaml`.

## Also included

A small `on_page_markdown` hook (`docs-overrides/hooks/blog_star_cta.py`) that appends a "Star on GitHub" call-to-action — linking `apache/sedona`, `apache/sedona-db`, and `apache/sedona-spatialbench` — to the end of every blog post. It's a separate concern kept in its own commit; happy to split it into its own PR if you'd prefer.

## Notes

- Opening as a **draft** for review.
- The code examples were run against Apache Sedona; the console output shown in the post is real.
