### PR TITLE
[GH-3240] Run Makefile prek commands through uv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,19 +18,19 @@
 .PHONY: check check-from-ref check-install check-last check-stage clean docsbuild docsinstall install run-docs sync-no-dev update update-deps
 
 check: install ## run all pre-commit checks
-	prek run --all-files
+	uv run prek run --all-files
 
 check-from-ref: install ## will run prek checks for all changes since you branched off
-	prek run --from-ref master
+	uv run prek run --from-ref master
 
 check-install: ## checks for a uv installation
 	@command -v uv >/dev/null 2>&1 || (echo 'uv not found, install via: curl -LsSf https://astral.sh/uv/install.sh | sh' && exit 1)
 
 check-last: install ## will run pre-commit checks on last commit only
-	prek --last-commit
+	uv run prek --last-commit
 
 check-stage: install ## runs check on currently staged changes
-	prek
+	uv run prek
 
 clean:
 	@echo "Cleaning up generated files... (TODO)"
@@ -51,7 +51,7 @@ docsinstall: check-install
 
 install: check-install ## Sync all dependencies (including development) using uv
 	uv sync --all-groups
-	prek install
+	uv run prek install
 
 run-docs:
 	docker build -f docker/docs/Dockerfile -t mkdocs-sedona .
@@ -61,8 +61,8 @@ sync-no-dev: check-install ## Sync non-development dependencies using uv
 	uv sync --no-dev
 
 update: install
-	prek auto-update --freeze
+	uv run prek auto-update --freeze
 
 update-deps: check-install ## Update pre-commit hooks and local dependencies
-	prek auto-update --freeze || :
+	uv run prek auto-update --freeze || :
 	uv sync --all-groups --upgrade


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/).

## Is this PR related to a ticket?

- Yes, and the PR name follows the `[GH-XXX] my subject` format. Closes #3240.

## What changes were proposed in this PR?

- Run every Makefile `prek` invocation through `uv run`, including check, installation, and update targets.
- Ensure those targets consistently use the project-managed development environment, matching the existing documentation.

## How was this patch tested?

- `make -n check check-from-ref check-last check-stage update update-deps`
- `uv run prek run --files Makefile`
- `uv run prek run check-makefiles-tabs --hook-stage manual --files Makefile`
- `uv run prek run insert-license --files Makefile`
- `git diff --check`

The auto-update targets were inspected with `make -n` rather than executed because running them would intentionally update hook and dependency locks.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API, so no documentation change is needed. The existing documentation already describes `uv`-managed execution; this patch makes the Makefile honor that behavior.
