### PR TITLE
[GH-3179] Add Flink Geography support for ST_X and ST_Y

### DIFF
--- a/flink/src/main/java/org/apache/sedona/flink/expressions/Functions.java
+++ b/flink/src/main/java/org/apache/sedona/flink/expressions/Functions.java
@@ -1737,6 +1737,16 @@ public class Functions {
       Geometry geom = (Geometry) o;
       return org.apache.sedona.common.Functions.x(geom);
     }
+
+    @DataTypeHint("Double")
+    public Double eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = GeographyTypeSerializer.class,
+                bridgedTo = org.apache.sedona.common.S2Geography.Geography.class)
+            org.apache.sedona.common.S2Geography.Geography geog) {
+      return org.apache.sedona.common.geography.Functions.x(geog);
+    }
   }
 
   public static class ST_Y extends ScalarFunction {
@@ -1749,6 +1759,16 @@ public class Functions {
             Object o) {
       Geometry geom = (Geometry) o;
       return org.apache.sedona.common.Functions.y(geom);
+    }
+
+    @DataTypeHint("Double")
+    public Double eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = GeographyTypeSerializer.class,
+                bridgedTo = org.apache.sedona.common.S2Geography.Geography.class)
+            org.apache.sedona.common.S2Geography.Geography geog) {
+      return org.apache.sedona.common.geography.Functions.y(geog);
     }
   }
 

--- a/flink/src/test/java/org/apache/sedona/flink/GeographyFunctionTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/GeographyFunctionTest.java
@@ -22,6 +22,7 @@ import static org.apache.flink.table.api.Expressions.$;
 import static org.apache.flink.table.api.Expressions.call;
 import static org.apache.flink.table.api.Expressions.lit;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -138,6 +139,23 @@ public class GeographyFunctionTest extends TestBase {
     Object out =
         eval("POINT (1 2)", call(Functions.ST_GeometryType.class.getSimpleName(), $("geog")));
     assertEquals("ST_Point", out.toString());
+  }
+
+  @Test
+  public void testXY() {
+    String wkt = "POINT (-73.9857 40.7484)";
+    Object x = eval(wkt, call(Functions.ST_X.class.getSimpleName(), $("geog")));
+    Object y = eval(wkt, call(Functions.ST_Y.class.getSimpleName(), $("geog")));
+    assertEquals(-73.9857, (Double) x, 1e-12);
+    assertEquals(40.7484, (Double) y, 1e-12);
+  }
+
+  @Test
+  public void testXYReturnNullForNonPointAndEmpty() {
+    for (String wkt : new String[] {"LINESTRING (0 0, 1 1)", "POINT EMPTY"}) {
+      assertNull(eval(wkt, call(Functions.ST_X.class.getSimpleName(), $("geog"))));
+      assertNull(eval(wkt, call(Functions.ST_Y.class.getSimpleName(), $("geog"))));
+    }
   }
 
   @Test


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Follow-up to #3179 and #3188.

## What changes were proposed in this PR?

- Add Flink Geography overloads for `ST_X` and `ST_Y`.
- Return longitude and latitude directly from Geography points.
- Preserve null behavior for non-point and empty-point Geography inputs.

## How was this patch tested?

- Flink Geography function suite: 17 passed.
- Existing Flink Geometry `ST_X` and `ST_Y` regression tests: passed.
- Spotless, pre-commit hooks, and `git diff --check`: passed.

## Did this PR include necessary documentation updates?

- No additional documentation changes are needed; #3188 already added the Geography `ST_X` and `ST_Y` API pages and index entries.
