### PR TITLE
[GH-3134] Implement distributed GeoPandas affine_transform

### DIFF
--- a/python/sedona/spark/geopandas/base.py
+++ b/python/sedona/spark/geopandas/base.py
@@ -1375,6 +1375,56 @@ class GeoFrame(metaclass=ABCMeta):
         """
         return _delegate_to_geometry_column("segmentize", self, max_segment_length)
 
+    def affine_transform(self, matrix):
+        """Return a ``GeoSeries`` with transformed geometries.
+
+        The coefficient matrix is provided as an ordered sequence with 6 or
+        12 items for 2D or 3D transformations, respectively.
+
+        For a 2D affine transformation, ``matrix`` is
+        ``[a, b, d, e, xoff, yoff]`` and the transformed coordinates are::
+
+            x' = a * x + b * y + xoff
+            y' = d * x + e * y + yoff
+
+        For a 3D affine transformation, ``matrix`` is
+        ``[a, b, c, d, e, f, g, h, i, xoff, yoff, zoff]`` and the transformed
+        coordinates are::
+
+            x' = a * x + b * y + c * z + xoff
+            y' = d * x + e * y + f * z + yoff
+            z' = g * x + h * y + i * z + zoff
+
+        Parameters
+        ----------
+        matrix : sequence of float
+            Six or twelve coefficients for a 2D or 3D affine transformation.
+
+        Returns
+        -------
+        GeoSeries
+            The transformed geometries.
+
+        Notes
+        -----
+        Results for mixed 2D/3D ``GeometryCollection`` objects, M or ZM
+        ordinates, and NaN Z coordinates may differ from GeoPandas because
+        Sedona uses JTS while GeoPandas uses Shapely. This method applies
+        Sedona's distributed semantics and does not materialize geometries
+        locally to emulate Shapely.
+
+        Examples
+        --------
+        >>> from shapely.geometry import Point, LineString
+        >>> from sedona.spark.geopandas import GeoSeries
+        >>> s = GeoSeries([Point(1, 1), LineString([(1, -1), (1, 0)])])
+        >>> s.affine_transform([0, 1, 1, 0, 0, 0])
+        0                   POINT (1 1)
+        1    LINESTRING (-1 1, 0 1)
+        dtype: geometry
+        """
+        return _delegate_to_geometry_column("affine_transform", self, matrix)
+
     # def transform(self, transformation, include_z=False):
     #     raise NotImplementedError("This method is not implemented yet.")
 

--- a/python/sedona/spark/geopandas/geoseries.py
+++ b/python/sedona/spark/geopandas/geoseries.py
@@ -1176,6 +1176,14 @@ class GeoSeries(GeoFrame, pspd.Series):
             raise TypeError("'matrix' must be a local ordered sequence")
 
         try:
+            matrix_length = len(matrix)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise TypeError("'matrix' must be a local ordered sequence") from exc
+
+        if matrix_length not in (6, 12):
+            raise ValueError("'matrix' expects either 6 or 12 coefficients")
+
+        try:
             matrix = tuple(matrix)
         except (TypeError, ValueError) as exc:
             raise TypeError("'matrix' must be a local ordered sequence") from exc

--- a/python/sedona/spark/geopandas/geoseries.py
+++ b/python/sedona/spark/geopandas/geoseries.py
@@ -1156,6 +1156,73 @@ class GeoSeries(GeoFrame, pspd.Series):
             returns_geom=True,
         )
 
+    def affine_transform(self, matrix) -> "GeoSeries":
+        invalid_matrix_types = (
+            str,
+            bytes,
+            bytearray,
+            dict,
+            set,
+            frozenset,
+            PandasOnSparkSeries,
+            PandasOnSparkDataFrame,
+            pspd.Index,
+        )
+        if (
+            isinstance(matrix, invalid_matrix_types)
+            or not hasattr(matrix, "__len__")
+            or not hasattr(matrix, "__iter__")
+        ):
+            raise TypeError("'matrix' must be a local ordered sequence")
+
+        try:
+            matrix = tuple(matrix)
+        except (TypeError, ValueError) as exc:
+            raise TypeError("'matrix' must be a local ordered sequence") from exc
+
+        if len(matrix) not in (6, 12):
+            raise ValueError("'matrix' expects either 6 or 12 coefficients")
+
+        coefficients = []
+        for coefficient in matrix:
+            if (
+                coefficient is None
+                or isinstance(coefficient, (str, bytes, bytearray))
+                or not np.isscalar(coefficient)
+            ):
+                raise TypeError("'matrix' must contain only numeric coefficients")
+            try:
+                coefficients.append(float(coefficient))
+            except (TypeError, ValueError, OverflowError) as exc:
+                raise TypeError(
+                    "'matrix' must contain only numeric coefficients"
+                ) from exc
+
+        if len(coefficients) == 6:
+            a, b, d, e, xoff, yoff = coefficients
+            spark_expr = stf.ST_Affine(self.spark.column, a, b, d, e, xoff, yoff)
+        else:
+            a, b, c, d, e, f, g, h, i, xoff, yoff, zoff = coefficients
+            # ST_Affine's Python wrapper lists the 2D coefficients first, so
+            # reorder the GeoPandas matrix before selecting its 3D overload.
+            spark_expr = stf.ST_Affine(
+                self.spark.column,
+                a,
+                b,
+                d,
+                e,
+                xoff,
+                yoff,
+                c,
+                f,
+                g,
+                h,
+                i,
+                zoff,
+            )
+
+        return self._query_geometry_column(spark_expr, returns_geom=True)
+
     def transform(self, transformation, include_z=False):
         # Implementation of the abstract method.
         raise NotImplementedError("This method is not implemented yet.")

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -1991,6 +1991,26 @@ e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3
     def test_affine_transform_validates_matrix(self):
         source = GeoSeries([Point(1, 2)])
 
+        class OversizedSequence:
+            def __len__(self):
+                return 10**9
+
+            def __iter__(self):
+                raise AssertionError("invalid-length matrices must not be iterated")
+
+        with pytest.raises(ValueError, match="either 6 or 12 coefficients"):
+            source.affine_transform(OversizedSequence())
+
+        class InconsistentSequence:
+            def __len__(self):
+                return 6
+
+            def __iter__(self):
+                return iter([1] * 7)
+
+        with pytest.raises(ValueError, match="either 6 or 12 coefficients"):
+            source.affine_transform(InconsistentSequence())
+
         for matrix in ([1] * 5, [1] * 7, [1] * 11, [1] * 13):
             with pytest.raises(ValueError):
                 source.affine_transform(matrix)

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -23,6 +23,7 @@ import geopandas as gpd
 import pyspark.pandas as ps
 import sedona.spark.geopandas as sgpd
 from sedona.spark.geopandas import GeoSeries, GeoDataFrame
+from sedona.spark.sql import st_functions as stf
 from tests.geopandas.test_geopandas_base import TestGeopandasBase
 from shapely import wkt
 from shapely.geometry import (
@@ -1886,6 +1887,125 @@ e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3
             ],
         )
         self.check_sgpd_equals_gpd(result, expected)
+
+    def test_affine_transform_preserves_metadata_and_delegates(self):
+        geoms = [
+            Point(1, 2),
+            LineString([(0, 0), (2, 1)]),
+            Polygon([(0, 0), (2, 0), (1, 1), (0, 0)]),
+            MultiPoint([(0, 0), (1, 2)]),
+            Polygon(),
+            None,
+        ]
+        index = pd.Index(
+            ["point", "line", "polygon", "multipoint", "empty", "null"],
+            name="feature_id",
+        )
+        matrix = [2, 1, -1, 3, 4, -5]
+        source = GeoSeries(geoms, index=index, crs="EPSG:3857")
+        expected = gpd.GeoSeries(geoms, index=index, crs="EPSG:3857").affine_transform(
+            matrix
+        )
+
+        result = source.affine_transform(matrix)
+
+        self.check_sgpd_equals_gpd(result, expected)
+        assert result.crs == source.crs == expected.crs
+        actual = result.to_geopandas()
+        assert actual.loc["empty"].is_empty
+        assert actual.loc["empty"].geom_type == "Polygon"
+        assert actual.loc["null"] is None
+
+        srids = result._internal.spark_frame.select(
+            stf.ST_SRID(result.spark.column).alias("srid")
+        ).collect()
+        assert {row.srid for row in srids if row.srid is not None} == {3857}
+
+        # GeoDataFrame inherits the base geometry-column delegation.
+        frame_result = source.to_geoframe().affine_transform(matrix)
+        assert isinstance(frame_result, GeoSeries)
+        self.check_sgpd_equals_gpd(frame_result, expected)
+        assert frame_result.crs == source.crs
+
+    def test_affine_transform_3d_coefficient_order(self):
+        source = GeoSeries([wkt.loads("POINT Z (1 2 3)")], crs="EPSG:4326")
+        result = source.affine_transform(range(1, 13))
+
+        point = result.to_geopandas().iloc[0]
+        assert tuple(point.coords[0]) == pytest.approx((24.0, 43.0, 62.0))
+        srid = result._internal.spark_frame.select(
+            stf.ST_SRID(result.spark.column).alias("srid")
+        ).first()
+        assert srid.srid == 4326
+        assert result.crs == source.crs
+
+    def test_affine_transform_dimension_handling(self):
+        z_geoms = [
+            Point(1, 2, 3),
+            LineString([(0, 0, 4), (2, 1, 5)]),
+            Polygon([(0, 0, 1), (2, 0, 2), (1, 1, 3), (0, 0, 1)]),
+        ]
+        matrix_2d = [2, 0, 0, 3, 4, -5]
+        result_2d_on_z = GeoSeries(z_geoms).affine_transform(matrix_2d)
+        expected_2d_on_z = gpd.GeoSeries(z_geoms).affine_transform(matrix_2d)
+        self.check_sgpd_equals_gpd(result_2d_on_z, expected_2d_on_z)
+
+        actual_2d_on_z = result_2d_on_z.to_geopandas()
+        assert all(geom.has_z for geom in actual_2d_on_z)
+        assert actual_2d_on_z.iloc[0].z == pytest.approx(3.0)
+        assert [coord[2] for coord in actual_2d_on_z.iloc[1].coords] == [4.0, 5.0]
+
+        xy_geoms = [
+            Point(1, 2),
+            LineString([(0, 0), (2, 1)]),
+            Polygon([(0, 0), (2, 0), (1, 1), (0, 0)]),
+        ]
+        matrix_3d = [
+            1.0,
+            0.5,
+            0.25,
+            -0.5,
+            2.0,
+            0.75,
+            0.1,
+            -0.2,
+            1.5,
+            3.0,
+            -4.0,
+            5.0,
+        ]
+        result_3d_on_2d = GeoSeries(xy_geoms).affine_transform(matrix_3d)
+        expected_3d_on_2d = gpd.GeoSeries(xy_geoms).affine_transform(matrix_3d)
+        self.check_sgpd_equals_gpd(result_3d_on_2d, expected_3d_on_2d)
+        assert not any(geom.has_z for geom in result_3d_on_2d.to_geopandas())
+
+        special_geoms = [Polygon(), None]
+        result_3d_special = GeoSeries(special_geoms).affine_transform(matrix_3d)
+        expected_3d_special = gpd.GeoSeries(special_geoms).affine_transform(matrix_3d)
+        self.check_sgpd_equals_gpd(result_3d_special, expected_3d_special)
+        actual_3d_special = result_3d_special.to_geopandas()
+        assert actual_3d_special.iloc[0].is_empty
+        assert actual_3d_special.iloc[0].geom_type == "Polygon"
+        assert actual_3d_special.iloc[1] is None
+
+    def test_affine_transform_validates_matrix(self):
+        source = GeoSeries([Point(1, 2)])
+
+        for matrix in ([1] * 5, [1] * 7, [1] * 11, [1] * 13):
+            with pytest.raises(ValueError):
+                source.affine_transform(matrix)
+
+        for coefficient in ("not-numeric", "1", None, np.array([1])):
+            matrix = [1, 0, 0, 1, 0, coefficient]
+            with pytest.raises(TypeError, match="only numeric coefficients"):
+                source.affine_transform(matrix)
+
+        for matrix in ("123456", 123456, {1, 2, 3, 4, 5, 6}):
+            with pytest.raises(TypeError, match="local ordered sequence"):
+                source.affine_transform(matrix)
+
+        with pytest.raises(TypeError, match="local ordered sequence"):
+            source.affine_transform(ps.Series([1, 0, 0, 1, 0, 0]))
 
     def test_transform(self):
         pass

--- a/python/tests/geopandas/test_match_geopandas_series.py
+++ b/python/tests/geopandas/test_match_geopandas_series.py
@@ -992,6 +992,60 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
         gpd_result = gpd.GeoSeries(geoms).segmentize(psser.to_pandas())
         self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
 
+    @pytest.mark.parametrize(
+        "matrix",
+        [
+            (1.0, 0.0, 0.0, 1.0, 0.0, 0.0),
+            (1, 0, 0, 1, 3, -2),
+            (2.0, 0.0, 0.0, 0.5, 0.0, 0.0),
+            (0.0, -1.0, 1.0, 0.0, 0.0, 0.0),
+            (1.0, 0.5, -0.25, 1.0, 0.0, 0.0),
+        ],
+        ids=["identity", "translation", "scale", "rotation", "shear"],
+    )
+    def test_affine_transform_2d(self, matrix):
+        geoms = [
+            self.points[2],
+            self.linestrings[2],
+            self.polygons[2],
+            self.multipoints[2],
+            self.multilinestrings[2],
+            self.multipolygons[1],
+            self.geomcollection[1],
+        ]
+
+        sgpd_result = GeoSeries(geoms).affine_transform(matrix)
+        gpd_result = gpd.GeoSeries(geoms).affine_transform(matrix)
+
+        self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
+
+    def test_affine_transform_3d(self):
+        geoms = [
+            Point(1, 2, 3),
+            LineString([(0, 0, 1), (2, 1, 4)]),
+            Polygon([(0, 0, 1), (2, 0, 2), (1, 1, 3), (0, 0, 1)]),
+            MultiPoint([(0, 0, 1), (1, 2, 3)]),
+        ]
+        matrix = [
+            1.0,
+            0.5,
+            0.25,
+            -0.5,
+            2.0,
+            0.75,
+            0.1,
+            -0.2,
+            1.5,
+            3.0,
+            -4.0,
+            5.0,
+        ]
+
+        sgpd_result = GeoSeries(geoms).affine_transform(matrix)
+        gpd_result = gpd.GeoSeries(geoms).affine_transform(matrix)
+
+        self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
+
     def test_transform(self):
         pass
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/).

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`.
- Closes #3134.
- Part of #2230.

## What changes were proposed in this PR?

- Add `GeoSeries.affine_transform(matrix)` and GeoDataFrame geometry-column delegation.
- Execute 2D and 3D affine transforms as distributed `ST_Affine` Spark expressions without driver collection or Python row UDFs.
- Validate that matrices contain exactly 6 or 12 numeric coefficients, reject distributed/per-row inputs, and normalize valid coefficients to Python floats.
- Map GeoPandas' 12-value coefficient order explicitly to Sedona's Python wrapper order.
- Preserve index, CRS, SRID, nulls, typed empty geometries, and Z coordinates for 2D transforms.
- Document JTS/Shapely differences for mixed-dimensional collections, M/ZM ordinates, and NaN Z values.
- Add direct and GeoPandas parity coverage for 2D/3D transformations, geometry families, metadata, delegation, validation, and the coefficient-order regression.

## How was this patch tested?

- `python -m pytest -p no:cacheprovider -q tests/geopandas/test_geoseries.py tests/geopandas/test_match_geopandas_series.py -k affine_transform` — 10 passed.
- Repository formatting, lint, security, and license hooks passed for all four changed files.

## Did this PR include necessary documentation updates?

- Yes. The new public API includes its coefficient layouts, equations, example, and engine-compatibility notes in the API docstring.
