### PR TITLE
[GH-3237] Install Spark from the official apache/spark Docker image

### DIFF
--- a/docker/install-spark.sh
+++ b/docker/install-spark.sh
@@ -20,9 +20,8 @@
 set -e
 
 # Define variables
-spark_version=$1
-hadoop_s3_version=$2
-aws_sdk_version=$3
+hadoop_s3_version=$1
+aws_sdk_version=$2
 
 # Helper function to download with throttled progress updates (every 5 seconds)
 download_with_progress() {
@@ -31,7 +30,7 @@ download_with_progress() {
     local description=${3:-"Downloading"}
 
     # Start download in background, redirect progress to /dev/null
-    curl -L --silent --show-error --retry 5 --retry-delay 10 --retry-connrefused "${url}" -o "${output}" &
+    curl -L --fail --silent --show-error --retry 5 --retry-delay 10 --retry-connrefused "${url}" -o "${output}" &
     local curl_pid=$!
 
     # Monitor progress every 5 seconds
@@ -61,24 +60,14 @@ download_with_progress() {
     fi
 }
 
-# Download Spark jar and set up PySpark
-# Download from Lyra Hosting mirror (faster) but verify checksum from Apache archive
-spark_filename="spark-${spark_version}-bin-hadoop3.tgz"
-spark_download_url="https://mirror.lyrahosting.com/apache/spark/spark-${spark_version}/${spark_filename}"
-checksum_url="https://archive.apache.org/dist/spark/spark-${spark_version}/${spark_filename}.sha512"
-
-echo "Downloading Spark ${spark_version} from Lyra Hosting mirror..."
-download_with_progress "${spark_download_url}" "${spark_filename}" "Downloading Spark"
-
-echo "Downloading checksum from Apache archive..."
-curl -L --silent --show-error --retry 5 --retry-delay 10 --retry-connrefused "${checksum_url}" -o "${spark_filename}.sha512"
-
-echo "Verifying checksum..."
-sha512sum -c "${spark_filename}.sha512" || { echo "Checksum verification failed!"; exit 1; }
-
-echo "Checksum verified successfully. Extracting Spark..."
-tar -xf "${spark_filename}" && mv spark-"${spark_version}"-bin-hadoop3/* "${SPARK_HOME}"/
-rm "${spark_filename}" "${spark_filename}.sha512" && rm -rf spark-"${spark_version}"-bin-hadoop3
+# Spark itself is provided by the official apache/spark image via a multi-stage
+# COPY in sedona-docker.dockerfile. That image ships without a conf directory,
+# so create it here. The tgz distribution's conf templates only contain
+# commented-out examples, so empty files are equivalent; start.sh appends the
+# actual settings at container startup.
+mkdir -p "${SPARK_HOME}"/conf
+touch "${SPARK_HOME}"/conf/spark-defaults.conf
+touch "${SPARK_HOME}"/conf/spark-env.sh.template
 
 # Add S3 jars
 echo "Downloading Hadoop AWS S3 jar..."
@@ -87,9 +76,6 @@ download_with_progress "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-
 # Add AWS SDK v2 bundle (required by spark-extension 2.14.2+)
 echo "Downloading AWS SDK v2 bundle..."
 download_with_progress "https://repo1.maven.org/maven2/software/amazon/awssdk/bundle/${aws_sdk_version}/bundle-${aws_sdk_version}.jar" "${SPARK_HOME}/jars/aws-sdk-v2-bundle-${aws_sdk_version}.jar" "Downloading AWS SDK"
-
-# Set up master IP address and executor memory
-cp "${SPARK_HOME}"/conf/spark-defaults.conf.template "${SPARK_HOME}"/conf/spark-defaults.conf
 
 # Install required libraries for GeoPandas on Apple chip mac
 apt-get install -y gdal-bin libgdal-dev

--- a/docker/sedona-docker.dockerfile
+++ b/docker/sedona-docker.dockerfile
@@ -15,6 +15,13 @@
 # limitations under the License.
 #
 
+ARG spark_version=4.0.1
+
+# Official ASF Spark image, used only as the source of ${SPARK_HOME}.
+# Docker Hub keeps every historical version, unlike the ASF dist mirrors
+# which only carry current releases.
+FROM apache/spark:${spark_version} AS spark
+
 FROM ubuntu:24.04
 
 ARG shared_workspace=/opt/workspace
@@ -44,9 +51,10 @@ ENV PYTHONPATH=${SPARK_HOME}/python
 RUN apt-get update
 RUN apt-get install -y openjdk-17-jdk-headless curl python3-pip maven
 RUN pip3 install --no-cache-dir pipenv --break-system-packages
+COPY --from=spark --chown=root:root /opt/spark ${SPARK_HOME}
 COPY ./docker/install-spark.sh ${SEDONA_HOME}/docker/
 RUN chmod +x ${SEDONA_HOME}/docker/install-spark.sh
-RUN ${SEDONA_HOME}/docker/install-spark.sh ${spark_version} ${hadoop_s3_version} ${aws_sdk_version}
+RUN ${SEDONA_HOME}/docker/install-spark.sh ${hadoop_s3_version} ${aws_sdk_version}
 
 # Install Python dependencies
 # --ignore-installed is required because install-spark.sh installs GDAL


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #3237

## What changes were proposed in this PR?

The docker image build downloads Spark from a hardcoded third-party mirror (mirror.lyrahosting.com) that is currently failing TLS verification intermittently, so docker-build CI runs fail with `curl: (60) SSL certificate problem: certificate has expired`. The ASF dist mirrors and dlcdn.apache.org are not a drop-in replacement because they only carry current releases (the pinned Spark 4.0.1 has already rotated off), and archive.apache.org is slow and heavily throttled.

Instead, source Spark from the official apache/spark Docker image:

- `sedona-docker.dockerfile`: add a `FROM apache/spark:${spark_version} AS spark` stage and `COPY --from=spark /opt/spark ${SPARK_HOME}`. Docker Hub hosts every historical version in both amd64 and arm64, images are ASF-built, content-addressed, and served from a CDN.
- `docker/install-spark.sh`: drop the tgz download/checksum/extract logic. The official image ships without a conf directory, so create `conf/spark-defaults.conf` and `conf/spark-env.sh.template` (the tgz templates only contain commented-out examples; start.sh appends the real settings at startup). The hadoop-aws / AWS SDK jar downloads from Maven Central, GDAL, and SSH setup are unchanged, with `--fail` added to curl so HTTP errors are not silently saved as jars.

## How was this patch tested?

`bash -n` syntax check on the script; verified apache/spark:4.0.1 exists on Docker Hub with amd64 and arm64 images and contains `/opt/spark/{jars,bin,sbin,python,data,examples,R}`. The docker-build workflow on this PR builds the full image on both architectures.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.