### PR TITLE
[GH-3181] GeoPandas: Implement distributed dissolve and tools.collect

### DIFF
--- a/docs/tutorial/geopandas-api.md
+++ b/docs/tutorial/geopandas-api.md
@@ -356,6 +356,12 @@ all_building_parts = collect(buildings.geometry)
 `coverage`, and `disjoint_subset` unions are rejected explicitly. Multiple
 attribute aggregations remain a two-level pandas-on-Spark `MultiIndex`;
 GeoPandas instead represents their tuple labels in a one-level object index.
+Native `first`, `last`, and `count` aggregation supports every attribute type;
+`nunique` supports numeric, boolean, and string columns; and `min`, `max`,
+`sum`, `mean`, `median`, `std`, and `var` support numeric and boolean columns.
+String `sum` and every `prod` aggregation are rejected explicitly. Callable
+aliases are limited to built-in `min`, `max`, and `sum`, plus NumPy `amin`,
+`amax`, `min`, `max`, `sum`, `mean`, `median`, `std`, and `var`.
 Both operations aggregate input rows on Spark executors. `collect` transfers
 only aggregate metadata and the API's single geometry result to the driver.
 

--- a/docs/tutorial/geopandas-api.md
+++ b/docs/tutorial/geopandas-api.md
@@ -296,7 +296,7 @@ buildings_projected["perimeter"] = buildings_projected.geometry.length
 
 ## Supported Operations
 
-The GeoPandas API for Apache Sedona has implemented **39 GeoSeries functions** and **10 GeoDataFrame functions**, covering the most commonly used GeoPandas operations:
+The GeoPandas API for Apache Sedona has implemented **39 GeoSeries functions** and **11 GeoDataFrame functions**, covering the most commonly used GeoPandas operations:
 
 ### Data I/O
 
@@ -334,6 +334,30 @@ The GeoPandas API for Apache Sedona has implemented **39 GeoSeries functions** a
 - `intersection()` - Geometric intersection
 - `make_valid()` - Geometry validation and repair
 - `sindex` - Spatial indexing (limited functionality)
+
+### Distributed Geometry Aggregation
+
+- `GeoDataFrame.dissolve()` - Group rows and union each group's geometries
+  with Sedona's native distributed aggregate
+- `sedona.spark.geopandas.tools.collect()` - Collect a distributed GeoSeries
+  into one geometry, using a homogeneous multipart geometry when needed
+
+```python
+from sedona.spark.geopandas.tools import collect
+
+by_region = buildings.dissolve(
+    by="region",
+    aggfunc={"population": "sum", "name": "first"},
+)
+all_building_parts = collect(buildings.geometry)
+```
+
+`dissolve` supports the `unary` union method. Fixed-precision `grid_size`,
+`coverage`, and `disjoint_subset` unions are rejected explicitly. Multiple
+attribute aggregations remain a two-level pandas-on-Spark `MultiIndex`;
+GeoPandas instead represents their tuple labels in a one-level object index.
+Both operations aggregate input rows on Spark executors. `collect` transfers
+only aggregate metadata and the API's single geometry result to the driver.
 
 ### Data Conversion
 

--- a/docs/tutorial/geopandas-api.md
+++ b/docs/tutorial/geopandas-api.md
@@ -296,7 +296,7 @@ buildings_projected["perimeter"] = buildings_projected.geometry.length
 
 ## Supported Operations
 
-The GeoPandas API for Apache Sedona has implemented **39 GeoSeries functions** and **11 GeoDataFrame functions**, covering the most commonly used GeoPandas operations:
+The GeoPandas API for Apache Sedona implements the most commonly used GeoSeries and GeoDataFrame operations:
 
 ### Data I/O
 

--- a/docs/tutorial/geopandas-api.zh.md
+++ b/docs/tutorial/geopandas-api.zh.md
@@ -355,6 +355,11 @@ all_building_parts = collect(buildings.geometry)
 `dissolve` 支持 `unary` 并集方法，并会明确拒绝定点精度 `grid_size`、
 `coverage` 与 `disjoint_subset` 并集。多个属性聚合会保留为 pandas-on-Spark
 的两级 `MultiIndex`；GeoPandas 则把对应元组标签放在单级 object 索引中。
+原生 `first`、`last` 与 `count` 聚合支持所有属性类型；`nunique` 支持数值、
+布尔与字符串列；`min`、`max`、`sum`、`mean`、`median`、`std` 与 `var`
+支持数值和布尔列。字符串 `sum` 与所有 `prod` 聚合都会被明确拒绝。可调用
+聚合仅限 Python 内置的 `min`、`max`、`sum`，以及 NumPy 的 `amin`、
+`amax`、`min`、`max`、`sum`、`mean`、`median`、`std` 与 `var`。
 两个操作都在 Spark executor 上聚合输入行。`collect` 只会把聚合元数据和
 该 API 所需的单个几何结果传输到 driver。
 

--- a/docs/tutorial/geopandas-api.zh.md
+++ b/docs/tutorial/geopandas-api.zh.md
@@ -296,7 +296,7 @@ buildings_projected["perimeter"] = buildings_projected.geometry.length
 
 ## 已支持的操作
 
-Apache Sedona 的 GeoPandas API 已实现 **39 个 GeoSeries 函数** 与 **10 个 GeoDataFrame 函数**，覆盖了 GeoPandas 中最常用的操作：
+Apache Sedona 的 GeoPandas API 已实现 **39 个 GeoSeries 函数** 与 **11 个 GeoDataFrame 函数**，覆盖了 GeoPandas 中最常用的操作：
 
 ### 数据 I/O
 
@@ -334,6 +334,29 @@ Apache Sedona 的 GeoPandas API 已实现 **39 个 GeoSeries 函数** 与 **10 �
 - `intersection()` —— 几何相交
 - `make_valid()` —— 几何校验与修复
 - `sindex` —— 空间索引（功能有限）
+
+### 分布式几何聚合
+
+- `GeoDataFrame.dissolve()` —— 对行进行分组，并使用 Sedona 原生分布式聚合
+  对每组几何执行并集
+- `sedona.spark.geopandas.tools.collect()` —— 将分布式 GeoSeries 聚合为一个
+  几何，并在需要时使用同构多部件几何
+
+```python
+from sedona.spark.geopandas.tools import collect
+
+by_region = buildings.dissolve(
+    by="region",
+    aggfunc={"population": "sum", "name": "first"},
+)
+all_building_parts = collect(buildings.geometry)
+```
+
+`dissolve` 支持 `unary` 并集方法，并会明确拒绝定点精度 `grid_size`、
+`coverage` 与 `disjoint_subset` 并集。多个属性聚合会保留为 pandas-on-Spark
+的两级 `MultiIndex`；GeoPandas 则把对应元组标签放在单级 object 索引中。
+两个操作都在 Spark executor 上聚合输入行。`collect` 只会把聚合元数据和
+该 API 所需的单个几何结果传输到 driver。
 
 ### 数据转换
 

--- a/docs/tutorial/geopandas-api.zh.md
+++ b/docs/tutorial/geopandas-api.zh.md
@@ -296,7 +296,7 @@ buildings_projected["perimeter"] = buildings_projected.geometry.length
 
 ## 已支持的操作
 
-Apache Sedona 的 GeoPandas API 已实现 **39 个 GeoSeries 函数** 与 **11 个 GeoDataFrame 函数**，覆盖了 GeoPandas 中最常用的操作：
+Apache Sedona 的 GeoPandas API 已实现最常用的 GeoSeries 与 GeoDataFrame 操作：
 
 ### 数据 I/O
 

--- a/python/sedona/spark/geopandas/geodataframe.py
+++ b/python/sedona/spark/geopandas/geodataframe.py
@@ -2032,14 +2032,15 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
         # unsupported function/dtype combinations fail before Spark executes.
         crs = self.crs
         srid = crs.to_epsg() if crs is not None else 0
-        empty_geometry = stc.ST_GeomFromWKT(
-            F.lit("GEOMETRYCOLLECTION EMPTY"),
-            srid or 0,
-        )
-        geometry_union = F.coalesce(
-            sta.ST_Union_Aggr(F.col(geometry_input_name)),
-            empty_geometry,
-        )
+        geometry_union = sta.ST_Union_Aggr(F.col(geometry_input_name))
+        if hasattr(gpd.GeoSeries, "union_all"):
+            # GeoPandas 1.0 changed an all-null union from None to an empty
+            # GeometryCollection. Preserve its CRS in that representation.
+            empty_geometry = stc.ST_GeomFromWKT(
+                F.lit("GEOMETRYCOLLECTION EMPTY"),
+                srid or 0,
+            )
+            geometry_union = F.coalesce(geometry_union, empty_geometry)
         aggregated_sdf = aggregation_input.groupBy(*group_column_names).agg(
             geometry_union.alias(geometry_output_name),
             F.min(F.col(order_input_name)).alias(order_output_spark_name),

--- a/python/sedona/spark/geopandas/geodataframe.py
+++ b/python/sedona/spark/geopandas/geodataframe.py
@@ -29,10 +29,21 @@ import pyspark.pandas as pspd
 import sedona.spark.geopandas as sgpd
 from pyspark.pandas import Series as PandasOnSparkSeries
 from pyspark.pandas.frame import DataFrame as PandasOnSparkDataFrame
+from pyspark.pandas.internal import (
+    InternalField,
+    InternalFrame,
+    NATURAL_ORDER_COLUMN_NAME,
+    SPARK_INDEX_NAME_FORMAT,
+)
+from pyspark.pandas.series import first_series
+from pyspark.pandas.utils import scol_for
+from pyspark.sql import functions as F
 from pyspark.pandas.utils import log_advice
 
 from sedona.spark.geopandas._typing import Label
 from sedona.spark.geopandas.base import GeoFrame
+from sedona.spark.sql import st_aggregates as sta
+from sedona.spark.sql import st_constructors as stc
 
 from pandas.api.extensions import register_extension_dtype
 from geopandas.geodataframe import crs_mismatch_error
@@ -116,6 +127,56 @@ def _not_implemented_error(method_name: str, additional_info: str = "") -> str:
     )
 
     return base_message + workaround
+
+
+def _normalize_dissolve_aggfunc(aggfunc):
+    """Translate scalable callable aggregations to Spark aggregate names."""
+
+    callable_names = {
+        "amax": "max",
+        "amin": "min",
+        "average": "mean",
+    }
+
+    def normalize_one(value):
+        if isinstance(value, str):
+            return value
+        if callable(value):
+            name = getattr(value, "__name__", None)
+            if name:
+                name = callable_names.get(name, name)
+                if name in {
+                    "count",
+                    "first",
+                    "last",
+                    "max",
+                    "mean",
+                    "median",
+                    "min",
+                    "nunique",
+                    "prod",
+                    "std",
+                    "sum",
+                    "var",
+                }:
+                    return name
+        raise NotImplementedError(
+            "Sedona dissolve only supports named Spark aggregations and "
+            "equivalent built-in or NumPy aggregation functions."
+        )
+
+    if isinstance(aggfunc, dict):
+        return {
+            key: (
+                [normalize_one(value) for value in values]
+                if isinstance(values, (list, tuple))
+                else normalize_one(values)
+            )
+            for key, values in aggfunc.items()
+        }
+    if isinstance(aggfunc, (list, tuple)):
+        return [normalize_one(value) for value in aggfunc]
+    return normalize_one(aggfunc)
 
 
 class GeoDataFrame(GeoFrame, pspd.DataFrame):
@@ -396,7 +457,11 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
                 )
 
             raise MissingGeometryColumnError(msg)
-        return self[self._geometry_column_name]
+        geometry = self[self._geometry_column_name]
+        empty_crs_source = getattr(self, "_empty_crs_source", None)
+        if empty_crs_source is not None:
+            geometry._empty_crs_source = empty_crs_source
+        return geometry
 
     def _set_geometry(self, col):
         # This check is included in the original geopandas. Note that this prevents assigning a str to the property
@@ -591,6 +656,7 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
         if new_series:
             # Note: This casts GeoSeries back into pspd.Series, so we lose any metadata that's not serialized.
             frame[geo_column_name] = level
+            object.__setattr__(frame, "_empty_crs_source", level)
 
         if not inplace:
             return frame
@@ -1371,6 +1437,494 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
         >>> df.plot("BoroName", cmap="Set1")  # doctest: +SKIP
         """
         return self.to_geopandas().plot(*args, **kwargs)
+
+    def dissolve(
+        self,
+        by=None,
+        aggfunc="first",
+        as_index: bool = True,
+        level=None,
+        sort: bool = True,
+        observed: bool = False,
+        dropna: bool = True,
+        method: Literal["unary", "coverage", "disjoint_subset"] = "unary",
+        grid_size=None,
+        **kwargs,
+    ) -> GeoDataFrame:
+        """Dissolve geometries within groups using distributed aggregation.
+
+        Geometry unions are evaluated by Sedona's ``ST_Union_Aggr`` aggregate.
+        Attribute columns use pandas-on-Spark group aggregation and therefore
+        remain distributed as well.
+
+        Parameters
+        ----------
+        by : column label or list of column labels, default None
+            Columns defining the groups. ``None`` dissolves all rows into one
+            group. Arbitrary driver-side grouping vectors are not supported.
+        aggfunc : str, callable, list, or dict, default "first"
+            Scalable Spark aggregation(s) for non-geometry columns.
+        as_index : bool, default True
+            Place grouping columns in the result index.
+        level : int, name, or sequence, default None
+            Group by one or more input index levels. When supplied, ``level``
+            takes precedence over ``by``, matching pandas.
+        sort : bool, default True
+            Sort group keys. With ``False``, groups follow first occurrence.
+        observed : bool, default False
+            For categorical groupers, ``True`` returns observed groups.
+            Materializing unobserved categorical combinations is unsupported.
+        dropna : bool, default True
+            Drop null grouping keys when true.
+        method : {"unary"}, default "unary"
+            Union algorithm. Sedona currently supports only the robust unary
+            union for this API.
+        grid_size : None, default None
+            Fixed-precision union is not currently supported.
+        **kwargs
+            ``numeric_only`` is supported for non-dict aggregations.
+
+        Returns
+        -------
+        GeoDataFrame
+            A distributed GeoDataFrame with one row per group.
+
+        Examples
+        --------
+        >>> from sedona.spark.geopandas import GeoDataFrame
+        >>> from shapely.geometry import Point
+        >>> gdf = GeoDataFrame(
+        ...     {
+        ...         "zone": ["a", "a", "b"],
+        ...         "value": [1, 2, 3],
+        ...         "geometry": [Point(0, 0), Point(1, 1), Point(5, 5)],
+        ...     },
+        ...     crs="EPSG:4326",
+        ... )
+        >>> gdf.dissolve("zone", aggfunc="sum").sort_index()
+                                  geometry  value
+        zone
+        a     MULTIPOINT ((0 0), (1 1))      3
+        b                   POINT (5 5)      3
+
+        Notes
+        -----
+        Python row UDFs are not used. Callable aggregations are accepted only
+        when they map directly to a named Spark aggregate.
+
+        GeoPandas flattens multiple aggregation labels into a one-level object
+        index containing tuples. pandas-on-Spark cannot represent tuple-valued
+        labels in a one-level column index, so Sedona keeps those results as a
+        two-level ``MultiIndex`` and uses ``(geometry_name, "")`` for the
+        active geometry label.
+        """
+        if method != "unary":
+            raise NotImplementedError(
+                "Sedona dissolve currently supports only method='unary'."
+            )
+        if grid_size is not None:
+            raise NotImplementedError(
+                "Sedona dissolve does not support the grid_size argument."
+            )
+
+        unsupported_kwargs = set(kwargs) - {"numeric_only"}
+        if unsupported_kwargs:
+            unsupported = ", ".join(sorted(unsupported_kwargs))
+            raise NotImplementedError(
+                f"Sedona dissolve does not support aggregation keyword(s): {unsupported}."
+            )
+        numeric_only = kwargs.get("numeric_only", False)
+        if not isinstance(numeric_only, (bool, np.bool_)):
+            raise TypeError("numeric_only must be a boolean")
+        if isinstance(aggfunc, dict) and "numeric_only" in kwargs:
+            raise NotImplementedError(
+                "Sedona dissolve supports numeric_only only with non-dict "
+                "aggregations."
+            )
+
+        internal = self._internal.resolved_copy
+        if internal.column_labels_level != 1:
+            raise NotImplementedError(
+                "Sedona dissolve does not yet support MultiIndex columns."
+            )
+
+        geometry_name = self.active_geometry_name
+        geometry_label = self.geometry._column_label
+        crs = self.crs
+
+        group_expressions = []
+        group_fields = []
+        group_index_names = []
+        grouped_column_labels = []
+
+        if level is not None:
+            levels = list(level) if isinstance(level, (list, tuple)) else [level]
+            index_names = list(internal.index_names)
+
+            def level_position(value):
+                if isinstance(value, (int, np.integer)):
+                    position = int(value)
+                    if position < 0:
+                        position += len(index_names)
+                    if position < 0 or position >= len(index_names):
+                        raise IndexError(
+                            f"Too many levels: Index has only {len(index_names)} levels"
+                        )
+                    return position
+
+                wanted = value if isinstance(value, tuple) else (value,)
+                matches = [
+                    position
+                    for position, name in enumerate(index_names)
+                    if name == wanted
+                ]
+                if not matches:
+                    raise KeyError(f"Level {value} not found")
+                if len(matches) > 1:
+                    raise ValueError(
+                        f"The name {value} occurs multiple times, use a level number"
+                    )
+                return matches[0]
+
+            positions = [level_position(value) for value in levels]
+            for position in positions:
+                group_expressions.append(internal.index_spark_columns[position])
+                group_fields.append(internal.index_fields[position])
+                group_index_names.append(internal.index_names[position])
+        elif by is None:
+            group_expressions.append(F.lit(0))
+            group_fields.append(None)
+            group_index_names.append(None)
+        else:
+            if isinstance(by, PandasOnSparkSeries):
+                groupers = [by]
+                if by._psdf is not self:
+                    raise NotImplementedError(
+                        "Sedona dissolve requires Series groupers to come from "
+                        "the GeoDataFrame being dissolved."
+                    )
+            else:
+                try:
+                    candidate = self[by]
+                except (KeyError, TypeError):
+                    candidate = None
+
+                if isinstance(candidate, PandasOnSparkSeries):
+                    groupers = [candidate]
+                elif isinstance(by, list):
+                    groupers = []
+                    for key in by:
+                        try:
+                            grouper = self[key]
+                        except (KeyError, TypeError) as exc:
+                            raise NotImplementedError(
+                                "Sedona dissolve supports column labels, not "
+                                "driver-side grouping vectors."
+                            ) from exc
+                        if not isinstance(grouper, PandasOnSparkSeries):
+                            raise ValueError(
+                                f"Grouper for '{key}' is not 1-dimensional"
+                            )
+                        groupers.append(grouper)
+                else:
+                    raise NotImplementedError(
+                        "Sedona dissolve supports column labels, not driver-side "
+                        "grouping vectors."
+                    )
+
+            for grouper in groupers:
+                if grouper._column_label == geometry_label:
+                    raise NotImplementedError(
+                        "Grouping by the active geometry column is not supported."
+                    )
+                group_expressions.append(
+                    internal.spark_column_for(grouper._column_label)
+                )
+                group_fields.append(internal.field_for(grouper._column_label))
+                group_index_names.append(grouper._column_label)
+                grouped_column_labels.append(grouper._column_label)
+
+        if not group_expressions:
+            raise ValueError("No group keys passed")
+
+        if not observed:
+            categorical_groupers = [
+                field
+                for field in group_fields
+                if field is not None and isinstance(field.dtype, pd.CategoricalDtype)
+            ]
+            if categorical_groupers:
+                raise NotImplementedError(
+                    "Sedona dissolve cannot materialize unobserved categorical "
+                    "groups; pass observed=True."
+                )
+
+        existing_labels = set(internal.column_labels)
+        temporary_names = []
+        new_columns = list(internal.data_spark_columns)
+        new_fields = list(internal.data_fields)
+        new_labels = list(internal.column_labels)
+
+        for position, (expression, field) in enumerate(
+            zip(group_expressions, group_fields)
+        ):
+            suffix = position
+            name = f"__dissolve_group_{suffix}__"
+            label = (name,)
+            while label in existing_labels or name in internal.spark_frame.columns:
+                suffix += 1
+                name = f"__dissolve_group_{suffix}__"
+                label = (name,)
+            existing_labels.add(label)
+            temporary_names.append(name)
+            new_columns.append(expression.alias(name))
+            new_fields.append(field.copy(name=name) if field is not None else None)
+            new_labels.append(label)
+
+        working_internal = internal.with_new_columns(
+            new_columns,
+            column_labels=new_labels,
+            data_fields=new_fields,
+        )
+        working = GeoDataFrame(PandasOnSparkDataFrame(working_internal))
+        working._geometry_column_name = geometry_name
+
+        normalized_aggfunc = _normalize_dissolve_aggfunc(aggfunc)
+        available_attribute_labels = [
+            label for label in internal.column_labels if label != geometry_label
+        ]
+        if isinstance(normalized_aggfunc, dict):
+            if not normalized_aggfunc:
+                raise ValueError("No objects to concatenate")
+            missing_keys = [
+                key
+                for key in normalized_aggfunc
+                if (key,) not in available_attribute_labels
+            ]
+            if missing_keys:
+                missing = ", ".join(repr(key) for key in missing_keys)
+                raise KeyError(f"Column(s) [{missing}] do not exist")
+            # A grouping column is excluded from a normal aggregation, but a
+            # dict can request it explicitly, as pandas GroupBy.agg allows.
+            attribute_labels = available_attribute_labels
+        else:
+            attribute_labels = [
+                label
+                for label in available_attribute_labels
+                if label not in grouped_column_labels
+            ]
+        if numeric_only and not isinstance(aggfunc, dict):
+            attribute_labels = [
+                label
+                for label in attribute_labels
+                if pd.api.types.is_numeric_dtype(working[label[0]].dtype)
+            ]
+
+        aggregated_data = None
+        if attribute_labels:
+            attribute_names = [label[0] for label in attribute_labels]
+            data = PandasOnSparkDataFrame(
+                working[attribute_names + temporary_names]._internal
+            )
+            groupby_keys = (
+                temporary_names[0] if len(temporary_names) == 1 else temporary_names
+            )
+            aggregated_data = data.groupby(
+                groupby_keys,
+                as_index=True,
+                dropna=dropna,
+            ).agg(normalized_aggfunc)
+
+            data_internal = aggregated_data._internal
+            data_internal = data_internal.copy(index_names=group_index_names)
+            aggregated_data = PandasOnSparkDataFrame(data_internal)
+
+        source_sdf = working_internal.spark_frame
+        group_column_names = [
+            SPARK_INDEX_NAME_FORMAT(position)
+            for position in range(len(temporary_names))
+        ]
+        geometry_input_name = "__dissolve_geometry_input__"
+        order_input_name = "__dissolve_order_input__"
+        geometry_output_name = "__dissolve_geometry_output__"
+        order_output_name = "__dissolve_group_order__"
+        order_output_suffix = 0
+        while (order_output_name,) in existing_labels:
+            order_output_suffix += 1
+            order_output_name = f"__dissolve_group_order_{order_output_suffix}__"
+
+        aggregation_input = source_sdf.select(
+            *[
+                working[name].spark.column.alias(group_name)
+                for name, group_name in zip(temporary_names, group_column_names)
+            ],
+            working.geometry.spark.column.alias(geometry_input_name),
+            scol_for(source_sdf, NATURAL_ORDER_COLUMN_NAME).alias(order_input_name),
+        )
+
+        srid = crs.to_epsg() if crs is not None else 0
+        empty_geometry = stc.ST_GeomFromWKT(
+            F.lit("GEOMETRYCOLLECTION EMPTY"),
+            srid or 0,
+        )
+        geometry_union = F.coalesce(
+            sta.ST_Union_Aggr(F.col(geometry_input_name)),
+            empty_geometry,
+        )
+        aggregated_sdf = aggregation_input.groupBy(*group_column_names).agg(
+            geometry_union.alias(geometry_output_name),
+            F.min(F.col(order_input_name)).alias(order_output_name),
+        )
+        if dropna:
+            aggregated_sdf = aggregated_sdf.dropna(subset=group_column_names)
+
+        result_column_levels = (
+            aggregated_data._internal.column_labels_level
+            if aggregated_data is not None
+            else 1
+        )
+        result_geometry_label = geometry_label + ("",) * (
+            result_column_levels - len(geometry_label)
+        )
+        result_order_label = (order_output_name,) + ("",) * (result_column_levels - 1)
+        result_geometry_name = (
+            result_geometry_label[0]
+            if len(result_geometry_label) == 1
+            else result_geometry_label
+        )
+        result_order_name = (
+            result_order_label[0]
+            if len(result_order_label) == 1
+            else result_order_label
+        )
+        result_column_label_names = (
+            aggregated_data._internal.column_label_names
+            if aggregated_data is not None
+            else [None]
+        )
+
+        geometry_internal = InternalFrame(
+            spark_frame=aggregated_sdf,
+            index_spark_columns=[
+                scol_for(aggregated_sdf, name) for name in group_column_names
+            ],
+            index_names=group_index_names,
+            index_fields=[
+                (
+                    field.copy(name=name)
+                    if field is not None
+                    else InternalField.from_struct_field(aggregated_sdf.schema[name])
+                )
+                for field, name in zip(group_fields, group_column_names)
+            ],
+            column_labels=[result_geometry_label, result_order_label],
+            data_spark_columns=[
+                scol_for(aggregated_sdf, geometry_output_name),
+                scol_for(aggregated_sdf, order_output_name),
+            ],
+            data_fields=[
+                InternalField(
+                    np.dtype("object"),
+                    aggregated_sdf.schema[geometry_output_name],
+                ),
+                InternalField.from_struct_field(
+                    aggregated_sdf.schema[order_output_name]
+                ),
+            ],
+            column_label_names=result_column_label_names,
+        )
+        aggregated = GeoDataFrame(PandasOnSparkDataFrame(geometry_internal))
+        aggregated._geometry_column_name = result_geometry_name
+
+        if aggregated_data is not None:
+            data_internal = aggregated_data._internal
+            left_sdf = geometry_internal.spark_frame.alias("__geometry__")
+            right_sdf = data_internal.spark_frame.alias("__attributes__")
+            join_condition = F.lit(True)
+            for left_name, right_name in zip(
+                geometry_internal.index_spark_column_names,
+                data_internal.index_spark_column_names,
+            ):
+                join_condition = join_condition & left_sdf[left_name].eqNullSafe(
+                    right_sdf[right_name]
+                )
+
+            attribute_spark_names = [
+                f"__dissolve_attribute_{position}__"
+                for position in range(len(data_internal.data_spark_columns))
+            ]
+            combined_sdf = left_sdf.join(
+                right_sdf,
+                join_condition,
+                "left",
+            ).select(
+                *[
+                    left_sdf[name].alias(name)
+                    for name in geometry_internal.index_spark_column_names
+                ],
+                left_sdf[geometry_output_name],
+                left_sdf[order_output_name],
+                *[
+                    column.alias(name)
+                    for column, name in zip(
+                        data_internal.data_spark_columns,
+                        attribute_spark_names,
+                    )
+                ],
+            )
+            combined_internal = InternalFrame(
+                spark_frame=combined_sdf,
+                index_spark_columns=[
+                    scol_for(combined_sdf, name)
+                    for name in geometry_internal.index_spark_column_names
+                ],
+                index_names=group_index_names,
+                index_fields=[
+                    InternalField(field.dtype, combined_sdf.schema[field.name])
+                    for field in geometry_internal.index_fields
+                ],
+                column_labels=(
+                    geometry_internal.column_labels + data_internal.column_labels
+                ),
+                data_spark_columns=[
+                    scol_for(combined_sdf, geometry_output_name),
+                    scol_for(combined_sdf, order_output_name),
+                    *[scol_for(combined_sdf, name) for name in attribute_spark_names],
+                ],
+                data_fields=[
+                    InternalField(
+                        field.dtype,
+                        combined_sdf.schema[column_name],
+                    )
+                    for field, column_name in zip(
+                        geometry_internal.data_fields + data_internal.data_fields,
+                        [
+                            geometry_output_name,
+                            order_output_name,
+                            *attribute_spark_names,
+                        ],
+                    )
+                ],
+                column_label_names=result_column_label_names,
+            )
+            aggregated = GeoDataFrame(PandasOnSparkDataFrame(combined_internal))
+            aggregated._geometry_column_name = result_geometry_name
+
+        if sort:
+            aggregated = GeoDataFrame(aggregated.sort_index(na_position="last"))
+        else:
+            aggregated = GeoDataFrame(aggregated.sort_values(result_order_name))
+        aggregated._geometry_column_name = result_geometry_name
+
+        aggregated = GeoDataFrame(aggregated.drop(columns=[result_order_name]))
+        aggregated._geometry_column_name = result_geometry_name
+
+        if not as_index:
+            aggregated = GeoDataFrame(aggregated.reset_index())
+            aggregated._geometry_column_name = result_geometry_name
+
+        object.__setattr__(aggregated, "_empty_crs_source", self.geometry)
+        return aggregated
 
     # ============================================================================
     # SPATIAL OPERATIONS

--- a/python/sedona/spark/geopandas/geodataframe.py
+++ b/python/sedona/spark/geopandas/geodataframe.py
@@ -208,6 +208,197 @@ def _normalize_dissolve_aggfunc(aggfunc):
     return normalize_one(aggfunc)
 
 
+class _DissolveGroupers(typing.NamedTuple):
+    expressions: list
+    fields: list
+    index_names: list
+    column_labels: list
+
+
+def _resolve_dissolve_groupers(
+    frame,
+    internal,
+    geometry_label,
+    by,
+    level,
+    observed,
+):
+    """Resolve dissolve groupers without constructing the aggregation plan."""
+
+    group_expressions = []
+    group_fields = []
+    group_index_names = []
+    grouped_column_labels = []
+
+    if level is not None:
+        levels = list(level) if isinstance(level, (list, tuple)) else [level]
+        index_names = list(internal.index_names)
+
+        def level_position(value):
+            if isinstance(value, (int, np.integer)):
+                position = int(value)
+                if position < 0:
+                    position += len(index_names)
+                if position < 0 or position >= len(index_names):
+                    raise IndexError(
+                        f"Too many levels: Index has only {len(index_names)} levels"
+                    )
+                return position
+
+            wanted = value if isinstance(value, tuple) else (value,)
+            matches = [
+                position for position, name in enumerate(index_names) if name == wanted
+            ]
+            if not matches:
+                raise KeyError(f"Level {value} not found")
+            if len(matches) > 1:
+                raise ValueError(
+                    f"The name {value} occurs multiple times, use a level number"
+                )
+            return matches[0]
+
+        positions = [level_position(value) for value in levels]
+        for position in positions:
+            group_expressions.append(internal.index_spark_columns[position])
+            group_fields.append(internal.index_fields[position])
+            group_index_names.append(internal.index_names[position])
+    elif by is None:
+        group_expressions.append(F.lit(0).cast("long"))
+        group_fields.append(None)
+        group_index_names.append(None)
+    else:
+        groupers_are_column_labels = True
+        if isinstance(by, PandasOnSparkSeries):
+            groupers = [by]
+            groupers_are_column_labels = False
+            if by._psdf is not frame:
+                raise NotImplementedError(
+                    "Sedona dissolve requires Series groupers to come from "
+                    "the GeoDataFrame being dissolved."
+                )
+        else:
+            try:
+                candidate = frame[by]
+            except (KeyError, TypeError):
+                candidate = None
+
+            if isinstance(candidate, PandasOnSparkSeries):
+                groupers = [candidate]
+            elif isinstance(by, list):
+                groupers = []
+                for key in by:
+                    try:
+                        grouper = frame[key]
+                    except (KeyError, TypeError) as exc:
+                        raise NotImplementedError(
+                            "Sedona dissolve supports column labels, not "
+                            "driver-side grouping vectors."
+                        ) from exc
+                    if not isinstance(grouper, PandasOnSparkSeries):
+                        raise ValueError(f"Grouper for '{key}' is not 1-dimensional")
+                    groupers.append(grouper)
+            else:
+                raise NotImplementedError(
+                    "Sedona dissolve supports column labels, not driver-side "
+                    "grouping vectors."
+                )
+
+        for grouper in groupers:
+            if grouper._column_label == geometry_label:
+                raise NotImplementedError(
+                    "Grouping by the active geometry column is not supported."
+                )
+            group_expressions.append(internal.spark_column_for(grouper._column_label))
+            group_fields.append(internal.field_for(grouper._column_label))
+            group_index_names.append(grouper._column_label)
+            if groupers_are_column_labels:
+                grouped_column_labels.append(grouper._column_label)
+
+    if not group_expressions:
+        raise ValueError("No group keys passed")
+
+    if not observed:
+        categorical_groupers = [
+            field
+            for field in group_fields
+            if field is not None and isinstance(field.dtype, pd.CategoricalDtype)
+        ]
+        if categorical_groupers:
+            raise NotImplementedError(
+                "Sedona dissolve cannot materialize unobserved categorical "
+                "groups; pass observed=True."
+            )
+
+    return _DissolveGroupers(
+        group_expressions,
+        group_fields,
+        group_index_names,
+        grouped_column_labels,
+    )
+
+
+class _DissolveResultLabels(typing.NamedTuple):
+    geometry_label: Label
+    attribute_labels: list
+    order_label: Label
+    geometry_name: Label
+    order_name: Label
+    column_label_names: list
+
+
+def _build_dissolve_result_labels(
+    internal,
+    geometry_label,
+    aggregation_specs,
+    result_column_levels,
+):
+    """Build non-colliding output labels for a dissolve result."""
+
+    result_geometry_label = geometry_label + ("",) * (
+        result_column_levels - len(geometry_label)
+    )
+    result_attribute_labels = [spec[3] for spec in aggregation_specs]
+    result_order_label_name = "__dissolve_group_order__"
+    result_order_label = (result_order_label_name,) + ("",) * (result_column_levels - 1)
+    result_labels = {result_geometry_label, *result_attribute_labels}
+    result_order_suffix = 0
+    while result_order_label in result_labels:
+        result_order_suffix += 1
+        result_order_label_name = f"__dissolve_group_order_{result_order_suffix}__"
+        result_order_label = (result_order_label_name,) + ("",) * (
+            result_column_levels - 1
+        )
+
+    result_geometry_name = (
+        result_geometry_label[0]
+        if len(result_geometry_label) == 1
+        else result_geometry_label
+    )
+    result_order_name = (
+        result_order_label[0] if len(result_order_label) == 1 else result_order_label
+    )
+    result_column_label_names = [
+        internal.column_label_names[0],
+        *([None] * (result_column_levels - 1)),
+    ]
+    return _DissolveResultLabels(
+        result_geometry_label,
+        result_attribute_labels,
+        result_order_label,
+        result_geometry_name,
+        result_order_name,
+        result_column_label_names,
+    )
+
+
+def _as_geodataframe_with_geometry(frame, geometry_name):
+    """Wrap a pandas-on-Spark result and restore its active geometry label."""
+
+    result = GeoDataFrame(frame)
+    result._geometry_column_name = geometry_name
+    return result
+
+
 def _dissolve_aggregation_expression(
     column,
     field,
@@ -1599,6 +1790,8 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
             takes precedence over ``by``, matching pandas.
         sort : bool, default True
             Sort group keys. With ``False``, groups follow first occurrence.
+            Preserving that order still requires a distributed sort by each
+            group's first source-row position.
         observed : bool, default False
             For categorical groupers, ``True`` returns observed groups.
             Materializing unobserved categorical combinations is unsupported.
@@ -1681,118 +1874,20 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
                 "Sedona dissolve does not yet support MultiIndex columns."
             )
 
-        geometry_name = self.active_geometry_name
         geometry_label = self.geometry._column_label
 
-        group_expressions = []
-        group_fields = []
-        group_index_names = []
-        grouped_column_labels = []
-
-        if level is not None:
-            levels = list(level) if isinstance(level, (list, tuple)) else [level]
-            index_names = list(internal.index_names)
-
-            def level_position(value):
-                if isinstance(value, (int, np.integer)):
-                    position = int(value)
-                    if position < 0:
-                        position += len(index_names)
-                    if position < 0 or position >= len(index_names):
-                        raise IndexError(
-                            f"Too many levels: Index has only {len(index_names)} levels"
-                        )
-                    return position
-
-                wanted = value if isinstance(value, tuple) else (value,)
-                matches = [
-                    position
-                    for position, name in enumerate(index_names)
-                    if name == wanted
-                ]
-                if not matches:
-                    raise KeyError(f"Level {value} not found")
-                if len(matches) > 1:
-                    raise ValueError(
-                        f"The name {value} occurs multiple times, use a level number"
-                    )
-                return matches[0]
-
-            positions = [level_position(value) for value in levels]
-            for position in positions:
-                group_expressions.append(internal.index_spark_columns[position])
-                group_fields.append(internal.index_fields[position])
-                group_index_names.append(internal.index_names[position])
-        elif by is None:
-            group_expressions.append(F.lit(0).cast("long"))
-            group_fields.append(None)
-            group_index_names.append(None)
-        else:
-            groupers_are_column_labels = True
-            if isinstance(by, PandasOnSparkSeries):
-                groupers = [by]
-                groupers_are_column_labels = False
-                if by._psdf is not self:
-                    raise NotImplementedError(
-                        "Sedona dissolve requires Series groupers to come from "
-                        "the GeoDataFrame being dissolved."
-                    )
-            else:
-                try:
-                    candidate = self[by]
-                except (KeyError, TypeError):
-                    candidate = None
-
-                if isinstance(candidate, PandasOnSparkSeries):
-                    groupers = [candidate]
-                elif isinstance(by, list):
-                    groupers = []
-                    for key in by:
-                        try:
-                            grouper = self[key]
-                        except (KeyError, TypeError) as exc:
-                            raise NotImplementedError(
-                                "Sedona dissolve supports column labels, not "
-                                "driver-side grouping vectors."
-                            ) from exc
-                        if not isinstance(grouper, PandasOnSparkSeries):
-                            raise ValueError(
-                                f"Grouper for '{key}' is not 1-dimensional"
-                            )
-                        groupers.append(grouper)
-                else:
-                    raise NotImplementedError(
-                        "Sedona dissolve supports column labels, not driver-side "
-                        "grouping vectors."
-                    )
-
-            for grouper in groupers:
-                if grouper._column_label == geometry_label:
-                    raise NotImplementedError(
-                        "Grouping by the active geometry column is not supported."
-                    )
-                group_expressions.append(
-                    internal.spark_column_for(grouper._column_label)
-                )
-                group_fields.append(internal.field_for(grouper._column_label))
-                group_index_names.append(grouper._column_label)
-                if groupers_are_column_labels:
-                    grouped_column_labels.append(grouper._column_label)
-
-        if not group_expressions:
-            raise ValueError("No group keys passed")
-
-        if not observed:
-            categorical_groupers = [
-                field
-                for field in group_fields
-                if field is not None and isinstance(field.dtype, pd.CategoricalDtype)
-            ]
-            if categorical_groupers:
-                raise NotImplementedError(
-                    "Sedona dissolve cannot materialize unobserved categorical "
-                    "groups; pass observed=True."
-                )
+        groupers = _resolve_dissolve_groupers(
+            self,
+            internal,
+            geometry_label,
+            by,
+            level,
+            observed,
+        )
+        group_expressions = groupers.expressions
+        group_fields = groupers.fields
+        group_index_names = groupers.index_names
+        grouped_column_labels = groupers.column_labels
 
         normalized_aggfunc = _normalize_dissolve_aggfunc(aggfunc)
         available_attribute_labels = [
@@ -1953,36 +2048,12 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
         if dropna:
             aggregated_sdf = aggregated_sdf.dropna(subset=group_column_names)
 
-        result_geometry_label = geometry_label + ("",) * (
-            result_column_levels - len(geometry_label)
+        result_labels = _build_dissolve_result_labels(
+            internal,
+            geometry_label,
+            aggregation_specs,
+            result_column_levels,
         )
-        result_attribute_labels = [spec[3] for spec in aggregation_specs]
-        result_order_label_name = "__dissolve_group_order__"
-        result_order_label = (result_order_label_name,) + ("",) * (
-            result_column_levels - 1
-        )
-        result_labels = {result_geometry_label, *result_attribute_labels}
-        result_order_suffix = 0
-        while result_order_label in result_labels:
-            result_order_suffix += 1
-            result_order_label_name = f"__dissolve_group_order_{result_order_suffix}__"
-            result_order_label = (result_order_label_name,) + ("",) * (
-                result_column_levels - 1
-            )
-        result_geometry_name = (
-            result_geometry_label[0]
-            if len(result_geometry_label) == 1
-            else result_geometry_label
-        )
-        result_order_name = (
-            result_order_label[0]
-            if len(result_order_label) == 1
-            else result_order_label
-        )
-        result_column_label_names = [
-            internal.column_label_names[0],
-            *([None] * (result_column_levels - 1)),
-        ]
 
         result_internal = InternalFrame(
             spark_frame=aggregated_sdf,
@@ -1999,9 +2070,9 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
                 for field, name in zip(group_fields, group_column_names)
             ],
             column_labels=[
-                result_geometry_label,
-                result_order_label,
-                *result_attribute_labels,
+                result_labels.geometry_label,
+                result_labels.order_label,
+                *result_labels.attribute_labels,
             ],
             data_spark_columns=[
                 scol_for(aggregated_sdf, geometry_output_name),
@@ -2032,23 +2103,34 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
                     ), name in zip(aggregation_specs, attribute_output_names)
                 ],
             ],
-            column_label_names=result_column_label_names,
+            column_label_names=result_labels.column_label_names,
         )
-        aggregated = GeoDataFrame(PandasOnSparkDataFrame(result_internal))
-        aggregated._geometry_column_name = result_geometry_name
+        aggregated = _as_geodataframe_with_geometry(
+            PandasOnSparkDataFrame(result_internal),
+            result_labels.geometry_name,
+        )
 
         if sort:
-            aggregated = GeoDataFrame(aggregated.sort_index(na_position="last"))
+            aggregated = _as_geodataframe_with_geometry(
+                aggregated.sort_index(na_position="last"),
+                result_labels.geometry_name,
+            )
         else:
-            aggregated = GeoDataFrame(aggregated.sort_values(result_order_name))
-        aggregated._geometry_column_name = result_geometry_name
+            aggregated = _as_geodataframe_with_geometry(
+                aggregated.sort_values(result_labels.order_name),
+                result_labels.geometry_name,
+            )
 
-        aggregated = GeoDataFrame(aggregated.drop(columns=[result_order_name]))
-        aggregated._geometry_column_name = result_geometry_name
+        aggregated = _as_geodataframe_with_geometry(
+            aggregated.drop(columns=[result_labels.order_name]),
+            result_labels.geometry_name,
+        )
 
         if not as_index:
-            aggregated = GeoDataFrame(aggregated.reset_index())
-            aggregated._geometry_column_name = result_geometry_name
+            aggregated = _as_geodataframe_with_geometry(
+                aggregated.reset_index(),
+                result_labels.geometry_name,
+            )
 
         object.__setattr__(aggregated, "_empty_crs_source", self.geometry)
         return aggregated

--- a/python/sedona/spark/geopandas/geodataframe.py
+++ b/python/sedona/spark/geopandas/geodataframe.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import builtins
 from typing import Any, Literal, Callable, Union
 import typing
 
@@ -35,9 +36,19 @@ from pyspark.pandas.internal import (
     NATURAL_ORDER_COLUMN_NAME,
     SPARK_INDEX_NAME_FORMAT,
 )
-from pyspark.pandas.series import first_series
 from pyspark.pandas.utils import scol_for
 from pyspark.sql import functions as F
+from pyspark.sql.types import (
+    BooleanType,
+    ByteType,
+    DoubleType,
+    FloatType,
+    IntegerType,
+    LongType,
+    NumericType,
+    ShortType,
+    StringType,
+)
 from pyspark.pandas.utils import log_advice
 
 from sedona.spark.geopandas._typing import Label
@@ -130,39 +141,57 @@ def _not_implemented_error(method_name: str, additional_info: str = "") -> str:
 
 
 def _normalize_dissolve_aggfunc(aggfunc):
-    """Translate scalable callable aggregations to Spark aggregate names."""
+    """Translate explicitly supported callables to native aggregate names."""
 
-    callable_names = {
-        "amax": "max",
-        "amin": "min",
-        "average": "mean",
+    supported_names = {
+        "count",
+        "first",
+        "last",
+        "max",
+        "mean",
+        "median",
+        "min",
+        "nunique",
+        "std",
+        "sum",
+        "var",
     }
+    callable_names = (
+        (builtins.max, "max"),
+        (builtins.min, "min"),
+        (builtins.sum, "sum"),
+        (np.amax, "max"),
+        (np.amin, "min"),
+        (np.max, "max"),
+        (np.mean, "mean"),
+        (np.median, "median"),
+        (np.min, "min"),
+        (np.std, "std"),
+        (np.sum, "sum"),
+        (np.var, "var"),
+    )
 
     def normalize_one(value):
         if isinstance(value, str):
+            if value in {"prod", "product"}:
+                raise NotImplementedError(
+                    "Sedona dissolve does not support the prod aggregation."
+                )
+            if value not in supported_names:
+                raise NotImplementedError(
+                    f"Sedona dissolve does not support the {value!r} aggregation."
+                )
             return value
-        if callable(value):
-            name = getattr(value, "__name__", None)
-            if name:
-                name = callable_names.get(name, name)
-                if name in {
-                    "count",
-                    "first",
-                    "last",
-                    "max",
-                    "mean",
-                    "median",
-                    "min",
-                    "nunique",
-                    "prod",
-                    "std",
-                    "sum",
-                    "var",
-                }:
-                    return name
+        for known_callable, name in callable_names:
+            if value is known_callable:
+                return name
+        if value is np.prod:
+            raise NotImplementedError(
+                "Sedona dissolve does not support the prod aggregation."
+            )
         raise NotImplementedError(
-            "Sedona dissolve only supports named Spark aggregations and "
-            "equivalent built-in or NumPy aggregation functions."
+            "Sedona dissolve only supports documented aggregation names and "
+            "known built-in or NumPy aggregation callables."
         )
 
     if isinstance(aggfunc, dict):
@@ -177,6 +206,100 @@ def _normalize_dissolve_aggfunc(aggfunc):
     if isinstance(aggfunc, (list, tuple)):
         return [normalize_one(value) for value in aggfunc]
     return normalize_one(aggfunc)
+
+
+def _dissolve_aggregation_expression(
+    column,
+    field,
+    aggregation,
+    natural_order,
+    column_label,
+):
+    """Build a validated native Spark aggregation for one attribute column."""
+
+    spark_type = field.spark_type
+    is_categorical = isinstance(field.dtype, pd.CategoricalDtype)
+    is_boolean = isinstance(spark_type, BooleanType)
+    is_numeric = isinstance(spark_type, NumericType)
+    is_float = isinstance(spark_type, (FloatType, DoubleType))
+    dtype_name = str(field.dtype) if is_categorical else spark_type.simpleString()
+
+    clean_column = (
+        F.when(F.isnan(column), F.lit(None)).otherwise(column) if is_float else column
+    )
+
+    if aggregation == "first":
+        return F.min_by(
+            clean_column,
+            F.when(clean_column.isNotNull(), natural_order),
+        )
+    if aggregation == "last":
+        return F.max_by(
+            clean_column,
+            F.when(clean_column.isNotNull(), natural_order),
+        )
+    if aggregation == "count":
+        return F.count(clean_column)
+    if aggregation == "nunique":
+        if is_categorical or not (
+            is_numeric or is_boolean or isinstance(spark_type, StringType)
+        ):
+            raise NotImplementedError(
+                "Sedona dissolve does not support aggregation "
+                f"{aggregation!r} for column {column_label!r} with data "
+                f"type {dtype_name!r}."
+            )
+        return F.countDistinct(clean_column)
+
+    if is_categorical or not (is_numeric or is_boolean):
+        raise NotImplementedError(
+            "Sedona dissolve supports aggregation "
+            f"{aggregation!r} only for numeric or boolean columns; "
+            f"column {column_label!r} has data type {dtype_name!r}."
+        )
+
+    numeric_column = clean_column.cast("double") if is_boolean else clean_column
+
+    if aggregation == "sum":
+        if is_boolean or isinstance(
+            spark_type,
+            (ByteType, ShortType, IntegerType, LongType),
+        ):
+            result = F.sum(numeric_column.cast("long")).cast("long")
+            identity = F.lit(0).cast("long")
+        elif isinstance(spark_type, FloatType):
+            result = F.sum(numeric_column).cast("float")
+            identity = F.lit(0).cast("float")
+        elif isinstance(spark_type, DoubleType):
+            result = F.sum(numeric_column).cast("double")
+            identity = F.lit(0).cast("double")
+        else:
+            result = F.sum(numeric_column)
+            identity = F.lit(0).cast(spark_type)
+        return F.coalesce(result, identity)
+
+    if aggregation == "mean":
+        result = F.avg(numeric_column)
+    elif aggregation == "median":
+        result = F.median(numeric_column)
+    elif aggregation == "std":
+        result = F.stddev_samp(numeric_column)
+    elif aggregation == "var":
+        result = F.var_samp(numeric_column)
+    elif aggregation == "min":
+        if is_boolean:
+            return F.min(clean_column.cast("integer")).cast("boolean")
+        return F.min(clean_column)
+    elif aggregation == "max":
+        if is_boolean:
+            return F.max(clean_column.cast("integer")).cast("boolean")
+        return F.max(clean_column)
+    else:
+        raise AssertionError(f"Unexpected dissolve aggregation: {aggregation}")
+
+    if isinstance(spark_type, FloatType):
+        return result.cast("float")
+    return result
 
 
 class GeoDataFrame(GeoFrame, pspd.DataFrame):
@@ -1454,8 +1577,8 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
         """Dissolve geometries within groups using distributed aggregation.
 
         Geometry unions are evaluated by Sedona's ``ST_Union_Aggr`` aggregate.
-        Attribute columns use pandas-on-Spark group aggregation and therefore
-        remain distributed as well.
+        Attribute columns use validated native Spark aggregate expressions and
+        therefore remain distributed as well.
 
         Parameters
         ----------
@@ -1463,7 +1586,12 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
             Columns defining the groups. ``None`` dissolves all rows into one
             group. Arbitrary driver-side grouping vectors are not supported.
         aggfunc : str, callable, list, or dict, default "first"
-            Scalable Spark aggregation(s) for non-geometry columns.
+            Aggregation(s) for non-geometry columns. ``first``, ``last``, and
+            ``count`` support every Spark data type. ``nunique`` supports
+            numeric, boolean, and string columns. ``min``, ``max``, ``sum``,
+            ``mean``, ``median``, ``std``, and ``var`` support numeric and
+            boolean columns. String ``sum`` and every ``prod`` aggregation are
+            not supported.
         as_index : bool, default True
             Place grouping columns in the result index.
         level : int, name, or sequence, default None
@@ -1509,8 +1637,13 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
 
         Notes
         -----
-        Python row UDFs are not used. Callable aggregations are accepted only
-        when they map directly to a named Spark aggregate.
+        Python row UDFs are not used. Callable aliases are limited to built-in
+        ``min``, ``max``, and ``sum``, plus NumPy ``amin``, ``amax``, ``min``,
+        ``max``, ``sum``, ``mean``, ``median``, ``std``, and ``var``.
+        ``first`` and ``last`` follow source row order and skip null and NaN
+        values. Numeric and boolean ``sum`` use pandas' zero identity for an
+        all-null group; boolean sums are returned as integers and boolean
+        statistical aggregations as floating-point values.
 
         GeoPandas flattens multiple aggregation labels into a one-level object
         index containing tuples. pandas-on-Spark cannot represent tuple-valued
@@ -1550,7 +1683,6 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
 
         geometry_name = self.active_geometry_name
         geometry_label = self.geometry._column_label
-        crs = self.crs
 
         group_expressions = []
         group_fields = []
@@ -1592,7 +1724,7 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
                 group_fields.append(internal.index_fields[position])
                 group_index_names.append(internal.index_names[position])
         elif by is None:
-            group_expressions.append(F.lit(0))
+            group_expressions.append(F.lit(0).cast("long"))
             group_fields.append(None)
             group_index_names.append(None)
         else:
@@ -1659,36 +1791,6 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
                     "groups; pass observed=True."
                 )
 
-        existing_labels = set(internal.column_labels)
-        temporary_names = []
-        new_columns = list(internal.data_spark_columns)
-        new_fields = list(internal.data_fields)
-        new_labels = list(internal.column_labels)
-
-        for position, (expression, field) in enumerate(
-            zip(group_expressions, group_fields)
-        ):
-            suffix = position
-            name = f"__dissolve_group_{suffix}__"
-            label = (name,)
-            while label in existing_labels or name in internal.spark_frame.columns:
-                suffix += 1
-                name = f"__dissolve_group_{suffix}__"
-                label = (name,)
-            existing_labels.add(label)
-            temporary_names.append(name)
-            new_columns.append(expression.alias(name))
-            new_fields.append(field.copy(name=name) if field is not None else None)
-            new_labels.append(label)
-
-        working_internal = internal.with_new_columns(
-            new_columns,
-            column_labels=new_labels,
-            data_fields=new_fields,
-        )
-        working = GeoDataFrame(PandasOnSparkDataFrame(working_internal))
-        working._geometry_column_name = geometry_name
-
         normalized_aggfunc = _normalize_dissolve_aggfunc(aggfunc)
         available_attribute_labels = [
             label for label in internal.column_labels if label != geometry_label
@@ -1717,51 +1819,120 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
             attribute_labels = [
                 label
                 for label in attribute_labels
-                if pd.api.types.is_numeric_dtype(working[label[0]].dtype)
+                if pd.api.types.is_numeric_dtype(internal.field_for(label).dtype)
             ]
 
-        aggregated_data = None
-        if attribute_labels:
-            attribute_names = [label[0] for label in attribute_labels]
-            data = PandasOnSparkDataFrame(
-                working[attribute_names + temporary_names]._internal
+        aggregation_specs = []
+        if isinstance(normalized_aggfunc, dict):
+            result_column_levels = (
+                2
+                if any(
+                    isinstance(functions, list)
+                    for functions in normalized_aggfunc.values()
+                )
+                else 1
             )
-            groupby_keys = (
-                temporary_names[0] if len(temporary_names) == 1 else temporary_names
+            for key, functions in normalized_aggfunc.items():
+                source_label = (key,)
+                field = internal.field_for(source_label)
+                function_names = (
+                    functions if isinstance(functions, list) else [functions]
+                )
+                for function_name in function_names:
+                    result_label = (
+                        (key, function_name)
+                        if result_column_levels == 2
+                        else source_label
+                    )
+                    aggregation_specs.append(
+                        (source_label, field, function_name, result_label)
+                    )
+        else:
+            function_names = (
+                normalized_aggfunc
+                if isinstance(normalized_aggfunc, list)
+                else [normalized_aggfunc]
             )
-            aggregated_data = data.groupby(
-                groupby_keys,
-                as_index=True,
-                dropna=dropna,
-            ).agg(normalized_aggfunc)
+            if not function_names:
+                raise ValueError("No objects to concatenate")
+            result_column_levels = 2 if isinstance(normalized_aggfunc, list) else 1
+            for source_label in attribute_labels:
+                field = internal.field_for(source_label)
+                for function_name in function_names:
+                    result_label = (
+                        (source_label[0], function_name)
+                        if result_column_levels == 2
+                        else source_label
+                    )
+                    aggregation_specs.append(
+                        (source_label, field, function_name, result_label)
+                    )
 
-            data_internal = aggregated_data._internal
-            data_internal = data_internal.copy(index_names=group_index_names)
-            aggregated_data = PandasOnSparkDataFrame(data_internal)
+        if isinstance(normalized_aggfunc, list) and not aggregation_specs:
+            raise ValueError("No objects to concatenate")
+        if isinstance(normalized_aggfunc, dict) and not aggregation_specs:
+            # GeoPandas treats a non-empty dict containing only empty
+            # function lists as a geometry-only aggregation.
+            result_column_levels = 1
 
-        source_sdf = working_internal.spark_frame
+        source_sdf = internal.spark_frame
         group_column_names = [
             SPARK_INDEX_NAME_FORMAT(position)
-            for position in range(len(temporary_names))
+            for position in range(len(group_expressions))
         ]
         geometry_input_name = "__dissolve_geometry_input__"
         order_input_name = "__dissolve_order_input__"
         geometry_output_name = "__dissolve_geometry_output__"
-        order_output_name = "__dissolve_group_order__"
-        order_output_suffix = 0
-        while (order_output_name,) in existing_labels:
-            order_output_suffix += 1
-            order_output_name = f"__dissolve_group_order_{order_output_suffix}__"
+        order_output_spark_name = "__dissolve_group_order__"
+
+        attribute_input_names = {}
+        attribute_input_columns = []
+        for source_label, _, _, _ in aggregation_specs:
+            if source_label not in attribute_input_names:
+                input_name = (
+                    f"__dissolve_attribute_input_{len(attribute_input_names)}__"
+                )
+                attribute_input_names[source_label] = input_name
+                attribute_input_columns.append(
+                    internal.spark_column_for(source_label).alias(input_name)
+                )
 
         aggregation_input = source_sdf.select(
             *[
-                working[name].spark.column.alias(group_name)
-                for name, group_name in zip(temporary_names, group_column_names)
+                expression.alias(group_name)
+                for expression, group_name in zip(
+                    group_expressions,
+                    group_column_names,
+                )
             ],
-            working.geometry.spark.column.alias(geometry_input_name),
+            internal.spark_column_for(geometry_label).alias(geometry_input_name),
             scol_for(source_sdf, NATURAL_ORDER_COLUMN_NAME).alias(order_input_name),
+            *attribute_input_columns,
         )
 
+        attribute_output_names = [
+            f"__dissolve_attribute_{position}__"
+            for position in range(len(aggregation_specs))
+        ]
+        attribute_aggregations = [
+            _dissolve_aggregation_expression(
+                F.col(attribute_input_names[source_label]),
+                field,
+                function_name,
+                F.col(order_input_name),
+                source_label[0],
+            ).alias(output_name)
+            for (
+                source_label,
+                field,
+                function_name,
+                _,
+            ), output_name in zip(aggregation_specs, attribute_output_names)
+        ]
+
+        # CRS lookup is eager. Keep it after all aggregation validation so
+        # unsupported function/dtype combinations fail before Spark executes.
+        crs = self.crs
         srid = crs.to_epsg() if crs is not None else 0
         empty_geometry = stc.ST_GeomFromWKT(
             F.lit("GEOMETRYCOLLECTION EMPTY"),
@@ -1773,20 +1944,28 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
         )
         aggregated_sdf = aggregation_input.groupBy(*group_column_names).agg(
             geometry_union.alias(geometry_output_name),
-            F.min(F.col(order_input_name)).alias(order_output_name),
+            F.min(F.col(order_input_name)).alias(order_output_spark_name),
+            *attribute_aggregations,
         )
         if dropna:
             aggregated_sdf = aggregated_sdf.dropna(subset=group_column_names)
 
-        result_column_levels = (
-            aggregated_data._internal.column_labels_level
-            if aggregated_data is not None
-            else 1
-        )
         result_geometry_label = geometry_label + ("",) * (
             result_column_levels - len(geometry_label)
         )
-        result_order_label = (order_output_name,) + ("",) * (result_column_levels - 1)
+        result_attribute_labels = [spec[3] for spec in aggregation_specs]
+        result_order_label_name = "__dissolve_group_order__"
+        result_order_label = (result_order_label_name,) + ("",) * (
+            result_column_levels - 1
+        )
+        result_labels = {result_geometry_label, *result_attribute_labels}
+        result_order_suffix = 0
+        while result_order_label in result_labels:
+            result_order_suffix += 1
+            result_order_label_name = f"__dissolve_group_order_{result_order_suffix}__"
+            result_order_label = (result_order_label_name,) + ("",) * (
+                result_column_levels - 1
+            )
         result_geometry_name = (
             result_geometry_label[0]
             if len(result_geometry_label) == 1
@@ -1797,13 +1976,12 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
             if len(result_order_label) == 1
             else result_order_label
         )
-        result_column_label_names = (
-            aggregated_data._internal.column_label_names
-            if aggregated_data is not None
-            else [None]
-        )
+        result_column_label_names = [
+            internal.column_label_names[0],
+            *([None] * (result_column_levels - 1)),
+        ]
 
-        geometry_internal = InternalFrame(
+        result_internal = InternalFrame(
             spark_frame=aggregated_sdf,
             index_spark_columns=[
                 scol_for(aggregated_sdf, name) for name in group_column_names
@@ -1817,10 +1995,15 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
                 )
                 for field, name in zip(group_fields, group_column_names)
             ],
-            column_labels=[result_geometry_label, result_order_label],
+            column_labels=[
+                result_geometry_label,
+                result_order_label,
+                *result_attribute_labels,
+            ],
             data_spark_columns=[
                 scol_for(aggregated_sdf, geometry_output_name),
-                scol_for(aggregated_sdf, order_output_name),
+                scol_for(aggregated_sdf, order_output_spark_name),
+                *[scol_for(aggregated_sdf, name) for name in attribute_output_names],
             ],
             data_fields=[
                 InternalField(
@@ -1828,87 +2011,28 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
                     aggregated_sdf.schema[geometry_output_name],
                 ),
                 InternalField.from_struct_field(
-                    aggregated_sdf.schema[order_output_name]
+                    aggregated_sdf.schema[order_output_spark_name]
                 ),
+                *[
+                    (
+                        InternalField(field.dtype, aggregated_sdf.schema[name])
+                        if function_name in {"first", "last", "min", "max"}
+                        else InternalField.from_struct_field(
+                            aggregated_sdf.schema[name]
+                        )
+                    )
+                    for (
+                        _,
+                        field,
+                        function_name,
+                        _,
+                    ), name in zip(aggregation_specs, attribute_output_names)
+                ],
             ],
             column_label_names=result_column_label_names,
         )
-        aggregated = GeoDataFrame(PandasOnSparkDataFrame(geometry_internal))
+        aggregated = GeoDataFrame(PandasOnSparkDataFrame(result_internal))
         aggregated._geometry_column_name = result_geometry_name
-
-        if aggregated_data is not None:
-            data_internal = aggregated_data._internal
-            left_sdf = geometry_internal.spark_frame.alias("__geometry__")
-            right_sdf = data_internal.spark_frame.alias("__attributes__")
-            join_condition = F.lit(True)
-            for left_name, right_name in zip(
-                geometry_internal.index_spark_column_names,
-                data_internal.index_spark_column_names,
-            ):
-                join_condition = join_condition & left_sdf[left_name].eqNullSafe(
-                    right_sdf[right_name]
-                )
-
-            attribute_spark_names = [
-                f"__dissolve_attribute_{position}__"
-                for position in range(len(data_internal.data_spark_columns))
-            ]
-            combined_sdf = left_sdf.join(
-                right_sdf,
-                join_condition,
-                "left",
-            ).select(
-                *[
-                    left_sdf[name].alias(name)
-                    for name in geometry_internal.index_spark_column_names
-                ],
-                left_sdf[geometry_output_name],
-                left_sdf[order_output_name],
-                *[
-                    column.alias(name)
-                    for column, name in zip(
-                        data_internal.data_spark_columns,
-                        attribute_spark_names,
-                    )
-                ],
-            )
-            combined_internal = InternalFrame(
-                spark_frame=combined_sdf,
-                index_spark_columns=[
-                    scol_for(combined_sdf, name)
-                    for name in geometry_internal.index_spark_column_names
-                ],
-                index_names=group_index_names,
-                index_fields=[
-                    InternalField(field.dtype, combined_sdf.schema[field.name])
-                    for field in geometry_internal.index_fields
-                ],
-                column_labels=(
-                    geometry_internal.column_labels + data_internal.column_labels
-                ),
-                data_spark_columns=[
-                    scol_for(combined_sdf, geometry_output_name),
-                    scol_for(combined_sdf, order_output_name),
-                    *[scol_for(combined_sdf, name) for name in attribute_spark_names],
-                ],
-                data_fields=[
-                    InternalField(
-                        field.dtype,
-                        combined_sdf.schema[column_name],
-                    )
-                    for field, column_name in zip(
-                        geometry_internal.data_fields + data_internal.data_fields,
-                        [
-                            geometry_output_name,
-                            order_output_name,
-                            *attribute_spark_names,
-                        ],
-                    )
-                ],
-                column_label_names=result_column_label_names,
-            )
-            aggregated = GeoDataFrame(PandasOnSparkDataFrame(combined_internal))
-            aggregated._geometry_column_name = result_geometry_name
 
         if sort:
             aggregated = GeoDataFrame(aggregated.sort_index(na_position="last"))

--- a/python/sedona/spark/geopandas/geodataframe.py
+++ b/python/sedona/spark/geopandas/geodataframe.py
@@ -140,24 +140,6 @@ def _not_implemented_error(method_name: str, additional_info: str = "") -> str:
     return base_message + workaround
 
 
-def _dissolve_crs_with_metadata_fallback(geometry):
-    """Return CRS metadata even when every geometry value is null."""
-
-    crs = geometry.crs
-    if crs is not None:
-        return crs
-
-    source = geometry
-    seen = set()
-    while source is not None and id(source) not in seen:
-        seen.add(id(source))
-        crs = getattr(source, "_empty_crs_value", None)
-        if crs is not None:
-            return crs
-        source = getattr(source, "_empty_crs_source", None)
-    return None
-
-
 def _normalize_dissolve_aggfunc(aggfunc):
     """Translate explicitly supported callables to native aggregate names."""
 
@@ -1953,7 +1935,7 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
 
         # CRS lookup is eager. Keep it after all aggregation validation so
         # unsupported function/dtype combinations fail before Spark executes.
-        crs = _dissolve_crs_with_metadata_fallback(self.geometry)
+        crs = self.crs
         srid = crs.to_epsg() if crs is not None else 0
         empty_geometry = stc.ST_GeomFromWKT(
             F.lit("GEOMETRYCOLLECTION EMPTY"),

--- a/python/sedona/spark/geopandas/geodataframe.py
+++ b/python/sedona/spark/geopandas/geodataframe.py
@@ -1728,8 +1728,10 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
             group_fields.append(None)
             group_index_names.append(None)
         else:
+            groupers_are_column_labels = True
             if isinstance(by, PandasOnSparkSeries):
                 groupers = [by]
+                groupers_are_column_labels = False
                 if by._psdf is not self:
                     raise NotImplementedError(
                         "Sedona dissolve requires Series groupers to come from "
@@ -1774,7 +1776,8 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
                 )
                 group_fields.append(internal.field_for(grouper._column_label))
                 group_index_names.append(grouper._column_label)
-                grouped_column_labels.append(grouper._column_label)
+                if groupers_are_column_labels:
+                    grouped_column_labels.append(grouper._column_label)
 
         if not group_expressions:
             raise ValueError("No group keys passed")

--- a/python/sedona/spark/geopandas/geodataframe.py
+++ b/python/sedona/spark/geopandas/geodataframe.py
@@ -140,6 +140,24 @@ def _not_implemented_error(method_name: str, additional_info: str = "") -> str:
     return base_message + workaround
 
 
+def _dissolve_crs_with_metadata_fallback(geometry):
+    """Return CRS metadata even when every geometry value is null."""
+
+    crs = geometry.crs
+    if crs is not None:
+        return crs
+
+    source = geometry
+    seen = set()
+    while source is not None and id(source) not in seen:
+        seen.add(id(source))
+        crs = getattr(source, "_empty_crs_value", None)
+        if crs is not None:
+            return crs
+        source = getattr(source, "_empty_crs_source", None)
+    return None
+
+
 def _normalize_dissolve_aggfunc(aggfunc):
     """Translate explicitly supported callables to native aggregate names."""
 
@@ -1935,7 +1953,7 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
 
         # CRS lookup is eager. Keep it after all aggregation validation so
         # unsupported function/dtype combinations fail before Spark executes.
-        crs = self.crs
+        crs = _dissolve_crs_with_metadata_fallback(self.geometry)
         srid = crs.to_epsg() if crs is not None else 0
         empty_geometry = stc.ST_GeomFromWKT(
             F.lit("GEOMETRYCOLLECTION EMPTY"),

--- a/python/sedona/spark/geopandas/geoseries.py
+++ b/python/sedona/spark/geopandas/geoseries.py
@@ -485,7 +485,13 @@ class GeoSeries(GeoFrame, pspd.Series):
         srid = 0 if np.isnan(srid) else srid
 
         # Sedona returns 0 if SRID doesn't exist.
-        return CRS.from_user_input(srid) if srid != 0 else None
+        if srid != 0:
+            return CRS.from_user_input(srid)
+        if self._empty_crs_value is not None:
+            return self._empty_crs_value
+        if self._empty_crs_source is not None:
+            return self._empty_crs_source.crs
+        return None
 
     @crs.setter
     def crs(self, value: Union["CRS", None]):

--- a/python/sedona/spark/geopandas/geoseries.py
+++ b/python/sedona/spark/geopandas/geoseries.py
@@ -861,7 +861,12 @@ class GeoSeries(GeoFrame, pspd.Series):
         Same as `to_geopandas()`, without issuing the advice log for internal usage.
         """
         pd_series = self._to_internal_pandas()
-        return gpd.GeoSeries(pd_series, crs=self.crs)
+        return gpd.GeoSeries(
+            pd_series.array,
+            index=pd_series.index,
+            name=pd_series.name,
+            crs=self.crs,
+        )
 
     def to_spark_pandas(self) -> pspd.Series:
         return pspd.Series(pspd.DataFrame(self._psdf._internal))

--- a/python/sedona/spark/geopandas/geoseries.py
+++ b/python/sedona/spark/geopandas/geoseries.py
@@ -343,6 +343,8 @@ class GeoSeries(GeoFrame, pspd.Series):
         self._col_label: Label
         self._sindex: SpatialIndex = None
         self._empty_crs_source: typing.Optional["GeoSeries"] = None
+        # Explicit CRS metadata wins over the lineage fallback below when
+        # geometry rows are empty or carry SRID 0.
         self._empty_crs_value = None
 
         if isinstance(
@@ -462,6 +464,8 @@ class GeoSeries(GeoFrame, pspd.Series):
         from pyproj import CRS
 
         if self._is_empty():
+            # Empty data has no SRID to inspect, so explicit CRS metadata wins
+            # over the inherited lineage metadata.
             if self._empty_crs_value is not None:
                 return self._empty_crs_value
             if self._empty_crs_source is not None:
@@ -487,6 +491,9 @@ class GeoSeries(GeoFrame, pspd.Series):
         # Sedona returns 0 if SRID doesn't exist.
         if srid != 0:
             return CRS.from_user_input(srid)
+        # These fallbacks are metadata rather than a fresh read from geometry
+        # coordinates. Explicit metadata takes precedence over inherited
+        # lineage metadata, including for non-empty geometries with SRID 0.
         if self._empty_crs_value is not None:
             return self._empty_crs_value
         if self._empty_crs_source is not None:

--- a/python/sedona/spark/geopandas/geoseries.py
+++ b/python/sedona/spark/geopandas/geoseries.py
@@ -343,6 +343,7 @@ class GeoSeries(GeoFrame, pspd.Series):
         self._col_label: Label
         self._sindex: SpatialIndex = None
         self._empty_crs_source: typing.Optional["GeoSeries"] = None
+        self._empty_crs_value = None
 
         if isinstance(
             data, (GeoDataFrame, GeoSeries, PandasOnSparkSeries, PandasOnSparkDataFrame)
@@ -461,6 +462,8 @@ class GeoSeries(GeoFrame, pspd.Series):
         from pyproj import CRS
 
         if self._is_empty():
+            if self._empty_crs_value is not None:
+                return self._empty_crs_value
             if self._empty_crs_source is not None:
                 return self._empty_crs_source.crs
             return None
@@ -615,9 +618,15 @@ class GeoSeries(GeoFrame, pspd.Series):
 
         spark_col = stf.ST_SetSRID(self.spark.column, new_epsg)
         result = self._query_geometry_column(spark_col, keep_name=True)
+        result._empty_crs_value = crs
+        if crs is None:
+            result._empty_crs_source = None
 
         if inplace:
             self._update_inplace(result, invalidate_sindex=False)
+            self._empty_crs_value = crs
+            if crs is None:
+                self._empty_crs_source = None
             return None
 
         return result

--- a/python/sedona/spark/geopandas/tools/__init__.py
+++ b/python/sedona/spark/geopandas/tools/__init__.py
@@ -15,8 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from .collect import collect
 from .sjoin import sjoin
 
 __all__ = [
+    "collect",
     "sjoin",
 ]

--- a/python/sedona/spark/geopandas/tools/collect.py
+++ b/python/sedona/spark/geopandas/tools/collect.py
@@ -16,10 +16,14 @@
 # under the License.
 
 import geopandas as gpd
+import shapely
+from packaging.version import parse as parse_version
 from pyspark.sql import functions as F
 
 from sedona.spark.sql import st_aggregates as sta
 from sedona.spark.sql import st_functions as stf
+
+SHAPELY_LT_20 = parse_version(shapely.__version__) < parse_version("2.0.0")
 
 
 def collect(x, multi=False):
@@ -64,6 +68,13 @@ def collect(x, multi=False):
 
     geometry = x.spark.column
     geometry_type = stf.ST_GeometryType(geometry)
+    if SHAPELY_LT_20:
+        # Shapely 1 reports every empty geometry as GeometryCollection,
+        # regardless of whether the serializer retains its original family.
+        geometry_type = F.when(
+            stf.ST_IsEmpty(geometry),
+            F.lit("ST_GeometryCollection"),
+        ).otherwise(geometry_type)
     metadata = x._internal.spark_frame.agg(
         F.count(F.lit(1)).alias("__collect_count__"),
         F.count(geometry).alias("__collect_non_null_count__"),

--- a/python/sedona/spark/geopandas/tools/collect.py
+++ b/python/sedona/spark/geopandas/tools/collect.py
@@ -26,9 +26,9 @@ def collect(x, multi=False):
     """Collect single-part geometries into their multipart counterpart.
 
     A Sedona :class:`~sedona.spark.geopandas.GeoSeries` is aggregated on
-    executors with ``ST_Collect_Agg``. Only aggregate metadata and the single
-    geometry required by this scalar-returning API are materialized on the
-    driver. Local Shapely and GeoPandas inputs retain GeoPandas' behavior.
+    executors with ``ST_Collect_Agg``. One aggregate action materializes only
+    the metadata and single geometry required by this scalar-returning API on
+    the driver. Local Shapely and GeoPandas inputs retain GeoPandas' behavior.
 
     Parameters
     ----------
@@ -72,6 +72,8 @@ def collect(x, multi=False):
         F.max(F.when(stf.ST_IsEmpty(geometry), F.lit(1)).otherwise(F.lit(0))).alias(
             "__collect_has_empty__"
         ),
+        F.first(geometry, ignorenulls=True).alias("__collect_single_geometry__"),
+        sta.ST_Collect_Agg(geometry).alias("__collect_geometry__"),
     ).first()
 
     count = metadata["__collect_count__"]
@@ -94,7 +96,7 @@ def collect(x, multi=False):
         )
 
     if count == 1 and (is_multi or not multi):
-        return x._internal.spark_frame.select(geometry.alias("geometry")).first()[0]
+        return metadata["__collect_single_geometry__"]
 
     if geometry_type_name not in {"Point", "LineString", "Polygon"}:
         raise KeyError(geometry_type_name)
@@ -115,6 +117,4 @@ def collect(x, multi=False):
             f"Can't create Multi{geometry_type_name} with empty component"
         )
 
-    return x._internal.spark_frame.select(
-        sta.ST_Collect_Agg(geometry).alias("geometry")
-    ).first()[0]
+    return metadata["__collect_geometry__"]

--- a/python/sedona/spark/geopandas/tools/collect.py
+++ b/python/sedona/spark/geopandas/tools/collect.py
@@ -1,0 +1,120 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import geopandas as gpd
+from pyspark.sql import functions as F
+
+from sedona.spark.sql import st_aggregates as sta
+from sedona.spark.sql import st_functions as stf
+
+
+def collect(x, multi=False):
+    """Collect single-part geometries into their multipart counterpart.
+
+    A Sedona :class:`~sedona.spark.geopandas.GeoSeries` is aggregated on
+    executors with ``ST_Collect_Agg``. Only aggregate metadata and the single
+    geometry required by this scalar-returning API are materialized on the
+    driver. Local Shapely and GeoPandas inputs retain GeoPandas' behavior.
+
+    Parameters
+    ----------
+    x : GeoSeries, iterable, or Shapely geometry
+        Homogeneous geometries to collect.
+    multi : bool, default False
+        Force a singleton single-part geometry into its multipart type.
+
+    Returns
+    -------
+    shapely.geometry.base.BaseGeometry
+        A singleton geometry or its collected multipart geometry.
+
+    Raises
+    ------
+    ValueError
+        If geometry types differ, or multiple multipart geometries are passed.
+
+    Examples
+    --------
+    >>> from shapely.geometry import Point
+    >>> from sedona.spark.geopandas import GeoSeries
+    >>> from sedona.spark.geopandas.tools import collect
+    >>> collect(GeoSeries([Point(0, 0), Point(1, 1)]))
+    <MULTIPOINT ((0 0), (1 1))>
+    >>> collect(Point(0, 0), multi=True)
+    <MULTIPOINT ((0 0))>
+    """
+    from sedona.spark.geopandas import GeoSeries
+
+    if not isinstance(x, GeoSeries):
+        return gpd.tools.collect(x, multi=multi)
+
+    geometry = x.spark.column
+    geometry_type = stf.ST_GeometryType(geometry)
+    metadata = x._internal.spark_frame.agg(
+        F.count(F.lit(1)).alias("__collect_count__"),
+        F.count(geometry).alias("__collect_non_null_count__"),
+        F.countDistinct(geometry_type).alias("__collect_type_count__"),
+        F.first(geometry_type, ignorenulls=True).alias("__collect_type__"),
+        F.max(F.when(stf.ST_IsEmpty(geometry), F.lit(1)).otherwise(F.lit(0))).alias(
+            "__collect_has_empty__"
+        ),
+    ).first()
+
+    count = metadata["__collect_count__"]
+    non_null_count = metadata["__collect_non_null_count__"]
+    if count == 0:
+        raise IndexError("list index out of range")
+    if non_null_count != count:
+        raise AttributeError("'NoneType' object has no attribute 'geom_type'")
+    if metadata["__collect_type_count__"] != 1:
+        raise ValueError("Geometry type must be homogeneous")
+
+    geometry_type_name = metadata["__collect_type__"]
+    if geometry_type_name.startswith("ST_"):
+        geometry_type_name = geometry_type_name[3:]
+
+    is_multi = geometry_type_name.startswith("Multi")
+    if count > 1 and is_multi:
+        raise ValueError(
+            f"Cannot collect {geometry_type_name}. Must have single geometries"
+        )
+
+    if count == 1 and (is_multi or not multi):
+        return x._internal.spark_frame.select(geometry.alias("geometry")).first()[0]
+
+    if geometry_type_name not in {"Point", "LineString", "Polygon"}:
+        raise KeyError(geometry_type_name)
+
+    if metadata["__collect_has_empty__"] and geometry_type_name in {
+        "Point",
+        "LineString",
+    }:
+        # EmptyPartError was added after Shapely 1.7.0, Sedona's supported
+        # dependency floor. Keep importing this module safe on that version.
+        try:
+            from shapely.errors import EmptyPartError
+        except ImportError:
+            raise ValueError(
+                f"Can't create Multi{geometry_type_name} with empty component"
+            ) from None
+        raise EmptyPartError(
+            f"Can't create Multi{geometry_type_name} with empty component"
+        )
+
+    return x._internal.spark_frame.select(
+        sta.ST_Collect_Agg(geometry).alias("geometry")
+    ).first()[0]

--- a/python/sedona/spark/geopandas/tools/collect.py
+++ b/python/sedona/spark/geopandas/tools/collect.py
@@ -21,6 +21,7 @@ from packaging.version import parse as parse_version
 from pyspark.sql import functions as F
 
 from sedona.spark.sql import st_aggregates as sta
+from sedona.spark.sql import st_constructors as stc
 from sedona.spark.sql import st_functions as stf
 
 SHAPELY_LT_20 = parse_version(shapely.__version__) < parse_version("2.0.0")
@@ -68,23 +69,35 @@ def collect(x, multi=False):
 
     geometry = x.spark.column
     geometry_type = stf.ST_GeometryType(geometry)
+    geometry_is_empty = stf.ST_IsEmpty(geometry)
     if SHAPELY_LT_20:
         # Shapely 1 reports every empty geometry as GeometryCollection,
         # regardless of whether the serializer retains its original family.
         geometry_type = F.when(
-            stf.ST_IsEmpty(geometry),
+            geometry_is_empty,
             F.lit("ST_GeometryCollection"),
         ).otherwise(geometry_type)
+    non_empty_geometry = F.when(~geometry_is_empty, geometry)
+    first_geometry_type = F.first(geometry_type, ignorenulls=True)
+    empty_multipolygon = stc.ST_GeomFromWKT(
+        F.lit("MULTIPOLYGON EMPTY"),
+        F.first(stf.ST_SRID(geometry), ignorenulls=True),
+    )
+    collected_geometry = F.coalesce(
+        sta.ST_Collect_Agg(non_empty_geometry),
+        F.when(
+            first_geometry_type == F.lit("ST_Polygon"),
+            empty_multipolygon,
+        ),
+    )
     metadata = x._internal.spark_frame.agg(
         F.count(F.lit(1)).alias("__collect_count__"),
         F.count(geometry).alias("__collect_non_null_count__"),
+        F.count(non_empty_geometry).alias("__collect_non_empty_count__"),
         F.countDistinct(geometry_type).alias("__collect_type_count__"),
-        F.first(geometry_type, ignorenulls=True).alias("__collect_type__"),
-        F.max(F.when(stf.ST_IsEmpty(geometry), F.lit(1)).otherwise(F.lit(0))).alias(
-            "__collect_has_empty__"
-        ),
+        first_geometry_type.alias("__collect_type__"),
         F.first(geometry, ignorenulls=True).alias("__collect_single_geometry__"),
-        sta.ST_Collect_Agg(geometry).alias("__collect_geometry__"),
+        collected_geometry.alias("__collect_geometry__"),
     ).first()
 
     count = metadata["__collect_count__"]
@@ -112,7 +125,9 @@ def collect(x, multi=False):
     if geometry_type_name not in {"Point", "LineString", "Polygon"}:
         raise KeyError(geometry_type_name)
 
-    if metadata["__collect_has_empty__"] and geometry_type_name in {
+    non_empty_count = metadata["__collect_non_empty_count__"]
+    has_empty = non_empty_count != count
+    if has_empty and geometry_type_name in {
         "Point",
         "LineString",
     }:

--- a/python/tests/geopandas/test_geometry_aggregation.py
+++ b/python/tests/geopandas/test_geometry_aggregation.py
@@ -86,6 +86,7 @@ class TestGeometryAggregation(TestGeopandasBase):
         with ps.option_context("compute.ops_on_diff_frames", True):
             source = GeoDataFrame(expected_source)
 
+        assert source.crs == expected_source.crs
         result = source.dissolve("zone")
         expected = expected_source.dissolve("zone")
 

--- a/python/tests/geopandas/test_geometry_aggregation.py
+++ b/python/tests/geopandas/test_geometry_aggregation.py
@@ -20,6 +20,8 @@ import numpy as np
 import pandas as pd
 import pytest
 import pyspark.pandas as ps
+import shapely
+from packaging.version import parse as parse_version
 from pyspark.sql import DataFrame as SparkDataFrame
 
 try:
@@ -27,6 +29,7 @@ try:
 except ImportError:
     EmptyPartError = ValueError
 from shapely.geometry import (
+    GeometryCollection,
     LineString,
     MultiPoint,
     Point,
@@ -37,6 +40,9 @@ from sedona.spark.geopandas import GeoDataFrame, GeoSeries
 from sedona.spark.geopandas.tools import collect
 from sedona.spark.sql import st_functions as stf
 from tests.geopandas.test_geopandas_base import TestGeopandasBase
+
+SHAPELY_GE_20 = parse_version(shapely.__version__) >= parse_version("2.0.0")
+GEOPANDAS_HAS_UNION_ALL = hasattr(gpd.GeoSeries, "union_all")
 
 
 class TestGeometryAggregation(TestGeopandasBase):
@@ -70,7 +76,10 @@ class TestGeometryAggregation(TestGeopandasBase):
         collected = result.to_geopandas()
         null_group = collected[collected.index.isna()].iloc[0]
         assert null_group["label"] == "missing"
-        assert null_group["shape"].is_empty
+        if GEOPANDAS_HAS_UNION_ALL:
+            assert null_group["shape"].is_empty
+        else:
+            assert null_group["shape"] is None
 
         srids = (
             result.geometry._internal.spark_frame.select(
@@ -79,9 +88,10 @@ class TestGeometryAggregation(TestGeopandasBase):
             .distinct()
             .collect()
         )
-        assert [row.srid for row in srids] == [3857]
+        expected_srids = {3857} if GEOPANDAS_HAS_UNION_ALL else {3857, None}
+        assert {row.srid for row in srids} == expected_srids
 
-    def test_dissolve_all_null_geometry_preserves_crs_and_srid(self):
+    def test_dissolve_all_null_geometry_matches_geopandas_and_preserves_crs(self):
         expected_source = gpd.GeoDataFrame(
             {
                 "zone": ["a", "a"],
@@ -101,7 +111,8 @@ class TestGeometryAggregation(TestGeopandasBase):
         srids = result.geometry._internal.spark_frame.select(
             stf.ST_SRID(result.geometry.spark.column).alias("srid")
         ).collect()
-        assert [row.srid for row in srids] == [4326]
+        expected_srid = 4326 if GEOPANDAS_HAS_UNION_ALL else None
+        assert [row.srid for row in srids] == [expected_srid]
 
     def test_dissolve_series_grouper_retains_data_column(self):
         local = gpd.GeoDataFrame(
@@ -462,16 +473,39 @@ class TestGeometryAggregation(TestGeopandasBase):
         assert collected_lines.geom_type == "MultiLineString"
         assert len(collected_lines.geoms) == 2
 
-        polygons = [
-            Polygon(),
-            Polygon([(0, 0), (1, 0), (0, 1)]),
-        ]
-        collected_polygons = collect(GeoSeries(polygons))
-        assert collected_polygons.geom_type == "MultiPolygon"
-        assert len(collected_polygons.geoms) == 1
-        assert collect(GeoSeries([Polygon()]), multi=True).equals(
-            gpd.tools.collect(Polygon(), multi=True)
-        )
+        if SHAPELY_GE_20:
+            polygons = [
+                Polygon(),
+                Polygon([(0, 0), (1, 0), (0, 1)]),
+            ]
+            collected_polygons = collect(GeoSeries(polygons))
+            assert collected_polygons.geom_type == "MultiPolygon"
+            assert len(collected_polygons.geoms) == 1
+            assert collect(GeoSeries([Polygon()]), multi=True).equals(
+                gpd.tools.collect(Polygon(), multi=True)
+            )
+        else:
+            polygons = [
+                Polygon([(0, 0), (1, 0), (0, 1)]),
+                Polygon([(2, 0), (3, 0), (2, 1)]),
+            ]
+            collected_polygons = collect(GeoSeries(polygons))
+            assert collected_polygons.geom_type == "MultiPolygon"
+            assert len(collected_polygons.geoms) == 2
+            with pytest.raises(ValueError, match="homogeneous"):
+                collect(GeoSeries([Polygon(), polygons[0]]))
+            with pytest.raises(KeyError, match="GeometryCollection"):
+                collect(GeoSeries([Polygon()]), multi=True)
+
+        with pytest.raises(ValueError, match="homogeneous"):
+            collect(
+                GeoSeries(
+                    [
+                        GeometryCollection(),
+                        Polygon([(0, 0), (1, 0), (0, 1)]),
+                    ]
+                )
+            )
 
     def test_collect_validation_matches_geopandas(self):
         with pytest.raises(IndexError, match="list index out of range"):
@@ -489,5 +523,9 @@ class TestGeometryAggregation(TestGeopandasBase):
                     ]
                 )
             )
-        with pytest.raises(EmptyPartError, match="empty component"):
-            collect(GeoSeries([Point()]), multi=True)
+        if SHAPELY_GE_20:
+            with pytest.raises(EmptyPartError, match="empty component"):
+                collect(GeoSeries([Point()]), multi=True)
+        else:
+            with pytest.raises(KeyError, match="GeometryCollection"):
+                collect(GeoSeries([Point()]), multi=True)

--- a/python/tests/geopandas/test_geometry_aggregation.py
+++ b/python/tests/geopandas/test_geometry_aggregation.py
@@ -16,10 +16,15 @@
 # under the License.
 
 import geopandas as gpd
+import numpy as np
 import pandas as pd
 import pytest
 import pyspark.pandas as ps
-from shapely.errors import EmptyPartError
+
+try:
+    from shapely.errors import EmptyPartError
+except ImportError:
+    EmptyPartError = ValueError
 from shapely.geometry import (
     LineString,
     MultiPoint,
@@ -90,6 +95,7 @@ class TestGeometryAggregation(TestGeopandasBase):
         assert row["value"] == 5
         assert row["geometry"].equals(MultiPoint([(0, 0), (1, 1)]))
         assert result.crs == source.crs
+        assert result["index"].dtype == np.dtype("int64")
 
     def test_dissolve_level_multikey_and_sort(self):
         index = pd.MultiIndex.from_tuples(
@@ -126,7 +132,7 @@ class TestGeometryAggregation(TestGeopandasBase):
         assert multikey_result.index.names == ["kind", "value"]
 
     def test_dissolve_multiple_aggregations(self):
-        source = GeoDataFrame(
+        local = gpd.GeoDataFrame(
             {
                 "zone": ["a", "a", "b"],
                 "value": [1, 3, 2],
@@ -134,6 +140,9 @@ class TestGeometryAggregation(TestGeopandasBase):
                 "geometry": [Point(0, 0), Point(1, 1), Point(2, 2)],
             }
         )
+        local.columns.name = "attributes"
+        with ps.option_context("compute.ops_on_diff_frames", True):
+            source = GeoDataFrame(local)
         result = source.dissolve(
             "zone",
             aggfunc={
@@ -145,11 +154,106 @@ class TestGeometryAggregation(TestGeopandasBase):
         collected = result.to_geopandas()
 
         assert isinstance(result.columns, pd.MultiIndex)
+        assert result.columns.names == ["attributes", None]
         assert result.active_geometry_name == ("geometry", "")
         assert collected.loc["a", ("zone", "first")] == "a"
         assert collected.loc["a", ("value", "sum")] == 4
         assert collected.loc["a", ("value", "max")] == 3
         assert collected.loc["a", ("label", "first")] == "x"
+
+    def test_dissolve_first_last_skip_nulls_in_source_order(self):
+        source = GeoDataFrame(
+            {
+                "zone": ["a"] * 6 + ["b"] * 2,
+                "label": [
+                    None,
+                    "first",
+                    "middle",
+                    None,
+                    "last",
+                    None,
+                    None,
+                    None,
+                ],
+                "value": [
+                    np.nan,
+                    1.0,
+                    2.0,
+                    np.nan,
+                    3.0,
+                    np.nan,
+                    np.nan,
+                    np.nan,
+                ],
+                "geometry": [Point(i, i) for i in range(8)],
+            }
+        )
+        distributed_result = source.dissolve(
+            "zone",
+            aggfunc={
+                "label": ["first", "last", "count", "nunique"],
+                "value": ["first", "last", "count", "nunique"],
+            },
+        )
+        spark_frame = distributed_result._internal.spark_frame
+        if hasattr(spark_frame, "_jdf"):
+            plan = spark_frame._jdf.queryExecution().analyzed().toString().lower()
+            assert "min_by" in plan
+            assert "max_by" in plan
+        result = distributed_result.to_geopandas()
+
+        assert result.loc["a", ("label", "first")] == "first"
+        assert result.loc["a", ("label", "last")] == "last"
+        assert result.loc["a", ("label", "count")] == 3
+        assert result.loc["a", ("label", "nunique")] == 3
+        assert result.loc["a", ("value", "first")] == 1.0
+        assert result.loc["a", ("value", "last")] == 3.0
+        assert result.loc["a", ("value", "count")] == 3
+        assert result.loc["a", ("value", "nunique")] == 3
+        assert result.loc["b", ("label", "first")] is None
+        assert result.loc["b", ("label", "last")] is None
+        assert result.loc["b", ("label", "count")] == 0
+        assert result.loc["b", ("label", "nunique")] == 0
+        assert pd.isna(result.loc["b", ("value", "first")])
+        assert pd.isna(result.loc["b", ("value", "last")])
+
+    def test_dissolve_numeric_boolean_aggregation_semantics(self):
+        local = gpd.GeoDataFrame(
+            {
+                "zone": ["a", "a", "b", "b"],
+                "integer": [1, 2, 3, 4],
+                "number": [1.5, 2.5, np.nan, np.nan],
+                "flag": pd.Series([True, False, None, None], dtype="boolean"),
+                "geometry": [Point(i, i) for i in range(4)],
+            }
+        )
+        with ps.option_context("compute.ops_on_diff_frames", True):
+            source = GeoDataFrame(local)
+
+        result = source.dissolve(
+            "zone",
+            aggfunc={
+                "integer": [np.sum, np.mean],
+                "number": "sum",
+                "flag": ["sum", "mean", "median", "std", "var", "min", "max"],
+            },
+        ).to_geopandas()
+
+        assert result.loc["a", ("integer", "sum")] == 3
+        assert result.loc["a", ("integer", "mean")] == 1.5
+        assert result[("integer", "sum")].dtype == np.dtype("int64")
+        assert result.loc["b", ("number", "sum")] == 0.0
+        assert result.loc["a", ("flag", "sum")] == 1
+        assert result.loc["b", ("flag", "sum")] == 0
+        assert result[("flag", "sum")].dtype == np.dtype("int64")
+        assert result.loc["a", ("flag", "mean")] == 0.5
+        assert result.loc["a", ("flag", "median")] == 0.5
+        assert result.loc["a", ("flag", "std")] == pytest.approx(2**-0.5)
+        assert result.loc["a", ("flag", "var")] == 0.5
+        assert not bool(result.loc["a", ("flag", "min")])
+        assert bool(result.loc["a", ("flag", "max")])
+        for function_name in ["mean", "median", "std", "var"]:
+            assert result[("flag", function_name)].dtype == np.dtype("float64")
 
     def test_dissolve_empty_preserves_crs(self):
         with ps.option_context("compute.ops_on_diff_frames", True):
@@ -181,7 +285,7 @@ class TestGeometryAggregation(TestGeopandasBase):
             source.dissolve("zone", method="coverage")
         with pytest.raises(NotImplementedError, match="grid_size"):
             source.dissolve("zone", grid_size=1)
-        with pytest.raises(NotImplementedError, match="named Spark"):
+        with pytest.raises(NotImplementedError, match="known built-in"):
             source.dissolve("zone", aggfunc=lambda values: values.iloc[0])
         with pytest.raises(NotImplementedError, match="grouping vectors"):
             source.dissolve(["a"])
@@ -191,6 +295,38 @@ class TestGeometryAggregation(TestGeopandasBase):
                 aggfunc={"zone": "first"},
                 numeric_only=True,
             )
+        with pytest.raises(NotImplementedError, match="prod aggregation"):
+            source.dissolve("zone", aggfunc="prod")
+
+        strings = GeoDataFrame(
+            {
+                "zone": ["a", "a"],
+                "label": ["x", "y"],
+                "geometry": [Point(0, 0), Point(1, 1)],
+            }
+        )
+        for aggregation in ["min", "max", "sum", "mean", "median", "std", "var"]:
+            with pytest.raises(
+                NotImplementedError,
+                match=rf"'{aggregation}'.*column 'label'.*'string'",
+            ):
+                strings.dissolve("zone", aggfunc=aggregation)
+
+        def sum(values):
+            return values.sum()
+
+        with pytest.raises(NotImplementedError, match="known built-in"):
+            source.dissolve("zone", aggfunc=sum)
+
+        geometry_only = GeoDataFrame({"geometry": [Point(0, 0)]})
+        assert list(geometry_only.dissolve().columns) == ["geometry"]
+        with pytest.raises(ValueError, match="No objects to concatenate"):
+            geometry_only.dissolve(aggfunc=["first"])
+
+        empty_dict_functions = GeoDataFrame(
+            {"value": [1], "geometry": [Point(0, 0)]}
+        ).dissolve(aggfunc={"value": []})
+        assert list(empty_dict_functions.columns) == ["geometry"]
 
         with ps.option_context("compute.ops_on_diff_frames", True):
             categorical = GeoDataFrame(
@@ -203,6 +339,30 @@ class TestGeometryAggregation(TestGeopandasBase):
             )
         with pytest.raises(NotImplementedError, match="observed=True"):
             categorical.dissolve("zone")
+
+        categorical_values = gpd.GeoDataFrame(
+            {
+                "zone": ["a", "a"],
+                "category": pd.Categorical(["x", None]),
+                "geometry": [Point(0, 0), Point(1, 1)],
+            }
+        )
+        with ps.option_context("compute.ops_on_diff_frames", True):
+            distributed_categories = GeoDataFrame(categorical_values)
+        category_result = distributed_categories.dissolve(
+            "zone",
+            aggfunc={"category": "first"},
+        ).to_geopandas()
+        assert category_result.loc["a", "category"] == "x"
+        assert isinstance(category_result["category"].dtype, pd.CategoricalDtype)
+        with pytest.raises(
+            NotImplementedError,
+            match="'nunique'.*'category'",
+        ):
+            distributed_categories.dissolve(
+                "zone",
+                aggfunc={"category": "nunique"},
+            )
 
     def test_collect_scalar_and_distributed_singletons(self):
         point = Point(0, 0)

--- a/python/tests/geopandas/test_geometry_aggregation.py
+++ b/python/tests/geopandas/test_geometry_aggregation.py
@@ -23,6 +23,7 @@ import pyspark.pandas as ps
 import shapely
 from packaging.version import parse as parse_version
 from pyspark.sql import DataFrame as SparkDataFrame
+from pyspark.sql import functions as F
 
 try:
     from shapely.errors import EmptyPartError
@@ -139,6 +140,9 @@ class TestGeometryAggregation(TestGeopandasBase):
             "value",
         ]
         collected = series_result.to_geopandas()
+        assert collected.index.name == expected.index.name == "zone"
+        assert collected.geometry.name == "geometry"
+        assert collected.crs == expected.crs == source.crs
         assert collected.loc["a", "zone"] == "a"
         assert collected.loc["a", "label"] == "first-a"
         assert collected.loc["a", "value"] == 1
@@ -444,21 +448,63 @@ class TestGeometryAggregation(TestGeopandasBase):
         multi_point = MultiPoint([(0, 0), (1, 1)])
         assert collect(GeoSeries([multi_point]), multi=True).equals(multi_point)
 
-    def test_collect_uses_one_spark_action(self, monkeypatch):
+    @pytest.mark.parametrize(
+        "geometries, crs, expected_srid",
+        [
+            ([Point(0, 0), Point(1, 1)], None, 0),
+            pytest.param(
+                [
+                    Polygon(),
+                    Polygon([(0, 0), (1, 0), (0, 1)]),
+                ],
+                None,
+                0,
+                marks=pytest.mark.skipif(
+                    not SHAPELY_GE_20,
+                    reason="Shapely 1 does not retain typed empty geometries",
+                ),
+            ),
+            pytest.param(
+                [Polygon(), Polygon()],
+                "EPSG:4326",
+                4326,
+                marks=pytest.mark.skipif(
+                    not SHAPELY_GE_20,
+                    reason="Shapely 1 does not retain typed empty geometries",
+                ),
+            ),
+        ],
+    )
+    def test_collect_uses_one_spark_action(
+        self,
+        monkeypatch,
+        geometries,
+        crs,
+        expected_srid,
+    ):
         first_calls = 0
+        result_srids = []
         original_first = SparkDataFrame.first
 
         def count_first(frame):
             nonlocal first_calls
             first_calls += 1
-            return original_first(frame)
+            enriched = frame.select(
+                "*",
+                stf.ST_SRID(F.col("__collect_geometry__")).alias(
+                    "__collect_result_srid__"
+                ),
+            )
+            result = original_first(enriched)
+            result_srids.append(result["__collect_result_srid__"])
+            return result
 
         monkeypatch.setattr(SparkDataFrame, "first", count_first)
 
-        result = collect(GeoSeries([Point(0, 0), Point(1, 1)]))
+        collect(GeoSeries(geometries, crs=crs))
 
-        assert result.equals(MultiPoint([(0, 0), (1, 1)]))
         assert first_calls == 1
+        assert result_srids == [expected_srid]
 
     def test_collect_distributed_geometry_families(self):
         assert collect(GeoSeries([Point(0, 0), Point(1, 1)])).equals(
@@ -474,16 +520,31 @@ class TestGeometryAggregation(TestGeopandasBase):
         assert len(collected_lines.geoms) == 2
 
         if SHAPELY_GE_20:
-            polygons = [
-                Polygon(),
-                Polygon([(0, 0), (1, 0), (0, 1)]),
-            ]
-            collected_polygons = collect(GeoSeries(polygons))
-            assert collected_polygons.geom_type == "MultiPolygon"
-            assert len(collected_polygons.geoms) == 1
-            assert collect(GeoSeries([Polygon()]), multi=True).equals(
-                gpd.tools.collect(Polygon(), multi=True)
-            )
+            empty_polygon = Polygon()
+            polygon = Polygon([(0, 0), (1, 0), (0, 1)])
+            for polygons in (
+                [empty_polygon, polygon],
+                [polygon, empty_polygon],
+            ):
+                collected_polygons = collect(GeoSeries(polygons))
+                assert collected_polygons.geom_type == "MultiPolygon"
+                assert len(collected_polygons.geoms) == 1
+
+            singleton_empty = collect(GeoSeries([empty_polygon]))
+            assert singleton_empty.geom_type == "Polygon"
+            assert singleton_empty.is_empty
+
+            for polygons in (
+                [empty_polygon],
+                [empty_polygon, empty_polygon],
+            ):
+                collected_empty = collect(
+                    GeoSeries(polygons, crs="EPSG:4326"),
+                    multi=True,
+                )
+                assert collected_empty.geom_type == "MultiPolygon"
+                assert collected_empty.is_empty
+                assert len(collected_empty.geoms) == 0
         else:
             polygons = [
                 Polygon([(0, 0), (1, 0), (0, 1)]),
@@ -524,8 +585,17 @@ class TestGeometryAggregation(TestGeopandasBase):
                 )
             )
         if SHAPELY_GE_20:
-            with pytest.raises(EmptyPartError, match="empty component"):
-                collect(GeoSeries([Point()]), multi=True)
+            for empty, non_empty in (
+                (Point(), Point(0, 0)),
+                (LineString(), LineString([(0, 0), (1, 1)])),
+            ):
+                singleton_empty = collect(GeoSeries([empty]))
+                assert singleton_empty.geom_type == empty.geom_type
+                assert singleton_empty.is_empty
+                with pytest.raises(EmptyPartError, match="empty component"):
+                    collect(GeoSeries([empty]), multi=True)
+                with pytest.raises(EmptyPartError, match="empty component"):
+                    collect(GeoSeries([empty, non_empty]))
         else:
             with pytest.raises(KeyError, match="GeometryCollection"):
                 collect(GeoSeries([Point()]), multi=True)

--- a/python/tests/geopandas/test_geometry_aggregation.py
+++ b/python/tests/geopandas/test_geometry_aggregation.py
@@ -55,8 +55,9 @@ class TestGeometryAggregation(TestGeopandasBase):
         )
         spark_frame = result._internal.spark_frame
         if hasattr(spark_frame, "_jdf"):
-            plan = spark_frame._jdf.queryExecution().analyzed().toString()
-            assert "PythonUDF" not in plan
+            plan = spark_frame._jdf.queryExecution().executedPlan().toString()
+            assert "BatchEvalPython" not in plan
+            assert "ArrowEvalPython" not in plan
         expected = expected_source.dissolve(
             "zone",
             aggfunc={"label": "first", "value": "sum"},

--- a/python/tests/geopandas/test_geometry_aggregation.py
+++ b/python/tests/geopandas/test_geometry_aggregation.py
@@ -1,0 +1,259 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import geopandas as gpd
+import pandas as pd
+import pytest
+import pyspark.pandas as ps
+from shapely.errors import EmptyPartError
+from shapely.geometry import (
+    LineString,
+    MultiPoint,
+    Point,
+    Polygon,
+)
+
+from sedona.spark.geopandas import GeoDataFrame, GeoSeries
+from sedona.spark.geopandas.tools import collect
+from sedona.spark.sql import st_functions as stf
+from tests.geopandas.test_geopandas_base import TestGeopandasBase
+
+
+class TestGeometryAggregation(TestGeopandasBase):
+    def test_dissolve_grouped_matches_geopandas(self):
+        data = {
+            "zone": ["b", "a", "b", None],
+            "label": ["first-b", "only-a", "second-b", "missing"],
+            "value": [1, 2, 3, 4],
+            "shape": [Point(0, 0), Point(5, 5), Point(1, 1), None],
+        }
+        expected_source = gpd.GeoDataFrame(data, geometry="shape", crs="EPSG:3857")
+        with ps.option_context("compute.ops_on_diff_frames", True):
+            source = GeoDataFrame(expected_source)
+        result = source.dissolve(
+            "zone", aggfunc={"label": "first", "value": "sum"}, dropna=False
+        )
+        expected = expected_source.dissolve(
+            "zone",
+            aggfunc={"label": "first", "value": "sum"},
+            dropna=False,
+        )
+
+        self.check_sgpd_df_equals_gpd_df(result, expected)
+        assert result.active_geometry_name == "shape"
+        assert result.crs == expected.crs
+        collected = result.to_geopandas()
+        null_group = collected[collected.index.isna()].iloc[0]
+        assert null_group["label"] == "missing"
+        assert null_group["shape"].is_empty
+
+        srids = (
+            result.geometry._internal.spark_frame.select(
+                stf.ST_SRID(result.geometry.spark.column).alias("srid")
+            )
+            .distinct()
+            .collect()
+        )
+        assert [row.srid for row in srids] == [3857]
+
+    def test_dissolve_all_rows_and_as_index_false(self):
+        data = {
+            "label": ["first", "second"],
+            "value": [2, 3],
+            "geometry": [Point(0, 0), Point(1, 1)],
+        }
+        with ps.option_context("compute.ops_on_diff_frames", True):
+            source = GeoDataFrame(data, crs="EPSG:4326")
+        result = source.dissolve(
+            aggfunc={"label": "first", "value": "sum"},
+            as_index=False,
+        )
+
+        assert list(result.columns) == ["index", "geometry", "label", "value"]
+        row = result.to_geopandas().iloc[0]
+        assert row["index"] == 0
+        assert row["label"] == "first"
+        assert row["value"] == 5
+        assert row["geometry"].equals(MultiPoint([(0, 0), (1, 1)]))
+        assert result.crs == source.crs
+
+    def test_dissolve_level_multikey_and_sort(self):
+        index = pd.MultiIndex.from_tuples(
+            [("z", 2), ("a", 1), ("z", 1)],
+            names=["letter", "number"],
+        )
+        source = gpd.GeoDataFrame(
+            {
+                "kind": ["q", "q", "r"],
+                "value": [1, 2, 3],
+                "geometry": [Point(0, 0), Point(1, 1), Point(2, 2)],
+            },
+            index=index,
+            crs="EPSG:4326",
+        )
+
+        with ps.option_context("compute.ops_on_diff_frames", True):
+            distributed = GeoDataFrame(source)
+
+        level_result = distributed.dissolve(level="letter")
+        level_expected = source.dissolve(level="letter")
+        self.check_sgpd_df_equals_gpd_df(level_result, level_expected)
+        assert level_result.index.names == ["letter"]
+
+        multikey_result = distributed.dissolve(
+            by=["kind", "value"],
+            sort=False,
+        )
+        multikey_expected = source.dissolve(
+            by=["kind", "value"],
+            sort=False,
+        )
+        self.check_sgpd_df_equals_gpd_df(multikey_result, multikey_expected)
+        assert multikey_result.index.names == ["kind", "value"]
+
+    def test_dissolve_multiple_aggregations(self):
+        source = GeoDataFrame(
+            {
+                "zone": ["a", "a", "b"],
+                "value": [1, 3, 2],
+                "label": ["x", "y", "z"],
+                "geometry": [Point(0, 0), Point(1, 1), Point(2, 2)],
+            }
+        )
+        result = source.dissolve(
+            "zone",
+            aggfunc={
+                "zone": "first",
+                "value": ("sum", "max"),
+                "label": "first",
+            },
+        )
+        collected = result.to_geopandas()
+
+        assert isinstance(result.columns, pd.MultiIndex)
+        assert result.active_geometry_name == ("geometry", "")
+        assert collected.loc["a", ("zone", "first")] == "a"
+        assert collected.loc["a", ("value", "sum")] == 4
+        assert collected.loc["a", ("value", "max")] == 3
+        assert collected.loc["a", ("label", "first")] == "x"
+
+    def test_dissolve_empty_preserves_crs(self):
+        with ps.option_context("compute.ops_on_diff_frames", True):
+            source = GeoDataFrame(
+                gpd.GeoDataFrame(
+                    {
+                        "zone": pd.Series(dtype="object"),
+                        "geometry": gpd.GeoSeries([], crs="EPSG:3857"),
+                    },
+                    geometry="geometry",
+                    crs="EPSG:3857",
+                )
+            )
+        assert source.crs == "EPSG:3857"
+
+        result = source.dissolve("zone")
+        assert result.to_geopandas().empty
+        assert result.crs == source.crs
+        assert result.active_geometry_name == "geometry"
+
+        empty_geometry = result.geometry
+        empty_geometry.set_crs(None, inplace=True)
+        assert empty_geometry.crs is None
+
+    def test_dissolve_validation(self):
+        source = GeoDataFrame({"zone": ["a"], "geometry": [Point(0, 0)]})
+
+        with pytest.raises(NotImplementedError, match="method='unary'"):
+            source.dissolve("zone", method="coverage")
+        with pytest.raises(NotImplementedError, match="grid_size"):
+            source.dissolve("zone", grid_size=1)
+        with pytest.raises(NotImplementedError, match="named Spark"):
+            source.dissolve("zone", aggfunc=lambda values: values.iloc[0])
+        with pytest.raises(NotImplementedError, match="grouping vectors"):
+            source.dissolve(["a"])
+        with pytest.raises(NotImplementedError, match="numeric_only"):
+            source.dissolve(
+                "zone",
+                aggfunc={"zone": "first"},
+                numeric_only=True,
+            )
+
+        with ps.option_context("compute.ops_on_diff_frames", True):
+            categorical = GeoDataFrame(
+                gpd.GeoDataFrame(
+                    {
+                        "zone": pd.Categorical(["a"], categories=["a", "b"]),
+                        "geometry": [Point(0, 0)],
+                    }
+                )
+            )
+        with pytest.raises(NotImplementedError, match="observed=True"):
+            categorical.dissolve("zone")
+
+    def test_collect_scalar_and_distributed_singletons(self):
+        point = Point(0, 0)
+        assert collect(point) is point
+        assert collect(point, multi=True).equals(MultiPoint([(0, 0)]))
+
+        assert collect(GeoSeries([point])).equals(point)
+        assert collect(GeoSeries([point]), multi=True).equals(MultiPoint([(0, 0)]))
+
+        multi_point = MultiPoint([(0, 0), (1, 1)])
+        assert collect(GeoSeries([multi_point]), multi=True).equals(multi_point)
+
+    def test_collect_distributed_geometry_families(self):
+        assert collect(GeoSeries([Point(0, 0), Point(1, 1)])).equals(
+            MultiPoint([(0, 0), (1, 1)])
+        )
+
+        lines = [
+            LineString([(0, 0), (1, 1)]),
+            LineString([(2, 2), (3, 3)]),
+        ]
+        collected_lines = collect(GeoSeries(lines))
+        assert collected_lines.geom_type == "MultiLineString"
+        assert len(collected_lines.geoms) == 2
+
+        polygons = [
+            Polygon(),
+            Polygon([(0, 0), (1, 0), (0, 1)]),
+        ]
+        collected_polygons = collect(GeoSeries(polygons))
+        assert collected_polygons.geom_type == "MultiPolygon"
+        assert len(collected_polygons.geoms) == 1
+        assert collect(GeoSeries([Polygon()]), multi=True).equals(
+            gpd.tools.collect(Polygon(), multi=True)
+        )
+
+    def test_collect_validation_matches_geopandas(self):
+        with pytest.raises(IndexError, match="list index out of range"):
+            collect(GeoSeries([]))
+        with pytest.raises(AttributeError, match="geom_type"):
+            collect(GeoSeries([Point(0, 0), None]))
+        with pytest.raises(ValueError, match="homogeneous"):
+            collect(GeoSeries([Point(0, 0), LineString([(0, 0), (1, 1)])]))
+        with pytest.raises(ValueError, match="Cannot collect MultiPoint"):
+            collect(
+                GeoSeries(
+                    [
+                        MultiPoint([(0, 0)]),
+                        MultiPoint([(1, 1)]),
+                    ]
+                )
+            )
+        with pytest.raises(EmptyPartError, match="empty component"):
+            collect(GeoSeries([Point()]), multi=True)

--- a/python/tests/geopandas/test_geometry_aggregation.py
+++ b/python/tests/geopandas/test_geometry_aggregation.py
@@ -75,6 +75,36 @@ class TestGeometryAggregation(TestGeopandasBase):
         )
         assert [row.srid for row in srids] == [3857]
 
+    def test_dissolve_series_grouper_retains_data_column(self):
+        local = gpd.GeoDataFrame(
+            {
+                "zone": ["a", "a", "b"],
+                "label": ["first-a", "second-a", "only-b"],
+                "value": [1, 2, 3],
+                "geometry": [Point(0, 0), Point(1, 1), Point(2, 2)],
+            },
+            crs="EPSG:4326",
+        )
+        with ps.option_context("compute.ops_on_diff_frames", True):
+            source = GeoDataFrame(local)
+
+        label_result = source.dissolve(by="zone")
+        series_result = source.dissolve(by=source["zone"])
+        expected = local.dissolve(by=local["zone"])
+
+        assert "zone" not in label_result.columns
+        assert list(series_result.columns) == [
+            "geometry",
+            "zone",
+            "label",
+            "value",
+        ]
+        collected = series_result.to_geopandas()
+        assert collected.loc["a", "zone"] == "a"
+        assert collected.loc["a", "label"] == "first-a"
+        assert collected.loc["a", "value"] == 1
+        self.check_sgpd_df_equals_gpd_df(series_result, expected)
+
     def test_dissolve_all_rows_and_as_index_false(self):
         data = {
             "label": ["first", "second"],

--- a/python/tests/geopandas/test_geometry_aggregation.py
+++ b/python/tests/geopandas/test_geometry_aggregation.py
@@ -20,6 +20,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import pyspark.pandas as ps
+from pyspark.sql import DataFrame as SparkDataFrame
 
 try:
     from shapely.errors import EmptyPartError
@@ -52,6 +53,10 @@ class TestGeometryAggregation(TestGeopandasBase):
         result = source.dissolve(
             "zone", aggfunc={"label": "first", "value": "sum"}, dropna=False
         )
+        spark_frame = result._internal.spark_frame
+        if hasattr(spark_frame, "_jdf"):
+            plan = spark_frame._jdf.queryExecution().analyzed().toString()
+            assert "PythonUDF" not in plan
         expected = expected_source.dissolve(
             "zone",
             aggfunc={"label": "first", "value": "sum"},
@@ -183,7 +188,7 @@ class TestGeometryAggregation(TestGeopandasBase):
         self.check_sgpd_df_equals_gpd_df(multikey_result, multikey_expected)
         assert multikey_result.index.names == ["kind", "value"]
 
-    def test_dissolve_multiple_aggregations(self):
+    def test_dissolve_multiple_aggregations_including_grouping_column(self):
         local = gpd.GeoDataFrame(
             {
                 "zone": ["a", "a", "b"],
@@ -426,6 +431,22 @@ class TestGeometryAggregation(TestGeopandasBase):
 
         multi_point = MultiPoint([(0, 0), (1, 1)])
         assert collect(GeoSeries([multi_point]), multi=True).equals(multi_point)
+
+    def test_collect_uses_one_spark_action(self, monkeypatch):
+        first_calls = 0
+        original_first = SparkDataFrame.first
+
+        def count_first(frame):
+            nonlocal first_calls
+            first_calls += 1
+            return original_first(frame)
+
+        monkeypatch.setattr(SparkDataFrame, "first", count_first)
+
+        result = collect(GeoSeries([Point(0, 0), Point(1, 1)]))
+
+        assert result.equals(MultiPoint([(0, 0), (1, 1)]))
+        assert first_calls == 1
 
     def test_collect_distributed_geometry_families(self):
         assert collect(GeoSeries([Point(0, 0), Point(1, 1)])).equals(

--- a/python/tests/geopandas/test_geometry_aggregation.py
+++ b/python/tests/geopandas/test_geometry_aggregation.py
@@ -75,6 +75,27 @@ class TestGeometryAggregation(TestGeopandasBase):
         )
         assert [row.srid for row in srids] == [3857]
 
+    def test_dissolve_all_null_geometry_preserves_crs_and_srid(self):
+        expected_source = gpd.GeoDataFrame(
+            {
+                "zone": ["a", "a"],
+                "geometry": [None, None],
+            },
+            crs="EPSG:4326",
+        )
+        with ps.option_context("compute.ops_on_diff_frames", True):
+            source = GeoDataFrame(expected_source)
+
+        result = source.dissolve("zone")
+        expected = expected_source.dissolve("zone")
+
+        self.check_sgpd_df_equals_gpd_df(result, expected)
+        assert result.crs == expected.crs
+        srids = result.geometry._internal.spark_frame.select(
+            stf.ST_SRID(result.geometry.spark.column).alias("srid")
+        ).collect()
+        assert [row.srid for row in srids] == [4326]
+
     def test_dissolve_series_grouper_retains_data_column(self):
         local = gpd.GeoDataFrame(
             {


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #3181

## What changes were proposed in this PR?

This PR implements distributed GeoPandas-compatible `GeoDataFrame.dissolve` and `geopandas.tools.collect`.

`dissolve` uses a native Spark `groupBy` with Sedona `ST_Union_Aggr` and native Spark attribute aggregations. It supports GeoPandas grouping, index, ordering, aggregation, null, empty, CRS, and SRID semantics without a Python row UDF.

`tools.collect` performs geometry and validation-metadata aggregation in one Spark action with `ST_Collect_Aggr` on executors, then materializes only the single scalar result required by the API. It does not collect the input geometry rows to the driver.

English and Chinese GeoPandas API documentation are updated for the new APIs.

## How was this patch tested?

- `python/tests/geopandas/test_geometry_aggregation.py` (14 tests)
- Repository pre-commit hooks

The tests cover grouped and ungrouped dissolve, Series and MultiIndex groupers, grouping-column dictionaries, `as_index`, sorting, `dropna`, supported aggregation forms, source-order-sensitive aggregations, null/empty/all-null geometries, CRS/SRID preservation, native execution plans without Python UDF nodes, validation, and single-action distributed `tools.collect`.

## Did this PR include necessary documentation updates?

- Yes, I am adding new APIs. I am using the current SNAPSHOT version number `v1.9.1`.
- Yes, I have updated the documentation.
