### PR TITLE
[DOCS] Add robots.txt to keep archived doc versions out of search results

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,32 @@
+# robots.txt for https://sedona.apache.org/
+#
+# Goal: keep only the current stable documentation (served under /latest/) in
+# search engine indexes. Archived, numbered releases and the development
+# snapshot are stale or duplicate content and should not surface in search
+# results (e.g. an outdated /1.4.1/ page ranking above the current docs).
+#
+# This file is maintained by hand on the `website` branch. `mike` preserves
+# root-level files it does not manage (like .asf.yaml and .nojekyll) when it
+# deploys new versions, so this file persists across doc deployments.
+
+User-agent: *
+# Current stable docs (the "latest" alias) — the only versioned docs to index.
+Allow: /latest/
+# Development snapshot — unreleased, do not index.
+Disallow: /latest-snapshot/
+# Archived, numbered release docs. Every archived version lives in a top-level
+# directory that begins with a digit (e.g. /1.4.1/, /1.9.0/), so blocking the
+# digit prefixes covers all past and future numbered versions without needing
+# an update on each release. The current release is still indexable via /latest/.
+Disallow: /0
+Disallow: /1
+Disallow: /2
+Disallow: /3
+Disallow: /4
+Disallow: /5
+Disallow: /6
+Disallow: /7
+Disallow: /8
+Disallow: /9
+
+Sitemap: https://sedona.apache.org/latest/sitemap.xml


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a documentation update. The PR name follows the format `[DOCS] my subject`

## What changes were proposed in this PR?

Old, versioned documentation is being indexed by search engines and ranking above the current docs. For example, searching *"sedona apache discord"* returns the outdated `1.4.1` Discord invite page as the top result.

Root cause, verified against the live site:

| Check | Result |
|---|---|
| `https://sedona.apache.org/1.4.1/community/discord-invite-form.html` | **HTTP 200** — live & crawlable |
| Its `rel=canonical` → `https://sedona.apache.org/latest/community/discord-invite-form/` | **HTTP 404** — page no longer exists in current docs |
| `robots` meta tag on the page | none |

The `mike` plugin already sets `canonical_version: latest`, so every archived page carries a canonical to its `/latest/` equivalent. But when that equivalent has been removed (as with the Discord invite page), the canonical points at a 404 — search engines then ignore it and index the stale archived page. Archived numbered versions are frozen once released and never rebuilt, so a build-time `noindex` in the theme template cannot reach pages that are already deployed and indexed. The only control that covers all previously published versions at once is a site-root `robots.txt`.

This PR adds a root-level `robots.txt`, served at `https://sedona.apache.org/robots.txt`:

- Keeps only the current stable docs (`/latest/`) crawlable.
- Blocks the development snapshot (`/latest-snapshot/`) and every numbered archived version.
- Numbered versions all live in a top-level directory beginning with a digit, so blocking the digit prefixes (`/0`–`/9`) covers all past **and future** releases with no per-release maintenance. This also blocks the numbered duplicate of the current release (e.g. `/1.9.0/`) while keeping `/latest/` indexed — clean deduplication.
- Leaves the separate `/sedonadb/` and `/spatialbench/` sub-sites on the same domain untouched.
- Advertises the current sitemap (`/latest/sitemap.xml`).

The file sits alongside the other hand-maintained root files on the `website` branch (`.asf.yaml`, `.nojekyll`); `mike` preserves root-level files it does not manage when deploying new versions.

Note: `robots.txt` stops crawling and drops stale pages from results over time; it does not force instant removal of already-indexed URLs. Removal can be accelerated via the Search Console removal tool if desired.

## How was this patch tested?

Validated the rules against a robots.txt parser for every URL class that matters:

- Allowed: `/latest/…`, `/latest/sitemap.xml`, `/sedonadb/…`, `/spatialbench/…`, `/`, `/versions.json`
- Blocked: `/latest-snapshot/…`, `/1.4.1/…`, `/1.9.0/…`, `/1.0.0-1.2.0-incubating/…`

All cases matched the intended behavior.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
