### PR TITLE
[GH-3126] Fix STAC temporal pushdown and pagination

### DIFF
--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacBatch.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacBatch.scala
@@ -27,12 +27,13 @@ import org.apache.spark.sql.sedona_sql.io.stac.StacUtils.getNumPartitions
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.SerializableConfiguration
 
+import java.net.URI
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatterBuilder
 import java.time.temporal.ChronoField
 import scala.jdk.CollectionConverters._
 import scala.util.Random
-import scala.util.control.Breaks.breakable
+import scala.util.Try
 
 /**
  * The `StacBatch` class represents a batch of partitions for reading data in the SpatioTemporal
@@ -53,10 +54,21 @@ case class StacBatch(
     limitFilter: Option[Int])
     extends Batch {
 
+  private val configuredItemsLimitMax = opts.getOrElse("itemsLimitMax", "-1").toInt
+  private val effectiveItemsLimitMax: Option[Int] = {
+    val configuredLimit = Option(configuredItemsLimitMax).filter(_ > 0)
+    val sqlLimit = limitFilter.filter(_ >= 0)
+    (configuredLimit, sqlLimit) match {
+      case (Some(configured), Some(sql)) => Some(math.min(configured, sql))
+      case (configured @ Some(_), None) => configured
+      case (None, sql @ Some(_)) => sql
+      case _ => None
+    }
+  }
+
   private val defaultItemsLimitPerRequest: Int = {
-    val itemsLimitMax = opts.getOrElse("itemsLimitMax", "-1").toInt
     val limitPerRequest = opts.getOrElse("itemsLimitPerRequest", "10").toInt
-    if (itemsLimitMax > 0 && limitPerRequest > itemsLimitMax) itemsLimitMax else limitPerRequest
+    effectiveItemsLimitMax.map(math.min(limitPerRequest, _)).getOrElse(limitPerRequest)
   }
   private val itemsLoadProcessReportThreshold =
     opts.getOrElse("itemsLoadProcessReportThreshold", "1000000").toInt
@@ -85,22 +97,17 @@ case class StacBatch(
    *   An array of input partitions for reading STAC data.
    */
   override def planInputPartitions(): Array[InputPartition] = {
-    val stacCollectionBasePath = StacUtils.getStacCollectionBasePath(stacCollectionUrl)
-
     // Initialize the itemLinks array
     val itemLinks = scala.collection.mutable.ArrayBuffer[String]()
 
     // Get the maximum number of items to process
-    val itemsLimitMax = limitFilter match {
-      case Some(limit) if limit >= 0 => limit
-      case _ => opts.getOrElse("itemsLimitMax", "-1").toInt
-    }
-    val checkItemsLimitMax = itemsLimitMax > 0
+    val itemsLimitMax = effectiveItemsLimitMax.getOrElse(-1)
+    val checkItemsLimitMax = effectiveItemsLimitMax.isDefined
 
     // Start the recursive collection of item links
     setItemMaxLeft(itemsLimitMax)
 
-    collectItemLinks(stacCollectionBasePath, stacCollectionJson, itemLinks, checkItemsLimitMax)
+    collectItemLinks(stacCollectionUrl, stacCollectionJson, itemLinks, checkItemsLimitMax)
 
     // Handle when the number of items is less than 1
     if (itemLinks.isEmpty) {
@@ -138,15 +145,15 @@ case class StacBatch(
   /**
    * Recursively processes collections and collects item links.
    *
-   * @param collectionBasePath
-   *   The base path of the STAC collection.
+   * @param collectionUrl
+   *   The URL of the current STAC collection document.
    * @param collectionJson
    *   The JSON string representation of the STAC collection.
    * @param itemLinks
    *   The list of item links to populate.
    */
   def collectItemLinks(
-      collectionBasePath: String,
+      collectionUrl: String,
       collectionJson: String,
       itemLinks: scala.collection.mutable.ArrayBuffer[String],
       needCountNextItems: Boolean): Unit = {
@@ -166,58 +173,86 @@ case class StacBatch(
     val linksNode = rootNode.get("links")
     val iterator = linksNode.elements()
 
+    def isAbsoluteLink(href: String): Boolean =
+      href.startsWith("http") || href.startsWith("file")
+
+    def normalizeFileUrl(url: String): String = {
+      if (url.startsWith("file:/") && !url.startsWith("file://")) {
+        "file:///" + url.stripPrefix("file:/")
+      } else url
+    }
+
+    def resolveLink(baseUrl: String, href: String): String = {
+      if (href.startsWith("file")) normalizeFileUrl(href)
+      else if (isAbsoluteLink(href)) href
+      else if (baseUrl.startsWith("http")) {
+        Try {
+          if (href.startsWith("?")) {
+            baseUrl.takeWhile(character => character != '?' && character != '#') + href
+          } else if (href.startsWith("#")) {
+            baseUrl.takeWhile(_ != '#') + href
+          } else new URI(baseUrl).resolve(href).toString
+        }.getOrElse(StacUtils.getStacCollectionBasePath(baseUrl) + href)
+      } else if (baseUrl.startsWith("file")) {
+        normalizeFileUrl(new URI(baseUrl).resolve(href).toString)
+      } else StacUtils.getStacCollectionBasePath(baseUrl) + href
+    }
+
+    def getReturnedItemCount(itemRootNode: JsonNode): Int = {
+      val featureCount =
+        Option(itemRootNode.get("features")).filter(_.isArray).map(_.size())
+      val reportedCount = Option(itemRootNode.get("numberReturned"))
+        .filter(_.isIntegralNumber)
+        .map(_.asInt())
+        .filter(_ >= 0)
+      featureCount.orElse(reportedCount).getOrElse(0)
+    }
+
     def iterateItemsWithLimit(itemUrl: String, needCountNextItems: Boolean): Boolean = {
       // Load the item URL and process the response
       var nextUrl: Option[String] = Some(itemUrl)
-      breakable {
-        while (nextUrl.isDefined) {
-          val itemJson = StacUtils.loadStacCollectionToJson(nextUrl.get, headers)
-          val itemRootNode = mapper.readTree(itemJson)
-          // Check if there exists a "next" link
-          val itemLinksNode = itemRootNode.get("links")
-          if (itemLinksNode == null) {
+      while (nextUrl.isDefined) {
+        val currentUrl = nextUrl.get
+        val itemJson = StacUtils.loadStacCollectionToJson(currentUrl, headers)
+        val itemRootNode = mapper.readTree(itemJson)
+
+        if (needCountNextItems) {
+          itemMaxLeft = itemMaxLeft - getReturnedItemCount(itemRootNode)
+          if (itemMaxLeft <= 0) {
             return true
           }
-          val itemIterator = itemLinksNode.elements()
-          nextUrl = None
-          while (itemIterator.hasNext) {
-            val itemLinkNode = itemIterator.next()
-            val itemRel = itemLinkNode.get("rel").asText()
-            val itemHref = itemLinkNode.get("href").asText()
-            if (itemRel == "next") {
-              // Only check the number of items returned if there are more items to process
-              val numberReturnedNode = itemRootNode.get("numberReturned")
-              val numberReturned = if (numberReturnedNode == null) {
-                // From STAC API Spec:
-                // The optional limit parameter limits the number of
-                // items that are presented in the response document.
-                // The default value is 10.
-                defaultItemsLimitPerRequest
-              } else {
-                numberReturnedNode.asInt()
-              }
-              // count the number of items returned and left to be processed
-              itemMaxLeft = itemMaxLeft - numberReturned
-              // early exit if there are no more items to process
-              if (needCountNextItems && itemMaxLeft <= 0) {
-                return true
-              }
-              nextUrl = Some(if (itemHref.startsWith("http") || itemHref.startsWith("file")) {
-                itemHref
-              } else {
-                collectionBasePath + itemHref
-              })
+        }
+
+        val itemLinksNode = itemRootNode.get("links")
+        if (itemLinksNode == null || !itemLinksNode.isArray) {
+          return false
+        }
+
+        val itemIterator = itemLinksNode.elements()
+        var nextHref: Option[String] = None
+        while (itemIterator.hasNext && nextHref.isEmpty) {
+          val itemLinkNode = itemIterator.next()
+          if (itemLinkNode.path("rel").asText() == "next") {
+            val href = itemLinkNode.get("href")
+            if (href != null && href.isTextual) {
+              nextHref = Some(href.asText())
             }
           }
-          if (nextUrl.isDefined) {
-            itemLinks += nextUrl.get
-          }
+        }
+
+        // Pagination links are authoritative and may contain opaque cursor state. Changing their
+        // page size can alter page-number offsets or invalidate a signed URL.
+        nextUrl = nextHref.map(href => resolveLink(currentUrl, href))
+        if (nextUrl.isDefined) {
+          itemLinks += nextUrl.get
         }
       }
       false
     }
 
     while (iterator.hasNext) {
+      if (needCountNextItems && itemMaxLeft <= 0) return
+
       val linkNode = iterator.next()
       val rel = linkNode.get("rel").asText()
       val href = linkNode.get("href").asText()
@@ -225,50 +260,48 @@ case class StacBatch(
       // item links are identified by the "rel" value of "item" or "items"
       if (rel == "item" || rel == "items") {
         // need to handle relative paths and local file paths
-        val itemUrl = if (href.startsWith("http") || href.startsWith("file")) {
-          href
-        } else {
-          collectionBasePath + href
-        }
-        if (rel == "items" && href.startsWith("http")) {
-          itemLinks += (itemUrl + "?limit=" + defaultItemsLimitPerRequest)
-        } else {
-          itemLinks += itemUrl
-        }
-        if (needCountNextItems && itemMaxLeft <= 0) {
-          return
-        } else {
-          if (rel == "item" && needCountNextItems) {
-            // count the number of items returned and left to be processed
-            itemMaxLeft = itemMaxLeft - 1
-          } else if (rel == "items" && href.startsWith("http")) {
-            // iterate through the items and check if the limit is reached (if needed)
-            if (iterateItemsWithLimit(
-                getItemLink(itemUrl, defaultItemsLimitPerRequest, spatialFilter, temporalFilter),
-                needCountNextItems)) return
-          }
+        val itemUrl = resolveLink(collectionUrl, href)
+        val firstPageUrl = if (rel == "items" && itemUrl.startsWith("http")) {
+          getItemLink(itemUrl, defaultItemsLimitPerRequest, spatialFilter, temporalFilter)
+        } else itemUrl
+        itemLinks += firstPageUrl
+
+        if (rel == "item" && needCountNextItems) {
+          // count the number of items returned and left to be processed
+          itemMaxLeft = itemMaxLeft - 1
+        } else if (rel == "items" && itemUrl.startsWith("http")) {
+          // iterate through the items and check if the limit is reached (if needed)
+          if (iterateItemsWithLimit(firstPageUrl, needCountNextItems)) return
         }
       } else if (rel == "child") {
-        val childUrl = if (href.startsWith("http") || href.startsWith("file")) {
-          href
-        } else {
-          collectionBasePath + href
-        }
+        val childUrl = resolveLink(collectionUrl, href)
         // Recursively process the linked collection
         val linkedCollectionJson = StacUtils.loadStacCollectionToJson(childUrl, headers)
-        val nestedCollectionBasePath = StacUtils.getStacCollectionBasePath(childUrl)
         val collectionFiltered =
           filterCollection(linkedCollectionJson, spatialFilter, temporalFilter)
 
         if (!collectionFiltered) {
-          collectItemLinks(
-            nestedCollectionBasePath,
-            linkedCollectionJson,
-            itemLinks,
-            needCountNextItems)
+          collectItemLinks(childUrl, linkedCollectionJson, itemLinks, needCountNextItems)
         }
       }
     }
+  }
+
+  private def setLimitParameter(itemUrl: String, limit: Int): String = {
+    val fragmentIndex = itemUrl.indexOf('#')
+    val (urlWithoutFragment, fragment) = if (fragmentIndex >= 0) {
+      (itemUrl.substring(0, fragmentIndex), itemUrl.substring(fragmentIndex))
+    } else (itemUrl, "")
+    val queryIndex = urlWithoutFragment.indexOf('?')
+    val (path, existingQuery) = if (queryIndex >= 0) {
+      (urlWithoutFragment.substring(0, queryIndex), urlWithoutFragment.substring(queryIndex + 1))
+    } else (urlWithoutFragment, "")
+    val retainedParameters = existingQuery
+      .split("&", -1)
+      .filter(_.nonEmpty)
+      .filterNot(_.takeWhile(_ != '=') == "limit")
+    val query = (retainedParameters :+ s"limit=$limit").mkString("&")
+    s"$path?$query$fragment"
   }
 
   /** Adds an item link to the list of item links. */
@@ -277,9 +310,14 @@ case class StacBatch(
       defaultItemsLimitPerRequest: Int,
       spatialFilter: Option[GeoParquetSpatialFilter],
       temporalFilter: Option[TemporalFilter]): String = {
-    val baseUrl = itemUrl + "?limit=" + defaultItemsLimitPerRequest
-    val urlWithFilters = StacUtils.addFiltersToUrl(baseUrl, spatialFilter, temporalFilter)
-    urlWithFilters
+    val urlWithLimit = setLimitParameter(itemUrl, defaultItemsLimitPerRequest)
+    val fragmentIndex = urlWithLimit.indexOf('#')
+    val (urlWithoutFragment, fragment) = if (fragmentIndex >= 0) {
+      (urlWithLimit.substring(0, fragmentIndex), urlWithLimit.substring(fragmentIndex))
+    } else (urlWithLimit, "")
+    val urlWithFilters =
+      StacUtils.addFiltersToUrl(urlWithoutFragment, spatialFilter, temporalFilter)
+    urlWithFilters + fragment
   }
 
   /**
@@ -341,35 +379,52 @@ case class StacBatch(
     // Filter based on temporal extent
     val temporalFiltered = temporalFilter match {
       case Some(filter) =>
-        val extentNode = rootNode.path("extent").path("temporal").path("interval")
-        if (extentNode.isMissingNode) {
-          // if extent is missing, we assume the collection is not filtered
-          true
-        } else {
-          // parse the temporal intervals
-          val formatter = new DateTimeFormatterBuilder()
-            .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
-            .optionalStart()
-            .appendFraction(ChronoField.MILLI_OF_SECOND, 0, 3, true)
-            .optionalEnd()
-            .appendPattern("'Z'")
-            .toFormatter()
+        StacUtils.calculateTemporalBounds(filter) match {
+          // A proven-empty predicate cannot match any collection.
+          case None => true
+          // An unbounded envelope cannot safely prune a collection.
+          case Some(bounds) if bounds.isUnbounded => false
+          case Some(bounds) =>
+            val extentNode = rootNode.path("extent").path("temporal").path("interval")
+            if (extentNode.isMissingNode || !extentNode.isArray || extentNode.size() == 0) {
+              // Missing or unusable extent metadata cannot prove that a collection is disjoint.
+              false
+            } else {
+              val formatter = new DateTimeFormatterBuilder()
+                .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
+                .optionalStart()
+                .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
+                .optionalEnd()
+                .appendPattern("'Z'")
+                .toFormatter()
 
-          val intervals = extentNode
-            .elements()
-            .asScala
-            .map { intervalNode =>
-              val start = LocalDateTime.parse(intervalNode.get(0).asText(), formatter)
-              val end = LocalDateTime.parse(intervalNode.get(1).asText(), formatter)
-              (start, end)
+              def parseEndpoint(node: JsonNode): Option[Option[LocalDateTime]] = {
+                if (node == null || node.isNull) Some(None)
+                else Try(LocalDateTime.parse(node.asText(), formatter)).toOption.map(Some(_))
+              }
+
+              val intervals = extentNode
+                .elements()
+                .asScala
+                .map { intervalNode =>
+                  for {
+                    start <- parseEndpoint(intervalNode.get(0))
+                    end <- parseEndpoint(intervalNode.get(1))
+                  } yield (start, end)
+                }
+                .toList
+
+              // Malformed metadata is not evidence that the collection is outside the query.
+              if (intervals.exists(_.isEmpty)) false
+              else {
+                !intervals.flatten.exists { case (start, end) =>
+                  val invalidInterval =
+                    start.exists(startValue =>
+                      end.exists(endValue => startValue.isAfter(endValue)))
+                  invalidInterval || bounds.overlaps(start, end)
+                }
+              }
             }
-            .toList
-
-          // check if the filter evaluates to true for any of the interval start or end times
-          !intervals.exists { case (start, end) =>
-            filter.evaluate(Map("datetime" -> start)) ||
-            filter.evaluate(Map("datetime" -> end))
-          }
         }
       // if the collection is not filtered, return false
       case None => false

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacUtils.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacUtils.scala
@@ -367,63 +367,110 @@ object StacUtils {
     s"bbox=${unionEnvelope.getMinX}%2C${unionEnvelope.getMinY}%2C${unionEnvelope.getMaxX}%2C${unionEnvelope.getMaxY}"
   }
 
+  /**
+   * A conservative closed interval containing every timestamp accepted by a temporal filter.
+   * Missing bounds represent negative or positive infinity. An outer `None` from
+   * [[calculateTemporalBounds]] represents a filter that is proven empty.
+   */
+  private[stac] final case class TemporalBounds(
+      lower: Option[LocalDateTime],
+      upper: Option[LocalDateTime]) {
+
+    def isUnbounded: Boolean = lower.isEmpty && upper.isEmpty
+
+    /** Returns whether this interval overlaps another interval with optional open endpoints. */
+    def overlaps(
+        otherLower: Option[LocalDateTime],
+        otherUpper: Option[LocalDateTime]): Boolean = {
+      val endsBeforeOther = upper.exists(end => otherLower.exists(_.isAfter(end)))
+      val startsAfterOther = lower.exists(start => otherUpper.exists(_.isBefore(start)))
+      !endsBeforeOther && !startsAfterOther
+    }
+  }
+
+  private def intersectTemporalBounds(
+      left: TemporalBounds,
+      right: TemporalBounds): Option[TemporalBounds] = {
+    val lower = (left.lower, right.lower) match {
+      case (Some(leftValue), Some(rightValue)) =>
+        Some(if (leftValue.isAfter(rightValue)) leftValue else rightValue)
+      case (leftValue @ Some(_), None) => leftValue
+      case (None, rightValue @ Some(_)) => rightValue
+      case _ => None
+    }
+    val upper = (left.upper, right.upper) match {
+      case (Some(leftValue), Some(rightValue)) =>
+        Some(if (leftValue.isBefore(rightValue)) leftValue else rightValue)
+      case (leftValue @ Some(_), None) => leftValue
+      case (None, rightValue @ Some(_)) => rightValue
+      case _ => None
+    }
+
+    if (lower.exists(start => upper.exists(end => start.isAfter(end)))) None
+    else Some(TemporalBounds(lower, upper))
+  }
+
+  private def unionTemporalBounds(left: TemporalBounds, right: TemporalBounds): TemporalBounds = {
+    val lower = for {
+      leftValue <- left.lower
+      rightValue <- right.lower
+    } yield if (leftValue.isBefore(rightValue)) leftValue else rightValue
+    val upper = for {
+      leftValue <- left.upper
+      rightValue <- right.upper
+    } yield if (leftValue.isAfter(rightValue)) leftValue else rightValue
+    TemporalBounds(lower, upper)
+  }
+
+  /**
+   * Calculates a safe interval envelope for a temporal filter. `AND` intersects child envelopes;
+   * `OR` takes their convex hull, preserving an unbounded side if either child is unbounded
+   * there. Upper leaf bounds are widened to cover the full nanosecond range that Spark truncates
+   * into the same microsecond. This may fetch extra rows, which the retained Spark filter
+   * removes.
+   */
+  private[stac] def calculateTemporalBounds(filter: TemporalFilter): Option[TemporalBounds] = {
+    filter match {
+      case TemporalFilter.AndFilter(left, right) =>
+        for {
+          leftBounds <- calculateTemporalBounds(left)
+          rightBounds <- calculateTemporalBounds(right)
+          intersection <- intersectTemporalBounds(leftBounds, rightBounds)
+        } yield intersection
+      case TemporalFilter.OrFilter(left, right) =>
+        (calculateTemporalBounds(left), calculateTemporalBounds(right)) match {
+          case (Some(leftBounds), Some(rightBounds)) =>
+            Some(unionTemporalBounds(leftBounds, rightBounds))
+          case (leftBounds @ Some(_), None) => leftBounds
+          case (None, rightBounds @ Some(_)) => rightBounds
+          case _ => None
+        }
+      case TemporalFilter.LessThanFilter(_, value) =>
+        Some(TemporalBounds(None, Some(value.plusNanos(999L))))
+      case TemporalFilter.GreaterThanFilter(_, value) =>
+        Some(TemporalBounds(Some(value), None))
+      case TemporalFilter.EqualFilter(_, value) =>
+        Some(TemporalBounds(Some(value), Some(value.plusNanos(999L))))
+    }
+  }
+
   /** Returns the temporal filter string based on the temporal filter. */
   def getFilterTemporal(filter: TemporalFilter): String = {
     // Nine fractional digits (nanoseconds) match the finest precision STAC permits. Spark only
-    // keeps microseconds, so it truncates a legal item timestamp such as ...999999500Z down to
-    // ...999999 before the residual `datetime <= end` filter runs. A coarser pattern (or a bound
-    // pinned to microseconds) would let the remote catalog drop that item even though the residual
-    // filter would keep it; see the upper-bound widening below.
+    // keeps microseconds, so calculateTemporalBounds widens every finite upper leaf bound through
+    // the final nanosecond that Spark truncates into the same microsecond.
     val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS'Z'")
 
-    def formatDateTime(dateTime: LocalDateTime): String = {
-      if (dateTime == null) ".." else dateTime.format(formatter)
-    }
+    def formatDateTime(dateTime: Option[LocalDateTime]): String =
+      dateTime.map(_.format(formatter)).getOrElse("..")
 
-    def calculateUnionTemporal(filter: TemporalFilter): (LocalDateTime, LocalDateTime) = {
-      filter match {
-        case TemporalFilter.AndFilter(left, right) =>
-          val (leftStart, leftEnd) = calculateUnionTemporal(left)
-          val (rightStart, rightEnd) = calculateUnionTemporal(right)
-          val start =
-            if (leftStart == null || (rightStart != null && rightStart.isBefore(leftStart)))
-              rightStart
-            else leftStart
-          val end =
-            if (leftEnd == null || (rightEnd != null && rightEnd.isAfter(leftEnd))) rightEnd
-            else leftEnd
-          (start, end)
-        case TemporalFilter.OrFilter(left, right) =>
-          val (leftStart, leftEnd) = calculateUnionTemporal(left)
-          val (rightStart, rightEnd) = calculateUnionTemporal(right)
-          val start =
-            if (leftStart == null || (rightStart != null && rightStart.isBefore(leftStart)))
-              rightStart
-            else leftStart
-          val end =
-            if (leftEnd == null || (rightEnd != null && rightEnd.isAfter(leftEnd))) rightEnd
-            else leftEnd
-          (start, end)
-        case TemporalFilter.LessThanFilter(_, value) =>
-          (null, value)
-        case TemporalFilter.GreaterThanFilter(_, value) =>
-          (value, null)
-        case TemporalFilter.EqualFilter(_, value) =>
-          (value, value)
-      }
+    calculateTemporalBounds(filter) match {
+      // STAC intervals may have one open endpoint, but not two. An empty string also lets
+      // addFiltersToUrl omit a proven-empty interval and leave the residual Spark filter in charge.
+      case Some(bounds) if !bounds.isUnbounded =>
+        s"datetime=${formatDateTime(bounds.lower)}/${formatDateTime(bounds.upper)}"
+      case _ => ""
     }
-
-    val (start, end) = calculateUnionTemporal(filter)
-    // The pushed-down bounds come from Spark TimestampType literals, so `end` is aligned to a whole
-    // microsecond. Spark truncates every item timestamp to microseconds, so the residual `<= end`
-    // filter keeps any item whose true (up to nanosecond) value lands anywhere in that final
-    // microsecond. Widen the inclusive upper bound to its last nanosecond (+999 ns) so the remote
-    // catalog returns a superset of the residual result instead of dropping, e.g., an item at
-    // ...999999500Z. The lower bound is left exact; a slightly wider window is always safe because
-    // the residual filter re-checks each row at microsecond precision.
-    val inclusiveEnd = if (end == null) null else end.plusNanos(999L)
-    if (inclusiveEnd == null) s"datetime=${formatDateTime(start)}/.."
-    else s"datetime=${formatDateTime(start)}/${formatDateTime(inclusiveEnd)}"
   }
 
   /** Adds the spatial and temporal filters to the base URL. */

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/optimization/SpatialTemporalFilterPushDownForStacScan.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/optimization/SpatialTemporalFilterPushDownForStacScan.scala
@@ -81,20 +81,33 @@ class SpatialTemporalFilterPushDownForStacScan(sparkSession: SparkSession)
           filter.copy()
         case lr: DataSourceV2ScanRelation if isStacScanRelation(lr) =>
           val scan = lr.scan.asInstanceOf[StacScan]
-          val limit = extractLimit(plan)
-          limit match {
-            case Some(n) => scan.setLimit(n)
-            case None =>
-          }
+          // A limit is safe only when it is applied directly to this scan. Filters, sorts,
+          // aggregates, joins, and other intervening operators can reject or reorder rows.
+          scan.limit = extractDirectLimit(plan, lr)
           lr
       }
     }
   }
 
-  def extractLimit(plan: LogicalPlan): Option[Int] = {
-    plan.collectFirst {
-      case GlobalLimit(Literal(limit: Int, _), _) => limit
-      case LocalLimit(Literal(limit: Int, _), _) => limit
+  private[optimization] def extractDirectLimit(
+      plan: LogicalPlan,
+      target: LogicalPlan): Option[Int] = {
+    def literalLimit(expression: Expression): Option[Int] = expression match {
+      case Literal(limit: Int, _) => Some(limit)
+      case _ => None
+    }
+
+    plan match {
+      case GlobalLimit(globalExpression, LocalLimit(localExpression, child))
+          if child.eq(target) =>
+        for {
+          globalLimit <- literalLimit(globalExpression)
+          localLimit <- literalLimit(localExpression)
+          if localLimit >= globalLimit
+        } yield globalLimit
+      case GlobalLimit(expression, child) if child.eq(target) =>
+        literalLimit(expression)
+      case _ => None
     }
   }
 
@@ -128,27 +141,32 @@ class SpatialTemporalFilterPushDownForStacScan(sparkSession: SparkSession)
           temporalFilterRight <- translateToTemporalFilter(right, pushableColumn)
         } yield TemporalFilter.OrFilter(temporalFilterLeft, temporalFilterRight)
 
-      case LessThan(pushableColumn(name), Literal(v, TimestampType)) =>
+      case LessThan(pushableColumn(name), Literal(v, TimestampType))
+          if isPushableTemporalColumn(name) =>
         Some(
           TemporalFilter
             .LessThanFilter(unquote(name), microsToLocalDateTime(v.asInstanceOf[Long])))
 
-      case LessThanOrEqual(pushableColumn(name), Literal(v, TimestampType)) =>
+      case LessThanOrEqual(pushableColumn(name), Literal(v, TimestampType))
+          if isPushableTemporalColumn(name) =>
         Some(
           TemporalFilter
             .LessThanFilter(unquote(name), microsToLocalDateTime(v.asInstanceOf[Long])))
 
-      case GreaterThan(pushableColumn(name), Literal(v, TimestampType)) =>
+      case GreaterThan(pushableColumn(name), Literal(v, TimestampType))
+          if isPushableTemporalColumn(name) =>
         Some(
           TemporalFilter
             .GreaterThanFilter(unquote(name), microsToLocalDateTime(v.asInstanceOf[Long])))
 
-      case GreaterThanOrEqual(pushableColumn(name), Literal(v, TimestampType)) =>
+      case GreaterThanOrEqual(pushableColumn(name), Literal(v, TimestampType))
+          if isPushableTemporalColumn(name) =>
         Some(
           TemporalFilter
             .GreaterThanFilter(unquote(name), microsToLocalDateTime(v.asInstanceOf[Long])))
 
-      case EqualTo(pushableColumn(name), Literal(v, TimestampType)) =>
+      case EqualTo(pushableColumn(name), Literal(v, TimestampType))
+          if isPushableTemporalColumn(name) =>
         Some(
           TemporalFilter
             .EqualFilter(unquote(name), microsToLocalDateTime(v.asInstanceOf[Long])))
@@ -174,4 +192,6 @@ class SpatialTemporalFilterPushDownForStacScan(sparkSession: SparkSession)
   private def unquote(name: String): String = {
     parseColumnPath(name).mkString(".")
   }
+
+  private def isPushableTemporalColumn(name: String): Boolean = unquote(name) == "datetime"
 }

--- a/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacBatchTest.scala
+++ b/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacBatchTest.scala
@@ -20,14 +20,35 @@ package org.apache.spark.sql.sedona_sql.io.stac
 
 import org.apache.sedona.sql.TestBaseScala
 import org.apache.spark.sql.connector.read.InputPartition
+import org.apache.spark.sql.execution.datasource.stac.TemporalFilter
 import org.apache.spark.sql.types.StructType
 
+import com.sun.net.httpserver.{HttpExchange, HttpServer}
+import java.net.{InetSocketAddress, URI}
+import java.nio.charset.StandardCharsets
 import java.time.format.DateTimeFormatter
-import java.time.{LocalDate, ZoneOffset}
-import scala.io.Source
+import java.time.{LocalDate, LocalDateTime, ZoneOffset}
 import scala.collection.mutable
+import scala.io.Source
 
 class StacBatchTest extends TestBaseScala {
+
+  private def withHttpServer(responseFor: HttpExchange => String)(test: String => Unit): Unit = {
+    val server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
+    server.createContext(
+      "/",
+      exchange => {
+        val response = responseFor(exchange).getBytes(StandardCharsets.UTF_8)
+        exchange.getResponseHeaders.add("Content-Type", "application/geo+json")
+        exchange.sendResponseHeaders(200, response.length)
+        val body = exchange.getResponseBody
+        try body.write(response)
+        finally body.close()
+      })
+    server.start()
+    try test(s"http://127.0.0.1:${server.getAddress.getPort}")
+    finally server.stop(0)
+  }
 
   def loadJsonFromResource(resourceFilePath: String): String = {
     Source.fromResource(resourceFilePath).getLines().mkString("\n")
@@ -66,6 +87,136 @@ class StacBatchTest extends TestBaseScala {
     assert(itemLinks.nonEmpty)
     assert(itemLinks.length == 5)
     assert(duration > 0)
+  }
+
+  it("collectItemLinks should schedule the filtered first items page") {
+    val requests = mutable.ArrayBuffer[String]()
+    withHttpServer(exchange => {
+      requests.synchronized(requests += exchange.getRequestURI.toString)
+      """{"features":[]}"""
+    }) { serverUrl =>
+      val collectionJson =
+        """{"links":[{"rel":"items","href":"items?token=x"},{"rel":"item","href":"after.json"}]}"""
+      val temporalFilter =
+        TemporalFilter.GreaterThanFilter("datetime", LocalDateTime.parse("2025-03-06T00:00:00"))
+      val stacBatch = StacBatch(
+        null,
+        s"$serverUrl/api/collections/c",
+        collectionJson,
+        StructType(Seq()),
+        Map("itemsLimitPerRequest" -> "2"),
+        None,
+        Some(temporalFilter),
+        None)
+      val itemLinks = mutable.ArrayBuffer[String]()
+
+      stacBatch.collectItemLinks(
+        s"$serverUrl/api/collections/c",
+        collectionJson,
+        itemLinks,
+        needCountNextItems = false)
+
+      val expectedFirstPage =
+        s"$serverUrl/api/collections/items?token=x&limit=2&datetime=2025-03-06T00:00:00.000000000Z/.."
+      assert(itemLinks == Seq(expectedFirstPage, s"$serverUrl/api/collections/after.json"))
+      val expectedUri = new URI(expectedFirstPage)
+      assert(requests == Seq(s"${expectedUri.getRawPath}?${expectedUri.getRawQuery}"))
+    }
+  }
+
+  it("collectItemLinks should count actual features and preserve next links") {
+    val requests = mutable.ArrayBuffer[String]()
+    withHttpServer(exchange => {
+      val requestUri = exchange.getRequestURI.toString
+      requests.synchronized(requests += requestUri)
+      if (requestUri.contains("page=1")) {
+        """{"features":[{}],"links":[{"rel":"next","href":"?page=2&limit=7"}]}"""
+      } else if (requestUri.contains("page=2")) {
+        """{"features":[{}],"links":[{"rel":"next","href":"?page=3&limit=7"}]}"""
+      } else {
+        """{"features":[{}],"links":[]}"""
+      }
+    }) { serverUrl =>
+      val collectionJson = """{"links":[{"rel":"items","href":"items?page=1"}]}"""
+      val stacBatch = StacBatch(
+        null,
+        s"$serverUrl/api/collection",
+        collectionJson,
+        StructType(Seq()),
+        Map("itemsLimitPerRequest" -> "2"),
+        None,
+        None,
+        None)
+      stacBatch.setItemMaxLeft(3)
+      val itemLinks = mutable.ArrayBuffer[String]()
+
+      stacBatch.collectItemLinks(
+        s"$serverUrl/api/collection",
+        collectionJson,
+        itemLinks,
+        needCountNextItems = true)
+
+      assert(
+        itemLinks == Seq(
+          s"$serverUrl/api/items?page=1&limit=2",
+          s"$serverUrl/api/items?page=2&limit=7",
+          s"$serverUrl/api/items?page=3&limit=7"))
+      assert(
+        requests == Seq(
+          "/api/items?page=1&limit=2",
+          "/api/items?page=2&limit=7",
+          "/api/items?page=3&limit=7"))
+    }
+  }
+
+  it("collectItemLinks should stop at the direct item limit without adding an extra link") {
+    val collectionJson =
+      """{"links":[{"rel":"item","href":"file:/one.json"},{"rel":"item","href":"two.json"}]}"""
+    val stacBatch = StacBatch(
+      null,
+      "file:///collection.json",
+      collectionJson,
+      StructType(Seq()),
+      Map.empty,
+      None,
+      None,
+      None)
+    stacBatch.setItemMaxLeft(1)
+    val itemLinks = mutable.ArrayBuffer[String]()
+
+    stacBatch.collectItemLinks(
+      "file:///collection.json",
+      collectionJson,
+      itemLinks,
+      needCountNextItems = true)
+
+    assert(itemLinks == Seq("file:///one.json"))
+  }
+
+  it("getItemLink should preserve existing queries and fragments") {
+    assert(
+      batch.getItemLink("https://example.test/items?token=x&limit=100#results", 2, None, None) ==
+        "https://example.test/items?token=x&limit=2#results")
+  }
+
+  it("planInputPartitions should use the smaller configured and SQL limits") {
+    val collectionJson =
+      """{"links":[{"rel":"item","href":"one.json"},{"rel":"item","href":"two.json"}]}"""
+    val stacBatch = StacBatch(
+      null,
+      "file:///collection.json",
+      collectionJson,
+      StructType(Seq()),
+      Map("itemsLimitMax" -> "1"),
+      None,
+      None,
+      Some(2))
+
+    val plannedItems = stacBatch
+      .planInputPartitions()
+      .flatMap(_.asInstanceOf[StacPartition].items)
+
+    assert(plannedItems.length == 1)
   }
 
   it("planInputPartitions should create correct number of partitions") {
@@ -153,5 +304,67 @@ class StacBatchTest extends TestBaseScala {
     assert(partitions(0).asInstanceOf[StacPartition].items.length == 2)
     assert(partitions(1).asInstanceOf[StacPartition].items.length == 2)
     assert(partitions(2).asInstanceOf[StacPartition].items.length == 1)
+  }
+
+  private val batch = StacBatch(
+    broadcastConf = null,
+    stacCollectionUrl = "",
+    stacCollectionJson = "",
+    schema = new StructType(),
+    opts = Map.empty,
+    spatialFilter = None,
+    temporalFilter = None,
+    limitFilter = None)
+
+  private def collectionIsFilteredOut(intervalsJson: String, filter: TemporalFilter): Boolean = {
+    val collectionJson = s"""{"extent":{"temporal":{"interval":$intervalsJson}}}"""
+    batch.filterCollection(collectionJson, None, Some(filter))
+  }
+
+  it("temporal pruning keeps a collection containing an equality inside its extent") {
+    val filter = TemporalFilter.OrFilter(
+      TemporalFilter.EqualFilter("datetime", LocalDateTime.parse("2025-03-06T00:00:00")),
+      TemporalFilter.GreaterThanFilter("datetime", LocalDateTime.parse("2025-03-10T00:00:00")))
+
+    assert(
+      !collectionIsFilteredOut("""[["2025-03-04T00:00:00Z","2025-03-08T00:00:00Z"]]""", filter))
+  }
+
+  it("temporal pruning checks interval overlap instead of only collection endpoints") {
+    val filter = TemporalFilter.AndFilter(
+      TemporalFilter.GreaterThanFilter("datetime", LocalDateTime.parse("2025-03-05T00:00:00")),
+      TemporalFilter.LessThanFilter("datetime", LocalDateTime.parse("2025-03-06T00:00:00")))
+
+    assert(
+      !collectionIsFilteredOut("""[["2025-03-01T00:00:00Z","2025-03-10T00:00:00Z"]]""", filter))
+    assert(
+      collectionIsFilteredOut("""[["2025-03-01T00:00:00Z","2025-03-04T00:00:00Z"]]""", filter))
+  }
+
+  it("temporal pruning retains collections with missing, open, or malformed extents") {
+    val filter =
+      TemporalFilter.EqualFilter("datetime", LocalDateTime.parse("2025-03-05T00:00:00"))
+
+    assert(!batch.filterCollection("{}", None, Some(filter)))
+    assert(!collectionIsFilteredOut("[[null,null]]", filter))
+    assert(!collectionIsFilteredOut("""[["not-a-timestamp",null]]""", filter))
+  }
+
+  it("temporal pruning accepts nanosecond collection extents in the final Spark microsecond") {
+    val filter =
+      TemporalFilter.LessThanFilter("datetime", LocalDateTime.parse("2020-05-31T23:59:59.999999"))
+
+    assert(
+      !collectionIsFilteredOut(
+        """[["2020-05-31T23:59:59.999999500Z","2020-05-31T23:59:59.999999999Z"]]""",
+        filter))
+  }
+
+  it("temporal pruning filters every collection for a proven-empty envelope") {
+    val filter = TemporalFilter.AndFilter(
+      TemporalFilter.GreaterThanFilter("datetime", LocalDateTime.parse("2025-03-07T00:00:00")),
+      TemporalFilter.LessThanFilter("datetime", LocalDateTime.parse("2025-03-06T00:00:00")))
+
+    assert(batch.filterCollection("{}", None, Some(filter)))
   }
 }

--- a/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacUtilsTest.scala
+++ b/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacUtilsTest.scala
@@ -685,14 +685,76 @@ class StacUtilsTest extends AnyFunSuite {
     assert(result == "datetime=2025-03-06T00:00:00.000000000Z/2025-03-07T00:00:00.000000999Z")
   }
 
-  test("getFilterTemporal with OrFilter") {
+  test("getFilterTemporal omits a fully unbounded OrFilter") {
     val dateTime1 = LocalDateTime.parse("2025-03-06T00:00:00")
     val dateTime2 = LocalDateTime.parse("2025-03-07T00:00:00")
     val filter1 = TemporalFilter.GreaterThanFilter("timestamp", dateTime1)
     val filter2 = TemporalFilter.LessThanFilter("timestamp", dateTime2)
     val orFilter = TemporalFilter.OrFilter(filter1, filter2)
-    val result = getFilterTemporal(orFilter)
-    assert(result == "datetime=2025-03-06T00:00:00.000000000Z/2025-03-07T00:00:00.000000999Z")
+    assert(getFilterTemporal(orFilter).isEmpty)
+    assert(getFilterTemporal(TemporalFilter.OrFilter(filter2, filter1)).isEmpty)
+  }
+
+  test("getFilterTemporal preserves an open side of an OrFilter") {
+    val equality =
+      TemporalFilter.EqualFilter("timestamp", LocalDateTime.parse("2025-03-05T00:00:00"))
+    val lowerBound =
+      TemporalFilter.GreaterThanFilter("timestamp", LocalDateTime.parse("2025-03-06T00:00:00"))
+    val upperBound =
+      TemporalFilter.LessThanFilter("timestamp", LocalDateTime.parse("2025-03-04T00:00:00"))
+
+    val openUpper = TemporalFilter.OrFilter(equality, lowerBound)
+    assert(
+      getFilterTemporal(openUpper) ==
+        "datetime=2025-03-05T00:00:00.000000000Z/..")
+    assert(
+      getFilterTemporal(TemporalFilter.OrFilter(lowerBound, equality)) ==
+        getFilterTemporal(openUpper))
+
+    val openLower = TemporalFilter.OrFilter(equality, upperBound)
+    assert(
+      getFilterTemporal(openLower) ==
+        "datetime=../2025-03-05T00:00:00.000000999Z")
+    assert(
+      getFilterTemporal(TemporalFilter.OrFilter(upperBound, equality)) ==
+        getFilterTemporal(openLower))
+  }
+
+  test("getFilterTemporal takes the convex hull of disjoint bounded OrFilter ranges") {
+    val firstRange = TemporalFilter.AndFilter(
+      TemporalFilter.GreaterThanFilter("timestamp", LocalDateTime.parse("2025-03-01T00:00:00")),
+      TemporalFilter.LessThanFilter("timestamp", LocalDateTime.parse("2025-03-02T00:00:00")))
+    val secondRange = TemporalFilter.AndFilter(
+      TemporalFilter.GreaterThanFilter("timestamp", LocalDateTime.parse("2025-03-04T00:00:00")),
+      TemporalFilter.LessThanFilter("timestamp", LocalDateTime.parse("2025-03-05T00:00:00")))
+
+    assert(
+      getFilterTemporal(TemporalFilter.OrFilter(firstRange, secondRange)) ==
+        "datetime=2025-03-01T00:00:00.000000000Z/2025-03-05T00:00:00.000000999Z")
+  }
+
+  test("getFilterTemporal intersects nested AndFilter ranges") {
+    val outerRange = TemporalFilter.AndFilter(
+      TemporalFilter.GreaterThanFilter("timestamp", LocalDateTime.parse("2025-03-01T00:00:00")),
+      TemporalFilter.LessThanFilter("timestamp", LocalDateTime.parse("2025-03-10T00:00:00")))
+    val innerRange = TemporalFilter.AndFilter(
+      TemporalFilter.GreaterThanFilter("timestamp", LocalDateTime.parse("2025-03-03T00:00:00")),
+      TemporalFilter.LessThanFilter("timestamp", LocalDateTime.parse("2025-03-07T00:00:00")))
+
+    assert(
+      getFilterTemporal(TemporalFilter.AndFilter(outerRange, innerRange)) ==
+        "datetime=2025-03-03T00:00:00.000000000Z/2025-03-07T00:00:00.000000999Z")
+  }
+
+  test("getFilterTemporal omits a contradictory AndFilter") {
+    val filter = TemporalFilter.AndFilter(
+      TemporalFilter.GreaterThanFilter("timestamp", LocalDateTime.parse("2025-03-07T00:00:00")),
+      TemporalFilter.LessThanFilter("timestamp", LocalDateTime.parse("2025-03-06T00:00:00")))
+
+    assert(getFilterTemporal(filter).isEmpty)
+    assert(
+      StacUtils.addFiltersToUrl("http://example.com/stac", None, Some(filter)) ==
+        "http://example.com/stac")
   }
 
   test("addFiltersToUrl with no filters") {

--- a/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/optimization/SpatialTemporalFilterPushDownForStacScanTest.scala
+++ b/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/optimization/SpatialTemporalFilterPushDownForStacScanTest.scala
@@ -19,7 +19,8 @@
 package org.apache.spark.sql.sedona_sql.optimization
 
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, GreaterThanOrEqual, LessThanOrEqual, Literal}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, GreaterThan, GreaterThanOrEqual, LessThan, LessThanOrEqual, Literal, Or}
+import org.apache.spark.sql.catalyst.plans.logical.{GlobalLimit, LocalLimit, LogicalPlan}
 import org.apache.spark.sql.execution.datasource.stac.TemporalFilter
 import org.apache.spark.sql.sedona_sql.io.stac.StacUtils.getFilterTemporal
 import org.apache.spark.sql.types.TimestampType
@@ -45,6 +46,9 @@ class SpatialTemporalFilterPushDownForStacScanTest extends AnyFunSuite {
   }
 
   private val datetime = AttributeReference("datetime", TimestampType)()
+
+  private def firstLeaf(plan: LogicalPlan): LogicalPlan =
+    plan.collectFirst { case node if node.children.isEmpty => node }.get
 
   // The push-down must not truncate the microsecond bound to milliseconds (it once divided by
   // 1000, pushing 23:59:59.999999Z as 23:59:59.999Z), and the serialized inclusive upper bound is
@@ -99,4 +103,67 @@ class SpatialTemporalFilterPushDownForStacScanTest extends AnyFunSuite {
         s"$ts must fall within the pushed remote bound $remoteEnd")
     }
   }
+
+  test("push-down omits a fully unbounded OR envelope") {
+    val lowerTail =
+      GreaterThan(datetime, Literal(toMicros("2025-03-06T00:00:00"), TimestampType))
+    val upperTail =
+      LessThan(datetime, Literal(toMicros("2025-03-07T00:00:00"), TimestampType))
+    val filters = pushDown.translateToTemporalFilters(Seq(Or(lowerTail, upperTail)))
+
+    assert(filters.size == 1)
+    assert(getFilterTemporal(filters.head).isEmpty)
+  }
+
+  test("push-down ignores timestamp columns not represented by the STAC datetime parameter") {
+    val created = AttributeReference("created", TimestampType)()
+    val predicate =
+      GreaterThanOrEqual(created, Literal(toMicros("2025-03-06T00:00:00"), TimestampType))
+
+    assert(pushDown.translateToTemporalFilters(Seq(predicate)).isEmpty)
+  }
+
+  test("limit push-down only accepts a limit directly above one scan") {
+    val directPlan = spark.range(10).limit(3).queryExecution.optimizedPlan
+    assert(pushDown.extractDirectLimit(directPlan, firstLeaf(directPlan)).contains(3))
+
+    val localOnlyPlan = LocalLimit(Literal(2), firstLeaf(directPlan))
+    assert(pushDown.extractDirectLimit(localOnlyPlan, firstLeaf(localOnlyPlan)).isEmpty)
+
+    val mismatchedLimitsPlan =
+      GlobalLimit(Literal(10), LocalLimit(Literal(2), firstLeaf(directPlan)))
+    assert(
+      pushDown
+        .extractDirectLimit(mismatchedLimitsPlan, firstLeaf(mismatchedLimitsPlan))
+        .isEmpty)
+
+    val filteredPlan = spark.range(10).filter("id > 5").limit(1).queryExecution.optimizedPlan
+    assert(pushDown.extractDirectLimit(filteredPlan, firstLeaf(filteredPlan)).isEmpty)
+
+    val sortedPlan = spark
+      .range(10)
+      .orderBy(org.apache.spark.sql.functions.desc("id"))
+      .limit(1)
+      .queryExecution
+      .optimizedPlan
+    assert(pushDown.extractDirectLimit(sortedPlan, firstLeaf(sortedPlan)).isEmpty)
+
+    val aggregatePlan = spark
+      .range(10)
+      .agg(org.apache.spark.sql.functions.count("*").as("count"))
+      .limit(1)
+      .queryExecution
+      .optimizedPlan
+    assert(pushDown.extractDirectLimit(aggregatePlan, firstLeaf(aggregatePlan)).isEmpty)
+
+    val left = spark.range(10).withColumnRenamed("id", "left_id")
+    val right = spark.range(10).withColumnRenamed("id", "right_id")
+    val joinPlan = left
+      .join(right, left("left_id") === right("right_id"))
+      .limit(1)
+      .queryExecution
+      .optimizedPlan
+    assert(pushDown.extractDirectLimit(joinPlan, firstLeaf(joinPlan)).isEmpty)
+  }
+
 }


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/).

## Is this PR related to a ticket?

- Yes, and the PR name follows the `[GH-XXX]` format. Closes #3126.

## What changes were proposed in this PR?

- Compute conservative temporal envelopes by intersecting `AND` predicates and taking the convex hull of `OR` predicates, while preserving unbounded endpoints and omitting unsafe or empty remote intervals.
- Prune collection extents by interval overlap at nanosecond precision and only translate the STAC `datetime` column to the remote temporal parameter.
- Restrict SQL limit pushdown to a limit directly above the target scan and combine it safely with the configured item cap.
- Make STAC pagination use the same filtered first-page URL for planning and reading, resolve relative links against the document that contains them, count actual returned features, and preserve server-provided `next` links unchanged.

The temporal false negatives came from using the same widening logic for `AND` and `OR`, which could erase an unbounded side of an `OR` predicate. The pagination path also scheduled a different first URL than it inspected and treated relative pagination links as catalog-root paths. Together, those behaviors could omit matching items or read the wrong pages before Spark applied its residual operators.

## How was this patch tested?

- `mvn -pl spark/common -Dspark=3.4 -Dscala=2.12 -Dgeotools -DwildcardSuites=org.apache.spark.sql.sedona_sql.io.stac.StacBatchTest,org.apache.spark.sql.sedona_sql.io.stac.StacUtilsTest,org.apache.spark.sql.sedona_sql.optimization.SpatialTemporalFilterPushDownForStacScanTest clean test`
- `mvn -pl spark/common -Dspark=3.4 -Dscala=2.13 -Dgeotools -DwildcardSuites=org.apache.spark.sql.sedona_sql.io.stac.StacBatchTest,org.apache.spark.sql.sedona_sql.io.stac.StacUtilsTest,org.apache.spark.sql.sedona_sql.optimization.SpatialTemporalFilterPushDownForStacScanTest clean test`

Both variants passed 240 Java tests and 59 targeted Scala tests.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API, so no documentation update is needed.
