### PR TITLE
[CI] Commit website branch changes as the GitHub Actions bot

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -105,8 +105,11 @@ jobs:
           uv run bash -c 'cd python/sedona/doc && make clean && make html'
           mkdir -p docs/api/pydocs
           cp -r python/sedona/doc/_build/html/* docs/api/pydocs/
-      - run: git config --global user.name = "GitHub Action"
-      - run: git config --global user.email = "test@abc.com"
+      # Commit as the GitHub Actions bot so website-branch commits are
+      # attributed to the Actions bot account rather than to whichever GitHub
+      # user happens to own a placeholder email address.
+      - run: git config --global user.name "github-actions[bot]"
+      - run: git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - run: uv run mkdocs build
       - name: Deploy the doc to the website branch
         if: ${{ github.event_name != 'pull_request' && github.repository == 'apache/sedona' }}
@@ -130,8 +133,8 @@ jobs:
           git fetch origin website --depth=1
           git worktree add website-branch FETCH_HEAD
           python3 tools/noindex_archived_docs.py website-branch
-          git -C website-branch config user.name "GitHub Action"
-          git -C website-branch config user.email "test@abc.com"
+          git -C website-branch config user.name "github-actions[bot]"
+          git -C website-branch config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           if [[ -n "$(git -C website-branch status --porcelain)" ]]; then
             git -C website-branch add -A
             git -C website-branch commit -m "Mark archived documentation versions noindex"


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

Commits pushed to the `website` branch by the docs workflow are attributed to the wrong identities:

- The noindex step added in #3125 commits as `GitHub Action <test@abc.com>`. GitHub resolves commit authorship by email, and `test@abc.com` is owned by an unrelated GitHub user, so those commits show up on GitHub as authored by a stranger's account.
- The pre-existing global config lines contain a stray `=` (`git config --global user.name = "GitHub Action"`), which git parses as the *value*. The effective identity is literally `= <=>`, which is why every `mike` deploy commit on the `website` branch is authored as `=` and attributed to no account.

This PR sets the standard GitHub Actions bot identity in both places and fixes the config syntax:

```
github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
```

That identity maps to the official Actions bot account and cannot be claimed by any user. The two existing misattributed commits on `website` are left in history; all future workflow commits will carry the bot identity.

## How was this patch tested?

- `actionlint`, `yamllint`, and `prettier` pass on the workflow file (pre-commit).
- The identity/email pair is the documented github-actions bot identity used to attribute workflow commits to the Actions bot.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
