### PR TITLE
[GH-3150] Preserve GeoParquet CRS metadata

### DIFF
--- a/spark/common/src/main/scala/org/apache/spark/sql/execution/datasources/geoparquet/GeoParquetMetaData.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/execution/datasources/geoparquet/GeoParquetMetaData.scala
@@ -26,7 +26,7 @@ import org.datasyslab.proj4sedona.core.Proj
 import org.datasyslab.proj4sedona.parser.CRSSerializer
 import org.json4s.jackson.JsonMethods.parse
 import org.json4s.jackson.compactJson
-import org.json4s.{DefaultFormats, Extraction, JField, JNothing, JNull, JObject, JValue}
+import org.json4s.{DefaultFormats, Extraction, JField, JInt, JNothing, JNull, JObject, JString, JValue}
 
 /**
  * A case class that holds the metadata of geometry column in GeoParquet metadata
@@ -124,7 +124,7 @@ object GeoParquetMetaData {
           columnObject \ "crs" match {
             case JNothing => name -> fieldMetadata.copy(crs = None)
             case JNull => name -> fieldMetadata.copy(crs = Some(JNull))
-            case _ => name -> fieldMetadata
+            case crs => name -> fieldMetadata.copy(crs = Some(crs))
           }
         }
       metadata.copy(columns = columns)
@@ -184,24 +184,31 @@ object GeoParquetMetaData {
         // CRS explicitly null: unknown CRS
         0
       case Some(projjson) =>
-        // Use proj4sedona to extract authority and code from PROJJSON
-        try {
-          val jsonStr = compactJson(projjson)
-          val result = new Proj(jsonStr).toAuthority()
-          if (result != null && result.length == 2) {
-            result(0) match {
-              case "EPSG" =>
-                try { result(1).toInt }
-                catch { case _: NumberFormatException => 0 }
-              case "OGC" if result(1) == "CRS84" => DEFAULT_SRID
-              case _ => 0
-            }
-          } else {
-            0
-          }
-        } catch {
-          case NonFatal(_) => 0
+        // GeoParquet uses the declared top-level PROJJSON identifier as the SRID.
+        // Reading the identifier directly also supports CRS objects that omit the
+        // optional definition fields that a projection engine would need.
+        val authority = projjson \ "id" \ "authority"
+        val code = projjson \ "id" \ "code"
+        authority match {
+          case JString(value) if value.equalsIgnoreCase("EPSG") => positiveInt(code)
+          case JString(value) if value.equalsIgnoreCase("OGC") && code == JString("CRS84") =>
+            DEFAULT_SRID
+          case _ => 0
         }
+    }
+  }
+
+  private def positiveInt(value: JValue): Int = {
+    value match {
+      case JInt(code) if code.isValidInt && code > 0 => code.toInt
+      case JString(code) =>
+        try {
+          val parsed = code.trim.toInt
+          if (parsed > 0) parsed else 0
+        } catch {
+          case _: NumberFormatException => 0
+        }
+      case _ => 0
     }
   }
 

--- a/spark/common/src/main/scala/org/apache/spark/sql/execution/datasources/geoparquet/GeoParquetMetaData.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/execution/datasources/geoparquet/GeoParquetMetaData.scala
@@ -26,7 +26,7 @@ import org.datasyslab.proj4sedona.core.Proj
 import org.datasyslab.proj4sedona.parser.CRSSerializer
 import org.json4s.jackson.JsonMethods.parse
 import org.json4s.jackson.compactJson
-import org.json4s.{DefaultFormats, Extraction, JField, JInt, JNothing, JNull, JObject, JString, JValue}
+import org.json4s.{DefaultFormats, Extraction, JArray, JField, JInt, JNothing, JNull, JObject, JString, JValue}
 
 /**
  * A case class that holds the metadata of geometry column in GeoParquet metadata
@@ -136,10 +136,13 @@ object GeoParquetMetaData {
     val geoObject = Extraction.decompose(geoParquetMetadata)
 
     // Make sure that the keys of columns are not transformed to camel case, so we use the columns map with
-    // original keys to replace the transformed columns map.
+    // original keys to replace the transformed columns map. Preserve the raw CRS value separately because
+    // PROJJSON keys are independent of the GeoParquet metadata case classes.
     val columnsMap =
       (geoObject \ "columns").extract[Map[String, JValue]].map { case (name, columnObject) =>
-        name -> columnObject.underscoreKeys
+        val serializedColumn = columnObject.underscoreKeys
+        val rawCrs = geoParquetMetadata.columns(name).crs
+        name -> preserveRawCrs(serializedColumn, rawCrs)
       }
 
     // We are not using transformField here for binary compatibility with various json4s versions shipped with
@@ -154,6 +157,16 @@ object GeoParquetMetaData {
     compactJson(serializedGeoObject)
   }
 
+  private def preserveRawCrs(columnObject: JValue, rawCrs: Option[JValue]): JValue = {
+    (columnObject, rawCrs) match {
+      case (JObject(fields), Some(crs)) =>
+        JObject(fields.map { field =>
+          if (field._1 == "crs") JField("crs", crs) else field
+        })
+      case _ => columnObject
+    }
+  }
+
   /**
    * Default SRID for GeoParquet files where the CRS field is omitted. Per the GeoParquet spec,
    * omitting the CRS implies OGC:CRS84, which is equivalent to EPSG:4326.
@@ -166,8 +179,8 @@ object GeoParquetMetaData {
    * Per the GeoParquet specification:
    *   - If the CRS field is absent (None), the CRS is OGC:CRS84 (EPSG:4326).
    *   - If the CRS field is explicitly null, the CRS is unknown (SRID 0).
-   *   - If the CRS field is a PROJJSON object with an "id" containing "authority" and "code", the
-   *     EPSG code is used as the SRID.
+   *   - If the CRS field is a PROJJSON object with an "id" or "ids" containing "authority" and
+   *     "code", the first recognized identifier is used as the SRID.
    *
    * @param crs
    *   The CRS field from GeoParquet column metadata.
@@ -184,17 +197,32 @@ object GeoParquetMetaData {
         // CRS explicitly null: unknown CRS
         0
       case Some(projjson) =>
-        // GeoParquet uses the declared top-level PROJJSON identifier as the SRID.
+        // GeoParquet uses a declared top-level PROJJSON identifier as the SRID.
         // Reading the identifier directly also supports CRS objects that omit the
         // optional definition fields that a projection engine would need.
-        val authority = projjson \ "id" \ "authority"
-        val code = projjson \ "id" \ "code"
-        authority match {
-          case JString(value) if value.equalsIgnoreCase("EPSG") => positiveInt(code)
-          case JString(value) if value.equalsIgnoreCase("OGC") && code == JString("CRS84") =>
-            DEFAULT_SRID
+        val idSrid = identifierSrid(projjson \ "id")
+        if (idSrid != 0) {
+          idSrid
+        } else {
+          projjson \ "ids" match {
+            case JArray(ids) => ids.iterator.map(identifierSrid).find(_ != 0).getOrElse(0)
+            case _ => 0
+          }
+        }
+    }
+  }
+
+  private def identifierSrid(identifier: JValue): Int = {
+    val authority = identifier \ "authority"
+    val code = identifier \ "code"
+    authority match {
+      case JString(value) if value.equalsIgnoreCase("EPSG") => positiveInt(code)
+      case JString(value) if value.equalsIgnoreCase("OGC") =>
+        code match {
+          case JString(codeValue) if codeValue.equalsIgnoreCase("CRS84") => DEFAULT_SRID
           case _ => 0
         }
+      case _ => 0
     }
   }
 

--- a/spark/common/src/test/scala/org/apache/sedona/sql/geoparquetIOTests.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/geoparquetIOTests.scala
@@ -1440,7 +1440,7 @@ class geoparquetIOTests extends TestBaseScala with BeforeAndAfterAll {
   }
 
   describe("GeoParquetMetaData serialization") {
-    it("should preserve PROJJSON keys when metadata is parsed") {
+    it("should preserve PROJJSON keys when metadata is serialized and parsed") {
       val crs = parseJson(
         """{"type":"ProjectedCRS","name":"WGS 84 / UTM zone 32N",""" +
           """"base_crs":{"datum":{"ellipsoid":{"semi_major_axis":6378137,""" +
@@ -1448,6 +1448,7 @@ class geoparquetIOTests extends TestBaseScala with BeforeAndAfterAll {
           """"conversion":{"parameters":[{"name":"Longitude of natural origin","value":9,""" +
           """"unit":{"conversion_factor":0.017453292519943295}}]},""" +
           """"coordinate_system":{"subtype":"Cartesian"},""" +
+          """"vendorExtension":{"nestedProperty":"preserveMe"},""" +
           """"id":{"authority":"EPSG","code":32632}}""")
       val metadata = GeoParquetMetaData(
         Some(GeoParquetMetaData.VERSION),
@@ -1459,9 +1460,11 @@ class geoparquetIOTests extends TestBaseScala with BeforeAndAfterAll {
             bbox = None,
             crs = Some(crs))))
 
+      val serialized = GeoParquetMetaData.toJson(metadata)
+      assert((parseJson(serialized) \ "columns" \ "geometry" \ "crs") == crs)
+
       val parsed = GeoParquetMetaData
-        .parseKeyValueMetaData(
-          Collections.singletonMap("geo", GeoParquetMetaData.toJson(metadata)))
+        .parseKeyValueMetaData(Collections.singletonMap("geo", serialized))
         .get
 
       assert(parsed.columns("geometry").crs.contains(crs))
@@ -1503,10 +1506,17 @@ class geoparquetIOTests extends TestBaseScala with BeforeAndAfterAll {
       }
     }
 
-    it("should return 4326 for OGC:CRS84") {
+    it("should return 4326 for OGC:CRS84 regardless of case") {
       val projjson =
-        parseJson("""{"type":"GeographicCRS","id":{"authority":"OGC","code":"CRS84"}}""")
+        parseJson("""{"type":"GeographicCRS","id":{"authority":"ogc","code":"crs84"}}""")
       assert(GeoParquetMetaData.extractSridFromCrs(Some(projjson)) == 4326)
+    }
+
+    it("should extract the first recognized identifier from a PROJJSON ids array") {
+      val projjson = parseJson(
+        """{"type":"ProjectedCRS","ids":[{"authority":"IAU","code":49900},""" +
+          """{"authority":"epsg","code":"32632"}]}""")
+      assert(GeoParquetMetaData.extractSridFromCrs(Some(projjson)) == 32632)
     }
 
     it("should return 0 for CRS without id field") {

--- a/spark/common/src/test/scala/org/apache/sedona/sql/geoparquetIOTests.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/geoparquetIOTests.scala
@@ -27,7 +27,7 @@ import org.apache.spark.SparkException
 import org.apache.spark.scheduler.{SparkListener, SparkListenerTaskEnd}
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.SaveMode
-import org.apache.spark.sql.execution.datasources.geoparquet.{Covering, GeoParquetMetaData}
+import org.apache.spark.sql.execution.datasources.geoparquet.{Covering, GeoParquetMetaData, GeometryFieldMetaData}
 import org.apache.spark.sql.execution.datasources.geoparquet.internal.ParquetReadSupport
 import org.apache.spark.sql.functions.{col, expr}
 import org.apache.spark.sql.sedona_sql.UDT.GeometryUDT
@@ -1439,6 +1439,35 @@ class geoparquetIOTests extends TestBaseScala with BeforeAndAfterAll {
     }
   }
 
+  describe("GeoParquetMetaData serialization") {
+    it("should preserve PROJJSON keys when metadata is parsed") {
+      val crs = parseJson(
+        """{"type":"ProjectedCRS","name":"WGS 84 / UTM zone 32N",""" +
+          """"base_crs":{"datum":{"ellipsoid":{"semi_major_axis":6378137,""" +
+          """"inverse_flattening":298.257223563}}},""" +
+          """"conversion":{"parameters":[{"name":"Longitude of natural origin","value":9,""" +
+          """"unit":{"conversion_factor":0.017453292519943295}}]},""" +
+          """"coordinate_system":{"subtype":"Cartesian"},""" +
+          """"id":{"authority":"EPSG","code":32632}}""")
+      val metadata = GeoParquetMetaData(
+        Some(GeoParquetMetaData.VERSION),
+        "geometry",
+        Map(
+          "geometry" -> GeometryFieldMetaData(
+            encoding = "WKB",
+            geometryTypes = Seq("Point"),
+            bbox = None,
+            crs = Some(crs))))
+
+      val parsed = GeoParquetMetaData
+        .parseKeyValueMetaData(
+          Collections.singletonMap("geo", GeoParquetMetaData.toJson(metadata)))
+        .get
+
+      assert(parsed.columns("geometry").crs.contains(crs))
+    }
+  }
+
   describe("GeoParquetMetaData.extractSridFromCrs") {
     it("should return 4326 when CRS is omitted (None)") {
       assert(GeoParquetMetaData.extractSridFromCrs(None) == 4326)
@@ -1454,24 +1483,24 @@ class geoparquetIOTests extends TestBaseScala with BeforeAndAfterAll {
       assert(GeoParquetMetaData.extractSridFromCrs(Some(projjson)) == 4326)
     }
 
-    it("should extract non-4326 EPSG code") {
-      // Use a complete ProjectedCRS PROJJSON so proj4sedona can parse it
-      val projjson = parseJson(
-        """{"type":"ProjectedCRS","name":"WGS 84 / UTM zone 32N",""" +
-          """"base_crs":{"name":"WGS 84","datum":{"type":"GeodeticReferenceFrame",""" +
-          """"name":"World Geodetic System 1984",""" +
-          """"ellipsoid":{"name":"WGS 84","semi_major_axis":6378137,"inverse_flattening":298.257223563}}},""" +
-          """"conversion":{"name":"UTM zone 32N","method":{"name":"Transverse Mercator"},""" +
-          """"parameters":[{"name":"Latitude of natural origin","value":0},""" +
-          """{"name":"Longitude of natural origin","value":9},""" +
-          """{"name":"Scale factor at natural origin","value":0.9996},""" +
-          """{"name":"False easting","value":500000},""" +
-          """{"name":"False northing","value":0}]},""" +
-          """"coordinate_system":{"subtype":"Cartesian","axis":[""" +
-          """{"name":"Easting","direction":"east","unit":"metre"},""" +
-          """{"name":"Northing","direction":"north","unit":"metre"}]},""" +
-          """"id":{"authority":"EPSG","code":32632}}""")
+    it("should extract a declared EPSG code without requiring a complete CRS definition") {
+      val projjson =
+        parseJson("""{"type":"ProjectedCRS","id":{"authority":"EPSG","code":32632}}""")
       assert(GeoParquetMetaData.extractSridFromCrs(Some(projjson)) == 32632)
+    }
+
+    it("should accept a positive EPSG code represented as a string") {
+      val projjson =
+        parseJson("""{"type":"ProjectedCRS","id":{"authority":"epsg","code":"32632"}}""")
+      assert(GeoParquetMetaData.extractSridFromCrs(Some(projjson)) == 32632)
+    }
+
+    it("should return 0 for an invalid EPSG code") {
+      Seq("0", "-1", "not-a-code").foreach { code =>
+        val projjson =
+          parseJson(s"""{"type":"ProjectedCRS","id":{"authority":"EPSG","code":"$code"}}""")
+        assert(GeoParquetMetaData.extractSridFromCrs(Some(projjson)) == 0)
+      }
     }
 
     it("should return 4326 for OGC:CRS84") {


### PR DESCRIPTION
## Did you read the Contributor Guide?

- [x] Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)
- [ ] No, I haven't read it.

## Is this PR related to a ticket?

- [ ] Yes, and the PR name follows the format `[SEDONA-XXX] my subject`.
- [x] Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #3150
- [ ] No:
  - this is a documentation update. The PR name follows the format `[DOCS] my subject`
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

Preserve GeoParquet CRS metadata exactly as it appears in the nested PROJJSON object when parsing or serializing the `geo` metadata. The outer GeoParquet structure still uses the case conversion required by its case classes, but the raw `crs` subtree is restored afterward so standard keys and user-provided extensions are not changed in either direction.

Extract a geometry SRID directly from declared top-level PROJJSON identifiers instead of constructing a projection solely to call `toAuthority()`. Both the singular `id` and plural `ids` forms are supported. Positive numeric and numeric-string EPSG codes are accepted, `OGC:CRS84` maps to SRID 4326 case-insensitively, and invalid or unsupported identifiers map to SRID 0.

The root cause was recursive key conversion combined with requiring a complete executable CRS definition for identifier extraction. This could make GeoParquet files with non-default CRS metadata fail to round trip with the current proj4sedona parser, expose mutated CRS JSON through metadata queries, or lose their SRID.

This also improves the read path. `extractSridFromCrs` runs from `GeoParquetSchemaConverter` for each geometry column in each file footer; direct JSON field reads avoid repeatedly parsing PROJJSON, resolving registries and datums, and constructing full projection objects during multi-file scans.

The fix is user-visible through the `geoparquet.metadata` data source in all four Spark shims. They share `parseKeyValueMetaData`, so rendered `columnMetadata.crs` values now retain the original PROJJSON keys instead of exposing camelized JSON.

When PROJJSON contains neither a recognized top-level `id` nor a recognized entry in `ids`, this change deliberately returns SRID 0 rather than attempting parameter-based authority inference through proj4sedona. Sedona-written GeoParquet includes an identifier, while preserving the raw CRS object still lets callers inspect identifier-free third-party metadata.

Regression tests cover exact PROJJSON preservation on write and read, incomplete ID-bearing CRS objects, plural identifiers, case-insensitive OGC identifiers, numeric-string EPSG codes, and invalid codes.

## How was this patch tested?

- `geoparquetIOTests` with the released proj4sedona 0.1.2 dependency: 52 tests passed.
- `geoparquetIOTests` with the current proj4sedona main branch installed as a local snapshot: 52 tests passed.
- `CRSTransformProj4Test`, `geoparquetIOTests`, and `netcdfMetadataTest` together with that snapshot: 157 tests passed.
- The repository pre-commit hooks passed.

## Did this PR include necessary documentation updates?

- [ ] Yes, I am adding a new API. I am using the [current SNAPSHOT version number](https://github.com/apache/sedona/blob/99239524f17389fc4ae9548ea88756f8ea538bb9/pom.xml#L29) in `vX.Y.Z` format.
- [ ] Yes, I have updated the documentation.
- [x] No, this PR does not affect any public API so no need to change the documentation.
