### PR TITLE
[GH-3252] GeoPandas: align GeoDataFrame compatibility APIs

### DIFF
--- a/docs/setup/release-notes.md
+++ b/docs/setup/release-notes.md
@@ -30,6 +30,12 @@
   whose state contains a serialized `ST_MinimumBoundingRadius` result cannot restore from a
   checkpoint or savepoint taken with the previous serializer** — such jobs need to be restarted
   without state, or migrated before upgrading.
+* **GeoPandas `set_crs`**: `GeoSeries.set_crs` and `GeoDataFrame.set_crs` now default to
+  `allow_override=False`, matching GeoPandas. Replacing or removing an existing CRS now requires
+  `allow_override=True`; direct `.crs` assignment remains an explicit override. Calls using the
+  former positional `GeoDataFrame.set_crs(crs, inplace, allow_override)` signature remain
+  temporarily supported with a `FutureWarning`. When CRS metadata is unavailable, validation can
+  require a distributed lookup of the first non-null geometry's SRID.
 
 ## Sedona 1.9.1
 

--- a/docs/tutorial/geopandas-api.md
+++ b/docs/tutorial/geopandas-api.md
@@ -244,9 +244,10 @@ contains_result = left_df.sjoin(right_df, predicate="contains")
 Transform geometries between different coordinate reference systems:
 
 ```python
-# Set initial CRS
+# GeoParquet normally preserves CRS metadata. Assign it only when absent.
 buildings = gpd.read_parquet("buildings.parquet")
-buildings = buildings.set_crs("EPSG:4326")
+if buildings.crs is None:
+    buildings = buildings.set_crs("EPSG:4326")
 
 # Transform to projected CRS for area calculations
 buildings_projected = buildings.to_crs("EPSG:3857")
@@ -465,8 +466,9 @@ overture_path = DATA_DIR + overture_size + "/" + "overture-buildings/"
 postal_codes = gpd.read_parquet(postal_codes_path)
 buildings = gpd.read_parquet(overture_path)
 
-# Spatial analysis
-buildings = buildings.set_crs("EPSG:4326")
+# Spatial analysis (GeoParquet normally preserves CRS metadata)
+if buildings.crs is None:
+    buildings = buildings.set_crs("EPSG:4326")
 buildings_projected = buildings.to_crs("EPSG:3857")
 
 # Calculate areas and filter

--- a/docs/tutorial/geopandas-api.zh.md
+++ b/docs/tutorial/geopandas-api.zh.md
@@ -244,9 +244,10 @@ contains_result = left_df.sjoin(right_df, predicate="contains")
 在不同坐标参考系（CRS）之间转换几何对象：
 
 ```python
-# 设置初始 CRS
+# GeoParquet 通常会保留 CRS 元数据，仅在缺失时进行设置
 buildings = gpd.read_parquet("buildings.parquet")
-buildings = buildings.set_crs("EPSG:4326")
+if buildings.crs is None:
+    buildings = buildings.set_crs("EPSG:4326")
 
 # 转换为投影坐标系以便计算面积
 buildings_projected = buildings.to_crs("EPSG:3857")
@@ -450,8 +451,9 @@ overture_path = DATA_DIR + overture_size + "/" + "overture-buildings/"
 postal_codes = gpd.read_parquet(postal_codes_path)
 buildings = gpd.read_parquet(overture_path)
 
-# 空间分析
-buildings = buildings.set_crs("EPSG:4326")
+# 空间分析（GeoParquet 通常会保留 CRS 元数据）
+if buildings.crs is None:
+    buildings = buildings.set_crs("EPSG:4326")
 buildings_projected = buildings.to_crs("EPSG:3857")
 
 # 计算面积并过滤

--- a/python/sedona/spark/geopandas/geodataframe.py
+++ b/python/sedona/spark/geopandas/geodataframe.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import builtins
+from functools import wraps
 from typing import Any, Literal, Callable, Union
 import typing
 
@@ -145,6 +146,48 @@ def _not_implemented_error(method_name: str, additional_info: str = "") -> str:
     )
 
     return base_message + workaround
+
+
+def _support_legacy_set_crs_positionals(method):
+    """Preserve the former ``(crs, inplace, allow_override)`` positional form."""
+
+    @wraps(method)
+    def wrapper(self, *args, **kwargs):
+        if len(args) >= 2 and isinstance(args[1], bool):
+            if len(args) > 3:
+                raise TypeError(
+                    "GeoDataFrame.set_crs() accepts at most 3 legacy arguments"
+                )
+            if "epsg" in kwargs or "inplace" in kwargs:
+                raise TypeError(
+                    "GeoDataFrame.set_crs() received duplicate positional and keyword arguments"
+                )
+            if len(args) == 3 and "allow_override" in kwargs:
+                raise TypeError(
+                    "GeoDataFrame.set_crs() got multiple values for 'allow_override'"
+                )
+
+            legacy_allow_override = (
+                args[2] if len(args) == 3 else kwargs.pop("allow_override", True)
+            )
+            warnings.warn(
+                "Passing 'inplace' and 'allow_override' positionally follows "
+                "Sedona's former GeoDataFrame.set_crs signature and is "
+                "deprecated. Use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            return method(
+                self,
+                crs=args[0],
+                inplace=args[1],
+                allow_override=legacy_allow_override,
+                **kwargs,
+            )
+
+        return method(self, *args, **kwargs)
+
+    return wrapper
 
 
 def _normalize_dissolve_aggfunc(aggfunc):
@@ -1206,9 +1249,16 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
     @crs.setter
     def crs(self, value):
         # Since PySpark DataFrames are immutable, we can't modify in place, so we create the new GeoSeries and replace it.
-        self.geometry = self.geometry.set_crs(value)
+        self.geometry = self.geometry.set_crs(value, allow_override=True)
 
-    def set_crs(self, crs, inplace=False, allow_override=True):
+    @_support_legacy_set_crs_positionals
+    def set_crs(
+        self,
+        crs: Any | None = None,
+        epsg: int | None = None,
+        inplace: bool = False,
+        allow_override: bool = False,
+    ) -> GeoDataFrame:
         """
         Set the Coordinate Reference System (CRS) of the ``GeoDataFrame``.
 
@@ -1222,6 +1272,10 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
         The underlying geometries are not transformed to this CRS. To
         transform the geometries to a new CRS, use the ``to_crs`` method.
 
+        A boolean second positional argument is interpreted as ``inplace``
+        for compatibility with the former Sedona signature. This form is
+        deprecated; use keyword arguments instead.
+
         Parameters
         ----------
         crs : pyproj.CRS | None, optional
@@ -1234,11 +1288,10 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
             If True, the CRS of the GeoDataFrame will be changed in place
             (while still returning the result) instead of making a copy of
             the GeoDataFrame.
-        allow_override : bool, default True
+        allow_override : bool, default False
             If the GeoDataFrame already has a CRS, allow to replace the
-            existing CRS, even when both are not equal. In Sedona, setting this to True
-            will lead to eager evaluation instead of lazy evaluation. Unlike Geopandas,
-            True is the default value in Sedona for performance reasons.
+            existing CRS, even when both are not equal. Validating an existing
+            CRS when this is False may require eager metadata evaluation.
 
         Examples
         --------
@@ -1284,14 +1337,13 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
         --------
         GeoDataFrame.to_crs : re-project to another CRS
         """
-        # Since PySpark DataFrames are immutable, we can't modify in place, so we create the new GeoSeries and replace it.
-        new_geometry = self.geometry.set_crs(crs, allow_override=allow_override)
-        if inplace:
-            self.geometry = new_geometry
-        else:
-            df = self.copy()
-            df.geometry = new_geometry
-            return df
+        df = self if inplace else self.copy()
+        df.geometry = df.geometry.set_crs(
+            crs=crs,
+            epsg=epsg,
+            allow_override=allow_override,
+        )
+        return df
 
     def to_crs(
         self,
@@ -1385,6 +1437,35 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
             df.geometry = new_geometry
             return df
 
+    def estimate_utm_crs(self, datum_name: str = "WGS 84") -> CRS:
+        """Return the estimated UTM CRS based on the bounds of the dataset.
+
+        .. versionadded:: 2.0.0
+
+        Parameters
+        ----------
+        datum_name : str, optional
+            The name of the datum to use in the query. Default is ``"WGS 84"``.
+
+        Returns
+        -------
+        pyproj.CRS
+            The UTM coordinate reference system covering the center of the
+            active geometry column's bounds.
+
+        Notes
+        -----
+        Bounds are aggregated across the distributed geometry column. Driver
+        work is bounded to a one-row emptiness probe and four aggregate bound
+        values; the geometry column is not collected.
+
+        See Also
+        --------
+        GeoDataFrame.to_crs
+        GeoSeries.estimate_utm_crs
+        """
+        return self.geometry.estimate_utm_crs(datum_name=datum_name)
+
     @classmethod
     def from_dict(
         cls,
@@ -1449,7 +1530,8 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
             columns. This can be used to control the behavior of the conversion of the
             non-geometry columns to a pandas DataFrame. For example, you can use this
             to control the dtype conversion of the columns. By default, the `to_pandas`
-            method is called with no additional arguments.
+            method is called with no additional arguments. Requires GeoPandas 1.1 or
+            newer when provided.
 
         Returns
         -------
@@ -1478,12 +1560,11 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
         1    POLYGON ((0 0, 1 1, 0 1, 0 0))    2      b
         2      LINESTRING (0 0, -1 1, 0 -1)    3      c
         """
-        if to_pandas_kwargs is None:
-            to_pandas_kwargs = {}
+        kwargs: dict[str, Any] = {"geometry": geometry}
+        if to_pandas_kwargs is not None:
+            kwargs["to_pandas_kwargs"] = to_pandas_kwargs
 
-        gpd_df = gpd.GeoDataFrame.from_arrow(
-            table, geometry=geometry, **to_pandas_kwargs
-        )
+        gpd_df = gpd.GeoDataFrame.from_arrow(table, **kwargs)
         return GeoDataFrame(gpd_df)
 
     def to_json(

--- a/python/sedona/spark/geopandas/geodataframe.py
+++ b/python/sedona/spark/geopandas/geodataframe.py
@@ -29,6 +29,8 @@ import geopandas as gpd
 import pandas as pd
 import pyspark.pandas as pspd
 import sedona.spark.geopandas as sgpd
+from packaging.version import parse as parse_version
+from pyproj import CRS
 from pyspark.pandas import Series as PandasOnSparkSeries
 from pyspark.pandas.frame import DataFrame as PandasOnSparkDataFrame
 from pyspark.pandas.internal import (
@@ -780,8 +782,6 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
             else:
                 # Updating the existing Spark column directly avoids index
                 # alignment, which would multiply rows for duplicate indexes.
-                from pyproj import CRS
-
                 normalized_crs = CRS.from_user_input(crs)
                 new_epsg = normalized_crs.to_epsg() or 0
                 geometry_field = with_crs_metadata(
@@ -1290,8 +1290,15 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
             the GeoDataFrame.
         allow_override : bool, default False
             If the GeoDataFrame already has a CRS, allow to replace the
-            existing CRS, even when both are not equal. Validating an existing
-            CRS when this is False may require eager metadata evaluation.
+            existing CRS, even when both are not equal. Validation uses column
+            metadata when available. Without it, validation performs a
+            distributed lookup of the first non-null geometry's SRID.
+
+        Returns
+        -------
+        GeoDataFrame
+            A new GeoDataFrame unless ``inplace=True``, in which case the
+            mutated original is returned.
 
         Examples
         --------
@@ -1455,9 +1462,9 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
 
         Notes
         -----
-        Bounds are aggregated across the distributed geometry column. Driver
-        work is bounded to a one-row emptiness probe and four aggregate bound
-        values; the geometry column is not collected.
+        Bounds are computed with one distributed aggregation. Only its four
+        aggregate values are materialized on the driver; geometry rows are not
+        collected.
 
         See Also
         --------
@@ -1562,6 +1569,8 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
         """
         kwargs: dict[str, Any] = {"geometry": geometry}
         if to_pandas_kwargs is not None:
+            if parse_version(gpd.__version__) < parse_version("1.1.0"):
+                raise NotImplementedError("to_pandas_kwargs requires GeoPandas >= 1.1")
             kwargs["to_pandas_kwargs"] = to_pandas_kwargs
 
         gpd_df = gpd.GeoDataFrame.from_arrow(table, **kwargs)

--- a/python/sedona/spark/geopandas/geoseries.py
+++ b/python/sedona/spark/geopandas/geoseries.py
@@ -27,6 +27,7 @@ import sedona.spark.geopandas as sgpd
 import pandas as pd
 import pyspark.pandas as pspd
 import pyspark
+from pyproj import CRS
 from pyspark.pandas import Series as PandasOnSparkSeries
 from pyspark.pandas.frame import DataFrame as PandasOnSparkDataFrame
 from pyspark.pandas.internal import InternalField, InternalFrame
@@ -705,16 +706,11 @@ class GeoSeries(GeoFrame, pspd.Series):
         GeoSeries.set_crs : assign CRS
         GeoSeries.to_crs : re-project to another CRS
         """
-        from pyproj import CRS
-
         has_crs_metadata, metadata_crs = read_crs_metadata(
             self._internal.data_fields[0]
         )
         if has_crs_metadata:
             return metadata_crs
-
-        if self._is_empty():
-            return None
 
         # F.first is non-deterministic, but it doesn't matter because all non-null values should be the same.
         spark_col = stf.ST_SRID(F.first(self.spark.column, ignorenulls=True))
@@ -738,24 +734,6 @@ class GeoSeries(GeoFrame, pspd.Series):
     @crs.setter
     def crs(self, value: Union["CRS", None]):
         self.set_crs(value, inplace=True, allow_override=True)
-
-    @typing.overload
-    def set_crs(
-        self,
-        crs: Union[Any, None] = None,
-        epsg: Union[int, None] = None,
-        inplace: Literal[True] = True,
-        allow_override: bool = False,
-    ) -> "GeoSeries": ...
-
-    @typing.overload
-    def set_crs(
-        self,
-        crs: Union[Any, None] = None,
-        epsg: Union[int, None] = None,
-        inplace: Literal[False] = False,
-        allow_override: bool = False,
-    ) -> "GeoSeries": ...
 
     def set_crs(
         self,
@@ -788,8 +766,9 @@ class GeoSeries(GeoFrame, pspd.Series):
             the GeoSeries.
         allow_override : bool, default False
             If the GeoSeries already has a CRS, allow to replace the
-            existing CRS, even when both are not equal. Validating an existing
-            CRS when this is False may require eager metadata evaluation.
+            existing CRS, even when both are not equal. Validation uses column
+            metadata when available. Without it, validation performs a
+            distributed lookup of the first non-null geometry's SRID.
 
         Returns
         -------
@@ -840,8 +819,6 @@ class GeoSeries(GeoFrame, pspd.Series):
         GeoSeries.to_crs : re-project to another CRS
 
         """
-        from pyproj import CRS
-
         if crs is not None:
             crs = CRS.from_user_input(crs)
         elif epsg is not None:
@@ -4615,8 +4592,6 @@ class GeoSeries(GeoFrame, pspd.Series):
 
         """
 
-        from pyproj import CRS
-
         if crs is not None:
             crs = CRS.from_user_input(crs)
         elif epsg is not None:
@@ -4668,33 +4643,44 @@ class GeoSeries(GeoFrame, pspd.Series):
 
     @property
     def total_bounds(self):
-        import warnings
+        max_float = np.finfo(np.float64).max
 
-        if self._is_empty():
-            # numpy 'min' cannot handle empty arrays
-            # TODO with numpy >= 1.15, the 'initial' argument can be used
-            return np.array([np.nan, np.nan, np.nan, np.nan])
-        ps_df = self.bounds
-        with warnings.catch_warnings():
-            # if all rows are empty geometry / none, nan is expected
-            warnings.filterwarnings(
-                "ignore", r"All-NaN slice encountered", RuntimeWarning
+        def valid_bound(bound):
+            # Empty geometries use +/- Double.MAX_VALUE in JTS envelopes.
+            # Convert those sentinels, nulls, and NaNs to null so Spark's
+            # aggregate functions ignore them.
+            return F.when(
+                bound.isNull()
+                | F.isnan(bound)
+                | (bound == max_float)
+                | (bound == -max_float),
+                F.lit(None).cast("double"),
+            ).otherwise(bound)
+
+        geometry = self.spark.column
+        minx = valid_bound(stf.ST_XMin(geometry))
+        miny = valid_bound(stf.ST_YMin(geometry))
+        maxx = valid_bound(stf.ST_XMax(geometry))
+        maxy = valid_bound(stf.ST_YMax(geometry))
+
+        bounds = (
+            self._internal.spark_frame.agg(
+                F.min(minx).alias("minx"),
+                F.min(miny).alias("miny"),
+                F.max(maxx).alias("maxx"),
+                F.max(maxy).alias("maxy"),
             )
+            .first()
+            .asDict()
+        )
+        return np.array(
+            [
+                np.nan if bounds[name] is None else bounds[name]
+                for name in ("minx", "miny", "maxx", "maxy")
+            ]
+        )
 
-            minx = ps_df["minx"].min(skipna=True)
-            miny = ps_df["miny"].min(skipna=True)
-
-            # skipna=True doesn't work properly for max(), so we use dropna() as a workaround
-            maxx = ps_df["maxx"].dropna()
-            maxy = ps_df["maxy"].dropna()
-
-            maxx = maxx.max(skipna=True) if not maxx.empty else np.nan
-            maxy = maxy.max(skipna=True) if not maxy.empty else np.nan
-
-            return np.array((minx, miny, maxx, maxy))
-
-    # GeoSeries-only (not in GeoDataFrame)
-    def estimate_utm_crs(self, datum_name: str = "WGS 84") -> "CRS":
+    def estimate_utm_crs(self, datum_name: str = "WGS 84") -> CRS:
         """Returns the estimated UTM CRS based on the bounds of the dataset.
 
         Parameters
@@ -4730,7 +4716,6 @@ class GeoSeries(GeoFrame, pspd.Series):
         - Prime Meridian: Greenwich
         """
         import numpy as np
-        from pyproj import CRS
         from pyproj.aoi import AreaOfInterest
         from pyproj.database import query_utm_crs_info
 
@@ -4740,11 +4725,12 @@ class GeoSeries(GeoFrame, pspd.Series):
         # than the GeoPandas implementation. The rest of the implementation always executes on 4 points (minx, miny, maxx, maxy),
         # so the numpy and pyproj implementations are reasonable.
 
-        if not self.crs:
+        source_crs = self.crs
+        if not source_crs:
             raise RuntimeError("crs must be set to estimate UTM CRS.")
 
         minx, miny, maxx, maxy = self.total_bounds
-        if self.crs.is_geographic:
+        if source_crs.is_geographic:
             x_center = np.mean([minx, maxx])
             y_center = np.mean([miny, maxy])
         # ensure using geographic coordinates
@@ -4754,7 +4740,7 @@ class GeoSeries(GeoFrame, pspd.Series):
 
             TransformerFromCRS = lru_cache(Transformer.from_crs)
 
-            transformer = TransformerFromCRS(self.crs, "EPSG:4326", always_xy=True)
+            transformer = TransformerFromCRS(source_crs, "EPSG:4326", always_xy=True)
             minx, miny, maxx, maxy = transformer.transform_bounds(
                 minx, miny, maxx, maxy
             )

--- a/python/sedona/spark/geopandas/geoseries.py
+++ b/python/sedona/spark/geopandas/geoseries.py
@@ -4646,9 +4646,9 @@ class GeoSeries(GeoFrame, pspd.Series):
         max_float = np.finfo(np.float64).max
 
         def valid_bound(bound):
-            # Empty geometries use +/- Double.MAX_VALUE in JTS envelopes.
-            # Convert those sentinels, nulls, and NaNs to null so Spark's
-            # aggregate functions ignore them.
+            # ST_X/YMin/Max return null for empty geometries. Preserve the
+            # existing bounds behavior by also treating NaNs and
+            # +/- Double.MAX_VALUE as missing.
             return F.when(
                 bound.isNull()
                 | F.isnan(bound)

--- a/python/sedona/spark/geopandas/geoseries.py
+++ b/python/sedona/spark/geopandas/geoseries.py
@@ -660,7 +660,7 @@ class GeoSeries(GeoFrame, pspd.Series):
             )
 
         if crs is not None:
-            self.set_crs(crs, inplace=True)
+            self.set_crs(crs, inplace=True, allow_override=True)
 
     def _is_empty(self) -> bool:
         """Check if this GeoSeries has no rows without triggering a full Spark scan."""
@@ -737,7 +737,7 @@ class GeoSeries(GeoFrame, pspd.Series):
 
     @crs.setter
     def crs(self, value: Union["CRS", None]):
-        self.set_crs(value, inplace=True)
+        self.set_crs(value, inplace=True, allow_override=True)
 
     @typing.overload
     def set_crs(
@@ -746,7 +746,7 @@ class GeoSeries(GeoFrame, pspd.Series):
         epsg: Union[int, None] = None,
         inplace: Literal[True] = True,
         allow_override: bool = False,
-    ) -> None: ...
+    ) -> "GeoSeries": ...
 
     @typing.overload
     def set_crs(
@@ -762,8 +762,8 @@ class GeoSeries(GeoFrame, pspd.Series):
         crs: Union[Any, None] = None,
         epsg: Union[int, None] = None,
         inplace: bool = False,
-        allow_override: bool = True,
-    ) -> Union["GeoSeries", None]:
+        allow_override: bool = False,
+    ) -> "GeoSeries":
         """
         Set the Coordinate Reference System (CRS) of a ``GeoSeries``.
 
@@ -786,11 +786,10 @@ class GeoSeries(GeoFrame, pspd.Series):
             If True, the CRS of the GeoSeries will be changed in place
             (while still returning the result) instead of making a copy of
             the GeoSeries.
-        allow_override : bool, default True
+        allow_override : bool, default False
             If the GeoSeries already has a CRS, allow to replace the
-            existing CRS, even when both are not equal. In Sedona, setting this to True
-            will lead to eager evaluation instead of lazy evaluation. Unlike Geopandas,
-            True is the default value in Sedona for performance reasons.
+            existing CRS, even when both are not equal. Validating an existing
+            CRS when this is False may require eager metadata evaluation.
 
         Returns
         -------
@@ -848,8 +847,7 @@ class GeoSeries(GeoFrame, pspd.Series):
         elif epsg is not None:
             crs = CRS.from_epsg(epsg)
 
-        # The below block for the not allow_override case is eager due to the self.crs call.
-        # This hurts performance and user experience, hence the default being set to True in Sedona.
+        # Reading legacy CRS values without metadata may require eager evaluation.
         if not allow_override:
             curr_crs = self.crs
 
@@ -873,7 +871,7 @@ class GeoSeries(GeoFrame, pspd.Series):
 
         if inplace:
             self._update_inplace(result, invalidate_sindex=False)
-            return None
+            return self
 
         return result
 

--- a/python/tests/geopandas/test_geodataframe.py
+++ b/python/tests/geopandas/test_geodataframe.py
@@ -16,6 +16,7 @@
 # under the License.
 import shutil
 import tempfile
+import typing
 
 from shapely.geometry import (
     Point,
@@ -582,6 +583,16 @@ class TestGeoDataFrame(TestGeopandasBase):
             with pytest.raises(ValueError):
                 legacy.set_crs(4326, False, False)
 
+        with pytest.raises(TypeError, match="at most 3 legacy arguments"):
+            legacy.set_crs(4326, False, False, False)
+        for duplicate_keyword in ({"epsg": 3857}, {"inplace": True}):
+            with pytest.raises(
+                TypeError, match="duplicate positional and keyword arguments"
+            ):
+                legacy.set_crs(4326, False, **duplicate_keyword)
+        with pytest.raises(TypeError, match="multiple values for 'allow_override'"):
+            legacy.set_crs(4326, False, False, allow_override=True)
+
         with ps.option_context("compute.ops_on_diff_frames", True):
             inplace_result = sgpd_df.set_crs(
                 epsg=3857, inplace=True, allow_override=True
@@ -641,6 +652,8 @@ class TestGeoDataFrame(TestGeopandasBase):
 
     def test_estimate_utm_crs(self):
         from pyproj import CRS
+
+        assert typing.get_type_hints(GeoDataFrame.estimate_utm_crs)["return"] is CRS
 
         with ps.option_context("compute.ops_on_diff_frames", True):
             landmarks = sgpd.GeoDataFrame(
@@ -934,6 +947,14 @@ class TestGeoDataFrame(TestGeopandasBase):
                 gdf.to_arrow(), to_pandas_kwargs={"use_threads": False}
             )
             self.check_sgpd_df_equals_gpd_df(result, gdf)
+        else:
+            with pytest.raises(
+                NotImplementedError,
+                match="to_pandas_kwargs requires GeoPandas >= 1.1",
+            ):
+                GeoDataFrame.from_arrow(
+                    gdf.to_arrow(), to_pandas_kwargs={"use_threads": False}
+                )
 
         gdf = gpd.GeoDataFrame(
             {

--- a/python/tests/geopandas/test_geodataframe.py
+++ b/python/tests/geopandas/test_geodataframe.py
@@ -571,8 +571,34 @@ class TestGeoDataFrame(TestGeopandasBase):
         assert sgpd_df.crs.to_epsg() == 4326
 
         with ps.option_context("compute.ops_on_diff_frames", True):
-            sgpd_df.set_crs(3857, inplace=True, allow_override=True)
+            legacy = sgpd.GeoDataFrame({"geometry": [Point(0, 0)]}, crs="EPSG:4326")
+        with pytest.warns(FutureWarning, match="former GeoDataFrame.set_crs"):
+            with ps.option_context("compute.ops_on_diff_frames", True):
+                legacy_result = legacy.set_crs(3857, True)
+        assert legacy_result is legacy
+        assert legacy.crs.to_epsg() == 3857
+
+        with pytest.warns(FutureWarning, match="former GeoDataFrame.set_crs"):
+            with pytest.raises(ValueError):
+                legacy.set_crs(4326, False, False)
+
+        with ps.option_context("compute.ops_on_diff_frames", True):
+            inplace_result = sgpd_df.set_crs(
+                epsg=3857, inplace=True, allow_override=True
+            )
+        assert inplace_result is sgpd_df
         assert sgpd_df.crs.to_epsg() == 3857
+
+        with pytest.raises(ValueError):
+            sgpd_df.set_crs(4326)
+
+        with ps.option_context("compute.ops_on_diff_frames", True):
+            equivalent = sgpd_df.set_crs(epsg=3857)
+        assert equivalent.crs.to_epsg() == 3857
+
+        with ps.option_context("compute.ops_on_diff_frames", True):
+            sgpd_df.crs = 4326
+        assert sgpd_df.crs.to_epsg() == 4326
 
         with ps.option_context("compute.ops_on_diff_frames", True):
             sgpd_df = sgpd_df.set_crs(None, allow_override=True)
@@ -612,6 +638,27 @@ class TestGeoDataFrame(TestGeopandasBase):
             custom_result = all_null.set_crs(custom_crs)
         assert custom_result.crs == custom_crs
         assert custom_result.to_geopandas().crs == custom_crs
+
+    def test_estimate_utm_crs(self):
+        from pyproj import CRS
+
+        with ps.option_context("compute.ops_on_diff_frames", True):
+            landmarks = sgpd.GeoDataFrame(
+                {
+                    "name": ["Empire State Building", "Statue of Liberty"],
+                    "geometry": [Point(-73.9847, 40.7484), Point(-74.0446, 40.6893)],
+                },
+                crs="EPSG:4326",
+            )
+
+        assert landmarks.estimate_utm_crs() == CRS("EPSG:32618")
+        assert landmarks.estimate_utm_crs("NAD83") == CRS("EPSG:26918")
+        with ps.option_context("compute.ops_on_diff_frames", True):
+            projected = landmarks.to_crs("EPSG:3857")
+        assert projected.estimate_utm_crs() == CRS("EPSG:32618")
+
+        with pytest.raises(RuntimeError, match="crs must be set"):
+            sgpd.GeoDataFrame({"geometry": [Point(0, 0)]}).estimate_utm_crs()
 
     def test_crs_metadata_survives_frame_selection(self):
         source = GeoSeries([None], name="geometry", crs=4326)
@@ -881,6 +928,12 @@ class TestGeoDataFrame(TestGeopandasBase):
 
         result = GeoDataFrame.from_arrow(gdf.to_arrow())
         self.check_sgpd_df_equals_gpd_df(result, gdf)
+
+        if parse_version(gpd.__version__) >= parse_version("1.1.0"):
+            result = GeoDataFrame.from_arrow(
+                gdf.to_arrow(), to_pandas_kwargs={"use_threads": False}
+            )
+            self.check_sgpd_df_equals_gpd_df(result, gdf)
 
         gdf = gpd.GeoDataFrame(
             {

--- a/python/tests/geopandas/test_geometry_aggregation.py
+++ b/python/tests/geopandas/test_geometry_aggregation.py
@@ -347,7 +347,7 @@ class TestGeometryAggregation(TestGeopandasBase):
         assert result.active_geometry_name == "geometry"
 
         empty_geometry = result.geometry
-        empty_geometry.set_crs(None, inplace=True)
+        empty_geometry.set_crs(None, inplace=True, allow_override=True)
         assert empty_geometry.crs is None
 
     def test_dissolve_validation(self):

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -5857,9 +5857,9 @@ e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3
         assert geo_series.crs.to_epsg() == 4326
 
         with pytest.raises(ValueError):
-            geo_series.set_crs(4328, allow_override=False)
+            geo_series.set_crs(4328)
         with pytest.raises(ValueError):
-            geo_series.set_crs(None, allow_override=False)
+            geo_series.set_crs(None)
 
         geo_series = geo_series.set_crs(None, allow_override=True)
         assert geo_series.crs == None
@@ -5867,8 +5867,12 @@ e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3
         # Check that the name is preserved for set_crs
         geo_series.name = "geometry"
 
-        geo_series.set_crs(4326, inplace=True)
+        inplace_result = geo_series.set_crs(4326, inplace=True)
+        assert inplace_result is geo_series
         assert geo_series.crs.to_epsg() == 4326
+
+        geo_series.crs = 3857
+        assert geo_series.crs.to_epsg() == 3857
 
         # Check that the name is preserved for set_crs after inplace=True
         geo_series.name = "geometry"

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -16,6 +16,7 @@
 # under the License.
 
 from decimal import Decimal
+import typing
 
 import shapely
 import numpy as np
@@ -24,6 +25,7 @@ import pandas as pd
 import geopandas as gpd
 import pyspark.pandas as ps
 import sedona.spark.geopandas as sgpd
+from pyspark.sql import DataFrame as SparkDataFrame
 from pyspark.pandas.internal import InternalFrame, NATURAL_ORDER_COLUMN_NAME
 from pyspark.pandas.utils import scol_for
 from pyspark.sql import functions as F
@@ -561,7 +563,7 @@ class TestGeoSeries(TestGeopandasBase):
         df_result = geoseries.to_geoframe().bounds
         pd.testing.assert_frame_equal(df_result.to_pandas(), expected)
 
-    def test_total_bounds(self):
+    def test_total_bounds(self, monkeypatch):
         d = [
             Point(3, -1),
             Polygon([(0, 0), (1, 1), (1, 0)]),
@@ -569,17 +571,45 @@ class TestGeoSeries(TestGeopandasBase):
             None,
         ]
         geoseries = sgpd.GeoSeries(d, crs="EPSG:4326")
+        empty_geoseries = sgpd.GeoSeries([], crs="EPSG:4326")
+        all_empty_geoseries = sgpd.GeoSeries([Point(), Polygon()], crs="EPSG:4326")
+
+        original_first = SparkDataFrame.first
+        action_count = 0
+
+        def counting_first(frame):
+            nonlocal action_count
+            action_count += 1
+            return original_first(frame)
+
+        monkeypatch.setattr(SparkDataFrame, "first", counting_first)
+
         result = geoseries.total_bounds
         expected = np.array([0.0, -1.0, 3.0, 2.0])
         np.testing.assert_array_equal(result, expected)
+        assert action_count == 1
 
+        action_count = 0
         df_result = geoseries.to_geoframe().total_bounds
         np.testing.assert_array_equal(df_result, expected)
+        assert action_count == 1
+
+        action_count = 0
+        empty_result = empty_geoseries.total_bounds
+        np.testing.assert_array_equal(empty_result, np.full(4, np.nan))
+        assert action_count == 1
+
+        action_count = 0
+        all_empty_result = all_empty_geoseries.total_bounds
+        np.testing.assert_array_equal(all_empty_result, np.full(4, np.nan))
+        assert action_count == 1
 
     # These tests were taken directly from the TestEstimateUtmCrs class in the geopandas test suite
     # https://github.com/geopandas/geopandas/blob/main/geopandas/tests/test_array.py
     def test_estimate_utm_crs(self):
         from pyproj import CRS
+
+        assert typing.get_type_hints(GeoSeries.estimate_utm_crs)["return"] is CRS
 
         # setup
         esb = Point(-73.9847, 40.7484)

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -25,7 +25,6 @@ import pandas as pd
 import geopandas as gpd
 import pyspark.pandas as ps
 import sedona.spark.geopandas as sgpd
-from pyspark.sql import DataFrame as SparkDataFrame
 from pyspark.pandas.internal import InternalFrame, NATURAL_ORDER_COLUMN_NAME
 from pyspark.pandas.utils import scol_for
 from pyspark.sql import functions as F
@@ -574,7 +573,8 @@ class TestGeoSeries(TestGeopandasBase):
         empty_geoseries = sgpd.GeoSeries([], crs="EPSG:4326")
         all_empty_geoseries = sgpd.GeoSeries([Point(), Polygon()], crs="EPSG:4326")
 
-        original_first = SparkDataFrame.first
+        spark_dataframe_type = type(geoseries._internal.spark_frame)
+        original_first = spark_dataframe_type.first
         action_count = 0
 
         def counting_first(frame):
@@ -582,7 +582,9 @@ class TestGeoSeries(TestGeopandasBase):
             action_count += 1
             return original_first(frame)
 
-        monkeypatch.setattr(SparkDataFrame, "first", counting_first)
+        # Spark 4 uses a classic DataFrame subclass that overrides ``first``.
+        # Patch the runtime class so the assertion works across Spark versions.
+        monkeypatch.setattr(spark_dataframe_type, "first", counting_first)
 
         result = geoseries.total_bounds
         expected = np.array([0.0, -1.0, 3.0, 2.0])


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/).

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`.

Closes #3252.
Part of #2230.

## What changes were proposed in this PR?

- Add `GeoDataFrame.estimate_utm_crs` by delegating to the active distributed geometry column. Bounds are computed with one distributed aggregation; only the four aggregate values are materialized on the driver.
- Align `GeoDataFrame.set_crs` and `GeoSeries.set_crs` with GeoPandas:
  - accept the `epsg` keyword on `GeoDataFrame`;
  - default `allow_override` to `False`;
  - return the mutated object for `inplace=True`;
  - keep direct `.crs` assignment as an explicit override.
- Preserve Sedona's former positional `GeoDataFrame.set_crs(crs, inplace, allow_override)` calls through a `FutureWarning` deprecation path, including validation for ambiguous positional and keyword combinations.
- Fix `GeoDataFrame.from_arrow` to pass `to_pandas_kwargs` as one named dictionary on GeoPandas 1.1+, omit it on the GeoPandas 1.0 default path, and raise a clear error when the option is requested on GeoPandas 1.0.
- Consolidate `GeoSeries.total_bounds` into one Spark aggregation and cache CRS resolution during UTM estimation.
- Resolve public CRS return annotations and remove obsolete `set_crs` overloads and comments.
- Document the `allow_override=False` migration under the Sedona 2.0.0 breaking changes and correct the English and Chinese GeoPandas tutorials to assign CRS only when GeoParquet metadata is absent.

## How was this patch tested?

- Full GeoSeries and GeoPandas parity modules against a fresh Sedona 2.0 shaded jar and native geometry serializer: 394 passed, 1 skipped.
- Full GeoDataFrame test module: 50 passed.
- Focused compatibility matrix on GeoPandas 1.0.1: 7 passed.
- Focused compatibility matrix on GeoPandas 1.1.3: 7 passed.
- Regression coverage verifies normal, empty, and all-empty `total_bounds` results and exactly one Spark aggregation per call.
- All repository commit hooks passed, including Black, pyupgrade, Bandit, codespell, markdownlint, and license checks.
- `git diff --check` and Python 3.8 syntax validation passed.

## Did this PR include necessary documentation updates?

- Yes, I used the current SNAPSHOT version, `v2.0.0`.
- Yes, I updated the affected API docstrings, the English and Chinese GeoPandas tutorials, and the Sedona 2.0.0 breaking-change notes.
