### PR TITLE
[GH-3218] Support integer values in Moran's I

### DIFF
--- a/spark/common/src/main/scala/org/apache/sedona/stats/autocorrelation/Moran.scala
+++ b/spark/common/src/main/scala/org/apache/sedona/stats/autocorrelation/Moran.scala
@@ -44,7 +44,10 @@ object Moran {
     val spark = dataframe.sparkSession
     import spark.implicits._
 
-    val data = dataframe
+    val doubleValueDataframe =
+      dataframe.withColumn(valueColumnName, col(valueColumnName).cast("double"))
+
+    val data = doubleValueDataframe
       .selectExpr(s"avg($valueColumnName)", "count(*)")
       .as[(Double, Long)]
       .head()
@@ -81,7 +84,7 @@ object Moran {
 
     val s1 = sStats._1
 
-    val inumData = dataframe
+    val inumData = doubleValueDataframe
       .selectExpr(
         s"$idColumn AS id",
         s"$valueColumnName AS value",

--- a/spark/common/src/main/scala/org/apache/sedona/stats/autocorrelation/Moran.scala
+++ b/spark/common/src/main/scala/org/apache/sedona/stats/autocorrelation/Moran.scala
@@ -19,12 +19,15 @@
 package org.apache.sedona.stats.autocorrelation
 
 import org.apache.commons.math3.distribution.NormalDistribution
-import org.apache.spark.sql.{DataFrame, functions}
+import org.apache.spark.sql.{Column, DataFrame, functions}
 import org.apache.spark.sql.functions.{col, explode, pow}
 
 object Moran {
   private val ID_COLUMN = "id"
   private val VALUE_COLUMN = "value"
+
+  private def topLevelColumn(columnName: String): Column =
+    col(s"`${columnName.replace("`", "``")}`")
 
   private def normSf(x: Double, mean: Double = 0.0, stdDev: Double = 1.0): Double = {
     val normalDist = new NormalDistribution(mean, stdDev)
@@ -45,23 +48,34 @@ object Moran {
     import spark.implicits._
 
     val doubleValueDataframe =
-      dataframe.withColumn(valueColumnName, col(valueColumnName).cast("double"))
+      dataframe.withColumn(valueColumnName, topLevelColumn(valueColumnName).cast("double"))
 
     val data = doubleValueDataframe
-      .selectExpr(s"avg($valueColumnName)", "count(*)")
-      .as[(Double, Long)]
+      .select(
+        functions.avg(topLevelColumn(valueColumnName)).alias("mean"),
+        functions.count(functions.lit(1)).alias("count"))
       .head()
 
-    val yMean = data._1
+    if (data.isNullAt(0)) {
+      throw new IllegalArgumentException(
+        s"Value column '$valueColumnName' must contain at least one non-null value")
+    }
 
-    val n = data._2
+    val yMean = data.getDouble(0)
+
+    if (!java.lang.Double.isFinite(yMean)) {
+      throw new IllegalArgumentException(
+        s"Value column '$valueColumnName' must have a finite mean")
+    }
+
+    val n = data.getLong(1)
 
     val explodedWeights = dataframe
-      .select(col(idColumn), explode(col("weights")).alias("col"))
+      .select(topLevelColumn(idColumn).alias("id"), explode(col("weights")).alias("weight"))
       .select(
-        $"$idColumn".alias("id"),
-        $"col.neighbor.$idColumn".alias("n_id"),
-        $"col.value".alias("weight_value"))
+        col("id"),
+        col("weight").getField("neighbor").getField(idColumn).alias("n_id"),
+        col("weight").getField("value").alias("weight_value"))
 
     val s1Data = explodedWeights
       .alias("left")
@@ -84,12 +98,26 @@ object Moran {
 
     val s1 = sStats._1
 
+    val valueColumn = topLevelColumn(valueColumnName)
+    val yMeanColumn = functions.lit(yMean)
     val inumData = doubleValueDataframe
-      .selectExpr(
-        s"$idColumn AS id",
-        s"$valueColumnName AS value",
-        f"$valueColumnName - ${yMean} AS z",
-        f"transform(weights, w -> struct(w.neighbor.$idColumn AS id, w.value AS w, w.neighbor.$valueColumnName, w.neighbor.$valueColumnName - ${yMean} AS z)) AS weight")
+      .select(
+        topLevelColumn(idColumn).alias("id"),
+        valueColumn.alias("value"),
+        (valueColumn - yMeanColumn).alias("z"),
+        functions
+          .transform(
+            col("weights"),
+            weight => {
+              val neighbor = weight.getField("neighbor")
+              val neighborValue = neighbor.getField(valueColumnName).cast("double")
+              functions.struct(
+                neighbor.getField(idColumn).alias("id"),
+                weight.getField("value").alias("w"),
+                neighborValue.alias("value"),
+                (neighborValue - yMeanColumn).alias("z"))
+            })
+          .alias("weight"))
       .selectExpr(
         "z",
         "AGGREGATE(transform(weight, x-> x.z*x.w), CAST(0.0 AS DOUBLE), (acc, x) -> acc + x) AS ZL",

--- a/spark/common/src/test/scala/org/apache/sedona/stats/autocorrelation/MoranTest.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/stats/autocorrelation/MoranTest.scala
@@ -21,7 +21,7 @@ package org.apache.sedona.stats.autocorrelation
 import org.apache.sedona.sql.TestBaseScala
 import org.apache.sedona.stats.Weighting
 import org.apache.sedona.stats.autocorrelation.Moran
-import org.apache.spark.sql.functions.expr
+import org.apache.spark.sql.functions.{col, expr, lit, size, struct, transform}
 
 class MoranTest extends TestBaseScala with AutoCorrelationFixtures {
   describe("Moran's I") {
@@ -78,6 +78,64 @@ class MoranTest extends TestBaseScala with AutoCorrelationFixtures {
 
       assert(moranResult.getPNorm < 0.0001)
       assert(moranResult.getI > 0.99)
+    }
+
+    it("supports dots in id and value column names") {
+      val weights = Weighting
+        .addDistanceBandColumn(
+          positiveCorrelationFrame,
+          1.0,
+          savedAttributes = Seq("id", "value"))
+        .select(
+          col("id").alias("feature.id"),
+          col("geometry"),
+          col("value").alias("feature.value"),
+          transform(
+            col("weights"),
+            weight =>
+              struct(
+                struct(
+                  weight.getField("neighbor").getField("id").alias("feature.id"),
+                  weight.getField("neighbor").getField("value").alias("feature.value"))
+                  .alias("neighbor"),
+                (weight.getField("value") / size(col("weights"))).alias("value")))
+            .alias("weights"))
+
+      val moranResult =
+        Moran.getGlobal(weights, idColumn = "feature.id", valueColumnName = "feature.value")
+
+      assert(moranResult.getPNorm < 0.0001)
+      assert(moranResult.getI > 0.99)
+    }
+
+    it("rejects all-null value columns") {
+      val weights = Weighting
+        .addDistanceBandColumn(
+          positiveCorrelationFrame,
+          1.0,
+          savedAttributes = Seq("id", "value"))
+        .withColumn("value", lit(null).cast("double"))
+
+      val exception = intercept[IllegalArgumentException] {
+        Moran.getGlobal(weights)
+      }
+
+      assert(exception.getMessage.contains("must contain at least one non-null value"))
+    }
+
+    it("rejects value columns with non-finite means") {
+      val weights = Weighting
+        .addDistanceBandColumn(
+          positiveCorrelationFrame,
+          1.0,
+          savedAttributes = Seq("id", "value"))
+        .withColumn("value", lit(Double.NaN))
+
+      val exception = intercept[IllegalArgumentException] {
+        Moran.getGlobal(weights)
+      }
+
+      assert(exception.getMessage.contains("must have a finite mean"))
     }
 
     it("correlation is negative") {

--- a/spark/common/src/test/scala/org/apache/sedona/stats/autocorrelation/MoranTest.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/stats/autocorrelation/MoranTest.scala
@@ -63,6 +63,23 @@ class MoranTest extends TestBaseScala with AutoCorrelationFixtures {
       assert(moranResult.getI > 0.99)
     }
 
+    it("supports integer value columns") {
+      val weights = Weighting
+        .addDistanceBandColumn(
+          positiveCorrelationFrame
+            .selectExpr("id", "geometry", "CAST(value * 10 AS BIGINT) AS value"),
+          1.0,
+          savedAttributes = Seq("id", "value"))
+        .withColumn(
+          "weights",
+          expr("transform(weights, w -> struct(w.neighbor, w.value/size(weights) AS value))"))
+
+      val moranResult = Moran.getGlobal(weights, idColumn = "id")
+
+      assert(moranResult.getPNorm < 0.0001)
+      assert(moranResult.getI > 0.99)
+    }
+
     it("correlation is negative") {
       val weights = Weighting
         .addDistanceBandColumn(


### PR DESCRIPTION
## What changed

- Normalize the selected Moran value column to `DOUBLE` before computing the mean and centered-value statistics.
- Build mean, centering, and neighbor expressions with Spark's column API instead of interpolated SQL, including a typed literal for the mean.
- Treat configured ID and value column names as literal top-level and nested field names, including names containing dots.
- Reject all-null value columns and non-finite means with clear `IllegalArgumentException` messages.
- Add regression coverage for `BIGINT` values, dotted column names, all-null values, and `NaN` means.

## Why

Moran's I returns its intermediate aggregates through a typed tuple of `Double` values. With an integral input column, Spark inferred `z * z` and its sum as decimal values, then rejected the attempted upcast from `DECIMAL(38, scale)` to `DOUBLE`.

Normalizing the value column at the calculation boundary keeps the intermediate expressions consistent with the existing double-based result contract. Callers can now pass integer counts without adding their own cast.

The same calculation interpolated the mean and configured column names into SQL expressions. That made null or non-finite means fragile and caused dots in literal column names to be parsed as nested paths. Column expressions preserve the intended types and field names throughout the calculation.

## Validation

- `MoranTest` on Spark 3.4 / Scala 2.12: 8 tests passed.
- `MoranTest` on Spark 3.5.8 / Scala 2.12: 8 tests passed.
- `MoranTest` on Spark 4.1.1 / Scala 2.13: 8 tests passed.
- Repository pre-commit hooks passed.

Fixes #3218.
