### PR TITLE
[GH-3161] Fix RT90 transform accuracy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <scala-collection-compat.version>2.5.0</scala-collection-compat.version>
         <geoglib.version>1.52</geoglib.version>
         <caffeine.version>2.9.2</caffeine.version>
-        <proj4sedona.version>0.1.2</proj4sedona.version>
+        <proj4sedona.version>0.1.3</proj4sedona.version>
 
         <geotools.scope>provided</geotools.scope>
         <!-- Because it's not in Maven central, make it provided by default -->

--- a/spark/common/src/test/scala/org/apache/sedona/sql/CRSTransformProj4Test.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/CRSTransformProj4Test.scala
@@ -83,6 +83,20 @@ class CRSTransformProj4Test extends TestBaseScala {
       assertEquals(4180998.88, result.getCoordinate.y, COORD_TOLERANCE)
     }
 
+    it("should apply the RT90 datum shift for EPSG:3021 to EPSG:3006 (GH-3161)") {
+      val result = sparkSession
+        .sql("SELECT ST_Transform(ST_Point(1272691.622, 6404578.16), 'epsg:3021', 'epsg:3006')")
+        .first()
+        .getAs[Geometry](0)
+
+      assertNotNull(result)
+      assertEquals(3006, result.getSRID)
+      // PostGIS reference reported in GH-3161. proj4sedona uses the proj4js
+      // RT90 Helmert parameters, so sub-metre differences from PROJ are expected.
+      assertEquals(320728.44351324334, result.getCoordinate.x, COORD_TOLERANCE)
+      assertEquals(6400228.104394391, result.getCoordinate.y, COORD_TOLERANCE)
+    }
+
     it("should transform using PROJ string") {
       val projString =
         "+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +no_defs"


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/).

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #3161.

## What changes were proposed in this PR?

Upgrade proj4sedona from 0.1.2 to 0.1.3 and add a regression test for transforming RT90 (`EPSG:3021`) to SWEREF99 TM (`EPSG:3006`).

Sedona 1.9 switched CRS transformation to proj4sedona, but version 0.1.2 lacked the generated RT90 datum definition. The transform therefore omitted the required datum shift and produced an error exceeding 180 metres. Version 0.1.3 includes the complete upstream datum registry and restores the RT90 Helmert transformation.

## How was this patch tested?

- `mvn spotless:apply -Dscala=2.12 -Dspark=3.4 -B`
- `mvn -Dspark=3.4 -Dscala=2.12 -pl spark/common -am -DskipTests install -B`
- `mvn -Dspark=3.4 -Dscala=2.12 -pl spark/common -Dtest=__NoJavaTests__ -Dsurefire.failIfNoSpecifiedTests=false -Dsuites=org.apache.sedona.sql.CRSTransformProj4Test test -B`
- `CRSTransformProj4Test`: 37/37 tests passed, including the GH-3161 regression.
- The proj4sedona 0.1.3 JAR used by the test was verified byte-for-byte with a fresh Maven Central download (SHA-256 `2df4a9477ba4609d0b4dc34196b9fd1e44bc85b609e9ac6a726b559aad85d487`).

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API, so no documentation update is required.
