### PR TITLE
[DOCS] Keep archived doc versions out of search results

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -120,6 +120,25 @@ jobs:
             uv run mike deploy --update-aliases "$version" latest -b website -p
             uv run mike set-default latest -T docs-overrides/redirect.html -b website -p
           fi
+      - name: Mark archived documentation versions noindex
+        # Only the current stable docs (/latest/) should be indexed by search
+        # engines. Archived versions and the snapshot are frozen once deployed,
+        # so we tag them with a crawlable <meta name="robots" content="noindex">
+        # here rather than at build time. See tools/noindex_archived_docs.py.
+        if: ${{ github.event_name != 'pull_request' && github.repository == 'apache/sedona' }}
+        run: |
+          git fetch origin website --depth=1
+          git worktree add website-branch FETCH_HEAD
+          python3 tools/noindex_archived_docs.py website-branch
+          git -C website-branch config user.name "GitHub Action"
+          git -C website-branch config user.email "test@abc.com"
+          if [[ -n "$(git -C website-branch status --porcelain)" ]]; then
+            git -C website-branch add -A
+            git -C website-branch commit -m "Mark archived documentation versions noindex"
+            git -C website-branch push origin HEAD:website
+          else
+            echo "Archived documentation already noindexed; nothing to commit."
+          fi
       - run: mkdir staging
       - run: cp -r site/* staging/
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/tools/noindex_archived_docs.py
+++ b/tools/noindex_archived_docs.py
@@ -55,8 +55,12 @@ ROBOTS_META = '<meta name="robots" content="noindex, follow">'
 
 # Opening <head> tag, allowing attributes (e.g. <head class="...">).
 HEAD_RE = re.compile(r"(<head\b[^>]*>)", re.IGNORECASE)
-# Any existing robots meta tag, so the script is idempotent.
-HAS_ROBOTS_RE = re.compile(r"""<meta[^>]+name=["']robots["']""", re.IGNORECASE)
+# A complete existing robots meta tag (name= and content= in any order).
+ROBOTS_META_RE = re.compile(
+    r"""<meta\b[^>]*\bname=["']robots["'][^>]*>""", re.IGNORECASE
+)
+# The content="..." value of a meta tag.
+ROBOTS_CONTENT_RE = re.compile(r"""content=["']([^"']*)["']""", re.IGNORECASE)
 # Archived version directories all begin with a digit (e.g. 1.4.1).
 VERSION_DIR_RE = re.compile(r"^\d")
 
@@ -83,17 +87,49 @@ def is_archived_dir(name, current):
     return name == "latest-snapshot" or bool(VERSION_DIR_RE.match(name))
 
 
+def _directives(tag):
+    """Return the directive list from a robots meta tag's content attribute."""
+    match = ROBOTS_CONTENT_RE.search(tag)
+    if not match:
+        return []
+    return [d.strip() for d in match.group(1).split(",") if d.strip()]
+
+
+def _add_noindex(tag):
+    """Rewrite a robots meta tag so it forbids indexing, keeping other rules.
+
+    Returns the tag unchanged if it already contains ``noindex``. Otherwise
+    drops a conflicting ``index`` directive, prepends ``noindex``, and preserves
+    the rest (e.g. ``noarchive``). A robots tag with no content attribute is
+    replaced outright.
+    """
+    directives = _directives(tag)
+    if any(d.lower() == "noindex" for d in directives):
+        return tag
+    if not ROBOTS_CONTENT_RE.search(tag):
+        return ROBOTS_META
+    kept = ["noindex"] + [d for d in directives if d.lower() != "index"]
+    return ROBOTS_CONTENT_RE.sub(f'content="{", ".join(kept)}"', tag, count=1)
+
+
 def inject(path):
-    """Add the noindex meta tag to one HTML file. Return True if it changed."""
+    """Add a noindex directive to one HTML file. Return True if it changed."""
     with open(path, encoding="utf-8", errors="surrogatepass") as handle:
         html = handle.read()
-    if HAS_ROBOTS_RE.search(html):
-        return False
-    new_html, replaced = HEAD_RE.subn(r"\1\n    " + ROBOTS_META, html, count=1)
-    if replaced == 0:
-        # No <head> (e.g. a raw HTML fragment such as an embedded form page).
-        # Prepend the tag: an HTML parser places a leading <meta> into the head.
-        new_html = ROBOTS_META + "\n" + html
+
+    existing = ROBOTS_META_RE.search(html)
+    if existing:
+        replacement = _add_noindex(existing.group(0))
+        if replacement == existing.group(0):
+            return False  # already noindex; leave it untouched
+        new_html = html[: existing.start()] + replacement + html[existing.end() :]
+    else:
+        new_html, replaced = HEAD_RE.subn(r"\1\n    " + ROBOTS_META, html, count=1)
+        if replaced == 0:
+            # No <head> (e.g. a raw HTML fragment such as an embedded form page).
+            # Prepend the tag: an HTML parser hoists a leading <meta> into <head>.
+            new_html = ROBOTS_META + "\n" + html
+
     with open(path, "w", encoding="utf-8", errors="surrogatepass") as handle:
         handle.write(new_html)
     return True
@@ -112,13 +148,26 @@ def write_robots(root):
 
 
 def main(root):
+    # The current stable version is whatever `latest` points at; it must be
+    # identified so it is never tagged (tagging it would de-index the live docs,
+    # since /latest/ is a symlink to it). If `latest` is missing, is not a
+    # symlink, or points nowhere, fail loudly rather than tag every version.
     latest = os.path.join(root, "latest")
-    current = os.path.basename(os.readlink(latest)) if os.path.islink(latest) else None
-    if current is None:
+    if not os.path.islink(latest):
         print(
-            "warning: no 'latest' symlink found; not skipping any version",
+            f"error: '{latest}' is missing or is not a symlink; "
+            "cannot identify the current stable version",
             file=sys.stderr,
         )
+        return 1
+    current = os.path.basename(os.path.realpath(latest))
+    if not os.path.isdir(os.path.join(root, current)):
+        print(
+            f"error: 'latest' resolves to '{current}', "
+            f"which is not a directory under '{root}'",
+            file=sys.stderr,
+        )
+        return 1
 
     targets = sorted(
         name

--- a/tools/noindex_archived_docs.py
+++ b/tools/noindex_archived_docs.py
@@ -1,0 +1,154 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Mark archived documentation versions as noindex for search engines.
+
+The documentation site (https://sedona.apache.org) is a mike-managed, versioned
+MkDocs site. Only the current stable docs, served under ``/latest/``, should
+appear in search engine indexes; older versions and the development snapshot are
+stale or duplicate content that otherwise competes with the current docs in
+search results.
+
+robots.txt ``Disallow`` cannot be used for this: a blocked page can no longer be
+crawled, so search engines never observe a removal signal and may keep stale
+URLs in the index (Google explicitly advises against robots.txt for removal).
+Instead we add a crawlable
+
+    <meta name="robots" content="noindex, follow">
+
+to every page of the archived versions and leave them crawlable, which lets
+search engines drop them from their index while still following links.
+
+Archived versions are frozen once released and are never rebuilt, so this runs
+as a post-deploy step over the published ``website`` branch rather than at build
+time. It is idempotent: pages that already carry a robots meta tag are left
+untouched, so re-running it only changes versions that were newly archived.
+
+The current stable version is deliberately skipped: ``latest`` is a symlink to
+that version's directory, so tagging it would de-index the live docs. Its
+duplicate versioned URL (for example ``/1.9.0/``) is already consolidated onto
+``/latest/`` by the canonical tag that mike emits.
+
+Usage:
+    python3 tools/noindex_archived_docs.py <website-branch-checkout>
+"""
+
+import os
+import re
+import sys
+
+ROBOTS_META = '<meta name="robots" content="noindex, follow">'
+
+# Opening <head> tag, allowing attributes (e.g. <head class="...">).
+HEAD_RE = re.compile(r"(<head\b[^>]*>)", re.IGNORECASE)
+# Any existing robots meta tag, so the script is idempotent.
+HAS_ROBOTS_RE = re.compile(r"""<meta[^>]+name=["']robots["']""", re.IGNORECASE)
+# Archived version directories all begin with a digit (e.g. 1.4.1).
+VERSION_DIR_RE = re.compile(r"^\d")
+
+ROBOTS_TXT = """\
+# robots.txt for https://sedona.apache.org/
+#
+# Only the current stable documentation, served under /latest/, is indexed.
+# Archived versions and the development snapshot instead carry a crawlable
+# <meta name="robots" content="noindex"> tag (added by
+# tools/noindex_archived_docs.py) so search engines can visit them and drop the
+# stale pages. They are intentionally NOT disallowed here, because a disallowed
+# page cannot be crawled and its noindex would never be seen.
+User-agent: *
+Disallow:
+
+Sitemap: https://sedona.apache.org/latest/sitemap.xml
+"""
+
+
+def is_archived_dir(name, current):
+    """Return True if ``name`` is a version directory that should be noindexed."""
+    if name == "latest" or name == current:
+        return False
+    return name == "latest-snapshot" or bool(VERSION_DIR_RE.match(name))
+
+
+def inject(path):
+    """Add the noindex meta tag to one HTML file. Return True if it changed."""
+    with open(path, encoding="utf-8", errors="surrogatepass") as handle:
+        html = handle.read()
+    if HAS_ROBOTS_RE.search(html):
+        return False
+    new_html, replaced = HEAD_RE.subn(r"\1\n    " + ROBOTS_META, html, count=1)
+    if replaced == 0:
+        # No <head> (e.g. a raw HTML fragment such as an embedded form page).
+        # Prepend the tag: an HTML parser places a leading <meta> into the head.
+        new_html = ROBOTS_META + "\n" + html
+    with open(path, "w", encoding="utf-8", errors="surrogatepass") as handle:
+        handle.write(new_html)
+    return True
+
+
+def write_robots(root):
+    """Write a sitemap-only robots.txt, but only if it is missing or stale."""
+    path = os.path.join(root, "robots.txt")
+    if os.path.isfile(path):
+        with open(path, encoding="utf-8") as handle:
+            if handle.read() == ROBOTS_TXT:
+                return
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(ROBOTS_TXT)
+    print("wrote robots.txt")
+
+
+def main(root):
+    latest = os.path.join(root, "latest")
+    current = os.path.basename(os.readlink(latest)) if os.path.islink(latest) else None
+    if current is None:
+        print(
+            "warning: no 'latest' symlink found; not skipping any version",
+            file=sys.stderr,
+        )
+
+    targets = sorted(
+        name
+        for name in os.listdir(root)
+        if os.path.isdir(os.path.join(root, name))
+        and not os.path.islink(os.path.join(root, name))
+        and is_archived_dir(name, current)
+    )
+    print(f"current stable version: {current}")
+    print(f"archived versions to noindex: {', '.join(targets) or '(none)'}")
+
+    total = 0
+    for name in targets:
+        count = 0
+        for dirpath, _dirs, files in os.walk(os.path.join(root, name)):
+            for filename in files:
+                if filename.endswith(".html") and inject(
+                    os.path.join(dirpath, filename)
+                ):
+                    count += 1
+        print(f"  {name}: tagged {count} page(s)")
+        total += count
+
+    write_robots(root)
+    print(f"total pages tagged: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(__doc__)
+        sys.exit(2)
+    sys.exit(main(sys.argv[1]))


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a documentation update. The PR name follows the format `[DOCS] my subject`

## What changes were proposed in this PR?

Old, versioned documentation is being indexed by search engines and ranking above the current docs. For example, searching *"sedona apache discord"* returns the outdated `1.4.1` Discord invite page as the top result.

Root cause, verified on the live site:

| Check | Result |
|---|---|
| `https://sedona.apache.org/1.4.1/community/discord-invite-form.html` | **HTTP 200** — live & crawlable |
| Its `rel=canonical` → `https://sedona.apache.org/latest/community/discord-invite-form/` | **HTTP 404** — removed from current docs |
| `robots` meta tag on the page | none |

`mike` already sets `canonical_version: latest`, so archived pages carry a canonical to their `/latest/` equivalent — but when that equivalent has been removed, the canonical points at a 404 and search engines ignore it and index the stale archived page.

The intuitive fix — a `robots.txt` `Disallow` for the archived paths — does **not** work here: a disallowed page can no longer be crawled, so search engines never observe a removal signal and may keep the stale URL in the index (Google explicitly advises against robots.txt for removal, and Bing similarly needs the page crawlable to see a `noindex`). The reliable signal on static hosting (no control over response headers / redirects / 410s) is a **crawlable** `<meta name="robots" content="noindex">`.

This PR adds `tools/noindex_archived_docs.py` and a post-deploy step in `docs.yml` that:

- Adds `<meta name="robots" content="noindex, follow">` to every page of the archived versions and the development snapshot on the published `website` branch, leaving them crawlable so search engines can drop them.
- **Skips the current stable version.** `latest` is a symlink to that version's directory, so tagging it would de-index the live docs; its duplicate versioned URL (e.g. `/1.9.0/`) is already consolidated onto `/latest/` by the existing canonical tag.
- Handles raw HTML fragments with no `<head>` (the Discord invite pages in `1.4.1`/`1.5.0` — exactly the reported case) by prepending the tag, which the HTML parser hoists into the head.
- Writes a sitemap-only `robots.txt` (advertises `/latest/sitemap.xml`, blocks nothing) so the `noindex` stays crawlable.
- Is idempotent: pages that already carry a robots meta tag are untouched. It **backfills** existing archived versions on the next deploy and tags each version automatically as a new release supersedes it — no per-release maintenance.

Supersedes #3123 (the earlier robots.txt-only approach, which had this exact removal limitation).

## How was this patch tested?

- Ran the script against a current snapshot of the `website` branch: **19,671** archived pages tagged across all numbered versions + `latest-snapshot`; the current stable `1.9.0` (and the `latest` symlink) left untouched; **0** archived HTML pages left without a robots meta, including both headless Discord fragment pages.
- Verified idempotency (a second run tags 0 pages) and unit-level behavior in sandboxes (current skipped, archived + headless tagged, non-HTML ignored).
- `tools/noindex_archived_docs.py` passes `black`, `pyupgrade`, and the license-header hook; `docs.yml` passes `actionlint` and `yamllint` (pre-commit).

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
