### PR TITLE
[GH-3128] Fix geotiff.metadata partition values, scan identity, and option handling

### DIFF
--- a/docs/tutorial/files/geotiffmetadata-sedona-spark.md
+++ b/docs/tutorial/files/geotiffmetadata-sedona-spark.md
@@ -77,6 +77,22 @@ Or load a single file:
 df = sedona.read.format("geotiff.metadata").load("/path/to/image.tiff")
 ```
 
+For directory loads, `recursiveFileLookup=true` and a GeoTIFF extension
+`pathGlobFilter` are applied as defaults; an explicit option always wins. In
+particular, set `recursiveFileLookup=false` to keep Hive-style partition discovery
+(e.g. `year=2020/` subdirectories become a `year` column):
+
+```python
+df = (
+    sedona.read.format("geotiff.metadata")
+    .option("recursiveFileLookup", "false")
+    .load("/data/rasters/")
+)
+```
+
+The data source is read-only; writing is not supported, and neither are catalog
+table operations (`CREATE TABLE ... USING geotiff.metadata`).
+
 ## Output schema
 
 Each row represents one GeoTIFF file with the following columns:

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/geotiffmetadata/GeoTiffMetadataDataSource.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/geotiffmetadata/GeoTiffMetadataDataSource.scala
@@ -18,10 +18,14 @@
  */
 package org.apache.spark.sql.sedona_sql.io.geotiffmetadata
 
+import org.apache.hadoop.fs.FileStatus
 import org.apache.hadoop.fs.Path
+import org.apache.hadoop.mapreduce.Job
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.connector.catalog.TableProvider
 import org.apache.spark.sql.execution.datasources.FileFormat
+import org.apache.spark.sql.execution.datasources.OutputWriterFactory
 import org.apache.spark.sql.execution.datasources.v2.FileDataSourceV2
 import org.apache.spark.sql.sources.DataSourceRegister
 import org.apache.spark.sql.types.StructType
@@ -50,31 +54,37 @@ class GeoTiffMetadataDataSource
     var optionsWithoutPaths = getOptionsWithoutPaths(options)
     val tableName = getTableName(options, paths)
 
-    if (paths.size == 1) {
-      val head = paths.head
-      if (isDirectory(head, optionsWithoutPaths)) {
-        // Directory (with or without trailing slash): recurse and filter to GeoTIFF files
-        val newOptions =
-          new java.util.HashMap[String, String](optionsWithoutPaths.asCaseSensitiveMap())
+    // Explicit user options always win over the defaults below; presence checks go through the
+    // CaseInsensitiveStringMap because Spark data source options are case-insensitive, so e.g.
+    // an explicit `RecursiveFileLookup` must suppress the lowercase default.
+    val newOptions =
+      new java.util.HashMap[String, String](optionsWithoutPaths.asCaseSensitiveMap())
+    val hasUserGlobFilter = optionsWithoutPaths.containsKey("pathGlobFilter")
+    val hasUserRecursive = optionsWithoutPaths.containsKey("recursiveFileLookup")
+
+    if (paths.size == 1 && !isDirectory(paths.head, optionsWithoutPaths)) {
+      // Rewrite glob patterns like /path/to/some*glob*.tif into /path/to with
+      // pathGlobFilter="some*glob*.tif" to avoid listing .tif files as directories. When the
+      // user supplied their own pathGlobFilter, keep the glob path untouched so Spark applies
+      // both constraints natively (the rewrite could only keep one of them).
+      paths.head match {
+        case loadTifPattern(prefix, glob) if !hasUserGlobFilter =>
+          paths = Seq(prefix)
+          newOptions.put("pathGlobFilter", glob)
+        case _ =>
+      }
+    } else if (paths.exists(p => isDirectory(p, optionsWithoutPaths))) {
+      // Directory roots (single or multiple, with or without trailing slash): default to a
+      // recursive scan filtered to GeoTIFF extensions. These are defaults only — an explicit
+      // recursiveFileLookup=false keeps Hive-style partition discovery available.
+      if (!hasUserRecursive) {
         newOptions.put("recursiveFileLookup", "true")
-        if (!newOptions.containsKey("pathGlobFilter")) {
-          newOptions.put("pathGlobFilter", "*.{tif,tiff,TIF,TIFF}")
-        }
-        optionsWithoutPaths = new CaseInsensitiveStringMap(newOptions)
-      } else {
-        // Rewrite glob patterns like /path/to/some*glob*.tif into /path/to with
-        // pathGlobFilter="some*glob*.tif" to avoid listing .tif files as directories
-        head match {
-          case loadTifPattern(prefix, glob) =>
-            paths = Seq(prefix)
-            val newOptions =
-              new java.util.HashMap[String, String](optionsWithoutPaths.asCaseSensitiveMap())
-            newOptions.put("pathGlobFilter", glob)
-            optionsWithoutPaths = new CaseInsensitiveStringMap(newOptions)
-          case _ =>
-        }
+      }
+      if (!hasUserGlobFilter) {
+        newOptions.put("pathGlobFilter", "*.{tif,tiff,TIF,TIFF}")
       }
     }
+    optionsWithoutPaths = new CaseInsensitiveStringMap(newOptions)
 
     new GeoTiffMetadataTable(
       tableName,
@@ -96,8 +106,11 @@ class GeoTiffMetadataDataSource
   override def inferSchema(options: CaseInsensitiveStringMap): StructType =
     GeoTiffMetadataTable.SCHEMA
 
-  // Read-only data source — no V1 fallback needed
-  override def fallbackFileFormat: Class[_ <: FileFormat] = null
+  // Spark maps a FileDataSourceV2 back to this V1 FileFormat for catalog paths such as
+  // CREATE TABLE ... USING; a null class would NPE there, so return a stub that raises a
+  // descriptive error instead.
+  override def fallbackFileFormat: Class[_ <: FileFormat] =
+    classOf[GeoTiffMetadataUnsupportedFileFormat]
 
   /**
    * Check if a path points to a directory. A trailing `/` is treated as a directory without any
@@ -116,4 +129,40 @@ class GeoTiffMetadataDataSource
       fs.getFileStatus(path).isDirectory
     }.getOrElse(false)
   }
+}
+
+/**
+ * V1 fallback used by Spark for catalog paths such as `CREATE TABLE ... USING geotiff.metadata`.
+ * The data source is read-only and path-based, so those operations are unsupported — this stub
+ * exists to surface a clear error instead of the NullPointerException a null fallback class would
+ * produce.
+ *
+ * The constructor itself throws: Spark instantiates the fallback format whenever a catalog
+ * operation resolves the relation — including `CREATE TABLE` with an explicit schema, which skips
+ * `inferSchema` — so failing on instantiation rejects every V1 usage up front. Reads are
+ * unaffected because the V2 path only ever references the class, never constructs it.
+ */
+class GeoTiffMetadataUnsupportedFileFormat extends FileFormat {
+
+  throw GeoTiffMetadataUnsupportedFileFormat.unsupported()
+
+  override def inferSchema(
+      sparkSession: SparkSession,
+      options: Map[String, String],
+      files: Seq[FileStatus]): Option[StructType] =
+    throw GeoTiffMetadataUnsupportedFileFormat.unsupported()
+
+  override def prepareWrite(
+      sparkSession: SparkSession,
+      job: Job,
+      options: Map[String, String],
+      dataSchema: StructType): OutputWriterFactory =
+    throw GeoTiffMetadataUnsupportedFileFormat.unsupported()
+}
+
+object GeoTiffMetadataUnsupportedFileFormat {
+  private def unsupported(): UnsupportedOperationException =
+    new UnsupportedOperationException(
+      "geotiff.metadata does not support catalog table operations; " +
+        "read it with spark.read.format(\"geotiff.metadata\").load(path)")
 }

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/geotiffmetadata/GeoTiffMetadataDataSource.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/geotiffmetadata/GeoTiffMetadataDataSource.scala
@@ -73,10 +73,13 @@ class GeoTiffMetadataDataSource
           newOptions.put("pathGlobFilter", glob)
         case _ =>
       }
-    } else if (paths.exists(p => isDirectory(p, optionsWithoutPaths))) {
+    } else if (paths.nonEmpty && paths.forall(p => isDirectory(p, optionsWithoutPaths))) {
       // Directory roots (single or multiple, with or without trailing slash): default to a
       // recursive scan filtered to GeoTIFF extensions. These are defaults only — an explicit
-      // recursiveFileLookup=false keeps Hive-style partition discovery available.
+      // recursiveFileLookup=false keeps Hive-style partition discovery available. They apply
+      // only when EVERY root is a directory: Spark applies pathGlobFilter to all roots, so a
+      // mixed load(dir, explicitFile) must not silently drop an explicitly named file whose
+      // name does not match the extension filter.
       if (!hasUserRecursive) {
         newOptions.put("recursiveFileLookup", "true")
       }

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/geotiffmetadata/GeoTiffMetadataPartitionReaderFactory.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/geotiffmetadata/GeoTiffMetadataPartitionReaderFactory.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.connector.read.PartitionReader
 import org.apache.spark.sql.connector.read.PartitionReaderFactory
+import org.apache.spark.sql.execution.datasources.PartitionedFile
 import org.apache.spark.sql.execution.datasources.v2.PartitionReaderWithPartitionValues
 import org.apache.spark.sql.sedona_sql.io.raster.RasterInputPartition
 import org.apache.spark.sql.types.StructType
@@ -36,18 +37,23 @@ case class GeoTiffMetadataPartitionReaderFactory(
     extends PartitionReaderFactory {
 
   private def buildReader(partition: RasterInputPartition): PartitionReader[InternalRow] = {
+    // Each file in a bin-packed partition may belong to a different Hive partition and thus
+    // carry its own partition values, so wrap a per-file reader with that file's values rather
+    // than applying the first file's values to every row.
+    def readerForFile(file: PartitionedFile): PartitionReader[InternalRow] = {
+      val fileReader =
+        new GeoTiffMetadataPartitionReader(
+          broadcastedConf.value.value,
+          Array(file),
+          readDataSchema)
+      new PartitionReaderWithPartitionValues(
+        fileReader,
+        readDataSchema,
+        partitionSchema,
+        file.partitionValues)
+    }
 
-    val fileReader =
-      new GeoTiffMetadataPartitionReader(
-        broadcastedConf.value.value,
-        partition.files,
-        readDataSchema)
-
-    new PartitionReaderWithPartitionValues(
-      fileReader,
-      readDataSchema,
-      partitionSchema,
-      partition.files.head.partitionValues)
+    new GeoTiffMetadataConcatPartitionReader(partition.files, readerForFile)
   }
 
   override def createReader(partition: InputPartition): PartitionReader[InternalRow] = {
@@ -58,4 +64,36 @@ case class GeoTiffMetadataPartitionReaderFactory(
           s"Unexpected partition type: ${partition.getClass.getCanonicalName}")
     }
   }
+}
+
+/**
+ * Reads a bin-packed partition file-by-file, delegating each file to a reader built by
+ * `buildReader` (which attaches that file's partition values). Sub-readers are opened lazily and
+ * closed as the scan advances, so at most one file is open at a time.
+ */
+private class GeoTiffMetadataConcatPartitionReader(
+    files: Array[PartitionedFile],
+    buildReader: PartitionedFile => PartitionReader[InternalRow])
+    extends PartitionReader[InternalRow] {
+
+  private var fileIndex = 0
+  private var current: PartitionReader[InternalRow] = _
+
+  override def next(): Boolean = {
+    while (true) {
+      if (current == null) {
+        if (fileIndex >= files.length) return false
+        current = buildReader(files(fileIndex))
+        fileIndex += 1
+      }
+      if (current.next()) return true
+      current.close()
+      current = null
+    }
+    false // unreachable; satisfies the compiler
+  }
+
+  override def get(): InternalRow = current.get()
+
+  override def close(): Unit = if (current != null) current.close()
 }

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/geotiffmetadata/GeoTiffMetadataScanBuilder.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/geotiffmetadata/GeoTiffMetadataScanBuilder.scala
@@ -84,6 +84,26 @@ case class GeoTiffMetadataScan(
     extends FileScan
     with Batch {
 
+  // FileScan defines concrete equals/hashCode (comparing only fileIndex, read schema, and
+  // normalized filters), which suppresses the case-class-synthesized versions — so `pushedLimit`
+  // and `options` would not participate in equality. Since the pushed limit is enforced by the
+  // scan alone (the Limit operator is removed when isPartiallyPushed = false), two scans that
+  // differ only by limit must not compare equal, or exchange/subquery reuse could serve a
+  // limited scan's result for an unlimited one. Mirror how Spark's own pushdown-carrying scans
+  // (e.g. CSVScan) override equality.
+  override def equals(obj: Any): Boolean = obj match {
+    case o: GeoTiffMetadataScan =>
+      super.equals(o) && options == o.options && pushedLimit == o.pushedLimit
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    var result = super.hashCode()
+    result = 31 * result + options.hashCode()
+    result = 31 * result + pushedLimit.hashCode()
+    result
+  }
+
   override def isSplitable(path: org.apache.hadoop.fs.Path): Boolean = false
 
   private lazy val inputPartitions = {

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/netcdfmetadata/NetCdfMetadataDataSource.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/netcdfmetadata/NetCdfMetadataDataSource.scala
@@ -74,10 +74,13 @@ class NetCdfMetadataDataSource
           newOptions.put("pathGlobFilter", glob)
         case _ =>
       }
-    } else if (paths.exists(p => isDirectory(p, optionsWithoutPaths))) {
+    } else if (paths.nonEmpty && paths.forall(p => isDirectory(p, optionsWithoutPaths))) {
       // Directory roots (single or multiple, with or without trailing slash): default to a
       // recursive scan filtered to NetCDF extensions. These are defaults only — an explicit
-      // recursiveFileLookup=false keeps Hive-style partition discovery available.
+      // recursiveFileLookup=false keeps Hive-style partition discovery available. They apply
+      // only when EVERY root is a directory: Spark applies pathGlobFilter to all roots, so a
+      // mixed load(dir, explicitFile) must not silently drop an explicitly named file whose
+      // name does not match the extension filter.
       if (!hasUserRecursive) {
         newOptions.put("recursiveFileLookup", "true")
       }

--- a/spark/common/src/test/scala/org/apache/sedona/sql/geotiffMetadataTest.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/geotiffMetadataTest.scala
@@ -19,11 +19,15 @@
 package org.apache.sedona.sql
 
 import org.apache.commons.io.FileUtils
+import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
+import org.apache.spark.sql.sedona_sql.io.geotiffmetadata.GeoTiffMetadataScan
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.junit.Assert.assertEquals
 import org.scalatest.BeforeAndAfterAll
 
 import java.io.File
 import java.nio.file.Files
+import java.util.Collections
 
 class geotiffMetadataTest extends TestBaseScala with BeforeAndAfterAll {
 
@@ -232,6 +236,135 @@ class geotiffMetadataTest extends TestBaseScala with BeforeAndAfterAll {
         .first()
       assertEquals(256, bandRow.getAs[Int]("blockWidth"))
       assertEquals(256, bandRow.getAs[Int]("blockHeight"))
+    }
+
+    it("should support Hive-style partition discovery when recursiveFileLookup is disabled") {
+      val base = new File(tempDir, "partitioned")
+      val d2020 = new File(base, "year=2020")
+      val d2021 = new File(base, "year=2021")
+      d2020.mkdirs()
+      d2021.mkdirs()
+      FileUtils.copyFile(new File(singleFileLocation), new File(d2020, "a.tiff"))
+      FileUtils.copyFile(new File(singleFileLocation), new File(d2021, "b.tiff"))
+
+      // Mixed-case option spelling: data source options are case-insensitive, so this must
+      // suppress the lowercase recursiveFileLookup default just the same
+      val df = sparkSession.read
+        .format("geotiff.metadata")
+        .option("RecursiveFileLookup", "false")
+        .load(base.getAbsolutePath)
+      // Partition inference stays available because the explicit option is respected
+      assert(df.schema.fieldNames.contains("year"))
+      val rows = df.selectExpr("path", "year").collect()
+      assertEquals(2, rows.length)
+      // Every row must carry the partition value of ITS OWN file, even when both files are
+      // bin-packed into one Spark partition
+      rows.foreach { r =>
+        assert(r.getAs[String]("path").contains(s"year=${r.getAs[Int]("year")}"))
+      }
+    }
+
+    it("should hash scans from every field used by equality") {
+      val scan = sparkSession.read
+        .format("geotiff.metadata")
+        .load(singleFileLocation)
+        .queryExecution
+        .executedPlan
+        .collectFirst { case exec: BatchScanExec =>
+          exec.scan.asInstanceOf[GeoTiffMetadataScan]
+        }
+        .getOrElse(fail("GeoTIFF metadata query did not contain a BatchScanExec"))
+
+      val equalScan = scan.copy()
+      val limitedScan = scan.copy(pushedLimit = Some(1))
+      val differentOptionsScan = scan.copy(options =
+        new CaseInsensitiveStringMap(Collections.singletonMap("hash-test", "different")))
+
+      assert(scan == equalScan)
+      assertEquals(scan.hashCode(), equalScan.hashCode())
+      assert(scan != limitedScan)
+      assert(scan.hashCode() != limitedScan.hashCode())
+      assert(scan != differentOptionsScan)
+      assert(scan.hashCode() != differentOptionsScan.hashCode())
+    }
+
+    it("should apply both a glob path and an explicit pathGlobFilter") {
+      // Native Spark semantics: both constraints apply, so a*.tiff restricted to b*.tiff is
+      // empty. The internal glob-to-filter rewrite must not discard either constraint.
+      val dir = new File(tempDir, "globAndFilter")
+      dir.mkdirs()
+      FileUtils.copyFile(new File(singleFileLocation), new File(dir, "a.tiff"))
+      FileUtils.copyFile(new File(singleFileLocation), new File(dir, "b.tiff"))
+
+      val both = sparkSession.read
+        .format("geotiff.metadata")
+        .option("pathGlobFilter", "b*.tiff")
+        .load(dir.getAbsolutePath + "/a*.tiff")
+      assertEquals(0L, both.count())
+
+      // Sanity: without the explicit filter, the glob path alone matches a.tiff
+      val globOnly =
+        sparkSession.read.format("geotiff.metadata").load(dir.getAbsolutePath + "/a*.tiff")
+      assertEquals(1L, globOnly.count())
+    }
+
+    it("should filter non-GeoTIFF files when loading multiple directories") {
+      val dirA = new File(tempDir, "multiA")
+      val dirB = new File(tempDir, "multiB")
+      dirA.mkdirs()
+      dirB.mkdirs()
+      FileUtils.copyFile(new File(singleFileLocation), new File(dirA, "a.tiff"))
+      FileUtils.writeStringToFile(new File(dirA, "junk.txt"), "not a geotiff", "UTF-8")
+      FileUtils.copyFile(new File(singleFileLocation), new File(dirB, "b.tiff"))
+
+      val df = sparkSession.read
+        .format("geotiff.metadata")
+        .load(dirA.getAbsolutePath, dirB.getAbsolutePath)
+      assertEquals(2L, df.count())
+      // Force a parse of every listed file — junk.txt would fail here if not filtered out
+      assertEquals(2, df.select("width").collect().length)
+    }
+
+    it("should fail catalog table creation with a clear error instead of an NPE") {
+      def messages(t: Throwable): Seq[String] =
+        if (t == null) Nil else Option(t.getMessage).toSeq ++ messages(t.getCause)
+
+      sparkSession.sql("DROP TABLE IF EXISTS geotiff_meta_tbl")
+      try {
+        val err = intercept[Exception] {
+          sparkSession.sql(
+            s"CREATE TABLE geotiff_meta_tbl USING `geotiff.metadata` LOCATION '$singleFileLocation'")
+        }
+        assert(
+          messages(err).exists(_.contains("does not support catalog table operations")),
+          s"unexpected error: $err")
+      } finally {
+        sparkSession.sql("DROP TABLE IF EXISTS geotiff_meta_tbl")
+      }
+    }
+
+    it("should reject catalog table creation with an explicit schema") {
+      // With a user-supplied schema Spark skips FileFormat.inferSchema, so rejection relies on
+      // the stub fallback format failing on instantiation. Depending on the Spark version the
+      // error surfaces at CREATE or at first SELECT — either way it must be the clear message,
+      // never an NPE or a silently unusable table.
+      def messages(t: Throwable): Seq[String] =
+        if (t == null) Nil else Option(t.getMessage).toSeq ++ messages(t.getCause)
+
+      sparkSession.sql("DROP TABLE IF EXISTS geotiff_meta_schema_tbl")
+      try {
+        val err = intercept[Exception] {
+          sparkSession.sql(
+            "CREATE TABLE geotiff_meta_schema_tbl (path STRING) " +
+              s"USING `geotiff.metadata` LOCATION '$singleFileLocation'")
+          sparkSession.sql("SELECT * FROM geotiff_meta_schema_tbl").collect()
+        }
+        assert(
+          messages(err).exists(_.contains("does not support catalog table operations")),
+          s"unexpected error: $err")
+      } finally {
+        sparkSession.sql("DROP TABLE IF EXISTS geotiff_meta_schema_tbl")
+      }
     }
   }
 }

--- a/spark/common/src/test/scala/org/apache/sedona/sql/geotiffMetadataTest.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/geotiffMetadataTest.scala
@@ -41,6 +41,18 @@ class geotiffMetadataTest extends TestBaseScala with BeforeAndAfterAll {
     super.afterAll()
   }
 
+  private def withSqlConf(pairs: (String, String)*)(f: => Unit): Unit = {
+    val conf = sparkSession.conf
+    val originals = pairs.map { case (k, _) => k -> conf.getOption(k) }
+    pairs.foreach { case (k, v) => conf.set(k, v) }
+    try f
+    finally
+      originals.foreach {
+        case (k, Some(v)) => conf.set(k, v)
+        case (k, None) => conf.unset(k)
+      }
+  }
+
   describe("GeoTiffMetadata data source") {
 
     it("should read test1.tiff with exact metadata values") {
@@ -247,21 +259,47 @@ class geotiffMetadataTest extends TestBaseScala with BeforeAndAfterAll {
       FileUtils.copyFile(new File(singleFileLocation), new File(d2020, "a.tiff"))
       FileUtils.copyFile(new File(singleFileLocation), new File(d2021, "b.tiff"))
 
-      // Mixed-case option spelling: data source options are case-insensitive, so this must
-      // suppress the lowercase recursiveFileLookup default just the same
+      // Force both files into a single bin-packed Spark partition; otherwise each file gets
+      // its own partition and the per-file partition-value handling is never exercised
+      withSqlConf(
+        "spark.sql.files.openCostInBytes" -> "0",
+        "spark.sql.files.minPartitionNum" -> "1",
+        "spark.sql.files.maxPartitionBytes" -> "1073741824") {
+        // Mixed-case option spelling: data source options are case-insensitive, so this must
+        // suppress the lowercase recursiveFileLookup default just the same
+        val df = sparkSession.read
+          .format("geotiff.metadata")
+          .option("RecursiveFileLookup", "false")
+          .load(base.getAbsolutePath)
+        // Partition inference stays available because the explicit option is respected
+        assert(df.schema.fieldNames.contains("year"))
+        assertEquals(1, df.rdd.getNumPartitions)
+        val rows = df.selectExpr("path", "year").collect()
+        assertEquals(2, rows.length)
+        // Every row must carry the partition value of ITS OWN file, even though both files
+        // are bin-packed into one Spark partition
+        rows.foreach { r =>
+          assert(r.getAs[String]("path").contains(s"year=${r.getAs[Int]("year")}"))
+        }
+      }
+    }
+
+    it("should not filter explicitly named files in a mixed directory-and-file load") {
+      // The extension filter is a directory-scan default; Spark applies pathGlobFilter to
+      // every root, so it must not be installed when an explicitly named file (here without
+      // an extension) is loaded alongside a directory.
+      val dir = new File(tempDir, "mixedRoots")
+      dir.mkdirs()
+      FileUtils.copyFile(new File(singleFileLocation), new File(dir, "a.tiff"))
+      val explicitFile = new File(tempDir, "explicit_geotiff_no_extension")
+      FileUtils.copyFile(new File(singleFileLocation), explicitFile)
+
       val df = sparkSession.read
         .format("geotiff.metadata")
-        .option("RecursiveFileLookup", "false")
-        .load(base.getAbsolutePath)
-      // Partition inference stays available because the explicit option is respected
-      assert(df.schema.fieldNames.contains("year"))
-      val rows = df.selectExpr("path", "year").collect()
-      assertEquals(2, rows.length)
-      // Every row must carry the partition value of ITS OWN file, even when both files are
-      // bin-packed into one Spark partition
-      rows.foreach { r =>
-        assert(r.getAs[String]("path").contains(s"year=${r.getAs[Int]("year")}"))
-      }
+        .load(dir.getAbsolutePath, explicitFile.getAbsolutePath)
+      assertEquals(2L, df.count())
+      // Both files must parse, including the extensionless explicit one
+      assertEquals(2, df.select("width").collect().length)
     }
 
     it("should hash scans from every field used by equality") {

--- a/spark/common/src/test/scala/org/apache/sedona/sql/netcdfMetadataTest.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/netcdfMetadataTest.scala
@@ -43,6 +43,18 @@ class netcdfMetadataTest extends TestBaseScala with BeforeAndAfterAll {
     super.afterAll()
   }
 
+  private def withSqlConf(pairs: (String, String)*)(f: => Unit): Unit = {
+    val conf = sparkSession.conf
+    val originals = pairs.map { case (k, _) => k -> conf.getOption(k) }
+    pairs.foreach { case (k, v) => conf.set(k, v) }
+    try f
+    finally
+      originals.foreach {
+        case (k, Some(v)) => conf.set(k, v)
+        case (k, None) => conf.unset(k)
+      }
+  }
+
   describe("NetCdfMetadata data source") {
 
     it("should read test.nc with exact metadata values") {
@@ -1002,21 +1014,47 @@ class netcdfMetadataTest extends TestBaseScala with BeforeAndAfterAll {
       FileUtils.copyFile(new File(singleFileLocation), new File(d2020, "a.nc"))
       FileUtils.copyFile(new File(singleFileLocation), new File(d2021, "b.nc"))
 
-      // Mixed-case option spelling: data source options are case-insensitive, so this must
-      // suppress the lowercase recursiveFileLookup default just the same
+      // Force both files into a single bin-packed Spark partition; otherwise each file gets
+      // its own partition and the per-file partition-value handling is never exercised
+      withSqlConf(
+        "spark.sql.files.openCostInBytes" -> "0",
+        "spark.sql.files.minPartitionNum" -> "1",
+        "spark.sql.files.maxPartitionBytes" -> "1073741824") {
+        // Mixed-case option spelling: data source options are case-insensitive, so this must
+        // suppress the lowercase recursiveFileLookup default just the same
+        val df = sparkSession.read
+          .format("netcdf.metadata")
+          .option("RecursiveFileLookup", "false")
+          .load(base.getAbsolutePath)
+        // Partition inference stays available because the explicit option is respected
+        assert(df.schema.fieldNames.contains("year"))
+        assertEquals(1, df.rdd.getNumPartitions)
+        val rows = df.selectExpr("path", "year").collect()
+        assertEquals(2, rows.length)
+        // Every row must carry the partition value of ITS OWN file, even though both files
+        // are bin-packed into one Spark partition
+        rows.foreach { r =>
+          assert(r.getAs[String]("path").contains(s"year=${r.getAs[Int]("year")}"))
+        }
+      }
+    }
+
+    it("should not filter explicitly named files in a mixed directory-and-file load") {
+      // The extension filter is a directory-scan default; Spark applies pathGlobFilter to
+      // every root, so it must not be installed when an explicitly named file (here without
+      // an extension) is loaded alongside a directory.
+      val dir = new File(tempDir, "mixedRoots")
+      dir.mkdirs()
+      FileUtils.copyFile(new File(singleFileLocation), new File(dir, "a.nc"))
+      val explicitFile = new File(tempDir, "explicit_netcdf_no_extension")
+      FileUtils.copyFile(new File(singleFileLocation), explicitFile)
+
       val df = sparkSession.read
         .format("netcdf.metadata")
-        .option("RecursiveFileLookup", "false")
-        .load(base.getAbsolutePath)
-      // Partition inference stays available because the explicit option is respected
-      assert(df.schema.fieldNames.contains("year"))
-      val rows = df.selectExpr("path", "year").collect()
-      assertEquals(2, rows.length)
-      // Every row must carry the partition value of ITS OWN file, even when both files are
-      // bin-packed into one Spark partition
-      rows.foreach { r =>
-        assert(r.getAs[String]("path").contains(s"year=${r.getAs[Int]("year")}"))
-      }
+        .load(dir.getAbsolutePath, explicitFile.getAbsolutePath)
+      assertEquals(2L, df.count())
+      // Both files must parse, including the extensionless explicit one
+      assertEquals(2, df.select("format").collect().length)
     }
 
     it("should apply both a glob path and an explicit pathGlobFilter") {


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #3128

## What changes were proposed in this PR?

Apply to `geotiff.metadata` the fixes that hardened the same code patterns in `netcdf.metadata` during the #2829 reviews. `netcdf.metadata` was originally modeled on `geotiff.metadata`, so these defects exist identically in the GeoTIFF package on master.

### Correctness (silent wrong results)

1. **Per-file partition values.** A bin-packed partition wrapped one reader in a single `PartitionReaderWithPartitionValues` using `partition.files.head.partitionValues`, so files from different Hive partitions (e.g. `year=2020/`, `year=2021/`) all reported the first file's partition values. Each file's reader is now wrapped with its own values (`GeoTiffMetadataConcatPartitionReader`; sub-readers open lazily, at most one file open at a time).

2. **Scan equality and hashing include pushdown state.** `FileScan`'s concrete `equals`/`hashCode` suppress the case-class-synthesized versions, so `pushedLimit` and `options` did not participate in equality. Since the scan alone enforces the pushed limit (`isPartiallyPushed = false` removes the Limit operator), exchange/subquery reuse could serve a limited scan's result for an unlimited one. `equals` now includes both fields and `hashCode` is derived from every equality field.

### Crash

3. **`fallbackFileFormat` no longer returns null.** `CREATE TABLE ... USING geotiff.metadata` threw a `NullPointerException`. The fallback is now a stub `FileFormat` that fails on instantiation with a descriptive `UnsupportedOperationException`, which also rejects `CREATE TABLE` with an explicit schema (that path skips `inferSchema`).

### Behavior

4. **Directory defaults never override explicit options.** Single-directory loads forced `recursiveFileLookup=true`, overriding an explicit `false` and silently disabling Hive-style partition discovery; multi-directory loads bypassed the GeoTIFF extension filter entirely. Both are now defaults only, applied for any directory root.

5. **Option presence checks are case-insensitive.** Defaults were guarded with `containsKey` on a copied `HashMap`, so an explicit mixed-case option (e.g. `RecursiveFileLookup=false`) could nondeterministically lose to the lowercase default.

6. **A glob path combined with an explicit `pathGlobFilter` keeps both constraints.** `.load("/dir/a*.tif")` with `pathGlobFilter="b*.tif"` previously rewrote the path and kept only one filter; the rewrite is now skipped when the user supplied a filter, so Spark applies both natively.

Every fix mirrors its review-hardened counterpart in `spark/common/.../io/netcdfmetadata/`, adjusted only for naming and the `.tif`/`.tiff` extensions. Documentation gains the directory-load defaults and the unsupported-catalog-operations note, mirroring the NetCDF page.

## How was this patch tested?

7 new tests in `geotiffMetadataTest.scala` (19 total), mirroring the netcdf.metadata regression coverage:

- Hive-style partition discovery with an explicit mixed-case `RecursiveFileLookup=false`, asserting every row carries its own file's partition value even when bin-packed into one Spark partition
- Scan hash/equality consistency across equal, limit-differing, and options-differing copies
- Glob path + explicit `pathGlobFilter` returning the native empty intersection (with a glob-only sanity check)
- Multi-directory loads filtering non-GeoTIFF files
- `CREATE TABLE ... USING geotiff.metadata` failing with a clear error instead of an NPE, both without and with an explicit schema

Full `geotiffMetadataTest`, `netcdfMetadataTest`, and `rasteralgebraTest` suites pass on Spark 3.4/Scala 2.12 (240 tests); sources cross-compile on Spark 4.0/Scala 2.13.

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.
