### PR TITLE
[GH-3233] Bump snowflake-tester parent version to 1.9.2-SNAPSHOT

### DIFF
--- a/snowflake-tester/pom.xml
+++ b/snowflake-tester/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.sedona</groupId>
         <artifactId>sedona-parent</artifactId>
-        <version>1.9.1-SNAPSHOT</version>
+        <version>1.9.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #3233

## What changes were proposed in this PR?

Bump the snowflake-tester parent reference from 1.9.1-SNAPSHOT to 1.9.2-SNAPSHOT. The parent pom on master moved to 1.9.2-SNAPSHOT when the 1.9.1 release was cut, and snowflake-tester is outside the release reactor so maven-release-plugin does not rewrite it. Without this bump the snowflake-tester build cannot resolve its parent on master. Same manual bump as #2845 last cycle.

## How was this patch tested?

Version-string change only; the module builds once the parent reference resolves.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.