### PR TITLE
[GH-3216] Transform geometry before rasterization

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/raster/RasterPredicates.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterPredicates.java
@@ -353,6 +353,20 @@ public class RasterPredicates {
   }
 
   /**
+   * Tests intersection without CRS conversion.
+   *
+   * @param raster raster defining the coordinate space
+   * @param queryWindow geometry already transformed into the raster's coordinate space
+   */
+  static boolean intersectsInRasterCoordinateSpace(GridCoverage2D raster, Geometry queryWindow) {
+    try {
+      return GeometryFunctions.convexHull(raster).intersects(queryWindow);
+    } catch (FactoryException | TransformException e) {
+      throw new RuntimeException("Failed to calculate the convex hull of the raster", e);
+    }
+  }
+
+  /**
    * Test if crs matches the EPSG code. This method tries to avoid the expensive CRS.decode and
    * CRS.equalsIgnoreMetadata calls. If the crs has an identifier matching the EPSG code, we assume
    * that the crs matches the EPSG code.

--- a/common/src/main/java/org/apache/sedona/common/raster/Rasterization.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/Rasterization.java
@@ -62,7 +62,8 @@ public class Rasterization {
     // Validate the input geometry and raster metadata
     double[] metadata = RasterAccessors.metadata(raster);
     validateRasterMetadata(metadata);
-    if (!RasterPredicates.rsIntersects(raster, geom)) {
+    geom = RasterUtils.transformToRasterCRS(raster, geom);
+    if (!RasterPredicates.intersectsInRasterCoordinateSpace(raster, geom)) {
       throw new IllegalArgumentException("Geometry does not intersect Raster.");
     }
 

--- a/common/src/main/java/org/apache/sedona/common/utils/RasterUtils.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/RasterUtils.java
@@ -577,8 +577,8 @@ public class RasterUtils {
     // In Sedona vector, we do not perform implicit CRS transform. Everything must be done
     // explicitly via ST_Transform
     // In Sedona raster, we do implicit CRS transform if the raster has a CRS. If the SRID of
-    // the geometry is 0, we assume it is 4326.
-    if (geomSRID == 0) {
+    // the geometry is not positive, we assume it is 4326.
+    if (geomSRID <= 0) {
       geomSRID = 4326;
     }
     if (targetCRS != null && !(targetCRS instanceof DefaultEngineeringCRS)) {
@@ -606,7 +606,7 @@ public class RasterUtils {
       targetCRS = DefaultGeographicCRS.WGS84;
     }
     int geometrySRID = geometry.getSRID();
-    if (geometrySRID == 0) {
+    if (geometrySRID <= 0) {
       geometrySRID = 4326;
     }
     if (RasterPredicates.isCRSMatchesSRID(targetCRS, geometrySRID)) {

--- a/common/src/main/java/org/apache/sedona/common/utils/RasterUtils.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/RasterUtils.java
@@ -59,6 +59,7 @@ import org.geotools.coverage.grid.GridEnvelope2D;
 import org.geotools.coverage.grid.GridGeometry2D;
 import org.geotools.geometry.Position2D;
 import org.geotools.referencing.crs.DefaultEngineeringCRS;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.geotools.referencing.operation.transform.AffineTransform2D;
 import org.geotools.util.NumberRange;
 import org.locationtech.jts.geom.Geometry;
@@ -588,6 +589,22 @@ public class RasterUtils {
       }
     }
     return geometry;
+  }
+
+  /**
+   * Transforms a geometry into a raster's coordinate space. Missing raster CRS metadata is
+   * interpreted as WGS84, matching the existing raster predicate policy.
+   *
+   * @param raster raster whose coordinate space is the target
+   * @param geometry geometry to transform
+   * @return geometry expressed in the raster's coordinate space
+   */
+  public static Geometry transformToRasterCRS(GridCoverage2D raster, Geometry geometry) {
+    CoordinateReferenceSystem targetCRS = raster.getCoordinateReferenceSystem();
+    if (targetCRS == null || targetCRS instanceof DefaultEngineeringCRS) {
+      targetCRS = DefaultGeographicCRS.WGS84;
+    }
+    return convertCRSIfNeeded(geometry, targetCRS);
   }
 
   /**

--- a/common/src/main/java/org/apache/sedona/common/utils/RasterUtils.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/RasterUtils.java
@@ -41,6 +41,7 @@ import org.apache.sedona.common.Functions;
 import org.apache.sedona.common.FunctionsGeoTools;
 import org.apache.sedona.common.raster.RasterAccessors;
 import org.apache.sedona.common.raster.RasterEditors;
+import org.apache.sedona.common.raster.RasterPredicates;
 import org.geotools.api.coverage.SampleDimensionType;
 import org.geotools.api.coverage.grid.GridEnvelope;
 import org.geotools.api.metadata.spatial.PixelOrientation;
@@ -603,6 +604,14 @@ public class RasterUtils {
     CoordinateReferenceSystem targetCRS = raster.getCoordinateReferenceSystem();
     if (targetCRS == null || targetCRS instanceof DefaultEngineeringCRS) {
       targetCRS = DefaultGeographicCRS.WGS84;
+    }
+    int geometrySRID = geometry.getSRID();
+    if (geometrySRID == 0) {
+      geometrySRID = 4326;
+    }
+    if (RasterPredicates.isCRSMatchesSRID(targetCRS, geometrySRID)) {
+      // Preserve the identifier-only fast path for the common matched-CRS case.
+      return geometry;
     }
     return convertCRSIfNeeded(geometry, targetCRS);
   }

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterConstructorsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterConstructorsTest.java
@@ -400,7 +400,7 @@ public class RasterConstructorsTest extends RasterTestBase {
       throws FactoryException, ParseException, TransformException {
     GridCoverage2D raster = RasterConstructors.makeEmptyRaster(1, 5, 5, 0, 5, 1, -1, 0, 0, 4326);
     Geometry geometry4326 =
-        Constructors.geomFromWKT("POLYGON ((1.2 1.2, 1.2 2.8, 2.8 2.8, 2.8 1.2, 1.2 1.2))", 4326);
+        Constructors.geomFromWKT("POLYGON ((1.2 1.2, 1.2 2.8, 3.6 2.8, 3.6 1.2, 1.2 1.2))", 4326);
     Geometry geometry3857 = FunctionsGeoTools.transform(geometry4326, "EPSG:4326", "EPSG:3857");
     geometry3857.setSRID(3857);
 

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterConstructorsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterConstructorsTest.java
@@ -34,6 +34,7 @@ import java.util.HashSet;
 import java.util.Set;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.sedona.common.Constructors;
+import org.apache.sedona.common.FunctionsGeoTools;
 import org.apache.sedona.common.utils.RasterUtils;
 import org.geotools.api.coverage.SampleDimensionType;
 import org.geotools.api.geometry.Position;
@@ -392,6 +393,29 @@ public class RasterConstructorsTest extends RasterTestBase {
     rasterized = RasterConstructors.asRaster(geom, raster_bottom_up, "d", false, 1d, null);
     actual = MapAlgebra.bandAsArray(rasterized, 1);
     assertArrayEquals(expected, actual, 0.1d);
+  }
+
+  @Test
+  public void testAsRasterTransformsGeometryToRasterCRS()
+      throws FactoryException, ParseException, TransformException {
+    GridCoverage2D raster = RasterConstructors.makeEmptyRaster(1, 5, 5, 0, 5, 1, -1, 0, 0, 4326);
+    Geometry geometry4326 =
+        Constructors.geomFromWKT("POLYGON ((1.2 1.2, 1.2 2.8, 2.8 2.8, 2.8 1.2, 1.2 1.2))", 4326);
+    Geometry geometry3857 = FunctionsGeoTools.transform(geometry4326, "EPSG:4326", "EPSG:3857");
+    geometry3857.setSRID(3857);
+
+    for (boolean useGeometryExtent : new boolean[] {false, true}) {
+      GridCoverage2D expected =
+          RasterConstructors.asRaster(geometry4326, raster, "d", false, 7, 0d, useGeometryExtent);
+      GridCoverage2D actual =
+          RasterConstructors.asRaster(geometry3857, raster, "d", false, 7, 0d, useGeometryExtent);
+
+      double[] expectedPixels = MapAlgebra.bandAsArray(expected, 1);
+      double[] actualPixels = MapAlgebra.bandAsArray(actual, 1);
+      Assert.assertTrue(Arrays.stream(expectedPixels).anyMatch(pixel -> pixel == 7));
+      assertEquals(expected.getEnvelope2D(), actual.getEnvelope2D());
+      assertArrayEquals(expectedPixels, actualPixels, 0d);
+    }
   }
 
   @Test

--- a/common/src/test/java/org/apache/sedona/common/utils/RasterUtilsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/utils/RasterUtilsTest.java
@@ -44,6 +44,17 @@ import org.locationtech.jts.geom.Geometry;
 
 public class RasterUtilsTest {
   @Test
+  public void testTransformToRasterCRSUsesMatchingIdentifierFastPath() throws FactoryException {
+    GridCoverage2D raster = RasterConstructors.makeEmptyRaster(1, 5, 5, 0, 5, 1, -1, 0, 0, 4326);
+    Geometry geometry = geomFromWKT("POINT (1 1)");
+
+    Geometry transformed = RasterUtils.transformToRasterCRS(raster, geometry);
+
+    Assert.assertSame(geometry, transformed);
+    Assert.assertEquals(0, transformed.getSRID());
+  }
+
+  @Test
   public void testNoDataValue() {
     GridSampleDimension band = new GridSampleDimension("test");
     Assert.assertTrue(Double.isNaN(RasterUtils.getNoDataValue(band)));

--- a/common/src/test/java/org/apache/sedona/common/utils/RasterUtilsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/utils/RasterUtilsTest.java
@@ -46,12 +46,26 @@ public class RasterUtilsTest {
   @Test
   public void testTransformToRasterCRSUsesMatchingIdentifierFastPath() throws FactoryException {
     GridCoverage2D raster = RasterConstructors.makeEmptyRaster(1, 5, 5, 0, 5, 1, -1, 0, 0, 4326);
-    Geometry geometry = geomFromWKT("POINT (1 1)");
+    for (int srid : new int[] {0, -1}) {
+      Geometry geometry = setSRID(geomFromWKT("POINT (1 1)"), srid);
+
+      Geometry transformed = RasterUtils.transformToRasterCRS(raster, geometry);
+
+      Assert.assertSame(geometry, transformed);
+      Assert.assertEquals(srid, transformed.getSRID());
+    }
+  }
+
+  @Test
+  public void testTransformToRasterCRSTreatsNegativeSRIDAsWGS84() throws FactoryException {
+    GridCoverage2D raster = RasterConstructors.makeEmptyRaster(1, 5, 5, 0, 5, 1, -1, 0, 0, 3857);
+    Geometry geometry = setSRID(geomFromWKT("POINT (2 1)"), -1);
 
     Geometry transformed = RasterUtils.transformToRasterCRS(raster, geometry);
 
-    Assert.assertSame(geometry, transformed);
-    Assert.assertEquals(0, transformed.getSRID());
+    Assert.assertEquals(3857, transformed.getSRID());
+    Assert.assertEquals(222638.9816, transformed.getCoordinate().x, 0.0001);
+    Assert.assertEquals(111325.1429, transformed.getCoordinate().y, 0.0001);
   }
 
   @Test


### PR DESCRIPTION
Closes #3216.

## What changed

- Transform the input geometry into the reference raster CRS before intersection validation.
- Reuse the same transformed geometry for intersection, output extent calculation, and pixel rasterization.
- Add a regression test comparing equivalent EPSG:4326 and EPSG:3857 geometries for both reference-raster and geometry-derived output extents.

## Why

`RS_AsRaster` previously used CRS-aligned operands only inside the intersection predicate. After that predicate succeeded, extent calculation and pixel burning still received the original geometry coordinates. With different known CRSs, this could produce an empty or misplaced raster, or fail while deriving the geometry-based output extent.

The new path aligns the geometry once to the raster coordinate space and performs the intersection check directly in that space, so every subsequent rasterization step uses consistent coordinates.

## Compatibility

This preserves the current CRS defaults: missing raster CRS metadata or geometry SRID is interpreted as WGS84. It does not relabel the reference raster, and custom non-EPSG raster CRSs remain supported.

## Validation

- `mvn -pl common -Dtest=RasterConstructorsTest#testAsRasterTransformsGeometryToRasterCRS test`
- `mvn -pl common test` — 1,229 tests passed
- Repository commit hooks passed
