### PR TITLE
[DOCS] Add 1.9.1 release news

### DIFF
--- a/docs-overrides/main.html
+++ b/docs-overrides/main.html
@@ -29,11 +29,11 @@
 
 {% block header %}
   {%- set announcement = {
-            'en': '🎉 SedonaDB 0.4.0 is out now! 🗺️ Python DataFrame API, R dplyr, Geography support & GPU-accelerated spatial joins. Read the release blog →',
-            'zh': '🎉 SedonaDB 0.4.0 已正式发布！🗺️ 新增 Python DataFrame API、R dplyr 接口、Geography 支持及 GPU 加速空间连接。阅读发布博客 →'
+            'en': '🎉 Apache Sedona 1.9.1 is out now! 🗺️ Geography SQL functions, Box2D & Box3D types, raster Python UDFs & more. Read the release notes →',
+            'zh': '🎉 Apache Sedona 1.9.1 已正式发布！🗺️ 新增 Geography SQL 函数、Box2D 与 Box3D 类型、栅格 Python UDF 等。查看发布说明 →'
   } -%}
   <div style="background: #CA463A; color: white; text-align: center; padding: 0.5rem;">
-        <a href="{{ 'blog/2026/06/19/sedonadb-040-release/' | url }}" title="Announcement">{{ announcement[cur_lang] }}</a>
+        <a href="{{ 'setup/release-notes/' | url }}" title="Announcement">{{ announcement[cur_lang] }}</a>
   </div>
   {{ super() }} {# This renders the original header below your test bar #}
 {% endblock %}

--- a/docs/download.md
+++ b/docs/download.md
@@ -33,6 +33,13 @@ Automatically generated binary JARs (per each Master branch commit): [GitHub Act
 
 ## Versions
 
+### 1.9.1
+
+| |                                    Download from ASF                                     |                                         Checksum                                          |                                      Signature                                      |
+|:-----------------:|:----------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------:|
+|    Source code    | [src](https://www.apache.org/dyn/closer.lua/sedona/1.9.1/apache-sedona-1.9.1-src.tar.gz) | [sha512](https://downloads.apache.org/sedona/1.9.1/apache-sedona-1.9.1-src.tar.gz.sha512) | [asc](https://downloads.apache.org/sedona/1.9.1/apache-sedona-1.9.1-src.tar.gz.asc) |
+|       Binary      | [bin](https://www.apache.org/dyn/closer.lua/sedona/1.9.1/apache-sedona-1.9.1-bin.tar.gz) | [sha512](https://downloads.apache.org/sedona/1.9.1/apache-sedona-1.9.1-bin.tar.gz.sha512) | [asc](https://downloads.apache.org/sedona/1.9.1/apache-sedona-1.9.1-bin.tar.gz.asc) |
+
 ### 1.9.0
 
 | |                                    Download from ASF                                     |                                         Checksum                                          |                                      Signature                                      |

--- a/docs/download.md
+++ b/docs/download.md
@@ -40,13 +40,6 @@ Automatically generated binary JARs (per each Master branch commit): [GitHub Act
 |    Source code    | [src](https://www.apache.org/dyn/closer.lua/sedona/1.9.1/apache-sedona-1.9.1-src.tar.gz) | [sha512](https://downloads.apache.org/sedona/1.9.1/apache-sedona-1.9.1-src.tar.gz.sha512) | [asc](https://downloads.apache.org/sedona/1.9.1/apache-sedona-1.9.1-src.tar.gz.asc) |
 |       Binary      | [bin](https://www.apache.org/dyn/closer.lua/sedona/1.9.1/apache-sedona-1.9.1-bin.tar.gz) | [sha512](https://downloads.apache.org/sedona/1.9.1/apache-sedona-1.9.1-bin.tar.gz.sha512) | [asc](https://downloads.apache.org/sedona/1.9.1/apache-sedona-1.9.1-bin.tar.gz.asc) |
 
-### 1.9.0
-
-| |                                    Download from ASF                                     |                                         Checksum                                          |                                      Signature                                      |
-|:-----------------:|:----------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------:|
-|    Source code    | [src](https://www.apache.org/dyn/closer.lua/sedona/1.9.0/apache-sedona-1.9.0-src.tar.gz) | [sha512](https://downloads.apache.org/sedona/1.9.0/apache-sedona-1.9.0-src.tar.gz.sha512) | [asc](https://downloads.apache.org/sedona/1.9.0/apache-sedona-1.9.0-src.tar.gz.asc) |
-|       Binary      | [bin](https://www.apache.org/dyn/closer.lua/sedona/1.9.0/apache-sedona-1.9.0-bin.tar.gz) | [sha512](https://downloads.apache.org/sedona/1.9.0/apache-sedona-1.9.0-bin.tar.gz.sha512) | [asc](https://downloads.apache.org/sedona/1.9.0/apache-sedona-1.9.0-bin.tar.gz.asc) |
-
 ### 1.8.1
 
 | |                                    Download from ASF                                     |                                         Checksum                                          |                                      Signature                                      |

--- a/docs/download.zh.md
+++ b/docs/download.zh.md
@@ -40,13 +40,6 @@
 |    源代码    | [src](https://www.apache.org/dyn/closer.lua/sedona/1.9.1/apache-sedona-1.9.1-src.tar.gz) | [sha512](https://downloads.apache.org/sedona/1.9.1/apache-sedona-1.9.1-src.tar.gz.sha512) | [asc](https://downloads.apache.org/sedona/1.9.1/apache-sedona-1.9.1-src.tar.gz.asc) |
 |       二进制      | [bin](https://www.apache.org/dyn/closer.lua/sedona/1.9.1/apache-sedona-1.9.1-bin.tar.gz) | [sha512](https://downloads.apache.org/sedona/1.9.1/apache-sedona-1.9.1-bin.tar.gz.sha512) | [asc](https://downloads.apache.org/sedona/1.9.1/apache-sedona-1.9.1-bin.tar.gz.asc) |
 
-### 1.9.0
-
-| |                                    从 ASF 下载                                     |                                         校验和                                          |                                      签名                                      |
-|:-----------------:|:----------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------:|
-|    源代码    | [src](https://www.apache.org/dyn/closer.lua/sedona/1.9.0/apache-sedona-1.9.0-src.tar.gz) | [sha512](https://downloads.apache.org/sedona/1.9.0/apache-sedona-1.9.0-src.tar.gz.sha512) | [asc](https://downloads.apache.org/sedona/1.9.0/apache-sedona-1.9.0-src.tar.gz.asc) |
-|       二进制      | [bin](https://www.apache.org/dyn/closer.lua/sedona/1.9.0/apache-sedona-1.9.0-bin.tar.gz) | [sha512](https://downloads.apache.org/sedona/1.9.0/apache-sedona-1.9.0-bin.tar.gz.sha512) | [asc](https://downloads.apache.org/sedona/1.9.0/apache-sedona-1.9.0-bin.tar.gz.asc) |
-
 ### 1.8.1
 
 | |                                    从 ASF 下载                                     |                                         校验和                                          |                                      签名                                      |

--- a/docs/download.zh.md
+++ b/docs/download.zh.md
@@ -33,6 +33,13 @@
 
 ## 版本
 
+### 1.9.1
+
+| |                                    从 ASF 下载                                     |                                         校验和                                          |                                      签名                                      |
+|:-----------------:|:----------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------:|
+|    源代码    | [src](https://www.apache.org/dyn/closer.lua/sedona/1.9.1/apache-sedona-1.9.1-src.tar.gz) | [sha512](https://downloads.apache.org/sedona/1.9.1/apache-sedona-1.9.1-src.tar.gz.sha512) | [asc](https://downloads.apache.org/sedona/1.9.1/apache-sedona-1.9.1-src.tar.gz.asc) |
+|       二进制      | [bin](https://www.apache.org/dyn/closer.lua/sedona/1.9.1/apache-sedona-1.9.1-bin.tar.gz) | [sha512](https://downloads.apache.org/sedona/1.9.1/apache-sedona-1.9.1-bin.tar.gz.sha512) | [asc](https://downloads.apache.org/sedona/1.9.1/apache-sedona-1.9.1-bin.tar.gz.asc) |
+
 ### 1.9.0
 
 | |                                    从 ASF 下载                                     |                                         校验和                                          |                                      签名                                      |

--- a/docs/usecases/README.md
+++ b/docs/usecases/README.md
@@ -73,14 +73,14 @@ For faster iteration during notebook authoring, you can replicate the harness wi
 
 - Python 3.10+ (image uses 3.12)
 - `pyspark==4.0.1`
-- `apache-sedona==1.9.0`
+- `apache-sedona==1.9.1`
 - `keplergl==0.3.7`, `geopandas`, `pyarrow`, `pandas`, `matplotlib`, `fiona==1.10.1`
 - `JAVA_HOME` pointing at a JDK 17 install
 
 Then export the Sedona Maven coordinates (the docker image bakes the JAR in directly; locally you let Maven pull it):
 
 ```bash
-export PYSPARK_SUBMIT_ARGS="--packages org.apache.sedona:sedona-spark-shaded-4.0_2.13:1.9.0,org.datasyslab:geotools-wrapper:1.9.0-33.5 --driver-memory 4g pyspark-shell"
+export PYSPARK_SUBMIT_ARGS="--packages org.apache.sedona:sedona-spark-shaded-4.0_2.13:1.9.1,org.datasyslab:geotools-wrapper:1.9.1-33.5 --driver-memory 4g pyspark-shell"
 ```
 
 Convert and run:


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a documentation update. The PR name follows the format `[DOCS] my subject`

## What changes were proposed in this PR?

Release-news documentation for 1.9.1, prepared ahead of the vote result:

- `docs/download.md` and `docs/download.zh.md`: add the 1.9.1 download section (src/bin + sha512 + asc links)
- `docs-overrides/main.html`: switch the homepage announcement banner (en/zh) to the 1.9.1 release, linking to the release notes
- `docs/usecases/README.md`: bump the pip and Maven coordinates to 1.9.1 / geotools-wrapper 1.9.1-33.5

Draft until the 1.9.1 vote passes and the artifacts are moved to dist/release — the download links resolve only after that.

## How was this patch tested?

Documentation-only change; pre-commit hooks pass.

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.