### PR TITLE
[DOCS] Bump Python, R, and Zeppelin versions to 1.9.1

### DIFF
--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: apache.sedona
 Title: R Interface for Apache Sedona
-Version: 1.9.0
+Version: 1.9.1
 Authors@R:
     c(person(family = "Apache Sedona",
              role = c("aut", "cre"),

--- a/R/R/dependencies.R
+++ b/R/R/dependencies.R
@@ -25,7 +25,7 @@ spark_dependencies <- function(spark_version, scala_version, ...) {
   }
 
   packages <- c(
-    "org.datasyslab:geotools-wrapper:1.9.0-33.5"
+    "org.datasyslab:geotools-wrapper:1.9.1-33.5"
   )
   jars <- NULL
 
@@ -38,7 +38,7 @@ spark_dependencies <- function(spark_version, scala_version, ...) {
       paste0(
         "org.apache.sedona:sedona-",
         c("spark-shaded"),
-        sprintf("-%s_%s:1.9.0", spark_version, scala_version)
+        sprintf("-%s_%s:1.9.1", spark_version, scala_version)
       ),
       packages
     )

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -205,14 +205,14 @@ extra:
     - icon: fontawesome/brands/discord
       link: 'https://discord.gg/9A3k5dEBsY'
   sedona:
-    current_version: 1.9.0
-    current_geotools: 1.9.0-33.5
+    current_version: 1.9.1
+    current_geotools: 1.9.1-33.5
   sedona_create_release:
-    current_version: 1.9.0
-    current_git_tag: sedona-1.9.0-rc1
-    current_rc: 1.9.0-rc1
-    current_snapshot: 1.9.1-SNAPSHOT
-    next_version: 1.9.1
+    current_version: 1.9.1
+    current_git_tag: sedona-1.9.1-rc1
+    current_rc: 1.9.1-rc1
+    current_snapshot: 1.9.2-SNAPSHOT
+    next_version: 1.9.2
 copyright: Copyright © 2026 The Apache Software Foundation. Apache Sedona, Sedona, Apache, the Apache feather logo, and the Apache Sedona project logo are either registered trademarks or trademarks of The Apache Software Foundation in the United States and other countries. All other marks mentioned may be trademarks or registered trademarks of their respective owners. Please visit <a href="https://www.apache.org/">Apache Software Foundation</a> for more details.<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=f3e121f6-c909-4592-8be6-5bd345768cba" /><img referrerpolicy="no-referrer-when-downgrade" src="https://analytics.apache.org/matomo.php?idsite=74&rec=1" />
 
 markdown_extensions:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -21,7 +21,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apache-sedona"
-version = "1.9.0"
+version = "1.9.1"
 description = "Apache Sedona is a cluster computing system for processing large-scale spatial data"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/python/sedona/version.py
+++ b/python/sedona/version.py
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version = "1.9.0"
+version = "1.9.1"

--- a/zeppelin/package-lock.json
+++ b/zeppelin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "apache-sedona",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "apache-sedona",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "BSD-2-Clause",
       "dependencies": {
         "jsts": "^1.6.2",

--- a/zeppelin/package.json
+++ b/zeppelin/package.json
@@ -2,7 +2,7 @@
   "name": "apache-sedona",
   "description": "Zeppelin visualization support for Sedona",
   "author": "Apache Sedona, original authors are listed on https://github.com/myuwono/zeppelin-leaflet",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a documentation update. The PR name follows the format `[DOCS] my subject`

## What changes were proposed in this PR?

Bump versions in preparation for the 1.9.1 release:

- `python/sedona/version.py` and `python/pyproject.toml` to 1.9.1
- `R/DESCRIPTION` to 1.9.1; `R/R/dependencies.R` to sedona-spark-shaded 1.9.1 and geotools-wrapper 1.9.1-33.5
- `zeppelin/package.json` and `zeppelin/package-lock.json` to 1.9.1
- `mkdocs.yml`: `current_version` 1.9.1, `current_geotools` 1.9.1-33.5, `current_rc` 1.9.1-rc1, `current_git_tag` sedona-1.9.1-rc1, `current_snapshot` 1.9.2-SNAPSHOT, `next_version` 1.9.2

## How was this patch tested?

Version-string changes only; pre-commit hooks pass.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.