### PR TITLE
[GH-3233] Bump development version to 2.0.0-SNAPSHOT

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.sedona</groupId>
         <artifactId>sedona-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>sedona-common</artifactId>

--- a/flink-shaded/pom.xml
+++ b/flink-shaded/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>sedona-parent</artifactId>
         <groupId>org.apache.sedona</groupId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>sedona-flink-shaded_${scala.compat.version}</artifactId>
 

--- a/flink/pom.xml
+++ b/flink/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.sedona</groupId>
         <artifactId>sedona-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>sedona-flink_${scala.compat.version}</artifactId>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -211,8 +211,8 @@ extra:
     current_version: 1.9.1
     current_git_tag: sedona-1.9.1-rc1
     current_rc: 1.9.1-rc1
-    current_snapshot: 1.9.2-SNAPSHOT
-    next_version: 1.9.2
+    current_snapshot: 2.0.0-SNAPSHOT
+    next_version: 2.0.0
 copyright: Copyright © 2026 The Apache Software Foundation. Apache Sedona, Sedona, Apache, the Apache feather logo, and the Apache Sedona project logo are either registered trademarks or trademarks of The Apache Software Foundation in the United States and other countries. All other marks mentioned may be trademarks or registered trademarks of their respective owners. Please visit <a href="https://www.apache.org/">Apache Software Foundation</a> for more details.<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=f3e121f6-c909-4592-8be6-5bd345768cba" /><img referrerpolicy="no-referrer-when-downgrade" src="https://analytics.apache.org/matomo.php?idsite=74&rec=1" />
 
 markdown_extensions:

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     </parent>
     <groupId>org.apache.sedona</groupId>
     <artifactId>sedona-parent</artifactId>
-    <version>1.9.2-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>sedona-parent</name>
     <url>https://sedona.apache.org/</url>

--- a/shade-proto/pom.xml
+++ b/shade-proto/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.sedona</groupId>
         <artifactId>sedona-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/snowflake-tester/pom.xml
+++ b/snowflake-tester/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.sedona</groupId>
         <artifactId>sedona-parent</artifactId>
-        <version>1.9.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/snowflake/pom.xml
+++ b/snowflake/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.sedona</groupId>
         <artifactId>sedona-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/spark-shaded/pom.xml
+++ b/spark-shaded/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>sedona-parent</artifactId>
         <groupId>org.apache.sedona</groupId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>sedona-spark-shaded-${spark.compat.version}_${scala.compat.version}</artifactId>
 

--- a/spark/common/pom.xml
+++ b/spark/common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.sedona</groupId>
         <artifactId>sedona-spark-parent-${spark.compat.version}_${scala.compat.version}</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>sedona-spark-common-${spark.compat.version}_${scala.compat.version}</artifactId>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.sedona</groupId>
         <artifactId>sedona-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>sedona-spark-parent-${spark.compat.version}_${scala.compat.version}</artifactId>

--- a/spark/spark-3.4/pom.xml
+++ b/spark/spark-3.4/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.sedona</groupId>
         <artifactId>sedona-spark-parent-${spark.compat.version}_${scala.compat.version}</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>sedona-spark-3.4_${scala.compat.version}</artifactId>

--- a/spark/spark-3.5/pom.xml
+++ b/spark/spark-3.5/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.sedona</groupId>
         <artifactId>sedona-spark-parent-${spark.compat.version}_${scala.compat.version}</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>sedona-spark-3.5_${scala.compat.version}</artifactId>

--- a/spark/spark-4.0/pom.xml
+++ b/spark/spark-4.0/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.sedona</groupId>
         <artifactId>sedona-spark-parent-${spark.compat.version}_${scala.compat.version}</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>sedona-spark-4.0_${scala.compat.version}</artifactId>

--- a/spark/spark-4.1/pom.xml
+++ b/spark/spark-4.1/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.sedona</groupId>
         <artifactId>sedona-spark-parent-${spark.compat.version}_${scala.compat.version}</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>sedona-spark-4.1_${scala.compat.version}</artifactId>


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #3233

## What changes were proposed in this PR?

Move the development version on master from 1.9.2-SNAPSHOT to 2.0.0-SNAPSHOT, since the next release will be 2.0.0:

- All 13 reactor poms: 1.9.2-SNAPSHOT → 2.0.0-SNAPSHOT
- `snowflake-tester/pom.xml`: parent reference 1.9.1-SNAPSHOT → 2.0.0-SNAPSHOT (outside the release reactor, so maven-release-plugin never rewrites it; without this its parent cannot resolve on master)
- `mkdocs.yml`: `current_snapshot` → 2.0.0-SNAPSHOT, `next_version` → 2.0.0

## How was this patch tested?

`mvn validate -Penable-all-submodules` passes on the full reactor, and `help:evaluate` on snowflake-tester resolves parent 2.0.0-SNAPSHOT.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.