### PR TITLE
[GH-3110] Fix STAC Client.search(datetime="YYYY-mm") raising TypeError

### DIFF
--- a/python/sedona/spark/stac/client.py
+++ b/python/sedona/spark/stac/client.py
@@ -168,9 +168,9 @@ class Client:
         :param datetime: A single datetime, RFC 3339-compliant timestamp,
             or a list of date-time ranges for filtering the items. The datetime can be specified in various formats:
 
-            - "YYYY" expands to ["YYYY-01-01T00:00:00Z", "YYYY-12-31T23:59:59Z"]
-            - "YYYY-mm" expands to ["YYYY-mm-01T00:00:00Z", "YYYY-mm-<last_day>T23:59:59Z"]
-            - "YYYY-mm-dd" expands to ["YYYY-mm-ddT00:00:00Z", "YYYY-mm-ddT23:59:59Z"]
+            - "YYYY" expands to ["YYYY-01-01T00:00:00Z", "YYYY-12-31T23:59:59.999999Z"]
+            - "YYYY-mm" expands to ["YYYY-mm-01T00:00:00Z", "YYYY-mm-<last_day>T23:59:59.999999Z"]
+            - "YYYY-mm-dd" expands to ["YYYY-mm-ddT00:00:00Z", "YYYY-mm-ddT23:59:59.999999Z"]
             - "YYYY-mm-ddTHH:MM:SSZ" remains as ["YYYY-mm-ddTHH:MM:SSZ", "YYYY-mm-ddTHH:MM:SSZ"]
             - A list of date-time ranges can be provided for multiple intervals.
 

--- a/python/sedona/spark/stac/collection_client.py
+++ b/python/sedona/spark/stac/collection_client.py
@@ -15,13 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import calendar
 import logging
 from typing import Iterator, Union, List
 from typing import Optional
 
 import datetime as python_datetime
 from pyspark.sql import DataFrame, SparkSession
-from pyspark.sql.types import dt
 from shapely.geometry.base import BaseGeometry
 
 
@@ -293,6 +293,13 @@ class CollectionClient:
 
         It then expands the date string to cover the entire time period for that date.
 
+        The end of an expanded period uses ``23:59:59.999999Z`` rather than a
+        whole second. Sedona stores STAC datetimes as timestamps and filters
+        them with an inclusive upper bound (``datetime <= end``), so a rounded
+        ``23:59:59Z`` bound would drop items that fall in the final fractional
+        second (e.g. ``23:59:59.5Z``). ``.999999`` matches Spark's microsecond
+        timestamp precision, keeping whole-period searches inclusive.
+
         Args:
             date_str (str): The date string to expand.
 
@@ -303,19 +310,25 @@ class CollectionClient:
             ValueError: If the date string format is invalid.
 
         Examples:
-        - "2017" expands to ["2017-01-01T00:00:00Z", "2017-12-31T23:59:59Z"]
-        - "2017-06" expands to ["2017-06-01T00:00:00Z", "2017-06-30T23:59:59Z"]
-        - "2017-06-10" expands to ["2017-06-10T00:00:00Z", "2017-06-10T23:59:59Z"]
+        - "2017" expands to ["2017-01-01T00:00:00Z", "2017-12-31T23:59:59.999999Z"]
+        - "2017-06" expands to ["2017-06-01T00:00:00Z", "2017-06-30T23:59:59.999999Z"]
+        - "2017-06-10" expands to ["2017-06-10T00:00:00Z", "2017-06-10T23:59:59.999999Z"]
         - "2017-06-01T00:00:00Z" remains as ["2017-06-01T00:00:00Z", "2017-06-01T00:00:00Z"]
         """
         if len(date_str) == 4:  # YYYY
-            return [f"{date_str}-01-01T00:00:00Z", f"{date_str}-12-31T23:59:59Z"]
+            return [
+                f"{date_str}-01-01T00:00:00Z",
+                f"{date_str}-12-31T23:59:59.999999Z",
+            ]
         elif len(date_str) == 7:  # YYYY-mm
-            year, month = date_str.split("-")
-            last_day = (dt(int(year), int(month) + 1, 1) - dt.timedelta(days=1)).day
-            return [f"{date_str}-01T00:00:00Z", f"{date_str}-{last_day}T23:59:59Z"]
+            year, month = (int(x) for x in date_str.split("-"))
+            last_day = calendar.monthrange(year, month)[1]
+            return [
+                f"{date_str}-01T00:00:00Z",
+                f"{date_str}-{last_day:02d}T23:59:59.999999Z",
+            ]
         elif len(date_str) == 10:  # YYYY-mm-dd
-            return [f"{date_str}T00:00:00Z", f"{date_str}T23:59:59Z"]
+            return [f"{date_str}T00:00:00Z", f"{date_str}T23:59:59.999999Z"]
         elif len(date_str) == 19:  # YYYY-mm-ddTHH:MM:SS
             return [date_str, date_str]
         elif len(date_str) == 20:  # YYYY-mm-ddTHH:MM:SSZ

--- a/python/tests/stac/test_collection_client.py
+++ b/python/tests/stac/test_collection_client.py
@@ -395,3 +395,85 @@ class TestStacReader(TestBase):
         # Both should return the same count
         assert df_with_tuple is not None
         assert df_with_list is not None
+
+    def test_expand_date(self) -> None:
+        """_expand_date should expand each supported STAC datetime form.
+
+        Whole-period upper bounds end at ``23:59:59.999999Z`` (Spark's
+        microsecond precision) so that the inclusive ``datetime <= end`` filter
+        keeps items in the final fractional second.
+        """
+        # YYYY
+        assert CollectionClient._expand_date("2017") == [
+            "2017-01-01T00:00:00Z",
+            "2017-12-31T23:59:59.999999Z",
+        ]
+        # YYYY-mm expands to the first and last day of the month
+        assert CollectionClient._expand_date("2017-06") == [
+            "2017-06-01T00:00:00Z",
+            "2017-06-30T23:59:59.999999Z",
+        ]
+        # December must not overflow into the next year
+        assert CollectionClient._expand_date("2020-12") == [
+            "2020-12-01T00:00:00Z",
+            "2020-12-31T23:59:59.999999Z",
+        ]
+        # Leap-year February resolves to the 29th
+        assert CollectionClient._expand_date("2020-02") == [
+            "2020-02-01T00:00:00Z",
+            "2020-02-29T23:59:59.999999Z",
+        ]
+        # Non-leap-year February resolves to the 28th
+        assert CollectionClient._expand_date("2021-02") == [
+            "2021-02-01T00:00:00Z",
+            "2021-02-28T23:59:59.999999Z",
+        ]
+        # YYYY-mm-dd
+        assert CollectionClient._expand_date("2017-06-10") == [
+            "2017-06-10T00:00:00Z",
+            "2017-06-10T23:59:59.999999Z",
+        ]
+        # Full timestamps are returned unchanged
+        assert CollectionClient._expand_date("2017-06-01T00:00:00Z") == [
+            "2017-06-01T00:00:00Z",
+            "2017-06-01T00:00:00Z",
+        ]
+
+    def test_expand_date_filter_includes_final_fractional_second(self) -> None:
+        """A whole-period search must keep items in the final fractional second.
+
+        Sedona filters STAC datetimes with an inclusive upper bound, so the
+        expanded end of ``YYYY``/``YYYY-mm``/``YYYY-mm-dd`` periods must cover
+        sub-second timestamps such as ``23:59:59.5Z``. This exercises the real
+        Spark filter, not just the string expansion.
+        """
+        from pyspark.sql import functions as F
+
+        # One row per period type, each sitting in the final fractional second
+        # of that period -- the exact rows that a rounded 23:59:59Z bound drops.
+        df = self.spark.createDataFrame(
+            [
+                ("year-edge", "2020-12-31T23:59:59.5Z"),
+                ("month-edge", "2020-05-31T23:59:59.5Z"),
+                ("day-edge", "2020-05-15T23:59:59.5Z"),
+                ("next-period", "2021-01-01T00:00:00Z"),
+            ],
+            ["id", "datetime_str"],
+        ).withColumn("datetime", F.to_timestamp("datetime_str"))
+
+        def matches(date_str):
+            interval = CollectionClient._expand_date(date_str)
+            filtered = CollectionClient._apply_spatial_temporal_filters(
+                df, datetime=[interval]
+            )
+            return {row["id"] for row in filtered.collect()}
+
+        # YYYY keeps the Dec-31 23:59:59.5 row and excludes the next year.
+        assert matches("2020") == {"year-edge", "month-edge", "day-edge"}
+        # YYYY-mm keeps the last-day fractional-second row.
+        assert "month-edge" in matches("2020-05")
+        assert "day-edge" in matches("2020-05")
+        # YYYY-mm-dd keeps the fractional-second row on that day.
+        assert matches("2020-05-15") == {"day-edge"}
+        # The first instant of the next period is never pulled in.
+        assert "next-period" not in matches("2020")

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacUtils.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacUtils.scala
@@ -369,10 +369,12 @@ object StacUtils {
 
   /** Returns the temporal filter string based on the temporal filter. */
   def getFilterTemporal(filter: TemporalFilter): String = {
-    // Six fractional digits (microseconds) match Spark's TimestampType precision. A coarser
-    // pattern would round the pushed-down bound and could exclude items in the final fraction of
-    // a second (e.g. an item at 23:59:59.999500Z under an inclusive 23:59:59.999999Z upper bound).
-    val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'")
+    // Nine fractional digits (nanoseconds) match the finest precision STAC permits. Spark only
+    // keeps microseconds, so it truncates a legal item timestamp such as ...999999500Z down to
+    // ...999999 before the residual `datetime <= end` filter runs. A coarser pattern (or a bound
+    // pinned to microseconds) would let the remote catalog drop that item even though the residual
+    // filter would keep it; see the upper-bound widening below.
+    val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS'Z'")
 
     def formatDateTime(dateTime: LocalDateTime): String = {
       if (dateTime == null) ".." else dateTime.format(formatter)
@@ -412,8 +414,16 @@ object StacUtils {
     }
 
     val (start, end) = calculateUnionTemporal(filter)
-    if (end == null) s"datetime=${formatDateTime(start)}/.."
-    else s"datetime=${formatDateTime(start)}/${formatDateTime(end)}"
+    // The pushed-down bounds come from Spark TimestampType literals, so `end` is aligned to a whole
+    // microsecond. Spark truncates every item timestamp to microseconds, so the residual `<= end`
+    // filter keeps any item whose true (up to nanosecond) value lands anywhere in that final
+    // microsecond. Widen the inclusive upper bound to its last nanosecond (+999 ns) so the remote
+    // catalog returns a superset of the residual result instead of dropping, e.g., an item at
+    // ...999999500Z. The lower bound is left exact; a slightly wider window is always safe because
+    // the residual filter re-checks each row at microsecond precision.
+    val inclusiveEnd = if (end == null) null else end.plusNanos(999L)
+    if (inclusiveEnd == null) s"datetime=${formatDateTime(start)}/.."
+    else s"datetime=${formatDateTime(start)}/${formatDateTime(inclusiveEnd)}"
   }
 
   /** Adds the spatial and temporal filters to the base URL. */

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacUtils.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacUtils.scala
@@ -369,7 +369,10 @@ object StacUtils {
 
   /** Returns the temporal filter string based on the temporal filter. */
   def getFilterTemporal(filter: TemporalFilter): String = {
-    val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    // Six fractional digits (microseconds) match Spark's TimestampType precision. A coarser
+    // pattern would round the pushed-down bound and could exclude items in the final fraction of
+    // a second (e.g. an item at 23:59:59.999500Z under an inclusive 23:59:59.999999Z upper bound).
+    val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'")
 
     def formatDateTime(dateTime: LocalDateTime): String = {
       if (dateTime == null) ".." else dateTime.format(formatter)

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/optimization/SpatialTemporalFilterPushDownForStacScan.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/optimization/SpatialTemporalFilterPushDownForStacScan.scala
@@ -131,45 +131,44 @@ class SpatialTemporalFilterPushDownForStacScan(sparkSession: SparkSession)
       case LessThan(pushableColumn(name), Literal(v, TimestampType)) =>
         Some(
           TemporalFilter
-            .LessThanFilter(
-              unquote(name),
-              LocalDateTime
-                .ofInstant(Instant.ofEpochMilli(v.asInstanceOf[Long] / 1000), ZoneOffset.UTC)))
+            .LessThanFilter(unquote(name), microsToLocalDateTime(v.asInstanceOf[Long])))
 
       case LessThanOrEqual(pushableColumn(name), Literal(v, TimestampType)) =>
         Some(
           TemporalFilter
-            .LessThanFilter(
-              unquote(name),
-              LocalDateTime
-                .ofInstant(Instant.ofEpochMilli(v.asInstanceOf[Long] / 1000), ZoneOffset.UTC)))
+            .LessThanFilter(unquote(name), microsToLocalDateTime(v.asInstanceOf[Long])))
 
       case GreaterThan(pushableColumn(name), Literal(v, TimestampType)) =>
         Some(
           TemporalFilter
-            .GreaterThanFilter(
-              unquote(name),
-              LocalDateTime
-                .ofInstant(Instant.ofEpochMilli(v.asInstanceOf[Long] / 1000), ZoneOffset.UTC)))
+            .GreaterThanFilter(unquote(name), microsToLocalDateTime(v.asInstanceOf[Long])))
 
       case GreaterThanOrEqual(pushableColumn(name), Literal(v, TimestampType)) =>
         Some(
           TemporalFilter
-            .GreaterThanFilter(
-              unquote(name),
-              LocalDateTime
-                .ofInstant(Instant.ofEpochMilli(v.asInstanceOf[Long] / 1000), ZoneOffset.UTC)))
+            .GreaterThanFilter(unquote(name), microsToLocalDateTime(v.asInstanceOf[Long])))
 
       case EqualTo(pushableColumn(name), Literal(v, TimestampType)) =>
         Some(
           TemporalFilter
-            .EqualFilter(
-              unquote(name),
-              LocalDateTime
-                .ofInstant(Instant.ofEpochMilli(v.asInstanceOf[Long] / 1000), ZoneOffset.UTC)))
+            .EqualFilter(unquote(name), microsToLocalDateTime(v.asInstanceOf[Long])))
 
       case _ => None
     }
+  }
+
+  /**
+   * Converts a Spark TimestampType literal (microseconds since the Unix epoch) to a
+   * [[LocalDateTime]] in UTC without losing sub-millisecond precision. The previous
+   * implementation divided by 1000 to obtain milliseconds, which truncated the pushed-down
+   * temporal bound to millisecond resolution and could drop items in the final fraction of a
+   * second before Spark's residual filter ran. `floorDiv`/`floorMod` keep the conversion correct
+   * for pre-epoch timestamps as well.
+   */
+  private def microsToLocalDateTime(micros: Long): LocalDateTime = {
+    val seconds = Math.floorDiv(micros, 1000000L)
+    val nanoOfSecond = Math.floorMod(micros, 1000000L) * 1000L
+    LocalDateTime.ofInstant(Instant.ofEpochSecond(seconds, nanoOfSecond), ZoneOffset.UTC)
   }
 
   private def unquote(name: String): String = {

--- a/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacUtilsTest.scala
+++ b/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacUtilsTest.scala
@@ -639,34 +639,40 @@ class StacUtilsTest extends AnyFunSuite {
   }
 
   test("getFilterTemporal with LessThanFilter") {
+    // The inclusive upper bound is widened to the last nanosecond of its microsecond so items
+    // Spark would truncate into range are not dropped remotely (see getFilterTemporal).
     val dateTime = LocalDateTime.parse("2025-03-07T00:00:00")
     val filter = TemporalFilter.LessThanFilter("timestamp", dateTime)
     val result = getFilterTemporal(filter)
-    assert(result == "datetime=../2025-03-07T00:00:00.000000Z")
+    assert(result == "datetime=../2025-03-07T00:00:00.000000999Z")
   }
 
   test("getFilterTemporal with GreaterThanFilter") {
+    // The lower bound is left exact (only the upper bound is widened).
     val dateTime = LocalDateTime.parse("2025-03-06T00:00:00")
     val filter = TemporalFilter.GreaterThanFilter("timestamp", dateTime)
     val result = getFilterTemporal(filter)
-    assert(result == "datetime=2025-03-06T00:00:00.000000Z/..")
+    assert(result == "datetime=2025-03-06T00:00:00.000000000Z/..")
   }
 
   test("getFilterTemporal with EqualFilter") {
+    // Equality becomes the closed micro-bucket [value, value + 999 ns]: exact lower bound,
+    // widened upper bound.
     val dateTime = LocalDateTime.parse("2025-03-06T00:00:00")
     val filter = TemporalFilter.EqualFilter("timestamp", dateTime)
     val result = getFilterTemporal(filter)
-    assert(result == "datetime=2025-03-06T00:00:00.000000Z/2025-03-06T00:00:00.000000Z")
+    assert(result == "datetime=2025-03-06T00:00:00.000000000Z/2025-03-06T00:00:00.000000999Z")
   }
 
-  test("getFilterTemporal preserves microseconds in the serialized bound") {
-    // A whole-period upper bound expands to 23:59:59.999999Z. Serializing with only
-    // millisecond precision would emit 23:59:59.999Z and drop items in the final fraction
-    // of a second before Spark's residual filter runs (issue #3110).
+  test("getFilterTemporal widens the inclusive upper bound to nanosecond precision") {
+    // A whole-period upper bound expands to 23:59:59.999999Z (Spark microsecond precision).
+    // The remote bound is widened to 23:59:59.999999999Z so a legal STAC item at
+    // 23:59:59.999999500Z -- which Spark truncates to .999999 and the residual filter keeps --
+    // is not excluded remotely (issue #3110).
     val dateTime = LocalDateTime.parse("2020-05-31T23:59:59.999999")
     val filter = TemporalFilter.LessThanFilter("timestamp", dateTime)
     val result = getFilterTemporal(filter)
-    assert(result == "datetime=../2020-05-31T23:59:59.999999Z")
+    assert(result == "datetime=../2020-05-31T23:59:59.999999999Z")
   }
 
   test("getFilterTemporal with AndFilter") {
@@ -676,7 +682,7 @@ class StacUtilsTest extends AnyFunSuite {
     val filter2 = TemporalFilter.LessThanFilter("timestamp", dateTime2)
     val andFilter = TemporalFilter.AndFilter(filter1, filter2)
     val result = getFilterTemporal(andFilter)
-    assert(result == "datetime=2025-03-06T00:00:00.000000Z/2025-03-07T00:00:00.000000Z")
+    assert(result == "datetime=2025-03-06T00:00:00.000000000Z/2025-03-07T00:00:00.000000999Z")
   }
 
   test("getFilterTemporal with OrFilter") {
@@ -686,7 +692,7 @@ class StacUtilsTest extends AnyFunSuite {
     val filter2 = TemporalFilter.LessThanFilter("timestamp", dateTime2)
     val orFilter = TemporalFilter.OrFilter(filter1, filter2)
     val result = getFilterTemporal(orFilter)
-    assert(result == "datetime=2025-03-06T00:00:00.000000Z/2025-03-07T00:00:00.000000Z")
+    assert(result == "datetime=2025-03-06T00:00:00.000000000Z/2025-03-07T00:00:00.000000999Z")
   }
 
   test("addFiltersToUrl with no filters") {
@@ -711,7 +717,7 @@ class StacUtilsTest extends AnyFunSuite {
     val temporalFilter = Some(
       TemporalFilter.GreaterThanFilter("timestamp", LocalDateTime.parse("2025-03-06T00:00:00")))
     val result = StacUtils.addFiltersToUrl(baseUrl, None, temporalFilter)
-    val expectedUrl = s"$baseUrl&datetime=2025-03-06T00:00:00.000000Z/.."
+    val expectedUrl = s"$baseUrl&datetime=2025-03-06T00:00:00.000000000Z/.."
     assert(result == expectedUrl)
   }
 
@@ -725,7 +731,7 @@ class StacUtilsTest extends AnyFunSuite {
       TemporalFilter.GreaterThanFilter("timestamp", LocalDateTime.parse("2025-03-06T00:00:00")))
     val result = StacUtils.addFiltersToUrl(baseUrl, spatialFilter, temporalFilter)
     val expectedUrl =
-      s"$baseUrl&bbox=1.0%2C3.0%2C2.0%2C4.0&datetime=2025-03-06T00:00:00.000000Z/.."
+      s"$baseUrl&bbox=1.0%2C3.0%2C2.0%2C4.0&datetime=2025-03-06T00:00:00.000000000Z/.."
     assert(result == expectedUrl)
   }
 

--- a/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacUtilsTest.scala
+++ b/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacUtilsTest.scala
@@ -642,21 +642,31 @@ class StacUtilsTest extends AnyFunSuite {
     val dateTime = LocalDateTime.parse("2025-03-07T00:00:00")
     val filter = TemporalFilter.LessThanFilter("timestamp", dateTime)
     val result = getFilterTemporal(filter)
-    assert(result == "datetime=../2025-03-07T00:00:00.000Z")
+    assert(result == "datetime=../2025-03-07T00:00:00.000000Z")
   }
 
   test("getFilterTemporal with GreaterThanFilter") {
     val dateTime = LocalDateTime.parse("2025-03-06T00:00:00")
     val filter = TemporalFilter.GreaterThanFilter("timestamp", dateTime)
     val result = getFilterTemporal(filter)
-    assert(result == "datetime=2025-03-06T00:00:00.000Z/..")
+    assert(result == "datetime=2025-03-06T00:00:00.000000Z/..")
   }
 
   test("getFilterTemporal with EqualFilter") {
     val dateTime = LocalDateTime.parse("2025-03-06T00:00:00")
     val filter = TemporalFilter.EqualFilter("timestamp", dateTime)
     val result = getFilterTemporal(filter)
-    assert(result == "datetime=2025-03-06T00:00:00.000Z/2025-03-06T00:00:00.000Z")
+    assert(result == "datetime=2025-03-06T00:00:00.000000Z/2025-03-06T00:00:00.000000Z")
+  }
+
+  test("getFilterTemporal preserves microseconds in the serialized bound") {
+    // A whole-period upper bound expands to 23:59:59.999999Z. Serializing with only
+    // millisecond precision would emit 23:59:59.999Z and drop items in the final fraction
+    // of a second before Spark's residual filter runs (issue #3110).
+    val dateTime = LocalDateTime.parse("2020-05-31T23:59:59.999999")
+    val filter = TemporalFilter.LessThanFilter("timestamp", dateTime)
+    val result = getFilterTemporal(filter)
+    assert(result == "datetime=../2020-05-31T23:59:59.999999Z")
   }
 
   test("getFilterTemporal with AndFilter") {
@@ -666,7 +676,7 @@ class StacUtilsTest extends AnyFunSuite {
     val filter2 = TemporalFilter.LessThanFilter("timestamp", dateTime2)
     val andFilter = TemporalFilter.AndFilter(filter1, filter2)
     val result = getFilterTemporal(andFilter)
-    assert(result == "datetime=2025-03-06T00:00:00.000Z/2025-03-07T00:00:00.000Z")
+    assert(result == "datetime=2025-03-06T00:00:00.000000Z/2025-03-07T00:00:00.000000Z")
   }
 
   test("getFilterTemporal with OrFilter") {
@@ -676,7 +686,7 @@ class StacUtilsTest extends AnyFunSuite {
     val filter2 = TemporalFilter.LessThanFilter("timestamp", dateTime2)
     val orFilter = TemporalFilter.OrFilter(filter1, filter2)
     val result = getFilterTemporal(orFilter)
-    assert(result == "datetime=2025-03-06T00:00:00.000Z/2025-03-07T00:00:00.000Z")
+    assert(result == "datetime=2025-03-06T00:00:00.000000Z/2025-03-07T00:00:00.000000Z")
   }
 
   test("addFiltersToUrl with no filters") {
@@ -701,7 +711,7 @@ class StacUtilsTest extends AnyFunSuite {
     val temporalFilter = Some(
       TemporalFilter.GreaterThanFilter("timestamp", LocalDateTime.parse("2025-03-06T00:00:00")))
     val result = StacUtils.addFiltersToUrl(baseUrl, None, temporalFilter)
-    val expectedUrl = s"$baseUrl&datetime=2025-03-06T00:00:00.000Z/.."
+    val expectedUrl = s"$baseUrl&datetime=2025-03-06T00:00:00.000000Z/.."
     assert(result == expectedUrl)
   }
 
@@ -714,7 +724,8 @@ class StacUtilsTest extends AnyFunSuite {
     val temporalFilter = Some(
       TemporalFilter.GreaterThanFilter("timestamp", LocalDateTime.parse("2025-03-06T00:00:00")))
     val result = StacUtils.addFiltersToUrl(baseUrl, spatialFilter, temporalFilter)
-    val expectedUrl = s"$baseUrl&bbox=1.0%2C3.0%2C2.0%2C4.0&datetime=2025-03-06T00:00:00.000Z/.."
+    val expectedUrl =
+      s"$baseUrl&bbox=1.0%2C3.0%2C2.0%2C4.0&datetime=2025-03-06T00:00:00.000000Z/.."
     assert(result == expectedUrl)
   }
 

--- a/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/optimization/SpatialTemporalFilterPushDownForStacScanTest.scala
+++ b/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/optimization/SpatialTemporalFilterPushDownForStacScanTest.scala
@@ -46,27 +46,27 @@ class SpatialTemporalFilterPushDownForStacScanTest extends AnyFunSuite {
 
   private val datetime = AttributeReference("datetime", TimestampType)()
 
-  // Pushdown must not truncate the microsecond bound to milliseconds. Before the fix, the
-  // upper bound was divided by 1000 (micros -> millis), so 23:59:59.999999Z was pushed to the
-  // remote catalog as 23:59:59.999Z and an item at 23:59:59.999500Z was dropped before Spark's
-  // residual filter could keep it (issue #3110).
-  test("push-down preserves microseconds on an inclusive upper bound") {
+  // The push-down must not truncate the microsecond bound to milliseconds (it once divided by
+  // 1000, pushing 23:59:59.999999Z as 23:59:59.999Z), and the serialized inclusive upper bound is
+  // widened to the last nanosecond of its microsecond so an item Spark would truncate into range
+  // (e.g. 23:59:59.999999500Z) is not dropped by the remote catalog (issue #3110).
+  test("push-down widens an inclusive upper bound to nanosecond precision") {
     val predicate =
       LessThanOrEqual(datetime, Literal(toMicros("2020-05-31T23:59:59.999999"), TimestampType))
     val filters = pushDown.translateToTemporalFilters(Seq(predicate))
     assert(filters.size == 1)
-    assert(getFilterTemporal(filters.head) == "datetime=../2020-05-31T23:59:59.999999Z")
+    assert(getFilterTemporal(filters.head) == "datetime=../2020-05-31T23:59:59.999999999Z")
   }
 
-  test("push-down preserves microseconds on a lower bound") {
+  test("push-down keeps a lower bound exact") {
     val predicate =
       GreaterThanOrEqual(datetime, Literal(toMicros("2020-05-01T00:00:00.000001"), TimestampType))
     val filters = pushDown.translateToTemporalFilters(Seq(predicate))
     assert(filters.size == 1)
-    assert(getFilterTemporal(filters.head) == "datetime=2020-05-01T00:00:00.000001Z/..")
+    assert(getFilterTemporal(filters.head) == "datetime=2020-05-01T00:00:00.000001000Z/..")
   }
 
-  test("push-down combines both bounds without losing precision") {
+  test("push-down combines an exact lower bound with a widened upper bound") {
     val lower =
       GreaterThanOrEqual(datetime, Literal(toMicros("2020-05-01T00:00:00.000000"), TimestampType))
     val upper =
@@ -75,6 +75,28 @@ class SpatialTemporalFilterPushDownForStacScanTest extends AnyFunSuite {
     val combined = filters.reduce(TemporalFilter.AndFilter)
     assert(
       getFilterTemporal(combined) ==
-        "datetime=2020-05-01T00:00:00.000000Z/2020-05-31T23:59:59.999999Z")
+        "datetime=2020-05-01T00:00:00.000000000Z/2020-05-31T23:59:59.999999999Z")
+  }
+
+  test("push-down upper bound covers 7-to-9 digit sub-microsecond timestamps") {
+    // STAC permits up to nine fractional digits. Spark truncates any such item to microseconds,
+    // so every item in the bound's final microsecond survives the residual `<= .999999` filter and
+    // must therefore also fall within the pushed remote bound. Assert that legal 7-, 8- and 9-digit
+    // timestamps in that microsecond are not after the widened remote upper bound.
+    val predicate =
+      LessThanOrEqual(datetime, Literal(toMicros("2020-05-31T23:59:59.999999"), TimestampType))
+    val url = getFilterTemporal(pushDown.translateToTemporalFilters(Seq(predicate)).head)
+    assert(url == "datetime=../2020-05-31T23:59:59.999999999Z")
+
+    val remoteEnd = LocalDateTime.parse(url.stripPrefix("datetime=../").stripSuffix("Z"))
+    Seq(
+      "2020-05-31T23:59:59.9999995", // 7 digits
+      "2020-05-31T23:59:59.99999999", // 8 digits
+      "2020-05-31T23:59:59.999999999" // 9 digits
+    ).foreach { ts =>
+      assert(
+        !LocalDateTime.parse(ts).isAfter(remoteEnd),
+        s"$ts must fall within the pushed remote bound $remoteEnd")
+    }
   }
 }

--- a/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/optimization/SpatialTemporalFilterPushDownForStacScanTest.scala
+++ b/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/optimization/SpatialTemporalFilterPushDownForStacScanTest.scala
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.spark.sql.sedona_sql.optimization
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, GreaterThanOrEqual, LessThanOrEqual, Literal}
+import org.apache.spark.sql.execution.datasource.stac.TemporalFilter
+import org.apache.spark.sql.sedona_sql.io.stac.StacUtils.getFilterTemporal
+import org.apache.spark.sql.types.TimestampType
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.time.{LocalDateTime, ZoneOffset}
+
+class SpatialTemporalFilterPushDownForStacScanTest extends AnyFunSuite {
+
+  private lazy val spark: SparkSession =
+    SparkSession
+      .builder()
+      .master("local")
+      .appName("SpatialTemporalFilterPushDownForStacScanTest")
+      .getOrCreate()
+
+  private lazy val pushDown = new SpatialTemporalFilterPushDownForStacScan(spark)
+
+  /** Spark stores TimestampType internally as microseconds since the Unix epoch. */
+  private def toMicros(isoLocal: String): Long = {
+    val instant = LocalDateTime.parse(isoLocal).toInstant(ZoneOffset.UTC)
+    instant.getEpochSecond * 1000000L + instant.getNano / 1000L
+  }
+
+  private val datetime = AttributeReference("datetime", TimestampType)()
+
+  // Pushdown must not truncate the microsecond bound to milliseconds. Before the fix, the
+  // upper bound was divided by 1000 (micros -> millis), so 23:59:59.999999Z was pushed to the
+  // remote catalog as 23:59:59.999Z and an item at 23:59:59.999500Z was dropped before Spark's
+  // residual filter could keep it (issue #3110).
+  test("push-down preserves microseconds on an inclusive upper bound") {
+    val predicate =
+      LessThanOrEqual(datetime, Literal(toMicros("2020-05-31T23:59:59.999999"), TimestampType))
+    val filters = pushDown.translateToTemporalFilters(Seq(predicate))
+    assert(filters.size == 1)
+    assert(getFilterTemporal(filters.head) == "datetime=../2020-05-31T23:59:59.999999Z")
+  }
+
+  test("push-down preserves microseconds on a lower bound") {
+    val predicate =
+      GreaterThanOrEqual(datetime, Literal(toMicros("2020-05-01T00:00:00.000001"), TimestampType))
+    val filters = pushDown.translateToTemporalFilters(Seq(predicate))
+    assert(filters.size == 1)
+    assert(getFilterTemporal(filters.head) == "datetime=2020-05-01T00:00:00.000001Z/..")
+  }
+
+  test("push-down combines both bounds without losing precision") {
+    val lower =
+      GreaterThanOrEqual(datetime, Literal(toMicros("2020-05-01T00:00:00.000000"), TimestampType))
+    val upper =
+      LessThanOrEqual(datetime, Literal(toMicros("2020-05-31T23:59:59.999999"), TimestampType))
+    val filters = pushDown.translateToTemporalFilters(Seq(lower, upper))
+    val combined = filters.reduce(TemporalFilter.AndFilter)
+    assert(
+      getFilterTemporal(combined) ==
+        "datetime=2020-05-01T00:00:00.000000Z/2020-05-31T23:59:59.999999Z")
+  }
+}


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #3110

## What changes were proposed in this PR?

Calling the STAC Python `Client.search()` (or `CollectionClient.get_dataframe()` / `get_items()`) with a `datetime` argument in `YYYY-mm` form failed with `RuntimeError: Failed to get filtered dataframe` wrapping `TypeError: 'NoneType' object is not callable`.

Root cause: `python/sedona/spark/stac/collection_client.py` imported `from pyspark.sql.types import dt`. `pyspark.sql.types` exposes no `dt`, so the name resolved to `None`, and the `YYYY-mm` branch of `_expand_date` then called `dt(...)`, raising the `TypeError`. The old arithmetic also overflowed for December (`int(month) + 1` == 13).

This PR:

- Removes the erroneous `from pyspark.sql.types import dt` import.
- Computes the last day of the month with `calendar.monthrange`, which handles December and leap years correctly, and zero-pads the day so the emitted timestamp stays valid ISO 8601.
- Makes whole-period upper bounds inclusive of the final fractional second. Sedona stores STAC datetimes as timestamps and filters them with an inclusive `datetime <= end` bound, so a rounded `23:59:59Z` end silently drops items in the last fraction of a second. The `YYYY`, `YYYY-mm`, and `YYYY-mm-dd` forms now expand to end at `23:59:59.999999Z` (Spark's microsecond timestamp precision), which is the bound the residual Spark filter uses.
- Preserves that precision through the remote filter push-down. `SpatialTemporalFilterPushDownForStacScan` previously converted the Spark `TimestampType` literal with `Instant.ofEpochMilli(v / 1000)`, discarding sub-millisecond digits; it now keeps full microseconds via a `floorDiv`/`floorMod` helper.
- Makes the pushed remote bound a superset of the residual Spark filter for sub-microsecond timestamps. STAC allows up to nine fractional digits, but Spark keeps only microseconds, so it truncates a legal item at `...999999500Z` down to `...999999`, which the residual `datetime <= end` filter retains. `StacUtils.getFilterTemporal` now serializes nine fractional digits and widens the inclusive upper bound (from `LessThan`/`LessThanOrEqual` and the upper side of an equality) by 999 ns to the last nanosecond of its microsecond, so the remote catalog no longer drops items Spark would keep. The lower bound is left exact; a slightly wider remote window is always safe because the residual filter re-checks each row at microsecond precision.

`_expand_date("2020-05")` now returns `["2020-05-01T00:00:00Z", "2020-05-31T23:59:59.999999Z"]`, consistent with the docstring and the STAC tutorial.

## How was this patch tested?

Python (`python/tests/stac/test_collection_client.py`):

- `test_expand_date` covers all supported forms plus the previously broken edge cases: December (`2020-12` -> 31), leap-year February (`2020-02` -> 29), and non-leap February (`2021-02` -> 28).
- `test_expand_date_filter_includes_final_fractional_second` runs the real Spark temporal filter over sub-second timestamps and asserts rows at `23:59:59.5Z` on the last day/month/year of a period are retained while the first instant of the next period is excluded.

Scala (`spark/common`), all run via the two suites below (38 tests, all passing locally):

- `SpatialTemporalFilterPushDownForStacScanTest` (new) feeds Catalyst `<=`/`>=` predicates with microsecond `TimestampType` literals through the push-down and asserts the serialized `datetime=` request preserves microseconds and widens the inclusive upper bound to nine digits. Its `covers 7-to-9 digit sub-microsecond timestamps` case asserts that legal 7-, 8- and 9-digit timestamps in the bound's final microsecond fall within the pushed remote bound.
- `StacUtilsTest` gains a `getFilterTemporal widens the inclusive upper bound to nanosecond precision` case; the existing `getFilterTemporal`/`addFiltersToUrl` expectations were updated to the nine-digit, widened bounds (exact lower bound, `+999 ns` upper bound).

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation. (The `Client.search` datetime docstring was refreshed to show the `.999999Z` bounds.)