### PR TITLE
[CI] Fix Snowflake V2 empty polygon orientation tests

### DIFF
--- a/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctionsV2.java
+++ b/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctionsV2.java
@@ -1211,8 +1211,9 @@ public class TestFunctionsV2 extends TestBase {
     verifySqlSingleRes(
         "SELECT sedona.ST_IsPolygonCW(ST_GeomFromWKT('POLYGON ((20 35, 45 20, 30 5, 10 10, 10 30, 20 35), (30 20, 20 25, 20 15, 30 20))'))",
         true);
-    verifySqlSingleRes("SELECT sedona.ST_IsPolygonCW(ST_GeomFromWKT('POLYGON EMPTY'))", true);
-    verifySqlSingleRes("SELECT sedona.ST_IsPolygonCW(ST_GeomFromWKT('MULTIPOLYGON EMPTY'))", true);
+    // Empty geometries cannot be tested here: Snowflake's native GEOMETRY parses
+    // 'POLYGON EMPTY' to NULL, so the UDF never receives an empty geometry.
+    // Empty inputs are covered by the WKB-based tests in TestFunctions.
   }
 
   @Test
@@ -1244,8 +1245,9 @@ public class TestFunctionsV2 extends TestBase {
     verifySqlSingleRes(
         "SELECT sedona.ST_IsPolygonCCW(ST_GeomFromWKT('POLYGON ((20 35, 10 30, 10 10, 30 5, 45 20, 20 35),(30 20, 20 15, 20 25, 30 20))'))",
         true);
-    verifySqlSingleRes("SELECT sedona.ST_IsPolygonCCW(ST_GeomFromWKT('POLYGON EMPTY'))", true);
-    verifySqlSingleRes("SELECT sedona.ST_IsPolygonCCW(ST_GeomFromWKT('MULTIPOLYGON EMPTY'))", true);
+    // Empty geometries cannot be tested here: Snowflake's native GEOMETRY parses
+    // 'POLYGON EMPTY' to NULL, so the UDF never receives an empty geometry.
+    // Empty inputs are covered by the WKB-based tests in TestFunctions.
   }
 
   @Test


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No: this is a CI update. The PR name follows the format `[CI] my subject`.

## What changes were proposed in this PR?

Remove the `POLYGON EMPTY` / `MULTIPOLYGON EMPTY` assertions from `TestFunctionsV2.test_ST_IsPolygonCW` and `test_ST_IsPolygonCCW` in the Snowflake tester, added in #3173.

These assertions can never pass against real Snowflake: the inner `ST_GeomFromWKT` in the V2 tests is Snowflake's built-in WKT parser, and Snowflake's native GEOMETRY type parses empty geometries to NULL. Since Sedona UDFs are registered with `RETURNS NULL ON NULL INPUT`, `sedona.ST_IsPolygonCW(NULL)` returns NULL instead of `true`:

```
TestFunctionsV2.test_ST_IsPolygonCW:1214   expected:<true> but was:<null>
TestFunctionsV2.test_ST_IsPolygonCCW:1247  expected:<true> but was:<null>
```

Empty-geometry behavior of `ST_IsPolygonCW`/`ST_IsPolygonCCW` remains covered by the WKB-based tests in `TestFunctions`, where geometry serialization stays fully in Sedona's control.

## How was this patch tested?

Verified against a real Snowflake environment in wherobots/sedona-cloud-vendor-tester#72: the full Snowflake integration suite passed with this change ([run](https://github.com/wherobots/sedona-cloud-vendor-tester/actions/runs/31079432797), 383 tests, 0 failures), where master previously failed the two assertions above ([failing run](https://github.com/wherobots/sedona-cloud-vendor-tester/actions/runs/31069974789)).

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.