### PR TITLE
[GH-3137] Bump jt-jiffle from 1.1.24 to 1.1.31

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -186,12 +186,27 @@
                                     <include>org.codehaus.janino:*</include>
                                 </includes>
                             </artifactSet>
+                            <transformers>
+                                <!-- Rewrite META-INF/services descriptors (e.g. the Janino
+                                     org.codehaus.commons.compiler.ICompilerFactory provider) to the
+                                     relocated class names so the shaded compiler is discoverable via
+                                     SPI. Without this, CompilerFactoryFactory.getDefaultCompilerFactory()
+                                     throws ServiceConfigurationError against the shaded artifact. -->
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                            </transformers>
                             <relocations>
                                 <relocation>
                                     <pattern>it.geosolutions.jaiext.jiffle</pattern>
                                     <shadedPattern>org.apache.sedona.shaded.jiffle</shadedPattern>
                                     <excludes>
                                         <exclude>it.geosolutions.jaiext.jiffle.runtime.*</exclude>
+                                        <!-- Keep the maxIterations JVM system-property key at its
+                                             upstream name so it matches the documented value on the
+                                             shaded artifact. Shade otherwise rewrites this string
+                                             literal (it has no trailing package segment excluded by
+                                             the pattern above) to the shaded prefix, silently
+                                             disabling the documented property. -->
+                                        <exclude>it.geosolutions.jaiext.jiffle.maxIterations</exclude>
                                     </excludes>
                                 </relocation>
                                 <relocation>

--- a/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/MapAlgebraTest.java
@@ -600,6 +600,29 @@ public class MapAlgebraTest extends RasterTestBase {
     }
   }
 
+  @Test
+  public void testMapAlgebraAtan2() throws FactoryException {
+    // atan2 was added to Jiffle in jt-jiffle 1.1.28; this guards the
+    // dependency from regressing below that version.
+    int width = 10;
+    int height = 10;
+    GridCoverage2D raster = RasterConstructors.makeEmptyRaster(2, "d", width, height, 10, 20, 1);
+    double[] band1 = new double[width * height];
+    double[] band2 = new double[width * height];
+    for (int i = 0; i < band1.length; i++) {
+      band1[i] = i + 1;
+      band2[i] = 2 * (i + 1);
+    }
+    raster = MapAlgebra.addBandFromArray(raster, band1, 1);
+    raster = MapAlgebra.addBandFromArray(raster, band2, 2);
+    GridCoverage2D result =
+        MapAlgebra.mapAlgebra(raster, "d", "out = atan2(rast[0], rast[1]);", null);
+    double[] bandResult = MapAlgebra.bandAsArray(result, 1);
+    for (int i = 0; i < band1.length; i++) {
+      Assert.assertEquals(Math.atan2(band1[i], band2[i]), bandResult[i], 1e-9);
+    }
+  }
+
   private void testMapAlgebra(int width, int height, String pixelType, Double noDataValue)
       throws FactoryException {
     GridCoverage2D raster = RasterConstructors.makeEmptyRaster(2, "b", width, height, 10, 20, 1);

--- a/docs/api/sql/Raster-map-algebra.md
+++ b/docs/api/sql/Raster-map-algebra.md
@@ -72,6 +72,9 @@ execution. We'll demonstrate both approaches to implementing commonly used map a
 
     This allows controlling the output pixel data type. Users should consider potential precision impacts when coercing to a smaller type.
 
+!!!Note
+    Jiffle limits scripts to 200 loop iterations per pixel by default, so a runaway `while` loop fails fast instead of hanging the executor. If a script legitimately needs more iterations per pixel, raise (or disable) the limit with the JVM system property `it.geosolutions.jaiext.jiffle.maxIterations` (a negative value disables the limit), e.g. `--conf "spark.executor.extraJavaOptions=-Dit.geosolutions.jaiext.jiffle.maxIterations=10000"`.
+
 ### NDVI
 
 The Normalized Difference Vegetation Index (NDVI) is a simple graphical indicator that can be used to analyze remote sensing measurements, typically, but not necessarily, from a space platform, and assess whether the target being observed contains live green vegetation or not. NDVI has become a de facto standard index used to determine whether a given area contains live green vegetation or not. The NDVI is calculated from these individual measurements as follows:

--- a/pom.xml
+++ b/pom.xml
@@ -76,8 +76,8 @@
         <jts2geojson.version>0.16.1</jts2geojson.version>
         <spatial4j.version>0.8</spatial4j.version>
 
-        <jt-jiffle.version>1.1.24</jt-jiffle.version>
-        <janino-version>3.1.9</janino-version>
+        <jt-jiffle.version>1.1.31</jt-jiffle.version>
+        <janino-version>3.1.12</janino-version>
 
         <!-- Actual scala, spark and log4j version will be set by activated profiles.
              Setting a default value helps IDE:s that can't make sense of profiles. -->


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes

## Is this PR related to a ticket?

- Yes, closes #3137.

## What changes were proposed in this PR?

Bump `jt-jiffle.version` 1.1.24 → 1.1.31 and `janino-version` 3.1.9 → 3.1.12 (the version jt-jiffle 1.1.31 is built against; janino is already shaded so Spark is unaffected). Add a `MapAlgebraTest` case for `atan2` (added to Jiffle in 1.1.28 — the test guards against regressing below that) and document the new loop-iteration cap in the map algebra docs.

## How was this patch tested?

- `mvn -pl common test -Dtest=MapAlgebraTest` — 27/27 pass (JDK 17), including the new `atan2` test which fails on 1.1.24.
- `mvn -pl common package` — verified the shaded jar still relocates antlr/janino/jiffle correctly, with `it.geosolutions.jaiext.jiffle.runtime.*` left unshaded per the existing shade rules (antlr stays 4.7.1 upstream, so relocations are unchanged).

## Why bump?

1. **Executor protection:** on 1.1.24 a Jiffle script with a runaway loop hangs the Spark executor forever — jt-jiffle 1.1.24 generates unguarded loops. 1.1.31 adds a per-pixel iteration guard (default 200), so such scripts throw instead. Configurable via `it.geosolutions.jaiext.jiffle.maxIterations` (negative disables); now documented in Raster-map-algebra.md.
2. **`atan2`** and other math functions added in 1.1.28.
3. NoData support in JiffleOp (1.1.29) and assorted fixes.

## Compatibility note

User scripts with legitimately heavy per-pixel loops (>200 iterations) will now fail with a clear error unless the system property is raised — suggest a release-note entry.