### PR TITLE
[GH-3186] Cache libpostal model data in CI

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -65,13 +65,18 @@ jobs:
           - spark: 4.1.1
             scala: 2.13.17
             jdk: '17'
+            skipLibPostalTests: 'true'
           - spark: 4.0.2
             scala: 2.13.17
             jdk: '17'
+            skipLibPostalTests: 'true'
           - spark: 3.5.8
             scala: 2.13.8
             jdk: '11'
             skipTests: ''
+            skipLibPostalTests: 'true'
+          # The libpostal suite needs ~1.3 GB of model data, so it runs in this
+          # combination only. See the libpostal steps below.
           - spark: 3.5.8
             scala: 2.12.15
             jdk: '11'
@@ -80,10 +85,12 @@ jobs:
             scala: 2.13.8
             jdk: '11'
             skipTests: ''
+            skipLibPostalTests: 'true'
           - spark: 3.4.0
             scala: 2.12.15
             jdk: '11'
             skipTests: ''
+            skipLibPostalTests: 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -101,10 +108,45 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
+      # jpostal downloads ~1.3 GB of model data the first time an address
+      # function runs. Cache it so the suite does not depend on the object
+      # store being reachable. The key is a constant because the data version
+      # is pinned by the jpostal dependency, not by anything in the tree; bump
+      # it when that dependency changes.
+      - name: Cache libpostal model data
+        if: ${{ !matrix.skipLibPostalTests }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: /tmp/libpostal
+          key: libpostal-senzing-v1.1.0-jpostal-1.2.2
+      # On a cache miss, fetch the data here rather than letting jpostal do it
+      # inside the test JVM: DataDownloadUtils has a 15 s connect timeout and
+      # no retry, so a transient stall fails the whole build.
+      - name: Pre-fetch libpostal model data
+        if: ${{ !matrix.skipLibPostalTests }}
+        run: |
+          set -euo pipefail
+          DIR=/tmp/libpostal
+          populated=1
+          for d in transliteration numex address_parser address_expansions language_classifier; do
+            [ -d "$DIR/$d" ] || populated=0
+          done
+          if [ "$populated" = 1 ]; then
+            echo "libpostal data already present, skipping download"
+            exit 0
+          fi
+          mkdir -p "$DIR"
+          for f in libpostal_data.tar.gz parser.tar.gz language_classifier.tar.gz; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 10 --connect-timeout 30 \
+              -o "$DIR/$f" "https://public-read-libpostal-data.s3.amazonaws.com/v1.1.0/$f"
+            tar -xzf "$DIR/$f" -C "$DIR"
+            rm -f "$DIR/$f"
+          done
       - env:
           SPARK_VERSION: ${{ matrix.spark }}
           SCALA_VERSION: ${{ matrix.scala }}
           SKIP_TESTS: ${{ matrix.skipTests }}
+          SEDONA_SKIP_LIBPOSTAL_TESTS: ${{ matrix.skipLibPostalTests }}
         run: |
           SPARK_COMPAT_VERSION=${SPARK_VERSION:0:3}
 

--- a/spark/common/src/test/scala/org/apache/sedona/sql/AddressProcessingFunctionsTest.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/AddressProcessingFunctionsTest.scala
@@ -18,40 +18,26 @@
  */
 package org.apache.sedona.sql
 
-import org.apache.sedona.core.utils.SedonaConf
 import org.apache.spark.sql.sedona_sql.expressions.st_functions.{ExpandAddress, ParseAddress}
 import org.apache.spark.sql.{Row, functions => f}
-import org.scalatest.BeforeAndAfterEach
-import org.slf4j.LoggerFactory
+import org.scalatest.{Canceled, Outcome}
 
-import java.nio.file.{Files, Paths}
 import scala.collection.mutable
 
-class AddressProcessingFunctionsTest extends TestBaseScala with BeforeAndAfterEach {
-  private val logger = LoggerFactory.getLogger(getClass)
-  var clearedLibPostal = false
+class AddressProcessingFunctionsTest extends TestBaseScala {
 
-  def clearLibpostalDataDir(): String = {
-    val dir = SedonaConf.fromActiveSession().getLibPostalDataDir
-    if (dir != null && dir.nonEmpty) {
-      try {
-        Files
-          .walk(Paths.get(dir))
-          .sorted(java.util.Comparator.reverseOrder())
-          .forEach(path => Files.deleteIfExists(path))
-      } catch {
-        case e: Exception =>
-          logger.warn(s"Failed to clear libpostal data directory: ${e.getMessage}")
-      }
-    }
-    dir
-  }
+  // These tests need ~1.3 GB of libpostal model data, which jpostal downloads
+  // on first use. CI runs them in a single matrix combination and sets this
+  // variable everywhere else; unset, the tests run as usual.
+  private val skipLibPostalTests =
+    sys.env.get("SEDONA_SKIP_LIBPOSTAL_TESTS").exists(_.equalsIgnoreCase("true"))
 
-  override def beforeEach(): Unit = {
-    super.beforeEach()
-    if (!clearedLibPostal) {
-      clearedLibPostal = true
-      clearLibpostalDataDir()
+  override def withFixture(test: NoArgTest): Outcome = {
+    if (skipLibPostalTests) {
+      Canceled(
+        "Skipping libpostal test - unset SEDONA_SKIP_LIBPOSTAL_TESTS to download the model data and run")
+    } else {
+      super.withFixture(test)
     }
   }
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #3186

## What changes were proposed in this PR?

`AddressProcessingFunctionsTest` downloads ~1.3 GB of libpostal model data on every job, in all six matrix combinations, with no retry. When the object store stalls, the whole build fails — for example [run 30229831581](https://github.com/apache/sedona/actions/runs/30229831581) on `master`:

```
- should return expected normalized forms *** FAILED ***
  java.lang.RuntimeException: Failed to download or extract language_classifier.tar.gz
  at com.mapzen.jpostal.DataDownloadUtils.populateDataDir(DataDownloadUtils.java:63)
  Cause: java.net.SocketTimeoutException: connect timed out
```

Three changes in `java.yml` and the test:

1. **Cache `/tmp/libpostal`.** jpostal already skips the download when the directory is populated — `LibPostal.getInstance` only calls `populateDataDir` when `downloadDataIfNeeded && !isDataDirPopulated(dataDir)`. The cache key is a constant rather than a `hashFiles`, because the data version is pinned by the jpostal dependency and the `useSenzing` default rather than by anything in the tree; the key names both so it is bumped deliberately when they change.

2. **Pre-fetch the archives in a workflow step using `curl --retry`.** `DataDownloadUtils.downloadFile` uses a 15 s connect timeout and no retry, so today a transient stall inside the test JVM fails the build. Moving the fetch into a step with retries makes a cold cache slow rather than fatal.

3. **Run the suite in one matrix combination** (Spark 3.5.8 / Scala 2.12.15) instead of all six, gated on `SEDONA_SKIP_LIBPOSTAL_TESTS`. The cache and pre-fetch steps are gated on the same matrix key, so only that job pays the data cost. The variable is opt-out: unset — as it is for local runs and for anyone building outside this workflow — the tests run exactly as before.

This also required removing `clearLibpostalDataDir`/`beforeEach` from the suite, which recursively deleted `spark.sedona.libpostal.dataDir` before the first test. Nothing asserts on it; it only forced the download path to be exercised, and it would have deleted the restored cache and re-triggered the download that fails here.

Net effect: libpostal traffic goes from roughly 8 GB per CI run to zero on a warm cache, and a cold cache no longer fails the build on a single timeout.

### Cache cost

Worth a reviewer's attention: the repo currently holds ~14.5 GB of active caches against GitHub's 10 GB limit, so it is already evicting. This adds one entry of roughly 1.3 GB.

In steady state it stays at one entry. The key is a constant, so once `master` has it, PR runs restore it from the default branch as an exact hit and do not re-save; only one of the six matrix jobs has the cache step at all. The exception is the window before `master` has the entry — during that time a PR that touches `java.yml` creates its own `refs/pull/N/merge`-scoped copy, which is the same behaviour the existing `~/.m2` cache already has here.

If that cost is judged not worth it, the pre-fetch step alone fixes the reported failure at no cache cost, and the cache step can be dropped from this PR.

## How was this patch tested?

Existing `AddressProcessingFunctionsTest` coverage is unchanged in the combination that runs it. Verified locally:

- `mvn test-compile -pl spark/common -am -Dspark=3.5 -Dscala=2.12`
- `mvn spotless:apply -pl spark/common` produces no changes
- `pre-commit run --files .github/workflows/java.yml spark/common/src/test/scala/org/apache/sedona/sql/AddressProcessingFunctionsTest.scala` passes, including `actionlint` and `yamllint`
- The five directory names the pre-fetch step checks are exactly those in `DataDownloadUtils.isDataDirPopulated`, and match the contents of the three archives.

The cache path itself is exercised by this PR's own CI run: the first run populates the cache, and any subsequent run on the branch should skip the download.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
