### PR TITLE
[GH-3179] Document Flink Geography coordinate accessors

### DIFF
--- a/docs/api/flink/Geography-Functions.md
+++ b/docs/api/flink/Geography-Functions.md
@@ -57,6 +57,8 @@ These functions edit, measure, or format geography objects. Measurements are com
 | [ST_MakeLine](Geography-Functions/ST_MakeLine.md) | Geography | Create a geography LineString from two Point, MultiPoint, or LineString geographies. | v1.9.1 |
 | [ST_NPoints](Geography-Functions/ST_NPoints.md) | Integer | Return the number of points (vertices) in a geography. | v1.9.1 |
 | [ST_NumGeometries](Geography-Functions/ST_NumGeometries.md) | Integer | Return the number of sub-geometries in a geography. | v1.9.1 |
+| [ST_X](Geography-Functions/ST_X.md) | Double | Return the longitude (X coordinate) of a point geography. | v1.9.1 |
+| [ST_Y](Geography-Functions/ST_Y.md) | Double | Return the latitude (Y coordinate) of a point geography. | v1.9.1 |
 
 ## Geography Predicates
 

--- a/docs/api/flink/Geography-Functions/ST_X.md
+++ b/docs/api/flink/Geography-Functions/ST_X.md
@@ -1,0 +1,42 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_X
+
+Introduction: Returns the longitude (X coordinate) of a point geography. Returns `NULL` for non-point geographies and empty points.
+
+Format:
+
+`ST_X (A: Geography)`
+
+Return type: `Double`
+
+Since: `v1.9.1`
+
+SQL Example
+
+```sql
+SELECT ST_X(ST_GeogFromWKT('POINT (-73.9857 40.7484)'));
+```
+
+Output:
+
+```
+-73.9857
+```

--- a/docs/api/flink/Geography-Functions/ST_Y.md
+++ b/docs/api/flink/Geography-Functions/ST_Y.md
@@ -1,0 +1,42 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_Y
+
+Introduction: Returns the latitude (Y coordinate) of a point geography. Returns `NULL` for non-point geographies and empty points.
+
+Format:
+
+`ST_Y (A: Geography)`
+
+Return type: `Double`
+
+Since: `v1.9.1`
+
+SQL Example
+
+```sql
+SELECT ST_Y(ST_GeogFromWKT('POINT (-73.9857 40.7484)'));
+```
+
+Output:
+
+```
+40.7484
+```


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/).

## Is this PR related to a ticket?

- Yes. This is the missing Flink documentation follow-up for #3179. The Spark/common implementation was merged in #3188 and the Flink implementation was merged in #3199.

## What changes were proposed in this PR?

- Add the Flink Geography `ST_X` API page.
- Add the Flink Geography `ST_Y` API page.
- Link both functions from the Flink Geography function index.
- Document that the accessors return longitude/latitude for point geographies and `NULL` for non-point or empty Geography values.

These files were deliberately removed from #3195 because they were unrelated to `ST_MakeLine`; this PR restores them as a docs-only coordinate-accessor change.

## How was this patch tested?

- Ran the repository pre-commit hooks on all three changed Markdown files.
- License, codespell, markdownlint, link/permalink, whitespace, and editorconfig checks passed.
- `git diff --check` passed.

## Did this PR include necessary documentation updates?

- Yes. Documentation is the entire scope of this PR.
