### PR TITLE
[CI] Bump proj4sedona to 0.1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <scala-collection-compat.version>2.5.0</scala-collection-compat.version>
         <geoglib.version>1.52</geoglib.version>
         <caffeine.version>2.9.2</caffeine.version>
-        <proj4sedona.version>0.1.5</proj4sedona.version>
+        <proj4sedona.version>0.1.6</proj4sedona.version>
 
         <geotools.scope>provided</geotools.scope>
         <!-- Because it's not in Maven central, make it provided by default -->


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/).

## Is this PR related to a ticket?

- No. This is a dependency-only update.

## What changes were proposed in this PR?

Bump `org.datasyslab:proj4sedona` from `0.1.5` to `0.1.6`.

The new release includes the remote CRS resolver reliability improvements from [proj4sedona#131](https://github.com/jiayuasu/proj4sedona/pull/131), including a jsDelivr primary endpoint, raw GitHub fallback, bounded retries, and local CRS definition caching.

## How was this patch tested?

- Verified `org.datasyslab:proj4sedona:0.1.6` resolves from Maven Central.
- `mvn -pl common -Dtest=FunctionsProj4Test test`
  - 43 tests passed.
- `mvn -pl spark/common -am -DskipTests -Dspark=3.5 -Dscala=2.12 install`
  - Reactor build passed.
- `mvn -pl spark/common -Dspark=3.5 -Dscala=2.12 -Dsuites=org.apache.sedona.sql.CRSTransformProj4Test scalatest:test`
  - 37 tests passed.
- A separate Spark SQL validation resolved non-built-in `EPSG:2154` through the default remote provider and confirmed that 10,000 subsequent transforms reused the cached CRS definition.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API, so no documentation change is needed.
