### PR TITLE
[GH-3171][GH-3172] Fix empty polygon orientation and GeoSeries skew flags

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/Functions.java
+++ b/common/src/main/java/org/apache/sedona/common/Functions.java
@@ -1614,7 +1614,8 @@ public class Functions {
   /**
    * This function accepts Polygon and MultiPolygon, if any other type is provided then it will
    * return false. If the exterior ring is clockwise and the interior ring(s) are counter-clockwise
-   * then returns true, otherwise false.
+   * then returns true, otherwise false. Empty Polygon and MultiPolygon inputs return true because
+   * they contain no rings with the opposite orientation.
    *
    * @param geom Polygon or MultiPolygon
    * @return
@@ -1623,11 +1624,12 @@ public class Functions {
     if (geom instanceof MultiPolygon) {
       MultiPolygon multiPolygon = (MultiPolygon) geom;
 
-      boolean arePolygonsCW = checkIfPolygonCW((Polygon) multiPolygon.getGeometryN(0));
-      for (int i = 1; i < multiPolygon.getNumGeometries(); i++) {
-        arePolygonsCW = arePolygonsCW && checkIfPolygonCW((Polygon) multiPolygon.getGeometryN(i));
+      for (int i = 0; i < multiPolygon.getNumGeometries(); i++) {
+        if (!checkIfPolygonCW((Polygon) multiPolygon.getGeometryN(i))) {
+          return false;
+        }
       }
-      return arePolygonsCW;
+      return true;
     } else if (geom instanceof Polygon) {
       return checkIfPolygonCW((Polygon) geom);
     }
@@ -1636,6 +1638,10 @@ public class Functions {
   }
 
   private static boolean checkIfPolygonCW(Polygon geom) {
+    if (geom.isEmpty()) {
+      return true;
+    }
+
     LinearRing exteriorRing = geom.getExteriorRing();
     boolean isExteriorRingCW = !Orientation.isCCW(exteriorRing.getCoordinateSequence());
 
@@ -1765,7 +1771,8 @@ public class Functions {
   /**
    * This function accepts Polygon and MultiPolygon, if any other type is provided then it will
    * return false. If the exterior ring is counter-clockwise and the interior ring(s) are clockwise
-   * then returns true, otherwise false.
+   * then returns true, otherwise false. Empty Polygon and MultiPolygon inputs return true because
+   * they contain no rings with the opposite orientation.
    *
    * @param geom Polygon or MultiPolygon
    * @return
@@ -1774,12 +1781,12 @@ public class Functions {
     if (geom instanceof MultiPolygon) {
       MultiPolygon multiPolygon = (MultiPolygon) geom;
 
-      boolean arePolygonsCCW = checkIfPolygonCCW(((Polygon) multiPolygon.getGeometryN(0)));
-      for (int i = 1; i < multiPolygon.getNumGeometries(); i++) {
-        arePolygonsCCW =
-            arePolygonsCCW && checkIfPolygonCCW((Polygon) multiPolygon.getGeometryN(i));
+      for (int i = 0; i < multiPolygon.getNumGeometries(); i++) {
+        if (!checkIfPolygonCCW((Polygon) multiPolygon.getGeometryN(i))) {
+          return false;
+        }
       }
-      return arePolygonsCCW;
+      return true;
     } else if (geom instanceof Polygon) {
       return checkIfPolygonCCW((Polygon) geom);
     }
@@ -1788,6 +1795,10 @@ public class Functions {
   }
 
   private static boolean checkIfPolygonCCW(Polygon geom) {
+    if (geom.isEmpty()) {
+      return true;
+    }
+
     LinearRing exteriorRing = geom.getExteriorRing();
     boolean isExteriorRingCCW = Orientation.isCCW(exteriorRing.getCoordinateSequence());
 

--- a/common/src/main/java/org/apache/sedona/common/Functions.java
+++ b/common/src/main/java/org/apache/sedona/common/Functions.java
@@ -1612,29 +1612,15 @@ public class Functions {
   }
 
   /**
-   * This function accepts Polygon and MultiPolygon, if any other type is provided then it will
-   * return false. If the exterior ring is clockwise and the interior ring(s) are counter-clockwise
-   * then returns true, otherwise false. Empty Polygon and MultiPolygon inputs return true because
-   * they contain no rings with the opposite orientation.
+   * Returns true if every polygonal component has a clockwise exterior ring and counter-clockwise
+   * interior rings. GeometryCollections are traversed recursively and non-polygonal components are
+   * ignored. Geometries without polygonal components return true.
    *
-   * @param geom Polygon or MultiPolygon
-   * @return
+   * @param geom Geometry to inspect
+   * @return Whether all polygonal components use clockwise orientation
    */
   public static boolean isPolygonCW(Geometry geom) {
-    if (geom instanceof MultiPolygon) {
-      MultiPolygon multiPolygon = (MultiPolygon) geom;
-
-      for (int i = 0; i < multiPolygon.getNumGeometries(); i++) {
-        if (!checkIfPolygonCW((Polygon) multiPolygon.getGeometryN(i))) {
-          return false;
-        }
-      }
-      return true;
-    } else if (geom instanceof Polygon) {
-      return checkIfPolygonCW((Polygon) geom);
-    }
-    // False for remaining geometry types
-    return false;
+    return arePolygonComponentsOriented(geom, true);
   }
 
   private static boolean checkIfPolygonCW(Polygon geom) {
@@ -1769,29 +1755,15 @@ public class Functions {
   }
 
   /**
-   * This function accepts Polygon and MultiPolygon, if any other type is provided then it will
-   * return false. If the exterior ring is counter-clockwise and the interior ring(s) are clockwise
-   * then returns true, otherwise false. Empty Polygon and MultiPolygon inputs return true because
-   * they contain no rings with the opposite orientation.
+   * Returns true if every polygonal component has a counter-clockwise exterior ring and clockwise
+   * interior rings. GeometryCollections are traversed recursively and non-polygonal components are
+   * ignored. Geometries without polygonal components return true.
    *
-   * @param geom Polygon or MultiPolygon
-   * @return
+   * @param geom Geometry to inspect
+   * @return Whether all polygonal components use counter-clockwise orientation
    */
   public static boolean isPolygonCCW(Geometry geom) {
-    if (geom instanceof MultiPolygon) {
-      MultiPolygon multiPolygon = (MultiPolygon) geom;
-
-      for (int i = 0; i < multiPolygon.getNumGeometries(); i++) {
-        if (!checkIfPolygonCCW((Polygon) multiPolygon.getGeometryN(i))) {
-          return false;
-        }
-      }
-      return true;
-    } else if (geom instanceof Polygon) {
-      return checkIfPolygonCCW((Polygon) geom);
-    }
-    // False for remaining geometry types
-    return false;
+    return arePolygonComponentsOriented(geom, false);
   }
 
   private static boolean checkIfPolygonCCW(Polygon geom) {
@@ -1814,6 +1786,24 @@ public class Functions {
     }
 
     return isExteriorRingCCW && isInteriorRingCCW;
+  }
+
+  private static boolean arePolygonComponentsOriented(Geometry geom, boolean clockwise) {
+    if (geom == null) {
+      return false;
+    }
+    if (geom instanceof Polygon) {
+      return clockwise ? checkIfPolygonCW((Polygon) geom) : checkIfPolygonCCW((Polygon) geom);
+    }
+    if (geom instanceof GeometryCollection) {
+      GeometryCollection collection = (GeometryCollection) geom;
+      for (int i = 0; i < collection.getNumGeometries(); i++) {
+        if (!arePolygonComponentsOriented(collection.getGeometryN(i), clockwise)) {
+          return false;
+        }
+      }
+    }
+    return true;
   }
 
   public static Geometry addMeasure(Geometry geom, double measure_start, double measure_end) {

--- a/common/src/main/java/org/apache/sedona/common/Functions.java
+++ b/common/src/main/java/org/apache/sedona/common/Functions.java
@@ -1612,15 +1612,29 @@ public class Functions {
   }
 
   /**
-   * Returns true if every polygonal component has a clockwise exterior ring and counter-clockwise
-   * interior rings. GeometryCollections are traversed recursively and non-polygonal components are
-   * ignored. Geometries without polygonal components return true.
+   * This function accepts Polygon and MultiPolygon, if any other type is provided then it will
+   * return false. If the exterior ring is clockwise and the interior ring(s) are counter-clockwise
+   * then returns true, otherwise false. Empty Polygon and MultiPolygon inputs return true because
+   * they contain no rings with the opposite orientation.
    *
-   * @param geom Geometry to inspect
-   * @return Whether all polygonal components use clockwise orientation
+   * @param geom Polygon or MultiPolygon
+   * @return
    */
   public static boolean isPolygonCW(Geometry geom) {
-    return arePolygonComponentsOriented(geom, true);
+    if (geom instanceof MultiPolygon) {
+      MultiPolygon multiPolygon = (MultiPolygon) geom;
+
+      for (int i = 0; i < multiPolygon.getNumGeometries(); i++) {
+        if (!checkIfPolygonCW((Polygon) multiPolygon.getGeometryN(i))) {
+          return false;
+        }
+      }
+      return true;
+    } else if (geom instanceof Polygon) {
+      return checkIfPolygonCW((Polygon) geom);
+    }
+    // False for remaining geometry types
+    return false;
   }
 
   private static boolean checkIfPolygonCW(Polygon geom) {
@@ -1755,15 +1769,29 @@ public class Functions {
   }
 
   /**
-   * Returns true if every polygonal component has a counter-clockwise exterior ring and clockwise
-   * interior rings. GeometryCollections are traversed recursively and non-polygonal components are
-   * ignored. Geometries without polygonal components return true.
+   * This function accepts Polygon and MultiPolygon, if any other type is provided then it will
+   * return false. If the exterior ring is counter-clockwise and the interior ring(s) are clockwise
+   * then returns true, otherwise false. Empty Polygon and MultiPolygon inputs return true because
+   * they contain no rings with the opposite orientation.
    *
-   * @param geom Geometry to inspect
-   * @return Whether all polygonal components use counter-clockwise orientation
+   * @param geom Polygon or MultiPolygon
+   * @return
    */
   public static boolean isPolygonCCW(Geometry geom) {
-    return arePolygonComponentsOriented(geom, false);
+    if (geom instanceof MultiPolygon) {
+      MultiPolygon multiPolygon = (MultiPolygon) geom;
+
+      for (int i = 0; i < multiPolygon.getNumGeometries(); i++) {
+        if (!checkIfPolygonCCW((Polygon) multiPolygon.getGeometryN(i))) {
+          return false;
+        }
+      }
+      return true;
+    } else if (geom instanceof Polygon) {
+      return checkIfPolygonCCW((Polygon) geom);
+    }
+    // False for remaining geometry types
+    return false;
   }
 
   private static boolean checkIfPolygonCCW(Polygon geom) {
@@ -1786,24 +1814,6 @@ public class Functions {
     }
 
     return isExteriorRingCCW && isInteriorRingCCW;
-  }
-
-  private static boolean arePolygonComponentsOriented(Geometry geom, boolean clockwise) {
-    if (geom == null) {
-      return false;
-    }
-    if (geom instanceof Polygon) {
-      return clockwise ? checkIfPolygonCW((Polygon) geom) : checkIfPolygonCCW((Polygon) geom);
-    }
-    if (geom instanceof GeometryCollection) {
-      GeometryCollection collection = (GeometryCollection) geom;
-      for (int i = 0; i < collection.getNumGeometries(); i++) {
-        if (!arePolygonComponentsOriented(collection.getGeometryN(i), clockwise)) {
-          return false;
-        }
-      }
-    }
-    return true;
   }
 
   public static Geometry addMeasure(Geometry geom, double measure_start, double measure_end) {

--- a/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
@@ -1927,10 +1927,10 @@ public class FunctionsTest extends TestBase {
     assertTrue(Functions.isPolygonCW(mPoly));
 
     Geometry point = Constructors.geomFromWKT("POINT (45 20)", 0);
-    assertTrue(Functions.isPolygonCW(point));
+    assertFalse(Functions.isPolygonCW(point));
 
     Geometry lineClosed = Constructors.geomFromWKT("LINESTRING (30 20, 20 25, 20 15, 30 20)", 0);
-    assertTrue(Functions.isPolygonCW(lineClosed));
+    assertFalse(Functions.isPolygonCW(lineClosed));
   }
 
   @Test
@@ -1955,24 +1955,21 @@ public class FunctionsTest extends TestBase {
     assertTrue(Functions.isPolygonCCW(mPoly));
 
     Geometry point = Constructors.geomFromWKT("POINT (45 20)", 0);
-    assertTrue(Functions.isPolygonCCW(point));
+    assertFalse(Functions.isPolygonCCW(point));
 
     Geometry lineClosed = Constructors.geomFromWKT("LINESTRING (30 20, 20 25, 20 15, 30 20)", 0);
-    assertTrue(Functions.isPolygonCCW(lineClosed));
+    assertFalse(Functions.isPolygonCCW(lineClosed));
   }
 
   @Test
-  public void testIsPolygonOrientationChecksOnlyPolygonalComponents() throws ParseException {
+  public void testIsPolygonOrientationHandlesEmptyPolygons() throws ParseException {
     Polygon emptyPolygon = GEOMETRY_FACTORY.createPolygon();
     MultiPolygon emptyMultiPolygon = GEOMETRY_FACTORY.createMultiPolygon(new Polygon[0]);
-    GeometryCollection emptyCollection = GEOMETRY_FACTORY.createGeometryCollection();
 
     assertTrue(Functions.isPolygonCW(emptyPolygon));
     assertTrue(Functions.isPolygonCCW(emptyPolygon));
     assertTrue(Functions.isPolygonCW(emptyMultiPolygon));
     assertTrue(Functions.isPolygonCCW(emptyMultiPolygon));
-    assertTrue(Functions.isPolygonCW(emptyCollection));
-    assertTrue(Functions.isPolygonCCW(emptyCollection));
 
     Polygon clockwisePolygon =
         (Polygon) Constructors.geomFromWKT("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))", 0);
@@ -1986,45 +1983,6 @@ public class FunctionsTest extends TestBase {
 
     assertTrue(Functions.isPolygonCW(clockwiseWithEmpty));
     assertTrue(Functions.isPolygonCCW(counterClockwiseWithEmpty));
-
-    Geometry noPolygonalComponents =
-        Constructors.geomFromWKT(
-            "GEOMETRYCOLLECTION (POINT (0 0), LINESTRING (0 0, 1 1), "
-                + "GEOMETRYCOLLECTION (MULTIPOINT ((0 0), (1 1)), "
-                + "MULTILINESTRING ((0 0, 1 1))))",
-            0);
-    assertTrue(Functions.isPolygonCW(noPolygonalComponents));
-    assertTrue(Functions.isPolygonCCW(noPolygonalComponents));
-
-    Geometry nestedClockwise =
-        GEOMETRY_FACTORY.createGeometryCollection(
-            new Geometry[] {
-              GEOMETRY_FACTORY.createPoint(new Coordinate(2, 2)),
-              GEOMETRY_FACTORY.createGeometryCollection(
-                  new Geometry[] {emptyPolygon, clockwisePolygon})
-            });
-    assertTrue(Functions.isPolygonCW(nestedClockwise));
-    assertFalse(Functions.isPolygonCCW(nestedClockwise));
-
-    Geometry nestedCounterClockwise =
-        GEOMETRY_FACTORY.createGeometryCollection(
-            new Geometry[] {
-              GEOMETRY_FACTORY.createLineString(
-                  new Coordinate[] {new Coordinate(0, 0), new Coordinate(1, 1)}),
-              GEOMETRY_FACTORY.createGeometryCollection(
-                  new Geometry[] {emptyMultiPolygon, counterClockwisePolygon})
-            });
-    assertFalse(Functions.isPolygonCW(nestedCounterClockwise));
-    assertTrue(Functions.isPolygonCCW(nestedCounterClockwise));
-
-    Geometry mixedOrientations =
-        GEOMETRY_FACTORY.createGeometryCollection(
-            new Geometry[] {clockwisePolygon, nestedCounterClockwise});
-    assertFalse(Functions.isPolygonCW(mixedOrientations));
-    assertFalse(Functions.isPolygonCCW(mixedOrientations));
-
-    assertFalse(Functions.isPolygonCW(null));
-    assertFalse(Functions.isPolygonCCW(null));
   }
 
   @Test

--- a/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
@@ -1927,10 +1927,10 @@ public class FunctionsTest extends TestBase {
     assertTrue(Functions.isPolygonCW(mPoly));
 
     Geometry point = Constructors.geomFromWKT("POINT (45 20)", 0);
-    assertFalse(Functions.isPolygonCW(point));
+    assertTrue(Functions.isPolygonCW(point));
 
     Geometry lineClosed = Constructors.geomFromWKT("LINESTRING (30 20, 20 25, 20 15, 30 20)", 0);
-    assertFalse(Functions.isPolygonCW(lineClosed));
+    assertTrue(Functions.isPolygonCW(lineClosed));
   }
 
   @Test
@@ -1955,21 +1955,24 @@ public class FunctionsTest extends TestBase {
     assertTrue(Functions.isPolygonCCW(mPoly));
 
     Geometry point = Constructors.geomFromWKT("POINT (45 20)", 0);
-    assertFalse(Functions.isPolygonCCW(point));
+    assertTrue(Functions.isPolygonCCW(point));
 
     Geometry lineClosed = Constructors.geomFromWKT("LINESTRING (30 20, 20 25, 20 15, 30 20)", 0);
-    assertFalse(Functions.isPolygonCCW(lineClosed));
+    assertTrue(Functions.isPolygonCCW(lineClosed));
   }
 
   @Test
-  public void testIsPolygonOrientationHandlesEmptyPolygons() throws ParseException {
+  public void testIsPolygonOrientationChecksOnlyPolygonalComponents() throws ParseException {
     Polygon emptyPolygon = GEOMETRY_FACTORY.createPolygon();
     MultiPolygon emptyMultiPolygon = GEOMETRY_FACTORY.createMultiPolygon(new Polygon[0]);
+    GeometryCollection emptyCollection = GEOMETRY_FACTORY.createGeometryCollection();
 
     assertTrue(Functions.isPolygonCW(emptyPolygon));
     assertTrue(Functions.isPolygonCCW(emptyPolygon));
     assertTrue(Functions.isPolygonCW(emptyMultiPolygon));
     assertTrue(Functions.isPolygonCCW(emptyMultiPolygon));
+    assertTrue(Functions.isPolygonCW(emptyCollection));
+    assertTrue(Functions.isPolygonCCW(emptyCollection));
 
     Polygon clockwisePolygon =
         (Polygon) Constructors.geomFromWKT("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))", 0);
@@ -1983,6 +1986,45 @@ public class FunctionsTest extends TestBase {
 
     assertTrue(Functions.isPolygonCW(clockwiseWithEmpty));
     assertTrue(Functions.isPolygonCCW(counterClockwiseWithEmpty));
+
+    Geometry noPolygonalComponents =
+        Constructors.geomFromWKT(
+            "GEOMETRYCOLLECTION (POINT (0 0), LINESTRING (0 0, 1 1), "
+                + "GEOMETRYCOLLECTION (MULTIPOINT ((0 0), (1 1)), "
+                + "MULTILINESTRING ((0 0, 1 1))))",
+            0);
+    assertTrue(Functions.isPolygonCW(noPolygonalComponents));
+    assertTrue(Functions.isPolygonCCW(noPolygonalComponents));
+
+    Geometry nestedClockwise =
+        GEOMETRY_FACTORY.createGeometryCollection(
+            new Geometry[] {
+              GEOMETRY_FACTORY.createPoint(new Coordinate(2, 2)),
+              GEOMETRY_FACTORY.createGeometryCollection(
+                  new Geometry[] {emptyPolygon, clockwisePolygon})
+            });
+    assertTrue(Functions.isPolygonCW(nestedClockwise));
+    assertFalse(Functions.isPolygonCCW(nestedClockwise));
+
+    Geometry nestedCounterClockwise =
+        GEOMETRY_FACTORY.createGeometryCollection(
+            new Geometry[] {
+              GEOMETRY_FACTORY.createLineString(
+                  new Coordinate[] {new Coordinate(0, 0), new Coordinate(1, 1)}),
+              GEOMETRY_FACTORY.createGeometryCollection(
+                  new Geometry[] {emptyMultiPolygon, counterClockwisePolygon})
+            });
+    assertFalse(Functions.isPolygonCW(nestedCounterClockwise));
+    assertTrue(Functions.isPolygonCCW(nestedCounterClockwise));
+
+    Geometry mixedOrientations =
+        GEOMETRY_FACTORY.createGeometryCollection(
+            new Geometry[] {clockwisePolygon, nestedCounterClockwise});
+    assertFalse(Functions.isPolygonCW(mixedOrientations));
+    assertFalse(Functions.isPolygonCCW(mixedOrientations));
+
+    assertFalse(Functions.isPolygonCW(null));
+    assertFalse(Functions.isPolygonCCW(null));
   }
 
   @Test

--- a/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
@@ -1962,6 +1962,30 @@ public class FunctionsTest extends TestBase {
   }
 
   @Test
+  public void testIsPolygonOrientationHandlesEmptyPolygons() throws ParseException {
+    Polygon emptyPolygon = GEOMETRY_FACTORY.createPolygon();
+    MultiPolygon emptyMultiPolygon = GEOMETRY_FACTORY.createMultiPolygon(new Polygon[0]);
+
+    assertTrue(Functions.isPolygonCW(emptyPolygon));
+    assertTrue(Functions.isPolygonCCW(emptyPolygon));
+    assertTrue(Functions.isPolygonCW(emptyMultiPolygon));
+    assertTrue(Functions.isPolygonCCW(emptyMultiPolygon));
+
+    Polygon clockwisePolygon =
+        (Polygon) Constructors.geomFromWKT("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))", 0);
+    Polygon counterClockwisePolygon =
+        (Polygon) Constructors.geomFromWKT("POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))", 0);
+
+    MultiPolygon clockwiseWithEmpty =
+        GEOMETRY_FACTORY.createMultiPolygon(new Polygon[] {emptyPolygon, clockwisePolygon});
+    MultiPolygon counterClockwiseWithEmpty =
+        GEOMETRY_FACTORY.createMultiPolygon(new Polygon[] {emptyPolygon, counterClockwisePolygon});
+
+    assertTrue(Functions.isPolygonCW(clockwiseWithEmpty));
+    assertTrue(Functions.isPolygonCCW(counterClockwiseWithEmpty));
+  }
+
+  @Test
   public void testTriangulatePolygon() throws ParseException {
     Geometry geom =
         Constructors.geomFromWKT(

--- a/docs/api/flink/Geometry-Accessors/ST_IsPolygonCCW.md
+++ b/docs/api/flink/Geometry-Accessors/ST_IsPolygonCCW.md
@@ -21,6 +21,8 @@
 
 Introduction: Returns true if all polygonal components in the input geometry have their exterior rings oriented counter-clockwise and interior rings oriented clockwise.
 
+`POLYGON EMPTY` and `MULTIPOLYGON EMPTY` return `true` because they contain no rings with the opposite orientation.
+
 ![ST_IsPolygonCCW](../../../image/ST_IsPolygonCCW/ST_IsPolygonCCW.svg "ST_IsPolygonCCW")
 
 Format: `ST_IsPolygonCCW(geom: Geometry)`

--- a/docs/api/flink/Geometry-Accessors/ST_IsPolygonCCW.md
+++ b/docs/api/flink/Geometry-Accessors/ST_IsPolygonCCW.md
@@ -21,7 +21,7 @@
 
 Introduction: Returns true if all polygonal components in the input geometry have their exterior rings oriented counter-clockwise and interior rings oriented clockwise.
 
-Non-polygonal components are ignored, and geometry collections are evaluated recursively. Inputs with no polygonal components, including empty geometries and closed line strings, return `true`.
+`POLYGON EMPTY` and `MULTIPOLYGON EMPTY` return `true` because they contain no rings with the opposite orientation.
 
 ![ST_IsPolygonCCW](../../../image/ST_IsPolygonCCW/ST_IsPolygonCCW.svg "ST_IsPolygonCCW")
 

--- a/docs/api/flink/Geometry-Accessors/ST_IsPolygonCCW.md
+++ b/docs/api/flink/Geometry-Accessors/ST_IsPolygonCCW.md
@@ -21,7 +21,7 @@
 
 Introduction: Returns true if all polygonal components in the input geometry have their exterior rings oriented counter-clockwise and interior rings oriented clockwise.
 
-`POLYGON EMPTY` and `MULTIPOLYGON EMPTY` return `true` because they contain no rings with the opposite orientation.
+Non-polygonal components are ignored, and geometry collections are evaluated recursively. Inputs with no polygonal components, including empty geometries and closed line strings, return `true`.
 
 ![ST_IsPolygonCCW](../../../image/ST_IsPolygonCCW/ST_IsPolygonCCW.svg "ST_IsPolygonCCW")
 

--- a/docs/api/flink/Geometry-Accessors/ST_IsPolygonCW.md
+++ b/docs/api/flink/Geometry-Accessors/ST_IsPolygonCW.md
@@ -21,6 +21,8 @@
 
 Introduction: Returns true if all polygonal components in the input geometry have their exterior rings oriented clockwise and interior rings oriented counter-clockwise.
 
+`POLYGON EMPTY` and `MULTIPOLYGON EMPTY` return `true` because they contain no rings with the opposite orientation.
+
 ![ST_IsPolygonCW](../../../image/ST_IsPolygonCW/ST_IsPolygonCW.svg "ST_IsPolygonCW")
 
 Format: `ST_IsPolygonCW(geom: Geometry)`

--- a/docs/api/flink/Geometry-Accessors/ST_IsPolygonCW.md
+++ b/docs/api/flink/Geometry-Accessors/ST_IsPolygonCW.md
@@ -21,7 +21,7 @@
 
 Introduction: Returns true if all polygonal components in the input geometry have their exterior rings oriented clockwise and interior rings oriented counter-clockwise.
 
-Non-polygonal components are ignored, and geometry collections are evaluated recursively. Inputs with no polygonal components, including empty geometries and closed line strings, return `true`.
+`POLYGON EMPTY` and `MULTIPOLYGON EMPTY` return `true` because they contain no rings with the opposite orientation.
 
 ![ST_IsPolygonCW](../../../image/ST_IsPolygonCW/ST_IsPolygonCW.svg "ST_IsPolygonCW")
 

--- a/docs/api/flink/Geometry-Accessors/ST_IsPolygonCW.md
+++ b/docs/api/flink/Geometry-Accessors/ST_IsPolygonCW.md
@@ -21,7 +21,7 @@
 
 Introduction: Returns true if all polygonal components in the input geometry have their exterior rings oriented clockwise and interior rings oriented counter-clockwise.
 
-`POLYGON EMPTY` and `MULTIPOLYGON EMPTY` return `true` because they contain no rings with the opposite orientation.
+Non-polygonal components are ignored, and geometry collections are evaluated recursively. Inputs with no polygonal components, including empty geometries and closed line strings, return `true`.
 
 ![ST_IsPolygonCW](../../../image/ST_IsPolygonCW/ST_IsPolygonCW.svg "ST_IsPolygonCW")
 

--- a/docs/api/snowflake/vector-data/Geometry-Accessors/ST_IsPolygonCCW.md
+++ b/docs/api/snowflake/vector-data/Geometry-Accessors/ST_IsPolygonCCW.md
@@ -21,6 +21,8 @@
 
 Introduction: Returns true if all polygonal components in the input geometry have their exterior rings oriented counter-clockwise and interior rings oriented clockwise.
 
+`POLYGON EMPTY` and `MULTIPOLYGON EMPTY` return `true` because they contain no rings with the opposite orientation.
+
 ![ST_IsPolygonCCW](../../../../image/ST_IsPolygonCCW/ST_IsPolygonCCW.svg "ST_IsPolygonCCW")
 
 Format: `ST_IsPolygonCCW(geom: Geometry)`

--- a/docs/api/snowflake/vector-data/Geometry-Accessors/ST_IsPolygonCCW.md
+++ b/docs/api/snowflake/vector-data/Geometry-Accessors/ST_IsPolygonCCW.md
@@ -21,7 +21,7 @@
 
 Introduction: Returns true if all polygonal components in the input geometry have their exterior rings oriented counter-clockwise and interior rings oriented clockwise.
 
-Non-polygonal components are ignored, and geometry collections are evaluated recursively. Inputs with no polygonal components, including empty geometries and closed line strings, return `true`.
+`POLYGON EMPTY` and `MULTIPOLYGON EMPTY` return `true` because they contain no rings with the opposite orientation.
 
 ![ST_IsPolygonCCW](../../../../image/ST_IsPolygonCCW/ST_IsPolygonCCW.svg "ST_IsPolygonCCW")
 

--- a/docs/api/snowflake/vector-data/Geometry-Accessors/ST_IsPolygonCCW.md
+++ b/docs/api/snowflake/vector-data/Geometry-Accessors/ST_IsPolygonCCW.md
@@ -21,7 +21,7 @@
 
 Introduction: Returns true if all polygonal components in the input geometry have their exterior rings oriented counter-clockwise and interior rings oriented clockwise.
 
-`POLYGON EMPTY` and `MULTIPOLYGON EMPTY` return `true` because they contain no rings with the opposite orientation.
+Non-polygonal components are ignored, and geometry collections are evaluated recursively. Inputs with no polygonal components, including empty geometries and closed line strings, return `true`.
 
 ![ST_IsPolygonCCW](../../../../image/ST_IsPolygonCCW/ST_IsPolygonCCW.svg "ST_IsPolygonCCW")
 

--- a/docs/api/snowflake/vector-data/Geometry-Accessors/ST_IsPolygonCW.md
+++ b/docs/api/snowflake/vector-data/Geometry-Accessors/ST_IsPolygonCW.md
@@ -21,6 +21,8 @@
 
 Introduction: Returns true if all polygonal components in the input geometry have their exterior rings oriented clockwise and interior rings oriented counter-clockwise.
 
+`POLYGON EMPTY` and `MULTIPOLYGON EMPTY` return `true` because they contain no rings with the opposite orientation.
+
 ![ST_IsPolygonCW](../../../../image/ST_IsPolygonCW/ST_IsPolygonCW.svg "ST_IsPolygonCW")
 
 Format: `ST_IsPolygonCW(geom: Geometry)`

--- a/docs/api/snowflake/vector-data/Geometry-Accessors/ST_IsPolygonCW.md
+++ b/docs/api/snowflake/vector-data/Geometry-Accessors/ST_IsPolygonCW.md
@@ -21,7 +21,7 @@
 
 Introduction: Returns true if all polygonal components in the input geometry have their exterior rings oriented clockwise and interior rings oriented counter-clockwise.
 
-Non-polygonal components are ignored, and geometry collections are evaluated recursively. Inputs with no polygonal components, including empty geometries and closed line strings, return `true`.
+`POLYGON EMPTY` and `MULTIPOLYGON EMPTY` return `true` because they contain no rings with the opposite orientation.
 
 ![ST_IsPolygonCW](../../../../image/ST_IsPolygonCW/ST_IsPolygonCW.svg "ST_IsPolygonCW")
 

--- a/docs/api/snowflake/vector-data/Geometry-Accessors/ST_IsPolygonCW.md
+++ b/docs/api/snowflake/vector-data/Geometry-Accessors/ST_IsPolygonCW.md
@@ -21,7 +21,7 @@
 
 Introduction: Returns true if all polygonal components in the input geometry have their exterior rings oriented clockwise and interior rings oriented counter-clockwise.
 
-`POLYGON EMPTY` and `MULTIPOLYGON EMPTY` return `true` because they contain no rings with the opposite orientation.
+Non-polygonal components are ignored, and geometry collections are evaluated recursively. Inputs with no polygonal components, including empty geometries and closed line strings, return `true`.
 
 ![ST_IsPolygonCW](../../../../image/ST_IsPolygonCW/ST_IsPolygonCW.svg "ST_IsPolygonCW")
 

--- a/docs/api/sql/Geometry-Accessors/ST_IsPolygonCCW.md
+++ b/docs/api/sql/Geometry-Accessors/ST_IsPolygonCCW.md
@@ -21,6 +21,8 @@
 
 Introduction: Returns true if all polygonal components in the input geometry have their exterior rings oriented counter-clockwise and interior rings oriented clockwise.
 
+`POLYGON EMPTY` and `MULTIPOLYGON EMPTY` return `true` because they contain no rings with the opposite orientation.
+
 ![ST_IsPolygonCCW](../../../image/ST_IsPolygonCCW/ST_IsPolygonCCW.svg "ST_IsPolygonCCW")
 
 Format: `ST_IsPolygonCCW(geom: Geometry)`

--- a/docs/api/sql/Geometry-Accessors/ST_IsPolygonCCW.md
+++ b/docs/api/sql/Geometry-Accessors/ST_IsPolygonCCW.md
@@ -21,7 +21,7 @@
 
 Introduction: Returns true if all polygonal components in the input geometry have their exterior rings oriented counter-clockwise and interior rings oriented clockwise.
 
-Non-polygonal components are ignored, and geometry collections are evaluated recursively. Inputs with no polygonal components, including empty geometries and closed line strings, return `true`.
+`POLYGON EMPTY` and `MULTIPOLYGON EMPTY` return `true` because they contain no rings with the opposite orientation.
 
 ![ST_IsPolygonCCW](../../../image/ST_IsPolygonCCW/ST_IsPolygonCCW.svg "ST_IsPolygonCCW")
 

--- a/docs/api/sql/Geometry-Accessors/ST_IsPolygonCCW.md
+++ b/docs/api/sql/Geometry-Accessors/ST_IsPolygonCCW.md
@@ -21,7 +21,7 @@
 
 Introduction: Returns true if all polygonal components in the input geometry have their exterior rings oriented counter-clockwise and interior rings oriented clockwise.
 
-`POLYGON EMPTY` and `MULTIPOLYGON EMPTY` return `true` because they contain no rings with the opposite orientation.
+Non-polygonal components are ignored, and geometry collections are evaluated recursively. Inputs with no polygonal components, including empty geometries and closed line strings, return `true`.
 
 ![ST_IsPolygonCCW](../../../image/ST_IsPolygonCCW/ST_IsPolygonCCW.svg "ST_IsPolygonCCW")
 

--- a/docs/api/sql/Geometry-Accessors/ST_IsPolygonCW.md
+++ b/docs/api/sql/Geometry-Accessors/ST_IsPolygonCW.md
@@ -21,6 +21,8 @@
 
 Introduction: Returns true if all polygonal components in the input geometry have their exterior rings oriented clockwise and interior rings oriented counter-clockwise.
 
+`POLYGON EMPTY` and `MULTIPOLYGON EMPTY` return `true` because they contain no rings with the opposite orientation.
+
 ![ST_IsPolygonCW](../../../image/ST_IsPolygonCW/ST_IsPolygonCW.svg "ST_IsPolygonCW")
 
 Format: `ST_IsPolygonCW(geom: Geometry)`

--- a/docs/api/sql/Geometry-Accessors/ST_IsPolygonCW.md
+++ b/docs/api/sql/Geometry-Accessors/ST_IsPolygonCW.md
@@ -21,7 +21,7 @@
 
 Introduction: Returns true if all polygonal components in the input geometry have their exterior rings oriented clockwise and interior rings oriented counter-clockwise.
 
-Non-polygonal components are ignored, and geometry collections are evaluated recursively. Inputs with no polygonal components, including empty geometries and closed line strings, return `true`.
+`POLYGON EMPTY` and `MULTIPOLYGON EMPTY` return `true` because they contain no rings with the opposite orientation.
 
 ![ST_IsPolygonCW](../../../image/ST_IsPolygonCW/ST_IsPolygonCW.svg "ST_IsPolygonCW")
 

--- a/docs/api/sql/Geometry-Accessors/ST_IsPolygonCW.md
+++ b/docs/api/sql/Geometry-Accessors/ST_IsPolygonCW.md
@@ -21,7 +21,7 @@
 
 Introduction: Returns true if all polygonal components in the input geometry have their exterior rings oriented clockwise and interior rings oriented counter-clockwise.
 
-`POLYGON EMPTY` and `MULTIPOLYGON EMPTY` return `true` because they contain no rings with the opposite orientation.
+Non-polygonal components are ignored, and geometry collections are evaluated recursively. Inputs with no polygonal components, including empty geometries and closed line strings, return `true`.
 
 ![ST_IsPolygonCW](../../../image/ST_IsPolygonCW/ST_IsPolygonCW.svg "ST_IsPolygonCW")
 

--- a/flink/src/main/java/org/apache/sedona/flink/expressions/Functions.java
+++ b/flink/src/main/java/org/apache/sedona/flink/expressions/Functions.java
@@ -1918,15 +1918,12 @@ public class Functions {
 
   public static class ST_IsPolygonCW extends ScalarFunction {
     @DataTypeHint("Boolean")
-    public Boolean eval(
+    public boolean eval(
         @DataTypeHint(
                 value = "RAW",
                 rawSerializer = GeometryTypeSerializer.class,
                 bridgedTo = Geometry.class)
             Object o) {
-      if (o == null) {
-        return null;
-      }
       Geometry geom = (Geometry) o;
       return org.apache.sedona.common.Functions.isPolygonCW(geom);
     }
@@ -3311,15 +3308,12 @@ public class Functions {
 
   public static class ST_IsPolygonCCW extends ScalarFunction {
     @DataTypeHint("Boolean")
-    public Boolean eval(
+    public boolean eval(
         @DataTypeHint(
                 value = "RAW",
                 rawSerializer = GeometryTypeSerializer.class,
                 bridgedTo = Geometry.class)
             Object o) {
-      if (o == null) {
-        return null;
-      }
       Geometry geom = (Geometry) o;
       return org.apache.sedona.common.Functions.isPolygonCCW(geom);
     }

--- a/flink/src/main/java/org/apache/sedona/flink/expressions/Functions.java
+++ b/flink/src/main/java/org/apache/sedona/flink/expressions/Functions.java
@@ -1918,12 +1918,15 @@ public class Functions {
 
   public static class ST_IsPolygonCW extends ScalarFunction {
     @DataTypeHint("Boolean")
-    public boolean eval(
+    public Boolean eval(
         @DataTypeHint(
                 value = "RAW",
                 rawSerializer = GeometryTypeSerializer.class,
                 bridgedTo = Geometry.class)
             Object o) {
+      if (o == null) {
+        return null;
+      }
       Geometry geom = (Geometry) o;
       return org.apache.sedona.common.Functions.isPolygonCW(geom);
     }
@@ -3308,12 +3311,15 @@ public class Functions {
 
   public static class ST_IsPolygonCCW extends ScalarFunction {
     @DataTypeHint("Boolean")
-    public boolean eval(
+    public Boolean eval(
         @DataTypeHint(
                 value = "RAW",
                 rawSerializer = GeometryTypeSerializer.class,
                 bridgedTo = Geometry.class)
             Object o) {
+      if (o == null) {
+        return null;
+      }
       Geometry geom = (Geometry) o;
       return org.apache.sedona.common.Functions.isPolygonCCW(geom);
     }

--- a/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
@@ -2703,6 +2703,22 @@ public class FunctionTest extends TestBase {
   }
 
   @Test
+  public void testIsPolygonOrientationForEmptyGeometries() {
+    Table result =
+        tableEnv.sqlQuery(
+            "SELECT "
+                + "ST_IsPolygonCW(ST_GeomFromWKT('POLYGON EMPTY')), "
+                + "ST_IsPolygonCCW(ST_GeomFromWKT('POLYGON EMPTY')), "
+                + "ST_IsPolygonCW(ST_GeomFromWKT('MULTIPOLYGON EMPTY')), "
+                + "ST_IsPolygonCCW(ST_GeomFromWKT('MULTIPOLYGON EMPTY'))");
+
+    Row row = first(result);
+    for (int i = 0; i < row.getArity(); i++) {
+      assertTrue((boolean) row.getField(i));
+    }
+  }
+
+  @Test
   public void testTranslate() {
     Table polyTable =
         tableEnv.sqlQuery(

--- a/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
@@ -2703,19 +2703,53 @@ public class FunctionTest extends TestBase {
   }
 
   @Test
-  public void testIsPolygonOrientationForEmptyGeometries() {
-    Table result =
-        tableEnv.sqlQuery(
-            "SELECT "
-                + "ST_IsPolygonCW(ST_GeomFromWKT('POLYGON EMPTY')), "
-                + "ST_IsPolygonCCW(ST_GeomFromWKT('POLYGON EMPTY')), "
-                + "ST_IsPolygonCW(ST_GeomFromWKT('MULTIPOLYGON EMPTY')), "
-                + "ST_IsPolygonCCW(ST_GeomFromWKT('MULTIPOLYGON EMPTY'))");
+  public void testIsPolygonOrientationChecksOnlyPolygonalComponents() {
+    Object[][] testCases = {
+      {"POLYGON EMPTY", true, true},
+      {"MULTIPOLYGON EMPTY", true, true},
+      {"POINT (0 0)", true, true},
+      {"LINESTRING (0 0, 1 0, 0 0)", true, true},
+      {"GEOMETRYCOLLECTION (POINT (0 0), GEOMETRYCOLLECTION (LINESTRING (0 0, 1 1)))", true, true},
+      {
+        "GEOMETRYCOLLECTION (POINT (2 2), GEOMETRYCOLLECTION (POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0)), MULTIPOLYGON EMPTY))",
+        true,
+        false
+      },
+      {
+        "GEOMETRYCOLLECTION (LINESTRING (0 0, 1 1), GEOMETRYCOLLECTION (POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))))",
+        false,
+        true
+      },
+      {
+        "GEOMETRYCOLLECTION (POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0)), GEOMETRYCOLLECTION (POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))))",
+        false,
+        false
+      }
+    };
 
-    Row row = first(result);
-    for (int i = 0; i < row.getArity(); i++) {
-      assertTrue((boolean) row.getField(i));
+    for (Object[] testCase : testCases) {
+      Row row =
+          first(
+              tableEnv.sqlQuery(
+                  "SELECT "
+                      + "ST_IsPolygonCW(ST_GeomFromWKT('"
+                      + testCase[0]
+                      + "')), "
+                      + "ST_IsPolygonCCW(ST_GeomFromWKT('"
+                      + testCase[0]
+                      + "'))"));
+      assertEquals(testCase[1], row.getField(0));
+      assertEquals(testCase[2], row.getField(1));
     }
+
+    Row nullRow =
+        first(
+            tableEnv.sqlQuery(
+                "SELECT "
+                    + "ST_IsPolygonCW(ST_GeomFromWKT(CAST(NULL AS STRING))), "
+                    + "ST_IsPolygonCCW(ST_GeomFromWKT(CAST(NULL AS STRING)))"));
+    assertNull(nullRow.getField(0));
+    assertNull(nullRow.getField(1));
   }
 
   @Test

--- a/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
@@ -2703,53 +2703,19 @@ public class FunctionTest extends TestBase {
   }
 
   @Test
-  public void testIsPolygonOrientationChecksOnlyPolygonalComponents() {
-    Object[][] testCases = {
-      {"POLYGON EMPTY", true, true},
-      {"MULTIPOLYGON EMPTY", true, true},
-      {"POINT (0 0)", true, true},
-      {"LINESTRING (0 0, 1 0, 0 0)", true, true},
-      {"GEOMETRYCOLLECTION (POINT (0 0), GEOMETRYCOLLECTION (LINESTRING (0 0, 1 1)))", true, true},
-      {
-        "GEOMETRYCOLLECTION (POINT (2 2), GEOMETRYCOLLECTION (POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0)), MULTIPOLYGON EMPTY))",
-        true,
-        false
-      },
-      {
-        "GEOMETRYCOLLECTION (LINESTRING (0 0, 1 1), GEOMETRYCOLLECTION (POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))))",
-        false,
-        true
-      },
-      {
-        "GEOMETRYCOLLECTION (POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0)), GEOMETRYCOLLECTION (POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))))",
-        false,
-        false
-      }
-    };
+  public void testIsPolygonOrientationForEmptyGeometries() {
+    Table result =
+        tableEnv.sqlQuery(
+            "SELECT "
+                + "ST_IsPolygonCW(ST_GeomFromWKT('POLYGON EMPTY')), "
+                + "ST_IsPolygonCCW(ST_GeomFromWKT('POLYGON EMPTY')), "
+                + "ST_IsPolygonCW(ST_GeomFromWKT('MULTIPOLYGON EMPTY')), "
+                + "ST_IsPolygonCCW(ST_GeomFromWKT('MULTIPOLYGON EMPTY'))");
 
-    for (Object[] testCase : testCases) {
-      Row row =
-          first(
-              tableEnv.sqlQuery(
-                  "SELECT "
-                      + "ST_IsPolygonCW(ST_GeomFromWKT('"
-                      + testCase[0]
-                      + "')), "
-                      + "ST_IsPolygonCCW(ST_GeomFromWKT('"
-                      + testCase[0]
-                      + "'))"));
-      assertEquals(testCase[1], row.getField(0));
-      assertEquals(testCase[2], row.getField(1));
+    Row row = first(result);
+    for (int i = 0; i < row.getArity(); i++) {
+      assertTrue((boolean) row.getField(i));
     }
-
-    Row nullRow =
-        first(
-            tableEnv.sqlQuery(
-                "SELECT "
-                    + "ST_IsPolygonCW(ST_GeomFromWKT(CAST(NULL AS STRING))), "
-                    + "ST_IsPolygonCCW(ST_GeomFromWKT(CAST(NULL AS STRING)))"));
-    assertNull(nullRow.getField(0));
-    assertNull(nullRow.getField(1));
   }
 
   @Test

--- a/python/sedona/spark/geopandas/geoseries.py
+++ b/python/sedona/spark/geopandas/geoseries.py
@@ -1624,10 +1624,10 @@ class GeoSeries(GeoFrame, pspd.Series):
 
         xs = _normalize_affine_scalar(xs, "'xs' must be a numeric scalar")
         ys = _normalize_affine_scalar(ys, "'ys' must be a numeric scalar")
-        if not isinstance(use_radians, (bool, np.bool_)):
+        if not isinstance(use_radians, (bool, np.bool_, int, np.integer)):
             raise TypeError("'use_radians' must be a boolean")
 
-        if not use_radians:
+        if not bool(use_radians):
             xs = xs * math.pi / 180.0
             ys = ys * math.pi / 180.0
         tan_x = math.tan(xs)

--- a/python/sedona/spark/sql/st_functions.py
+++ b/python/sedona/spark/sql/st_functions.py
@@ -1175,8 +1175,10 @@ def ST_IsPolygonCW(geometry: ColumnOrName) -> Column:
 
     :param geometry: Geometry column to check.
     :type geometry: ColumnOrName
-    :return: True if every exterior ring is clockwise and every interior ring
-        is counter-clockwise. Empty Polygon and MultiPolygon values return True.
+    :return: True if every polygonal component has clockwise exterior rings and
+        counter-clockwise interior rings. Geometry collections are checked
+        recursively, non-polygonal components are ignored, and inputs without
+        polygonal components return True.
     :rtype: Column
     """
     return _call_st_function("ST_IsPolygonCW", geometry)
@@ -2028,8 +2030,10 @@ def ST_IsPolygonCCW(geometry: ColumnOrName) -> Column:
 
     :param geometry: Geometry column to check.
     :type geometry: ColumnOrName
-    :return: True if every exterior ring is counter-clockwise and every interior
-        ring is clockwise. Empty Polygon and MultiPolygon values return True.
+    :return: True if every polygonal component has counter-clockwise exterior
+        rings and clockwise interior rings. Geometry collections are checked
+        recursively, non-polygonal components are ignored, and inputs without
+        polygonal components return True.
     :rtype: Column
     """
     return _call_st_function("ST_IsPolygonCCW", geometry)

--- a/python/sedona/spark/sql/st_functions.py
+++ b/python/sedona/spark/sql/st_functions.py
@@ -1171,12 +1171,12 @@ def ST_IsEmpty(geometry: ColumnOrName) -> Column:
 
 @validate_argument_types
 def ST_IsPolygonCW(geometry: ColumnOrName) -> Column:
-    """Check if the Polygon or MultiPolygon use a clockwise orientation for exterior ring and counter-clockwise
-    orientation for interior ring.
+    """Check whether polygon rings use clockwise exterior orientation.
 
     :param geometry: Geometry column to check.
     :type geometry: ColumnOrName
-    :return: True if the geometry is empty and False otherwise as a boolean column.
+    :return: True if every exterior ring is clockwise and every interior ring
+        is counter-clockwise. Empty Polygon and MultiPolygon values return True.
     :rtype: Column
     """
     return _call_st_function("ST_IsPolygonCW", geometry)
@@ -2024,11 +2024,12 @@ def ST_Snap(
 
 @validate_argument_types
 def ST_IsPolygonCCW(geometry: ColumnOrName) -> Column:
-    """Check if the Polygon or MultiPolygon use a counter-clockwise orientation for exterior ring and clockwise
-    orientation for interior ring.
+    """Check whether polygon rings use counter-clockwise exterior orientation.
+
     :param geometry: Geometry column to check.
     :type geometry: ColumnOrName
-    :return: True if the geometry is empty and False otherwise as a boolean column.
+    :return: True if every exterior ring is counter-clockwise and every interior
+        ring is clockwise. Empty Polygon and MultiPolygon values return True.
     :rtype: Column
     """
     return _call_st_function("ST_IsPolygonCCW", geometry)

--- a/python/sedona/spark/sql/st_functions.py
+++ b/python/sedona/spark/sql/st_functions.py
@@ -1175,10 +1175,8 @@ def ST_IsPolygonCW(geometry: ColumnOrName) -> Column:
 
     :param geometry: Geometry column to check.
     :type geometry: ColumnOrName
-    :return: True if every polygonal component has clockwise exterior rings and
-        counter-clockwise interior rings. Geometry collections are checked
-        recursively, non-polygonal components are ignored, and inputs without
-        polygonal components return True.
+    :return: True if every exterior ring is clockwise and every interior ring
+        is counter-clockwise. Empty Polygon and MultiPolygon values return True.
     :rtype: Column
     """
     return _call_st_function("ST_IsPolygonCW", geometry)
@@ -2030,10 +2028,8 @@ def ST_IsPolygonCCW(geometry: ColumnOrName) -> Column:
 
     :param geometry: Geometry column to check.
     :type geometry: ColumnOrName
-    :return: True if every polygonal component has counter-clockwise exterior
-        rings and clockwise interior rings. Geometry collections are checked
-        recursively, non-polygonal components are ignored, and inputs without
-        polygonal components return True.
+    :return: True if every exterior ring is counter-clockwise and every interior
+        ring is clockwise. Empty Polygon and MultiPolygon values return True.
     :rtype: Column
     """
     return _call_st_function("ST_IsPolygonCCW", geometry)

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -2976,6 +2976,29 @@ e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3
         assert list(numpy_bool_radians.coords) == pytest.approx(expected)
         assert list(clamped.coords) == [(0.0, 0.0), (2.0, 4.0)]
 
+    @pytest.mark.parametrize(
+        "use_radians",
+        [
+            pytest.param(0, id="int-false"),
+            pytest.param(1, id="int-true"),
+            pytest.param(np.int64(0), id="numpy-int-false"),
+            pytest.param(np.int64(1), id="numpy-int-true"),
+        ],
+    )
+    def test_skew_accepts_integer_use_radians(self, use_radians):
+        source = GeoSeries([LineString([(0, 0), (2, 4)])])
+        kwargs = {
+            "xs": 0.5,
+            "ys": -0.25,
+            "origin": (0, 0),
+            "use_radians": use_radians,
+        }
+
+        result = source.skew(**kwargs)
+        expected = source.to_geopandas().skew(**kwargs)
+
+        self.check_sgpd_equals_gpd(result, expected)
+
     def test_skew_center_and_centroid_origins(self):
         source = GeoSeries([Polygon([(0, 0), (4, 0), (0, 2), (0, 0)])])
 
@@ -3081,7 +3104,7 @@ e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3
             with pytest.raises(TypeError, match=rf"'{name}' must be a numeric scalar"):
                 source.skew(**{name: ps.Series([45.0])})
 
-        for use_radians in (None, 0, 1, "true", [True], np.array(True)):
+        for use_radians in (None, 0.0, 1.0, "true", [True], np.array(True)):
             with pytest.raises(TypeError, match="'use_radians' must be a boolean"):
                 source.skew(use_radians=use_radians)
 
@@ -3118,7 +3141,7 @@ e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3
             with pytest.raises(TypeError, match=rf"'{name}' must be a numeric scalar"):
                 empty_source.skew(**{name: None})
         with pytest.raises(TypeError, match="'use_radians' must be a boolean"):
-            empty_source.skew(use_radians=1)
+            empty_source.skew(use_radians=1.0)
         with pytest.raises(ValueError, match="origin must be"):
             empty_source.skew(origin="invalid")
 

--- a/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctions.java
+++ b/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctions.java
@@ -1267,6 +1267,10 @@ public class TestFunctions extends TestBase {
     verifySqlSingleRes(
         "SELECT sedona.ST_IsPolygonCW(sedona.ST_GeomFromWKT('POLYGON ((20 35, 45 20, 30 5, 10 10, 10 30, 20 35), (30 20, 20 25, 20 15, 30 20))'))",
         true);
+    verifySqlSingleRes(
+        "SELECT sedona.ST_IsPolygonCW(sedona.ST_GeomFromWKT('POLYGON EMPTY'))", true);
+    verifySqlSingleRes(
+        "SELECT sedona.ST_IsPolygonCW(sedona.ST_GeomFromWKT('MULTIPOLYGON EMPTY'))", true);
   }
 
   @Test
@@ -1291,6 +1295,10 @@ public class TestFunctions extends TestBase {
     verifySqlSingleRes(
         "SELECT sedona.ST_IsPolygonCCW(sedona.ST_GeomFromWKT('POLYGON ((20 35, 10 30, 10 10, 30 5, 45 20, 20 35),(30 20, 20 15, 20 25, 30 20))'))",
         true);
+    verifySqlSingleRes(
+        "SELECT sedona.ST_IsPolygonCCW(sedona.ST_GeomFromWKT('POLYGON EMPTY'))", true);
+    verifySqlSingleRes(
+        "SELECT sedona.ST_IsPolygonCCW(sedona.ST_GeomFromWKT('MULTIPOLYGON EMPTY'))", true);
   }
 
   @Test

--- a/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctions.java
+++ b/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctions.java
@@ -1271,6 +1271,18 @@ public class TestFunctions extends TestBase {
         "SELECT sedona.ST_IsPolygonCW(sedona.ST_GeomFromWKT('POLYGON EMPTY'))", true);
     verifySqlSingleRes(
         "SELECT sedona.ST_IsPolygonCW(sedona.ST_GeomFromWKT('MULTIPOLYGON EMPTY'))", true);
+    verifySqlSingleRes(
+        "SELECT sedona.ST_IsPolygonCW(sedona.ST_GeomFromWKT('LINESTRING (0 0, 1 0, 0 0)'))", true);
+    verifySqlSingleRes(
+        "SELECT sedona.ST_IsPolygonCW(sedona.ST_GeomFromWKT('GEOMETRYCOLLECTION (POINT (0 0), GEOMETRYCOLLECTION (LINESTRING (0 0, 1 1)))'))",
+        true);
+    verifySqlSingleRes(
+        "SELECT sedona.ST_IsPolygonCW(sedona.ST_GeomFromWKT('GEOMETRYCOLLECTION (POINT (2 2), GEOMETRYCOLLECTION (POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0)), MULTIPOLYGON EMPTY))'))",
+        true);
+    verifySqlSingleRes(
+        "SELECT sedona.ST_IsPolygonCW(sedona.ST_GeomFromWKT('GEOMETRYCOLLECTION (POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0)), GEOMETRYCOLLECTION (POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))))'))",
+        false);
+    verifySqlSingleRes("SELECT sedona.ST_IsPolygonCW(CAST(NULL AS BINARY))", null);
   }
 
   @Test
@@ -1299,6 +1311,18 @@ public class TestFunctions extends TestBase {
         "SELECT sedona.ST_IsPolygonCCW(sedona.ST_GeomFromWKT('POLYGON EMPTY'))", true);
     verifySqlSingleRes(
         "SELECT sedona.ST_IsPolygonCCW(sedona.ST_GeomFromWKT('MULTIPOLYGON EMPTY'))", true);
+    verifySqlSingleRes(
+        "SELECT sedona.ST_IsPolygonCCW(sedona.ST_GeomFromWKT('LINESTRING (0 0, 1 0, 0 0)'))", true);
+    verifySqlSingleRes(
+        "SELECT sedona.ST_IsPolygonCCW(sedona.ST_GeomFromWKT('GEOMETRYCOLLECTION (POINT (0 0), GEOMETRYCOLLECTION (LINESTRING (0 0, 1 1)))'))",
+        true);
+    verifySqlSingleRes(
+        "SELECT sedona.ST_IsPolygonCCW(sedona.ST_GeomFromWKT('GEOMETRYCOLLECTION (LINESTRING (0 0, 1 1), GEOMETRYCOLLECTION (POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))))'))",
+        true);
+    verifySqlSingleRes(
+        "SELECT sedona.ST_IsPolygonCCW(sedona.ST_GeomFromWKT('GEOMETRYCOLLECTION (POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0)), GEOMETRYCOLLECTION (POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))))'))",
+        false);
+    verifySqlSingleRes("SELECT sedona.ST_IsPolygonCCW(CAST(NULL AS BINARY))", null);
   }
 
   @Test

--- a/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctions.java
+++ b/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctions.java
@@ -1271,18 +1271,6 @@ public class TestFunctions extends TestBase {
         "SELECT sedona.ST_IsPolygonCW(sedona.ST_GeomFromWKT('POLYGON EMPTY'))", true);
     verifySqlSingleRes(
         "SELECT sedona.ST_IsPolygonCW(sedona.ST_GeomFromWKT('MULTIPOLYGON EMPTY'))", true);
-    verifySqlSingleRes(
-        "SELECT sedona.ST_IsPolygonCW(sedona.ST_GeomFromWKT('LINESTRING (0 0, 1 0, 0 0)'))", true);
-    verifySqlSingleRes(
-        "SELECT sedona.ST_IsPolygonCW(sedona.ST_GeomFromWKT('GEOMETRYCOLLECTION (POINT (0 0), GEOMETRYCOLLECTION (LINESTRING (0 0, 1 1)))'))",
-        true);
-    verifySqlSingleRes(
-        "SELECT sedona.ST_IsPolygonCW(sedona.ST_GeomFromWKT('GEOMETRYCOLLECTION (POINT (2 2), GEOMETRYCOLLECTION (POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0)), MULTIPOLYGON EMPTY))'))",
-        true);
-    verifySqlSingleRes(
-        "SELECT sedona.ST_IsPolygonCW(sedona.ST_GeomFromWKT('GEOMETRYCOLLECTION (POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0)), GEOMETRYCOLLECTION (POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))))'))",
-        false);
-    verifySqlSingleRes("SELECT sedona.ST_IsPolygonCW(CAST(NULL AS BINARY))", null);
   }
 
   @Test
@@ -1311,18 +1299,6 @@ public class TestFunctions extends TestBase {
         "SELECT sedona.ST_IsPolygonCCW(sedona.ST_GeomFromWKT('POLYGON EMPTY'))", true);
     verifySqlSingleRes(
         "SELECT sedona.ST_IsPolygonCCW(sedona.ST_GeomFromWKT('MULTIPOLYGON EMPTY'))", true);
-    verifySqlSingleRes(
-        "SELECT sedona.ST_IsPolygonCCW(sedona.ST_GeomFromWKT('LINESTRING (0 0, 1 0, 0 0)'))", true);
-    verifySqlSingleRes(
-        "SELECT sedona.ST_IsPolygonCCW(sedona.ST_GeomFromWKT('GEOMETRYCOLLECTION (POINT (0 0), GEOMETRYCOLLECTION (LINESTRING (0 0, 1 1)))'))",
-        true);
-    verifySqlSingleRes(
-        "SELECT sedona.ST_IsPolygonCCW(sedona.ST_GeomFromWKT('GEOMETRYCOLLECTION (LINESTRING (0 0, 1 1), GEOMETRYCOLLECTION (POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))))'))",
-        true);
-    verifySqlSingleRes(
-        "SELECT sedona.ST_IsPolygonCCW(sedona.ST_GeomFromWKT('GEOMETRYCOLLECTION (POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0)), GEOMETRYCOLLECTION (POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))))'))",
-        false);
-    verifySqlSingleRes("SELECT sedona.ST_IsPolygonCCW(CAST(NULL AS BINARY))", null);
   }
 
   @Test

--- a/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctionsV2.java
+++ b/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctionsV2.java
@@ -1211,6 +1211,8 @@ public class TestFunctionsV2 extends TestBase {
     verifySqlSingleRes(
         "SELECT sedona.ST_IsPolygonCW(ST_GeomFromWKT('POLYGON ((20 35, 45 20, 30 5, 10 10, 10 30, 20 35), (30 20, 20 25, 20 15, 30 20))'))",
         true);
+    verifySqlSingleRes("SELECT sedona.ST_IsPolygonCW(ST_GeomFromWKT('POLYGON EMPTY'))", true);
+    verifySqlSingleRes("SELECT sedona.ST_IsPolygonCW(ST_GeomFromWKT('MULTIPOLYGON EMPTY'))", true);
   }
 
   @Test
@@ -1242,6 +1244,8 @@ public class TestFunctionsV2 extends TestBase {
     verifySqlSingleRes(
         "SELECT sedona.ST_IsPolygonCCW(ST_GeomFromWKT('POLYGON ((20 35, 10 30, 10 10, 30 5, 45 20, 20 35),(30 20, 20 15, 20 25, 30 20))'))",
         true);
+    verifySqlSingleRes("SELECT sedona.ST_IsPolygonCCW(ST_GeomFromWKT('POLYGON EMPTY'))", true);
+    verifySqlSingleRes("SELECT sedona.ST_IsPolygonCCW(ST_GeomFromWKT('MULTIPOLYGON EMPTY'))", true);
   }
 
   @Test

--- a/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctionsV2.java
+++ b/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctionsV2.java
@@ -1213,6 +1213,18 @@ public class TestFunctionsV2 extends TestBase {
         true);
     verifySqlSingleRes("SELECT sedona.ST_IsPolygonCW(ST_GeomFromWKT('POLYGON EMPTY'))", true);
     verifySqlSingleRes("SELECT sedona.ST_IsPolygonCW(ST_GeomFromWKT('MULTIPOLYGON EMPTY'))", true);
+    verifySqlSingleRes(
+        "SELECT sedona.ST_IsPolygonCW(ST_GeomFromWKT('LINESTRING (0 0, 1 0, 0 0)'))", true);
+    verifySqlSingleRes(
+        "SELECT sedona.ST_IsPolygonCW(ST_GeomFromWKT('GEOMETRYCOLLECTION (POINT (0 0), GEOMETRYCOLLECTION (LINESTRING (0 0, 1 1)))'))",
+        true);
+    verifySqlSingleRes(
+        "SELECT sedona.ST_IsPolygonCW(ST_GeomFromWKT('GEOMETRYCOLLECTION (POINT (2 2), GEOMETRYCOLLECTION (POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0)), MULTIPOLYGON EMPTY))'))",
+        true);
+    verifySqlSingleRes(
+        "SELECT sedona.ST_IsPolygonCW(ST_GeomFromWKT('GEOMETRYCOLLECTION (POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0)), GEOMETRYCOLLECTION (POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))))'))",
+        false);
+    verifySqlSingleRes("SELECT sedona.ST_IsPolygonCW(CAST(NULL AS GEOMETRY))", null);
   }
 
   @Test
@@ -1246,6 +1258,18 @@ public class TestFunctionsV2 extends TestBase {
         true);
     verifySqlSingleRes("SELECT sedona.ST_IsPolygonCCW(ST_GeomFromWKT('POLYGON EMPTY'))", true);
     verifySqlSingleRes("SELECT sedona.ST_IsPolygonCCW(ST_GeomFromWKT('MULTIPOLYGON EMPTY'))", true);
+    verifySqlSingleRes(
+        "SELECT sedona.ST_IsPolygonCCW(ST_GeomFromWKT('LINESTRING (0 0, 1 0, 0 0)'))", true);
+    verifySqlSingleRes(
+        "SELECT sedona.ST_IsPolygonCCW(ST_GeomFromWKT('GEOMETRYCOLLECTION (POINT (0 0), GEOMETRYCOLLECTION (LINESTRING (0 0, 1 1)))'))",
+        true);
+    verifySqlSingleRes(
+        "SELECT sedona.ST_IsPolygonCCW(ST_GeomFromWKT('GEOMETRYCOLLECTION (LINESTRING (0 0, 1 1), GEOMETRYCOLLECTION (POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))))'))",
+        true);
+    verifySqlSingleRes(
+        "SELECT sedona.ST_IsPolygonCCW(ST_GeomFromWKT('GEOMETRYCOLLECTION (POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0)), GEOMETRYCOLLECTION (POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))))'))",
+        false);
+    verifySqlSingleRes("SELECT sedona.ST_IsPolygonCCW(CAST(NULL AS GEOMETRY))", null);
   }
 
   @Test

--- a/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctionsV2.java
+++ b/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctionsV2.java
@@ -1213,18 +1213,6 @@ public class TestFunctionsV2 extends TestBase {
         true);
     verifySqlSingleRes("SELECT sedona.ST_IsPolygonCW(ST_GeomFromWKT('POLYGON EMPTY'))", true);
     verifySqlSingleRes("SELECT sedona.ST_IsPolygonCW(ST_GeomFromWKT('MULTIPOLYGON EMPTY'))", true);
-    verifySqlSingleRes(
-        "SELECT sedona.ST_IsPolygonCW(ST_GeomFromWKT('LINESTRING (0 0, 1 0, 0 0)'))", true);
-    verifySqlSingleRes(
-        "SELECT sedona.ST_IsPolygonCW(ST_GeomFromWKT('GEOMETRYCOLLECTION (POINT (0 0), GEOMETRYCOLLECTION (LINESTRING (0 0, 1 1)))'))",
-        true);
-    verifySqlSingleRes(
-        "SELECT sedona.ST_IsPolygonCW(ST_GeomFromWKT('GEOMETRYCOLLECTION (POINT (2 2), GEOMETRYCOLLECTION (POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0)), MULTIPOLYGON EMPTY))'))",
-        true);
-    verifySqlSingleRes(
-        "SELECT sedona.ST_IsPolygonCW(ST_GeomFromWKT('GEOMETRYCOLLECTION (POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0)), GEOMETRYCOLLECTION (POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))))'))",
-        false);
-    verifySqlSingleRes("SELECT sedona.ST_IsPolygonCW(CAST(NULL AS GEOMETRY))", null);
   }
 
   @Test
@@ -1258,18 +1246,6 @@ public class TestFunctionsV2 extends TestBase {
         true);
     verifySqlSingleRes("SELECT sedona.ST_IsPolygonCCW(ST_GeomFromWKT('POLYGON EMPTY'))", true);
     verifySqlSingleRes("SELECT sedona.ST_IsPolygonCCW(ST_GeomFromWKT('MULTIPOLYGON EMPTY'))", true);
-    verifySqlSingleRes(
-        "SELECT sedona.ST_IsPolygonCCW(ST_GeomFromWKT('LINESTRING (0 0, 1 0, 0 0)'))", true);
-    verifySqlSingleRes(
-        "SELECT sedona.ST_IsPolygonCCW(ST_GeomFromWKT('GEOMETRYCOLLECTION (POINT (0 0), GEOMETRYCOLLECTION (LINESTRING (0 0, 1 1)))'))",
-        true);
-    verifySqlSingleRes(
-        "SELECT sedona.ST_IsPolygonCCW(ST_GeomFromWKT('GEOMETRYCOLLECTION (LINESTRING (0 0, 1 1), GEOMETRYCOLLECTION (POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))))'))",
-        true);
-    verifySqlSingleRes(
-        "SELECT sedona.ST_IsPolygonCCW(ST_GeomFromWKT('GEOMETRYCOLLECTION (POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0)), GEOMETRYCOLLECTION (POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))))'))",
-        false);
-    verifySqlSingleRes("SELECT sedona.ST_IsPolygonCCW(CAST(NULL AS GEOMETRY))", null);
   }
 
   @Test

--- a/spark/common/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
@@ -1563,46 +1563,18 @@ class functionTestScala
       assert(actual == false)
     }
 
-    it("Should check only polygonal components for polygon orientation predicates") {
-      val results = sparkSession
+    it("Should pass polygon orientation predicates for empty polygonal geometries") {
+      val actual = sparkSession
         .sql("""
             |SELECT
-            |  wkt,
-            |  ST_IsPolygonCW(ST_GeomFromWKT(wkt)) AS actual_cw,
-            |  ST_IsPolygonCCW(ST_GeomFromWKT(wkt)) AS actual_ccw,
-            |  expected_cw,
-            |  expected_ccw
-            |FROM VALUES
-            |  ('POLYGON EMPTY', true, true),
-            |  ('MULTIPOLYGON EMPTY', true, true),
-            |  ('POINT (0 0)', true, true),
-            |  ('LINESTRING (0 0, 1 0, 0 0)', true, true),
-            |  ('GEOMETRYCOLLECTION (POINT (0 0), GEOMETRYCOLLECTION (LINESTRING (0 0, 1 1)))', true, true),
-            |  ('GEOMETRYCOLLECTION (POINT (2 2), GEOMETRYCOLLECTION (POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0)), MULTIPOLYGON EMPTY))', true, false),
-            |  ('GEOMETRYCOLLECTION (LINESTRING (0 0, 1 1), GEOMETRYCOLLECTION (POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))))', false, true),
-            |  ('GEOMETRYCOLLECTION (POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0)), GEOMETRYCOLLECTION (POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))))', false, false)
-            |AS test_cases(wkt, expected_cw, expected_ccw)
-            |""".stripMargin)
-        .collect()
-
-      results.foreach { row =>
-        assert(
-          row.getBoolean(1) == row.getBoolean(3),
-          s"Unexpected CW result for ${row.getString(0)}")
-        assert(
-          row.getBoolean(2) == row.getBoolean(4),
-          s"Unexpected CCW result for ${row.getString(0)}")
-      }
-
-      val nullResults = sparkSession
-        .sql("""
-            |SELECT
-            |  ST_IsPolygonCW(ST_GeomFromWKT(CAST(NULL AS STRING))),
-            |  ST_IsPolygonCCW(ST_GeomFromWKT(CAST(NULL AS STRING)))
+            |  ST_IsPolygonCW(ST_GeomFromWKT('POLYGON EMPTY')),
+            |  ST_IsPolygonCCW(ST_GeomFromWKT('POLYGON EMPTY')),
+            |  ST_IsPolygonCW(ST_GeomFromWKT('MULTIPOLYGON EMPTY')),
+            |  ST_IsPolygonCCW(ST_GeomFromWKT('MULTIPOLYGON EMPTY'))
             |""".stripMargin)
         .first()
-      assertTrue(nullResults.isNullAt(0))
-      assertTrue(nullResults.isNullAt(1))
+
+      (0 until 4).foreach(index => assertTrue(actual.getBoolean(index)))
     }
 
     it("Should pass ST_IsLineStringCCW") {

--- a/spark/common/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
@@ -1563,6 +1563,20 @@ class functionTestScala
       assert(actual == false)
     }
 
+    it("Should pass polygon orientation predicates for empty polygonal geometries") {
+      val actual = sparkSession
+        .sql("""
+            |SELECT
+            |  ST_IsPolygonCW(ST_GeomFromWKT('POLYGON EMPTY')),
+            |  ST_IsPolygonCCW(ST_GeomFromWKT('POLYGON EMPTY')),
+            |  ST_IsPolygonCW(ST_GeomFromWKT('MULTIPOLYGON EMPTY')),
+            |  ST_IsPolygonCCW(ST_GeomFromWKT('MULTIPOLYGON EMPTY'))
+            |""".stripMargin)
+        .first()
+
+      (0 until 4).foreach(index => assertTrue(actual.getBoolean(index)))
+    }
+
     it("Should pass ST_IsLineStringCCW") {
       val actual = sparkSession
         .sql("""

--- a/spark/common/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/functionTestScala.scala
@@ -1563,18 +1563,46 @@ class functionTestScala
       assert(actual == false)
     }
 
-    it("Should pass polygon orientation predicates for empty polygonal geometries") {
-      val actual = sparkSession
+    it("Should check only polygonal components for polygon orientation predicates") {
+      val results = sparkSession
         .sql("""
             |SELECT
-            |  ST_IsPolygonCW(ST_GeomFromWKT('POLYGON EMPTY')),
-            |  ST_IsPolygonCCW(ST_GeomFromWKT('POLYGON EMPTY')),
-            |  ST_IsPolygonCW(ST_GeomFromWKT('MULTIPOLYGON EMPTY')),
-            |  ST_IsPolygonCCW(ST_GeomFromWKT('MULTIPOLYGON EMPTY'))
+            |  wkt,
+            |  ST_IsPolygonCW(ST_GeomFromWKT(wkt)) AS actual_cw,
+            |  ST_IsPolygonCCW(ST_GeomFromWKT(wkt)) AS actual_ccw,
+            |  expected_cw,
+            |  expected_ccw
+            |FROM VALUES
+            |  ('POLYGON EMPTY', true, true),
+            |  ('MULTIPOLYGON EMPTY', true, true),
+            |  ('POINT (0 0)', true, true),
+            |  ('LINESTRING (0 0, 1 0, 0 0)', true, true),
+            |  ('GEOMETRYCOLLECTION (POINT (0 0), GEOMETRYCOLLECTION (LINESTRING (0 0, 1 1)))', true, true),
+            |  ('GEOMETRYCOLLECTION (POINT (2 2), GEOMETRYCOLLECTION (POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0)), MULTIPOLYGON EMPTY))', true, false),
+            |  ('GEOMETRYCOLLECTION (LINESTRING (0 0, 1 1), GEOMETRYCOLLECTION (POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))))', false, true),
+            |  ('GEOMETRYCOLLECTION (POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0)), GEOMETRYCOLLECTION (POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))))', false, false)
+            |AS test_cases(wkt, expected_cw, expected_ccw)
+            |""".stripMargin)
+        .collect()
+
+      results.foreach { row =>
+        assert(
+          row.getBoolean(1) == row.getBoolean(3),
+          s"Unexpected CW result for ${row.getString(0)}")
+        assert(
+          row.getBoolean(2) == row.getBoolean(4),
+          s"Unexpected CCW result for ${row.getString(0)}")
+      }
+
+      val nullResults = sparkSession
+        .sql("""
+            |SELECT
+            |  ST_IsPolygonCW(ST_GeomFromWKT(CAST(NULL AS STRING))),
+            |  ST_IsPolygonCCW(ST_GeomFromWKT(CAST(NULL AS STRING)))
             |""".stripMargin)
         .first()
-
-      (0 until 4).foreach(index => assertTrue(actual.getBoolean(index)))
+      assertTrue(nullResults.isNullAt(0))
+      assertTrue(nullResults.isNullAt(1))
     }
 
     it("Should pass ST_IsLineStringCCW") {


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`.

Closes #3171.
Closes #3172.

## What changes were proposed in this PR?

- Treat empty `Polygon` and `MultiPolygon` inputs as vacuously true in both `ST_IsPolygonCW` and `ST_IsPolygonCCW`.
- Avoid accessing the first component of an empty `MultiPolygon`, and treat empty members of mixed multipolygons as neutral.
- Add common, Spark, Flink, and Snowflake coverage and document the empty-geometry behavior across all three engines.
- Accept Python and NumPy integer values for `GeoSeries.skew(use_radians=...)`, matching GeoPandas truthiness behavior while retaining strict rejection of non-integral values.

The orientation predicates previously accessed `getGeometryN(0)` unconditionally for multipolygons and did not handle an empty polygon consistently. The GeoSeries method separately restricted `use_radians` to boolean scalar types even though GeoPandas also accepts integer boolean-like values.

Full PostGIS parity for non-polygonal inputs and geometry collections is deferred to #3174 because it changes existing predicate results and should be handled at a major-version boundary.

## How was this patch tested?

- `mvn -pl common -Dtest=FunctionsTest test` (302 tests)
- Spark `functionTestScala` suite (235 tests)
- Focused Flink empty-polygon orientation test
- `python -m pytest -q tests/geopandas/test_geoseries.py -k skew` (20 tests)
- `mvn -Dsnowflake=true -pl snowflake-tester -am -DskipTests package`
- Repository pre-commit hooks

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.
