### PR TITLE
[GH-3200] Serialize empty Geography LineStrings as valid WKB

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/S2Geography/WKBWriter.java
+++ b/common/src/main/java/org/apache/sedona/common/S2Geography/WKBWriter.java
@@ -250,6 +250,10 @@ public class WKBWriter {
     writeByteOrder(os);
     writeGeometryType(geometryType, polyline, os);
     List<S2Polyline> s2line = polyline.getPolylines();
+    if (s2line.isEmpty()) {
+      writeInt(0, os);
+      return;
+    }
     for (S2Polyline s2 : s2line) {
       List<S2Point> verts = s2.vertices();
       writeInt(verts.size(), os);

--- a/common/src/test/java/org/apache/sedona/common/S2Geography/WKBGeographyTest.java
+++ b/common/src/test/java/org/apache/sedona/common/S2Geography/WKBGeographyTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.io.ByteOrderValues;
 import org.locationtech.jts.io.ParseException;
@@ -135,6 +136,19 @@ public class WKBGeographyTest {
     // S2 should be cached from construction
     Geography roundTrip = geog.getS2Geography();
     assertSame(s2Geog, roundTrip);
+  }
+
+  @Test
+  public void fromS2Geography_emptyLineString_roundTripsToJTS() {
+    Geography s2Geog = new SinglePolylineGeography();
+    s2Geog.setSRID(4326);
+
+    WKBGeography geog = WKBGeography.fromS2Geography(s2Geog);
+    Geometry jts = geog.getJTSGeometry();
+
+    assertTrue(jts instanceof LineString);
+    assertTrue(jts.isEmpty());
+    assertEquals(4326, jts.getSRID());
   }
 
   // ─── Lazy S2 delegation ──────────────────────────────────────────────────

--- a/common/src/test/java/org/apache/sedona/common/S2Geography/WKBWriterTest.java
+++ b/common/src/test/java/org/apache/sedona/common/S2Geography/WKBWriterTest.java
@@ -91,6 +91,18 @@ public class WKBWriterTest {
   }
 
   @Test
+  public void EmptySinglePolylineWritesValidWKB() throws IOException, ParseException {
+    Geography inputLine = new SinglePolylineGeography();
+
+    byte[] wkb = new WKBWriter(2, ByteOrderValues.LITTLE_ENDIAN, false).write(inputLine);
+
+    assertEquals("010200000000000000", WKBWriter.toHex(wkb));
+    Geography outputLine = new WKBReader().read(wkb);
+    assertTrue(outputLine instanceof SinglePolylineGeography);
+    assertEquals(0, outputLine.numShapes());
+  }
+
+  @Test
   public void MultiPointTest() throws ParseException, IOException {
     String wkt = "MULTIPOINT ((10 40), (40 30))";
     WKTReader reader = new WKTReader();


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/).

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #3200.

## What changes were proposed in this PR?

- Write the required zero coordinate count when serializing an empty `SinglePolylineGeography`.
- Produce valid `LINESTRING EMPTY` WKB instead of a header-only, malformed byte sequence.
- Allow `WKBGeography.fromS2Geography()` to round-trip an empty LineString through JTS while preserving its SRID.

The malformed WKB was discovered while reviewing #3195. This PR isolates the pre-existing serialization defect from the `ST_MakeLine` feature. It does not define the separate behavior for `ST_MakeLine(EMPTY, non-empty)`, which is tracked by #3202.

## How was this patch tested?

- Full common module suite: 1,181 tests, 0 failures.
- Added an exact-WKB assertion for `010200000000000000`.
- Added WKB-to-S2 and S2-to-WKB-to-JTS empty LineString round-trip coverage.
- Formatting and commit hooks passed.

## Did this PR include necessary documentation updates?

- No. This corrects malformed internal serialization without changing the public API.
