### PR TITLE
[CI] Download Zeppelin from the Apache CDN instead of the Lyra mirror

### DIFF
--- a/docker/install-zeppelin.sh
+++ b/docker/install-zeppelin.sh
@@ -30,7 +30,7 @@ download_with_progress() {
     local description=${3:-"Downloading"}
 
     # Start download in background
-    curl -L --silent --show-error --retry 5 --retry-delay 10 --retry-connrefused "${url}" -o "${output}" &
+    curl -L --fail --silent --show-error --retry 5 --retry-delay 10 --retry-connrefused "${url}" -o "${output}" &
     local curl_pid=$!
 
     # Monitor progress every 5 seconds
@@ -61,13 +61,19 @@ download_with_progress() {
 }
 
 # Download and extract Zeppelin
-# Download from Lyra Hosting mirror (faster) but verify checksum from Apache archive
+# Download from the Apache CDN, falling back to the Apache archive (dlcdn only
+# hosts current releases); verify checksum from the Apache archive either way.
 zeppelin_filename="zeppelin-${ZEPPELIN_VERSION}-bin-netinst.tgz"
-zeppelin_download_url="https://mirror.lyrahosting.com/apache/zeppelin/zeppelin-${ZEPPELIN_VERSION}/${zeppelin_filename}"
+zeppelin_download_url="https://dlcdn.apache.org/zeppelin/zeppelin-${ZEPPELIN_VERSION}/${zeppelin_filename}"
+zeppelin_fallback_url="https://archive.apache.org/dist/zeppelin/zeppelin-${ZEPPELIN_VERSION}/${zeppelin_filename}"
 checksum_url="https://archive.apache.org/dist/zeppelin/zeppelin-${ZEPPELIN_VERSION}/${zeppelin_filename}.sha512"
 
-echo "Downloading Zeppelin ${ZEPPELIN_VERSION} from Lyra Hosting mirror..."
-download_with_progress "${zeppelin_download_url}" "${zeppelin_filename}" "Downloading Zeppelin"
+echo "Downloading Zeppelin ${ZEPPELIN_VERSION} from Apache CDN..."
+if ! download_with_progress "${zeppelin_download_url}" "${zeppelin_filename}" "Downloading Zeppelin"; then
+    echo "Apache CDN download failed. Falling back to Apache archive..."
+    rm -f "${zeppelin_filename}"
+    download_with_progress "${zeppelin_fallback_url}" "${zeppelin_filename}" "Downloading Zeppelin"
+fi
 
 echo "Downloading checksum from Apache archive..."
 curl -L --silent --show-error --retry 5 --retry-delay 10 --retry-connrefused "${checksum_url}" -o "${zeppelin_filename}.sha512"


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No, this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

The nightly docker image build has been failing intermittently since 2026-08-05 with:

```
Downloading Zeppelin 0.12.0 from Lyra Hosting mirror...
curl: (60) SSL certificate problem: certificate has expired
```

`mirror.lyrahosting.com` sits behind a load balancer where one backend has been serving an expired TLS certificate (expired 2026-08-04); whether a given `curl` hits the good or bad backend is a coin flip, so the amd64 and arm64 build stages can fail independently.

Changes to `docker/install-zeppelin.sh`:

- Download Zeppelin from `dlcdn.apache.org` (the Apache CDN) instead of the third-party Lyra mirror.
- Fall back to `archive.apache.org` if the CDN download fails, since dlcdn only hosts current releases. The sha512 checksum is still fetched from the Apache archive and verified either way.
- Pass `--fail` to curl (matching `install-spark.sh`) so an HTTP error page is not saved as the tarball and a 404 correctly triggers the fallback.

## How was this patch tested?

- Verified both `dlcdn.apache.org` and `archive.apache.org` serve `zeppelin-0.12.0-bin-netinst.tgz` (HTTP 200).
- Smoke-tested the fallback path locally: a 404 on the primary URL now fails fast and the archive fallback downloads and passes the content check.
- `bash -n` and shellcheck (pre-commit) pass.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.