### PR TITLE
[GH-3201] Preserve empty Geography envelopes

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/geography/Functions.java
+++ b/common/src/main/java/org/apache/sedona/common/geography/Functions.java
@@ -42,8 +42,9 @@ public class Functions {
 
   public static Geography getEnvelope(Geography geography, boolean splitAtAntiMeridian) {
     if (geography == null) return null;
-    // Empty points are encoded in WKB with NaN ordinates. Avoid constructing an S2PointRegion
-    // from those ordinates; other empty geography types produce an empty rectangle below.
+    // Empty Point WKB stores NaN ordinates, which getPointX() reports as null. The isPoint() guard
+    // distinguishes that case from non-point inputs, for which getPointX() also returns null.
+    // Avoid constructing an S2PointRegion from the NaN ordinates.
     if (geography instanceof WKBGeography
         && ((WKBGeography) geography).isPoint()
         && ((WKBGeography) geography).getPointX() == null) {

--- a/common/src/main/java/org/apache/sedona/common/geography/Functions.java
+++ b/common/src/main/java/org/apache/sedona/common/geography/Functions.java
@@ -42,8 +42,16 @@ public class Functions {
 
   public static Geography getEnvelope(Geography geography, boolean splitAtAntiMeridian) {
     if (geography == null) return null;
+    // Empty points are encoded in WKB with NaN ordinates. Avoid constructing an S2PointRegion
+    // from those ordinates; other empty geography types produce an empty rectangle below.
+    if (geography instanceof WKBGeography
+        && ((WKBGeography) geography).isPoint()
+        && ((WKBGeography) geography).getPointX() == null) {
+      return geography;
+    }
     S2LatLngRect rect = geography.region().getRectBound();
-    if (rect.isEmpty()) return null;
+    // Match the Geometry overload by preserving an empty input's type and SRID.
+    if (rect.isEmpty()) return geography;
     double lngLo = rect.lngLo().degrees();
     double latLo = rect.latLo().degrees();
     double lngHi = rect.lngHi().degrees();

--- a/common/src/test/java/org/apache/sedona/common/Geography/FunctionTest.java
+++ b/common/src/test/java/org/apache/sedona/common/Geography/FunctionTest.java
@@ -133,12 +133,17 @@ public class FunctionTest {
   public void getEnvelopeEmptyGeography() throws ParseException {
     for (String wkt :
         new String[] {
-          "POINT EMPTY", "LINESTRING EMPTY", "POLYGON EMPTY", "GEOMETRYCOLLECTION EMPTY"
+          "POINT EMPTY",
+          "LINESTRING EMPTY",
+          "POLYGON EMPTY",
+          "MULTIPOINT EMPTY",
+          "MULTILINESTRING EMPTY",
+          "MULTIPOLYGON EMPTY",
+          "GEOMETRYCOLLECTION EMPTY"
         }) {
       Geography geography = Constructors.geogFromWKT(wkt, 3857);
       for (boolean splitAtAntiMeridian : new boolean[] {false, true}) {
         Geography envelope = Functions.getEnvelope(geography, splitAtAntiMeridian);
-        assertSame(geography, envelope);
         assertEquals(wkt, envelope.toString());
         assertEquals(3857, envelope.getSRID());
       }

--- a/common/src/test/java/org/apache/sedona/common/Geography/FunctionTest.java
+++ b/common/src/test/java/org/apache/sedona/common/Geography/FunctionTest.java
@@ -130,6 +130,22 @@ public class FunctionTest {
   }
 
   @Test
+  public void getEnvelopeEmptyGeography() throws ParseException {
+    for (String wkt :
+        new String[] {
+          "POINT EMPTY", "LINESTRING EMPTY", "POLYGON EMPTY", "GEOMETRYCOLLECTION EMPTY"
+        }) {
+      Geography geography = Constructors.geogFromWKT(wkt, 3857);
+      for (boolean splitAtAntiMeridian : new boolean[] {false, true}) {
+        Geography envelope = Functions.getEnvelope(geography, splitAtAntiMeridian);
+        assertSame(geography, envelope);
+        assertEquals(wkt, envelope.toString());
+        assertEquals(3857, envelope.getSRID());
+      }
+    }
+  }
+
+  @Test
   public void testEnvelopeWKTCompare() throws Exception {
     String antarctica = "POLYGON ((-180 -90, -180 -63.27066, 180 -63.27066, 180 -90, -180 -90))";
     Geography g = Constructors.geogFromWKT(antarctica, 4326);

--- a/flink/src/test/java/org/apache/sedona/flink/GeographyFunctionTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/GeographyFunctionTest.java
@@ -52,6 +52,10 @@ public class GeographyFunctionTest extends TestBase {
    * A single-row table whose column "geog" is the geography parsed from {@code wkt} (SRID 4326).
    */
   private Table geogTable(String wkt) {
+    return geogTable(wkt, 4326);
+  }
+
+  private Table geogTable(String wkt, int srid) {
     RowTypeInfo ti =
         new RowTypeInfo(
             new TypeInformation<?>[] {BasicTypeInfo.STRING_TYPE_INFO}, new String[] {"v"});
@@ -59,12 +63,16 @@ public class GeographyFunctionTest extends TestBase {
     return tableEnv
         .fromDataStream(ds)
         .select(
-            call(GeographyConstructors.ST_GeogFromWKT.class.getSimpleName(), $("v"), lit(4326))
+            call(GeographyConstructors.ST_GeogFromWKT.class.getSimpleName(), $("v"), lit(srid))
                 .as("geog"));
   }
 
   private Object eval(String wkt, ApiExpression call) {
     return first(geogTable(wkt).select(call.as("o"))).getFieldAs("o");
+  }
+
+  private Object eval(String wkt, int srid, ApiExpression call) {
+    return first(geogTable(wkt, srid).select(call.as("o"))).getFieldAs("o");
   }
 
   @Test
@@ -255,6 +263,28 @@ public class GeographyFunctionTest extends TestBase {
             Constructors.geogFromWKT(wkt, 4326), true);
     assertEquals(expected.toEWKT(), ((Geography) out).toEWKT());
     assertTrue(expected.toEWKT().contains("MULTIPOLYGON"));
+  }
+
+  @Test
+  public void testEnvelopePreservesEmptyGeography() {
+    for (String wkt :
+        new String[] {
+          "POINT EMPTY", "LINESTRING EMPTY", "POLYGON EMPTY", "GEOMETRYCOLLECTION EMPTY"
+        }) {
+      for (boolean splitAtAntiMeridian : new boolean[] {false, true}) {
+        Geography out =
+            (Geography)
+                eval(
+                    wkt,
+                    3857,
+                    call(
+                        Functions.ST_Envelope.class.getSimpleName(),
+                        $("geog"),
+                        lit(splitAtAntiMeridian)));
+        assertEquals(wkt, out.toString());
+        assertEquals(3857, out.getSRID());
+      }
+    }
   }
 
   @Test

--- a/spark/common/src/test/scala/org/apache/sedona/sql/geography/FunctionsDataFrameAPITest.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/geography/FunctionsDataFrameAPITest.scala
@@ -59,6 +59,22 @@ class FunctionsDataFrameAPITest extends TestBaseScala {
     assertEquals(expectedWKT, env.toString)
   }
 
+  it("ST_Envelope preserves empty Geography") {
+    Seq("POINT EMPTY", "LINESTRING EMPTY", "POLYGON EMPTY", "GEOMETRYCOLLECTION EMPTY").foreach {
+      wkt =>
+        Seq(false, true).foreach { split =>
+          val df = sparkSession
+            .sql(s"SELECT '$wkt' AS wkt")
+            .select(st_constructors.ST_GeogFromWKT(col("wkt"), lit(3857)).as("geog"))
+            .select(st_functions.ST_Envelope(col("geog"), split).as("env"))
+
+          val env = df.first().getAs[Geography]("env")
+          assertEquals(wkt, env.toString)
+          assertEquals(3857, env.getSRID)
+        }
+    }
+  }
+
   it("Passed ST_AsEWKT") {
     val wkt = "LINESTRING (1 2, 3 4, 5 6)"
     val wktExpected = "SRID=4326; LINESTRING (1 2, 3 4, 5 6)"


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/).

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #3201.

## What changes were proposed in this PR?

- Return an empty Geography unchanged from `ST_Envelope`, preserving its subtype, SRID, and object identity.
- Detect WKB `POINT EMPTY` directly before constructing an `S2PointRegion` from its NaN ordinates.
- Return the input when another empty Geography region produces an empty S2 rectangle.
- Apply the same behavior for both values of `splitAtAntiMeridian`; SQL `NULL` behavior remains unchanged.

This matches Sedona's existing Geometry `ST_Envelope` behavior for typed empty values. Empty LineString WKB serialization is an independent defect covered by #3200.

## How was this patch tested?

- Common Geography `FunctionTest`: 78 tests, 0 failures.
- Spark Geography DataFrame API suite: 19 tests, 0 failures.
- Flink Geography function suite: 18 tests, 0 failures.
- Common coverage includes empty Point, LineString, Polygon, and GeometryCollection values with both antimeridian settings.
- Spark and Flink integration coverage verifies `POINT EMPTY`, SRID preservation, and both settings.
- Spotless and commit hooks passed.

## Did this PR include necessary documentation updates?

- No. This fixes an exception for an existing API and aligns it with the established empty Geometry behavior.
