### PR TITLE
[GH-3257] GeoPandas: Implement distributed hilbert_distance

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/Functions.java
+++ b/common/src/main/java/org/apache/sedona/common/Functions.java
@@ -68,7 +68,6 @@ import org.locationtech.jts.operation.valid.IsValidOp;
 import org.locationtech.jts.operation.valid.TopologyValidationError;
 import org.locationtech.jts.precision.GeometryPrecisionReducer;
 import org.locationtech.jts.precision.MinimumClearance;
-import org.locationtech.jts.shape.fractal.HilbertCode;
 import org.locationtech.jts.simplify.DouglasPeuckerSimplifier;
 import org.locationtech.jts.simplify.PolygonHullSimplifier;
 import org.locationtech.jts.simplify.TopologyPreservingSimplifier;
@@ -1966,61 +1965,6 @@ public class Functions {
     List<S2CellId> s2CellObjs =
         Arrays.stream(cellIds).mapToObj(S2CellId::new).collect(Collectors.toList());
     return s2CellObjs.stream().map(S2Utils::toJTSPolygon).toArray(Polygon[]::new);
-  }
-
-  /**
-   * Computes the unsigned Hilbert-curve address of a geometry envelope's midpoint.
-   *
-   * <p>The midpoint is rescaled into the inclusive integer grid {@code [0, 2^level - 1]} for each
-   * axis. Coordinates outside the supplied extent are clipped to the nearest edge. A zero-width
-   * axis maps to coordinate zero.
-   *
-   * @param geometry input geometry
-   * @param xmin minimum X value of the rescaling extent
-   * @param ymin minimum Y value of the rescaling extent
-   * @param xmax maximum X value of the rescaling extent
-   * @param ymax maximum Y value of the rescaling extent
-   * @param level curve level; values at or below zero map to address zero
-   * @return unsigned 32-bit Hilbert address represented as a long
-   */
-  public static long hilbertDistance(
-      Geometry geometry, double xmin, double ymin, double xmax, double ymax, int level) {
-    if (geometry.isEmpty()) {
-      throw new IllegalArgumentException(
-          "Hilbert distance cannot be computed for an empty geometry");
-    }
-    if (level > HilbertCode.MAX_LEVEL) {
-      throw new IllegalArgumentException("Level out of range");
-    }
-    if (level <= 0) {
-      return 0L;
-    }
-
-    Envelope envelope = geometry.getEnvelopeInternal();
-    double xMidpoint = (envelope.getMinX() + envelope.getMaxX()) / 2.0;
-    double yMidpoint = (envelope.getMinY() + envelope.getMaxY()) / 2.0;
-    int sideLength = (1 << level) - 1;
-    int x = scaleToHilbertGrid(xMidpoint, xmin, xmax, sideLength);
-    int y = scaleToHilbertGrid(yMidpoint, ymin, ymax, sideLength);
-
-    return Integer.toUnsignedLong(HilbertCode.encode(level, x, y));
-  }
-
-  private static int scaleToHilbertGrid(double value, double lower, double upper, int sideLength) {
-    double width = upper - lower;
-    if (width == 0.0) {
-      return 0;
-    }
-
-    // Preserve the operation order used by GeoPandas so boundary rounding and truncation agree.
-    double scaled = (value - lower) * (sideLength / width);
-    if (Double.isNaN(scaled) || scaled <= 0.0) {
-      return 0;
-    }
-    if (scaled >= sideLength) {
-      return sideLength;
-    }
-    return (int) scaled;
   }
 
   /**

--- a/common/src/main/java/org/apache/sedona/common/Functions.java
+++ b/common/src/main/java/org/apache/sedona/common/Functions.java
@@ -68,6 +68,7 @@ import org.locationtech.jts.operation.valid.IsValidOp;
 import org.locationtech.jts.operation.valid.TopologyValidationError;
 import org.locationtech.jts.precision.GeometryPrecisionReducer;
 import org.locationtech.jts.precision.MinimumClearance;
+import org.locationtech.jts.shape.fractal.HilbertCode;
 import org.locationtech.jts.simplify.DouglasPeuckerSimplifier;
 import org.locationtech.jts.simplify.PolygonHullSimplifier;
 import org.locationtech.jts.simplify.TopologyPreservingSimplifier;
@@ -1965,6 +1966,61 @@ public class Functions {
     List<S2CellId> s2CellObjs =
         Arrays.stream(cellIds).mapToObj(S2CellId::new).collect(Collectors.toList());
     return s2CellObjs.stream().map(S2Utils::toJTSPolygon).toArray(Polygon[]::new);
+  }
+
+  /**
+   * Computes the unsigned Hilbert-curve address of a geometry envelope's midpoint.
+   *
+   * <p>The midpoint is rescaled into the inclusive integer grid {@code [0, 2^level - 1]} for each
+   * axis. Coordinates outside the supplied extent are clipped to the nearest edge. A zero-width
+   * axis maps to coordinate zero.
+   *
+   * @param geometry input geometry
+   * @param xmin minimum X value of the rescaling extent
+   * @param ymin minimum Y value of the rescaling extent
+   * @param xmax maximum X value of the rescaling extent
+   * @param ymax maximum Y value of the rescaling extent
+   * @param level curve level; values at or below zero map to address zero
+   * @return unsigned 32-bit Hilbert address represented as a long
+   */
+  public static long hilbertDistance(
+      Geometry geometry, double xmin, double ymin, double xmax, double ymax, int level) {
+    if (geometry.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Hilbert distance cannot be computed for an empty geometry");
+    }
+    if (level > HilbertCode.MAX_LEVEL) {
+      throw new IllegalArgumentException("Level out of range");
+    }
+    if (level <= 0) {
+      return 0L;
+    }
+
+    Envelope envelope = geometry.getEnvelopeInternal();
+    double xMidpoint = (envelope.getMinX() + envelope.getMaxX()) / 2.0;
+    double yMidpoint = (envelope.getMinY() + envelope.getMaxY()) / 2.0;
+    int sideLength = (1 << level) - 1;
+    int x = scaleToHilbertGrid(xMidpoint, xmin, xmax, sideLength);
+    int y = scaleToHilbertGrid(yMidpoint, ymin, ymax, sideLength);
+
+    return Integer.toUnsignedLong(HilbertCode.encode(level, x, y));
+  }
+
+  private static int scaleToHilbertGrid(double value, double lower, double upper, int sideLength) {
+    double width = upper - lower;
+    if (width == 0.0) {
+      return 0;
+    }
+
+    // Preserve the operation order used by GeoPandas so boundary rounding and truncation agree.
+    double scaled = (value - lower) * (sideLength / width);
+    if (Double.isNaN(scaled) || scaled <= 0.0) {
+      return 0;
+    }
+    if (scaled >= sideLength) {
+      return sideLength;
+    }
+    return (int) scaled;
   }
 
   /**

--- a/common/src/main/java/org/apache/sedona/common/utils/HilbertDistance.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/HilbertDistance.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.common.utils;
+
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.shape.fractal.HilbertCode;
+
+/** Computes Hilbert-curve addresses for geometry envelope midpoints. */
+public final class HilbertDistance {
+
+  private HilbertDistance() {}
+
+  /**
+   * Computes the unsigned Hilbert-curve address of a geometry envelope's midpoint.
+   *
+   * <p>The midpoint is rescaled into the inclusive integer grid {@code [0, 2^level - 1]} for each
+   * axis. Coordinates outside the supplied extent are clipped to the nearest edge. A zero-width
+   * axis maps to coordinate zero.
+   *
+   * @param geometry input geometry
+   * @param xmin minimum X value of the rescaling extent
+   * @param ymin minimum Y value of the rescaling extent
+   * @param xmax maximum X value of the rescaling extent
+   * @param ymax maximum Y value of the rescaling extent
+   * @param level curve level; values at or below zero map to address zero
+   * @return unsigned 32-bit Hilbert address represented as a long
+   * @throws IllegalArgumentException if the geometry is empty or the level exceeds 16
+   */
+  public static long compute(
+      Geometry geometry, double xmin, double ymin, double xmax, double ymax, int level) {
+    if (geometry.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Hilbert distance cannot be computed for an empty geometry");
+    }
+    if (level > HilbertCode.MAX_LEVEL) {
+      throw new IllegalArgumentException("Level out of range");
+    }
+    if (level <= 0) {
+      return 0L;
+    }
+
+    Envelope envelope = geometry.getEnvelopeInternal();
+    double xMidpoint = (envelope.getMinX() + envelope.getMaxX()) / 2.0;
+    double yMidpoint = (envelope.getMinY() + envelope.getMaxY()) / 2.0;
+    int sideLength = (1 << level) - 1;
+    int x = scaleToGrid(xMidpoint, xmin, xmax, sideLength);
+    int y = scaleToGrid(yMidpoint, ymin, ymax, sideLength);
+
+    return Integer.toUnsignedLong(HilbertCode.encode(level, x, y));
+  }
+
+  private static int scaleToGrid(double value, double lower, double upper, int sideLength) {
+    double width = upper - lower;
+    if (width == 0.0) {
+      return 0;
+    }
+
+    // Preserve the operation order used by GeoPandas so boundary rounding and truncation agree.
+    double scaled = (value - lower) * (sideLength / width);
+    if (Double.isNaN(scaled) || scaled <= 0.0) {
+      return 0;
+    }
+    if (scaled >= sideLength) {
+      return sideLength;
+    }
+    return (int) scaled;
+  }
+}

--- a/common/src/test/java/org/apache/sedona/common/HilbertDistanceTest.java
+++ b/common/src/test/java/org/apache/sedona/common/HilbertDistanceTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.sedona.common;
 
+import static org.apache.sedona.common.utils.HilbertDistance.compute;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -44,39 +45,38 @@ public class HilbertDistanceTest {
         GEOMETRY_FACTORY.createLineString(
             new Coordinate[] {new Coordinate(0.0, 0.0), new Coordinate(2.0, 2.0)});
 
-    assertEquals(2L, Functions.hilbertDistance(line, 0.0, 0.0, 2.0, 2.0, 2));
+    assertEquals(2L, compute(line, 0.0, 0.0, 2.0, 2.0, 2));
   }
 
   @Test
   public void clipsCoordinatesOutsideTheExtent() {
     Geometry point = GEOMETRY_FACTORY.createPoint(new Coordinate(2.0, -1.0));
 
-    assertEquals(15L, Functions.hilbertDistance(point, 0.0, 0.0, 1.0, 1.0, 2));
+    assertEquals(15L, compute(point, 0.0, 0.0, 1.0, 1.0, 2));
   }
 
   @Test
   public void mapsZeroWidthAndNanAxesToZero() {
     Geometry zeroWidthPoint = GEOMETRY_FACTORY.createPoint(new Coordinate(5.0, 1.0));
-    assertEquals(5L, Functions.hilbertDistance(zeroWidthPoint, 5.0, 0.0, 5.0, 1.0, 2));
+    assertEquals(5L, compute(zeroWidthPoint, 5.0, 0.0, 5.0, 1.0, 2));
 
     Geometry nanBoundsPoint = GEOMETRY_FACTORY.createPoint(new Coordinate(0.5, 0.5));
-    assertEquals(
-        3L, Functions.hilbertDistance(nanBoundsPoint, Double.NaN, 0.0, Double.NaN, 1.0, 2));
+    assertEquals(3L, compute(nanBoundsPoint, Double.NaN, 0.0, Double.NaN, 1.0, 2));
   }
 
   @Test
   public void mapsNonPositiveLevelsToZero() {
     Geometry point = GEOMETRY_FACTORY.createPoint(new Coordinate(1.0, 0.0));
 
-    assertEquals(0L, Functions.hilbertDistance(point, 0.0, 0.0, 1.0, 1.0, 0));
-    assertEquals(0L, Functions.hilbertDistance(point, 0.0, 0.0, 1.0, 1.0, -4));
+    assertEquals(0L, compute(point, 0.0, 0.0, 1.0, 1.0, 0));
+    assertEquals(0L, compute(point, 0.0, 0.0, 1.0, 1.0, -4));
   }
 
   @Test
   public void rejectsEmptyGeometryBeforeCollapsingNonPositiveLevels() {
     Geometry emptyPoint = GEOMETRY_FACTORY.createPoint();
     try {
-      Functions.hilbertDistance(emptyPoint, 0.0, 0.0, 1.0, 1.0, 0);
+      compute(emptyPoint, 0.0, 0.0, 1.0, 1.0, 0);
       fail("Expected empty geometry to be rejected");
     } catch (IllegalArgumentException exception) {
       assertEquals(
@@ -87,11 +87,11 @@ public class HilbertDistanceTest {
   @Test(expected = IllegalArgumentException.class)
   public void rejectsLevelsAboveSixteen() {
     Geometry point = GEOMETRY_FACTORY.createPoint(new Coordinate(0.0, 0.0));
-    Functions.hilbertDistance(point, 0.0, 0.0, 1.0, 1.0, 17);
+    compute(point, 0.0, 0.0, 1.0, 1.0, 17);
   }
 
   private static long distance(double x, double y, int level) {
     Geometry point = GEOMETRY_FACTORY.createPoint(new Coordinate(x, y));
-    return Functions.hilbertDistance(point, 0.0, 0.0, 1.0, 1.0, level);
+    return compute(point, 0.0, 0.0, 1.0, 1.0, level);
   }
 }

--- a/common/src/test/java/org/apache/sedona/common/HilbertDistanceTest.java
+++ b/common/src/test/java/org/apache/sedona/common/HilbertDistanceTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.common;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+
+public class HilbertDistanceTest {
+  private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory();
+
+  @Test
+  public void encodesCornerAddressesAndUnsignedMaximum() {
+    assertEquals(0L, distance(0.0, 0.0, 2));
+    assertEquals(5L, distance(0.0, 1.0, 2));
+    assertEquals(10L, distance(1.0, 1.0, 2));
+    assertEquals(15L, distance(1.0, 0.0, 2));
+    assertEquals(4294967295L, distance(1.0, 0.0, 16));
+  }
+
+  @Test
+  public void usesTheGeometryEnvelopeMidpointAndTruncatesScaledCoordinates() {
+    Geometry line =
+        GEOMETRY_FACTORY.createLineString(
+            new Coordinate[] {new Coordinate(0.0, 0.0), new Coordinate(2.0, 2.0)});
+
+    assertEquals(2L, Functions.hilbertDistance(line, 0.0, 0.0, 2.0, 2.0, 2));
+  }
+
+  @Test
+  public void clipsCoordinatesOutsideTheExtent() {
+    Geometry point = GEOMETRY_FACTORY.createPoint(new Coordinate(2.0, -1.0));
+
+    assertEquals(15L, Functions.hilbertDistance(point, 0.0, 0.0, 1.0, 1.0, 2));
+  }
+
+  @Test
+  public void mapsZeroWidthAndNanAxesToZero() {
+    Geometry zeroWidthPoint = GEOMETRY_FACTORY.createPoint(new Coordinate(5.0, 1.0));
+    assertEquals(5L, Functions.hilbertDistance(zeroWidthPoint, 5.0, 0.0, 5.0, 1.0, 2));
+
+    Geometry nanBoundsPoint = GEOMETRY_FACTORY.createPoint(new Coordinate(0.5, 0.5));
+    assertEquals(
+        3L, Functions.hilbertDistance(nanBoundsPoint, Double.NaN, 0.0, Double.NaN, 1.0, 2));
+  }
+
+  @Test
+  public void mapsNonPositiveLevelsToZero() {
+    Geometry point = GEOMETRY_FACTORY.createPoint(new Coordinate(1.0, 0.0));
+
+    assertEquals(0L, Functions.hilbertDistance(point, 0.0, 0.0, 1.0, 1.0, 0));
+    assertEquals(0L, Functions.hilbertDistance(point, 0.0, 0.0, 1.0, 1.0, -4));
+  }
+
+  @Test
+  public void rejectsEmptyGeometryBeforeCollapsingNonPositiveLevels() {
+    Geometry emptyPoint = GEOMETRY_FACTORY.createPoint();
+    try {
+      Functions.hilbertDistance(emptyPoint, 0.0, 0.0, 1.0, 1.0, 0);
+      fail("Expected empty geometry to be rejected");
+    } catch (IllegalArgumentException exception) {
+      assertEquals(
+          "Hilbert distance cannot be computed for an empty geometry", exception.getMessage());
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void rejectsLevelsAboveSixteen() {
+    Geometry point = GEOMETRY_FACTORY.createPoint(new Coordinate(0.0, 0.0));
+    Functions.hilbertDistance(point, 0.0, 0.0, 1.0, 1.0, 17);
+  }
+
+  private static long distance(double x, double y, int level) {
+    Geometry point = GEOMETRY_FACTORY.createPoint(new Coordinate(x, y));
+    return Functions.hilbertDistance(point, 0.0, 0.0, 1.0, 1.0, level);
+  }
+}

--- a/docs/api/flink/Geometry-Functions.md
+++ b/docs/api/flink/Geometry-Functions.md
@@ -331,7 +331,7 @@ These functions produce or operate on bounding boxes and compute extent values.
 
 ## Spatial Indexing
 
-These functions work with spatial indexing systems including Bing Tiles, H3, S2, and GeoHash.
+These functions work with spatial indexing systems including Bing Tiles, H3, Hilbert curves, S2, and GeoHash.
 
 | Function | Return type | Description | Since |
 | :--- | :--- | :--- | :--- |
@@ -350,5 +350,6 @@ These functions work with spatial indexing systems including Bing Tiles, H3, S2,
 | [ST_H3CellIDs](Spatial-Indexing/ST_H3CellIDs.md) | `Array<Long>` | Cover the geometry by H3 cell IDs with the given resolution(level). To understand the cell statistics please refer to [H3 Doc](https://h3geo.org/docs/core-library/restable) H3 native fill functions... | v1.5.0 |
 | [ST_H3KRing](Spatial-Indexing/ST_H3KRing.md) | `Array<Long>` | return the result of H3 function [gridDisk(cell, k)](https://h3geo.org/docs/api/traversal#griddisk). | v1.5.0 |
 | [ST_H3ToGeom](Spatial-Indexing/ST_H3ToGeom.md) | `Array<Geometry>` | Return the result of H3 function [cellsToMultiPolygon(cells)](https://h3geo.org/docs/api/regions#cellstolinkedmultipolygon--cellstomultipolygon). | v1.6.0 |
+| [ST_HilbertDistance](Spatial-Indexing/ST_HilbertDistance.md) | Long | Maps the midpoint of a geometry's envelope to an unsigned Hilbert-curve address within a supplied extent. | v2.0.0 |
 | [ST_S2CellIDs](Spatial-Indexing/ST_S2CellIDs.md) | `Array<Long>` | Cover the geometry with Google S2 Cells, return the corresponding cell IDs with the given level. The level indicates the [size of cells](https://s2geometry.io/resources/s2cell_statistics.html). With... | v1.4.0 |
 | [ST_S2ToGeom](Spatial-Indexing/ST_S2ToGeom.md) | `Array<Geometry>` | Returns an array of Polygons for the corresponding S2 cell IDs. | v1.6.0 |

--- a/docs/api/flink/Spatial-Indexing/ST_HilbertDistance.md
+++ b/docs/api/flink/Spatial-Indexing/ST_HilbertDistance.md
@@ -31,6 +31,20 @@ The envelope midpoint is scaled independently on each axis to the integer grid f
 
 Levels from 1 through 16 provide increasingly fine ordering keys. A level at or below zero returns zero, while a level above 16 raises an error. The result is an unsigned value of up to 32 bits represented by `Long`; at level 16 it can be as large as `4294967295`. If any argument is null, the result is null. An empty geometry raises an error because it has no envelope midpoint.
 
+## How addresses are assigned
+
+At level 2, the extent becomes a 4-by-4 grid. The Hilbert curve visits every cell once and assigns addresses from 0 through 15 along that continuous path:
+
+![Level-2 Hilbert curve visiting a 4-by-4 grid in address order from 0 through 15](../../../image/ST_HilbertDistance/ST_HilbertDistance_curve.svg "Level-2 Hilbert grid and ordered addresses")
+
+*Consecutive addresses share a grid edge, which is why sorting by the returned key tends to keep nearby records together. The key is an ordering address, not a geometric distance.*
+
+For each input geometry, the function uses the midpoint of its envelope, normalizes that point into the supplied extent, and looks up the cell's Hilbert address. This example also shows how a midpoint outside the extent is clipped before lookup:
+
+![Five geometry envelopes and midpoints normalized onto a Hilbert grid, then sorted by addresses 0, 2, 4, 13, and 15](../../../image/ST_HilbertDistance/ST_HilbertDistance_workflow.svg "Geometry envelope midpoint to Hilbert sort key")
+
+*Only the envelope midpoint determines the address. Different geometries with midpoints in the same grid cell receive the same value at that level.*
+
 SQL example:
 
 ```sql

--- a/docs/api/flink/Spatial-Indexing/ST_HilbertDistance.md
+++ b/docs/api/flink/Spatial-Indexing/ST_HilbertDistance.md
@@ -1,0 +1,64 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_HilbertDistance
+
+Introduction: Maps the midpoint of a geometry's envelope to its address along a Hilbert curve constructed over a supplied extent. Nearby geometries often receive nearby addresses, so the result can be used as a spatial sort, clustering, or partitioning key. It is a one-dimensional curve address, not a geometric distance.
+
+Format: `ST_HilbertDistance(geometry: Geometry, xmin: Double, ymin: Double, xmax: Double, ymax: Double, level: Integer)`
+
+Return type: `Long`
+
+Since: `v2.0.0`
+
+The envelope midpoint is scaled independently on each axis to the integer grid from `0` through `2^level - 1`. Coordinates outside the supplied extent are clipped to its nearest edge. A zero-width axis maps to grid coordinate zero. Z and M coordinates do not affect the result.
+
+Levels from 1 through 16 provide increasingly fine ordering keys. A level at or below zero returns zero, while a level above 16 raises an error. The result is an unsigned value of up to 32 bits represented by `Long`; at level 16 it can be as large as `4294967295`. If any argument is null, the result is null. An empty geometry raises an error because it has no envelope midpoint.
+
+SQL example:
+
+```sql
+SELECT ST_HilbertDistance(
+    ST_GeomFromWKT('POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))'),
+    0.0, 0.0, 1.0, 1.0, 2
+)
+```
+
+Output:
+
+```
+2
+```
+
+The polygon's envelope midpoint is `(0.5, 0.5)`. At level 2, the supplied unit-square extent is divided into a 4-by-4 Hilbert grid and that midpoint has curve address `2`.
+
+The maximum level-16 address remains non-negative because the function returns a `Long`:
+
+```sql
+SELECT ST_HilbertDistance(
+    ST_GeomFromWKT('POINT (1 0)'),
+    0.0, 0.0, 1.0, 1.0, 16
+)
+```
+
+Output:
+
+```
+4294967295
+```

--- a/docs/api/snowflake/vector-data/Geometry-Functions.md
+++ b/docs/api/snowflake/vector-data/Geometry-Functions.md
@@ -320,7 +320,7 @@ These functions produce or operate on bounding boxes and compute extent values.
 
 ## Spatial Indexing
 
-These functions work with spatial indexing systems including Bing Tiles, H3, S2, and GeoHash.
+These functions work with spatial indexing systems including Bing Tiles, Hilbert curves, S2, and GeoHash.
 
 | Function | Description |
 | :--- | :--- |
@@ -335,4 +335,5 @@ These functions work with spatial indexing systems including Bing Tiles, H3, S2,
 | [ST_BingTileZoomLevel](Spatial-Indexing/ST_BingTileZoomLevel.md) | Returns the zoom level of the Bing Tile identified by the given quadkey. |
 | [ST_GeoHashNeighbor](Spatial-Indexing/ST_GeoHashNeighbor.md) | Returns the neighbor geohash cell in the given direction. Valid directions are: `n`, `ne`, `e`, `se`, `s`, `sw`, `w`, `nw` (case-insensitive). |
 | [ST_GeoHashNeighbors](Spatial-Indexing/ST_GeoHashNeighbors.md) | Returns the 8 neighboring geohash cells of a given geohash string. The result is an array of 8 geohash strings in the order: N, NE, E, SE, S, SW, W, NW. |
+| [ST_HilbertDistance](Spatial-Indexing/ST_HilbertDistance.md) | Maps the midpoint of a geometry's envelope to an unsigned Hilbert-curve address within a supplied extent. |
 | [ST_S2CellIDs](Spatial-Indexing/ST_S2CellIDs.md) | Cover the geometry with Google S2 Cells, return the corresponding cell IDs with the given level. The level indicates the [size of cells](https://s2geometry.io/resources/s2cell_statistics.html). With... |

--- a/docs/api/snowflake/vector-data/Spatial-Indexing/ST_HilbertDistance.md
+++ b/docs/api/snowflake/vector-data/Spatial-Indexing/ST_HilbertDistance.md
@@ -1,0 +1,64 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_HilbertDistance
+
+Introduction: Maps the midpoint of a geometry's envelope to its address along a Hilbert curve constructed over a supplied extent. Nearby geometries often receive nearby addresses, so the result can be used as a spatial sort, clustering, or partitioning key. It is a one-dimensional curve address, not a geometric distance.
+
+Format: `ST_HilbertDistance(geometry: Geometry, xmin: Double, ymin: Double, xmax: Double, ymax: Double, level: Integer)`
+
+Return type: `Long`
+
+The function is available for both Snowflake `GEOMETRY` and `GEOGRAPHY` values. It treats the input coordinates and supplied extent as planar X and Y values; it does not compute a geodesic distance.
+
+The envelope midpoint is scaled independently on each axis to the integer grid from `0` through `2^level - 1`. Coordinates outside the supplied extent are clipped to its nearest edge. A zero-width axis maps to grid coordinate zero. Z and M coordinates do not affect the result.
+
+Levels from 1 through 16 provide increasingly fine ordering keys. A level at or below zero returns zero, while a level above 16 raises an error. The result is an unsigned value of up to 32 bits represented by `Long`; at level 16 it can be as large as `4294967295`. If any argument is null, the result is null. An empty geometry raises an error because it has no envelope midpoint.
+
+SQL example:
+
+```sql
+SELECT SEDONA.ST_HilbertDistance(
+    ST_GeometryFromWKT('POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))'),
+    0.0, 0.0, 1.0, 1.0, 2
+)
+```
+
+Output:
+
+```
+2
+```
+
+The polygon's envelope midpoint is `(0.5, 0.5)`. At level 2, the supplied unit-square extent is divided into a 4-by-4 Hilbert grid and that midpoint has curve address `2`.
+
+The maximum level-16 address remains non-negative because the function returns a `Long`:
+
+```sql
+SELECT SEDONA.ST_HilbertDistance(
+    ST_GeometryFromWKT('POINT (1 0)'),
+    0.0, 0.0, 1.0, 1.0, 16
+)
+```
+
+Output:
+
+```
+4294967295
+```

--- a/docs/api/snowflake/vector-data/Spatial-Indexing/ST_HilbertDistance.md
+++ b/docs/api/snowflake/vector-data/Spatial-Indexing/ST_HilbertDistance.md
@@ -31,6 +31,20 @@ The envelope midpoint is scaled independently on each axis to the integer grid f
 
 Levels from 1 through 16 provide increasingly fine ordering keys. A level at or below zero returns zero, while a level above 16 raises an error. The result is an unsigned value of up to 32 bits represented by `Long`; at level 16 it can be as large as `4294967295`. If any argument is null, the result is null. An empty geometry raises an error because it has no envelope midpoint.
 
+## How addresses are assigned
+
+At level 2, the extent becomes a 4-by-4 grid. The Hilbert curve visits every cell once and assigns addresses from 0 through 15 along that continuous path:
+
+![Level-2 Hilbert curve visiting a 4-by-4 grid in address order from 0 through 15](../../../../image/ST_HilbertDistance/ST_HilbertDistance_curve.svg "Level-2 Hilbert grid and ordered addresses")
+
+*Consecutive addresses share a grid edge, which is why sorting by the returned key tends to keep nearby records together. The key is an ordering address, not a geometric distance.*
+
+For each input geometry, the function uses the midpoint of its envelope, normalizes that point into the supplied extent, and looks up the cell's Hilbert address. This example also shows how a midpoint outside the extent is clipped before lookup:
+
+![Five geometry envelopes and midpoints normalized onto a Hilbert grid, then sorted by addresses 0, 2, 4, 13, and 15](../../../../image/ST_HilbertDistance/ST_HilbertDistance_workflow.svg "Geometry envelope midpoint to Hilbert sort key")
+
+*Only the envelope midpoint determines the address. Different geometries with midpoints in the same grid cell receive the same value at that level.*
+
 SQL example:
 
 ```sql

--- a/docs/api/sql/Geometry-Functions.md
+++ b/docs/api/sql/Geometry-Functions.md
@@ -339,7 +339,7 @@ These functions produce or operate on bounding boxes and compute extent values.
 
 ## Spatial Indexing
 
-These functions work with spatial indexing systems including Bing Tiles, H3, S2, and GeoHash.
+These functions work with spatial indexing systems including Bing Tiles, H3, Hilbert curves, S2, and GeoHash.
 
 | Function | Return type | Description | Since |
 | :--- | :--- | :--- | :--- |
@@ -358,6 +358,7 @@ These functions work with spatial indexing systems including Bing Tiles, H3, S2,
 | [ST_H3CellIDs](Spatial-Indexing/ST_H3CellIDs.md) | `Array<Long>` | Cover the geometry by H3 cell IDs with the given resolution(level). To understand the cell statistics please refer to [H3 Doc](https://h3geo.org/docs/core-library/restable) H3 native fill functions... | v1.5.0 |
 | [ST_H3KRing](Spatial-Indexing/ST_H3KRing.md) | `Array<Long>` | return the result of H3 function [gridDisk(cell, k)](https://h3geo.org/docs/api/traversal#griddisk). | v1.5.0 |
 | [ST_H3ToGeom](Spatial-Indexing/ST_H3ToGeom.md) | `Array<Geometry>` | Return the result of H3 function [cellsToMultiPolygon(cells)](https://h3geo.org/docs/api/regions#cellstolinkedmultipolygon--cellstomultipolygon). | v1.6.0 |
+| [ST_HilbertDistance](Spatial-Indexing/ST_HilbertDistance.md) | Long | Maps the midpoint of a geometry's envelope to an unsigned Hilbert-curve address within a supplied extent. | v2.0.0 |
 | [ST_S2CellIDs](Spatial-Indexing/ST_S2CellIDs.md) | `Array<Long>` | Cover the geometry with Google S2 Cells, return the corresponding cell IDs with the given level. The level indicates the [size of cells](https://s2geometry.io/resources/s2cell_statistics.html). With... | v1.4.0 |
 | [ST_S2ToGeom](Spatial-Indexing/ST_S2ToGeom.md) | `Array<Geometry>` | Returns an array of Polygons for the corresponding S2 cell IDs. | v1.6.0 |
 

--- a/docs/api/sql/Spatial-Indexing/ST_HilbertDistance.md
+++ b/docs/api/sql/Spatial-Indexing/ST_HilbertDistance.md
@@ -31,6 +31,20 @@ The envelope midpoint is scaled independently on each axis to the integer grid f
 
 Levels from 1 through 16 provide increasingly fine ordering keys. A level at or below zero returns zero, while a level above 16 raises an error. The result is an unsigned value of up to 32 bits represented by `Long`; at level 16 it can be as large as `4294967295`. If any argument is null, the result is null. An empty geometry raises an error because it has no envelope midpoint.
 
+## How addresses are assigned
+
+At level 2, the extent becomes a 4-by-4 grid. The Hilbert curve visits every cell once and assigns addresses from 0 through 15 along that continuous path:
+
+![Level-2 Hilbert curve visiting a 4-by-4 grid in address order from 0 through 15](../../../image/ST_HilbertDistance/ST_HilbertDistance_curve.svg "Level-2 Hilbert grid and ordered addresses")
+
+*Consecutive addresses share a grid edge, which is why sorting by the returned key tends to keep nearby records together. The key is an ordering address, not a geometric distance.*
+
+For each input geometry, the function uses the midpoint of its envelope, normalizes that point into the supplied extent, and looks up the cell's Hilbert address. This example also shows how a midpoint outside the extent is clipped before lookup:
+
+![Five geometry envelopes and midpoints normalized onto a Hilbert grid, then sorted by addresses 0, 2, 4, 13, and 15](../../../image/ST_HilbertDistance/ST_HilbertDistance_workflow.svg "Geometry envelope midpoint to Hilbert sort key")
+
+*Only the envelope midpoint determines the address. Different geometries with midpoints in the same grid cell receive the same value at that level.*
+
 SQL example:
 
 ```sql

--- a/docs/api/sql/Spatial-Indexing/ST_HilbertDistance.md
+++ b/docs/api/sql/Spatial-Indexing/ST_HilbertDistance.md
@@ -1,0 +1,64 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_HilbertDistance
+
+Introduction: Maps the midpoint of a geometry's envelope to its address along a Hilbert curve constructed over a supplied extent. Nearby geometries often receive nearby addresses, so the result can be used as a spatial sort, clustering, or partitioning key. It is a one-dimensional curve address, not a geometric distance.
+
+Format: `ST_HilbertDistance(geometry: Geometry, xmin: Double, ymin: Double, xmax: Double, ymax: Double, level: Integer)`
+
+Return type: `Long`
+
+Since: `v2.0.0`
+
+The envelope midpoint is scaled independently on each axis to the integer grid from `0` through `2^level - 1`. Coordinates outside the supplied extent are clipped to its nearest edge. A zero-width axis maps to grid coordinate zero. Z and M coordinates do not affect the result.
+
+Levels from 1 through 16 provide increasingly fine ordering keys. A level at or below zero returns zero, while a level above 16 raises an error. The result is an unsigned value of up to 32 bits represented by `Long`; at level 16 it can be as large as `4294967295`. If any argument is null, the result is null. An empty geometry raises an error because it has no envelope midpoint.
+
+SQL example:
+
+```sql
+SELECT ST_HilbertDistance(
+    ST_GeomFromWKT('POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))'),
+    0.0, 0.0, 1.0, 1.0, 2
+)
+```
+
+Output:
+
+```
+2
+```
+
+The polygon's envelope midpoint is `(0.5, 0.5)`. At level 2, the supplied unit-square extent is divided into a 4-by-4 Hilbert grid and that midpoint has curve address `2`.
+
+The maximum level-16 address remains non-negative because the function returns a `Long`:
+
+```sql
+SELECT ST_HilbertDistance(
+    ST_GeomFromWKT('POINT (1 0)'),
+    0.0, 0.0, 1.0, 1.0, 16
+)
+```
+
+Output:
+
+```
+4294967295
+```

--- a/docs/image/ST_HilbertDistance/ST_HilbertDistance_curve.svg
+++ b/docs/image/ST_HilbertDistance/ST_HilbertDistance_curve.svg
@@ -1,0 +1,107 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1120 680" width="1120" height="680" role="img" aria-labelledby="hilbert-curve-title hilbert-curve-description">
+  <title id="hilbert-curve-title">Level-2 Hilbert grid and its ordered addresses</title>
+  <desc id="hilbert-curve-description">A four-by-four grid shows the continuous Hilbert curve visiting every cell exactly once. The traversal starts with address zero in the lower-left cell, winds through addresses one to fourteen, and ends with address fifteen in the lower-right cell. Explanatory cards state that level two creates four cells per axis and sixteen unsigned ordering addresses.</desc>
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+      text:not([fill]) { fill: #172033; }
+      .panel { fill: #f8fafc; stroke: #b8c3d1; stroke-width: 1.5; }
+      .panel-title { font-size: 16px; font-weight: 700; }
+      .caption { font-size: 13px; fill: #475569; }
+      .small { font-size: 12px; fill: #475569; }
+      .grid { stroke: #94a3b8; stroke-width: 1; }
+      .axis { font-size: 12px; fill: #475569; }
+      .address { font-size: 13px; font-weight: 700; text-anchor: middle; dominant-baseline: central; }
+      .formula { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 15px; }
+    </style>
+    <marker id="curve-arrow" markerWidth="10" markerHeight="10" refX="9" refY="5" orient="auto" markerUnits="userSpaceOnUse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#6d28d9"/>
+    </marker>
+  </defs>
+
+  <rect width="1120" height="680" fill="#ffffff"/>
+  <text x="560" y="34" text-anchor="middle" font-size="22" font-weight="700">A Hilbert address turns a 2D grid into one ordered key</text>
+  <text x="560" y="59" text-anchor="middle" class="caption">Level 2 visits all 16 grid cells along one continuous path</text>
+
+  <rect x="25" y="82" width="610" height="570" rx="10" class="panel"/>
+  <text x="48" y="112" class="panel-title">Level-2 curve</text>
+  <text x="48" y="134" class="caption">Cell labels are the values returned for midpoints normalized into those cells.</text>
+
+  <rect x="105" y="155" width="440" height="440" fill="#ffffff" stroke="#64748b" stroke-width="2"/>
+  <path d="M215 155 V595 M325 155 V595 M435 155 V595 M105 265 H545 M105 375 H545 M105 485 H545" class="grid"/>
+
+  <path d="M160 540 L270 540 L270 430 L160 430 L160 320 L160 210 L270 210 L270 320 L380 320 L380 210 L490 210 L490 320 L490 430 L380 430 L380 540 L490 540"
+        fill="none" stroke="#ede9fe" stroke-width="20" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M160 540 L270 540 L270 430 L160 430 L160 320 L160 210 L270 210 L270 320 L380 320 L380 210 L490 210 L490 320 L490 430 L380 430 L380 540 L490 540"
+        fill="none" stroke="#6d28d9" stroke-width="5" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#curve-arrow)"/>
+
+  <g>
+    <circle cx="160" cy="540" r="19" fill="#dff6ef" stroke="#007a65" stroke-width="3"/><text x="160" y="540" class="address" fill="#006b58">0</text>
+    <circle cx="270" cy="540" r="17" fill="#ffffff" stroke="#6d28d9" stroke-width="2"/><text x="270" y="540" class="address">1</text>
+    <circle cx="270" cy="430" r="17" fill="#ffffff" stroke="#6d28d9" stroke-width="2"/><text x="270" y="430" class="address">2</text>
+    <circle cx="160" cy="430" r="17" fill="#ffffff" stroke="#6d28d9" stroke-width="2"/><text x="160" y="430" class="address">3</text>
+    <circle cx="160" cy="320" r="17" fill="#ffffff" stroke="#6d28d9" stroke-width="2"/><text x="160" y="320" class="address">4</text>
+    <circle cx="160" cy="210" r="17" fill="#ffffff" stroke="#6d28d9" stroke-width="2"/><text x="160" y="210" class="address">5</text>
+    <circle cx="270" cy="210" r="17" fill="#ffffff" stroke="#6d28d9" stroke-width="2"/><text x="270" y="210" class="address">6</text>
+    <circle cx="270" cy="320" r="17" fill="#ffffff" stroke="#6d28d9" stroke-width="2"/><text x="270" y="320" class="address">7</text>
+    <circle cx="380" cy="320" r="17" fill="#ffffff" stroke="#6d28d9" stroke-width="2"/><text x="380" y="320" class="address">8</text>
+    <circle cx="380" cy="210" r="17" fill="#ffffff" stroke="#6d28d9" stroke-width="2"/><text x="380" y="210" class="address">9</text>
+    <circle cx="490" cy="210" r="17" fill="#ffffff" stroke="#6d28d9" stroke-width="2"/><text x="490" y="210" class="address">10</text>
+    <circle cx="490" cy="320" r="17" fill="#ffffff" stroke="#6d28d9" stroke-width="2"/><text x="490" y="320" class="address">11</text>
+    <circle cx="490" cy="430" r="17" fill="#ffffff" stroke="#6d28d9" stroke-width="2"/><text x="490" y="430" class="address">12</text>
+    <circle cx="380" cy="430" r="17" fill="#ffffff" stroke="#6d28d9" stroke-width="2"/><text x="380" y="430" class="address">13</text>
+    <circle cx="380" cy="540" r="17" fill="#ffffff" stroke="#6d28d9" stroke-width="2"/><text x="380" y="540" class="address">14</text>
+    <circle cx="490" cy="540" r="19" fill="#fff1e8" stroke="#c2410c" stroke-width="3"/><text x="490" y="540" class="address" fill="#9a3412">15</text>
+  </g>
+
+  <text x="160" y="617" text-anchor="middle" class="axis">x = 0</text>
+  <text x="270" y="617" text-anchor="middle" class="axis">x = 1</text>
+  <text x="380" y="617" text-anchor="middle" class="axis">x = 2</text>
+  <text x="490" y="617" text-anchor="middle" class="axis">x = 3</text>
+  <text x="87" y="544" text-anchor="end" class="axis">y = 0</text>
+  <text x="87" y="434" text-anchor="end" class="axis">y = 1</text>
+  <text x="87" y="324" text-anchor="end" class="axis">y = 2</text>
+  <text x="87" y="214" text-anchor="end" class="axis">y = 3</text>
+
+  <rect x="660" y="82" width="435" height="172" rx="10" class="panel"/>
+  <text x="684" y="113" class="panel-title">Grid size</text>
+  <text x="684" y="148" class="formula" fill="#5b21b6">cells per axis = 2² = 4</text>
+  <text x="684" y="180" class="formula" fill="#5b21b6">addresses = 4² = 16</text>
+  <text x="684" y="215" class="caption">At level 16, the same rule produces 2³² addresses,</text>
+  <text x="684" y="235" class="caption">represented by a non-negative Long.</text>
+
+  <rect x="660" y="274" width="435" height="186" rx="10" class="panel"/>
+  <text x="684" y="305" class="panel-title">Why the order is useful</text>
+  <path d="M700 342 H1038" stroke="#6d28d9" stroke-width="4" stroke-linecap="round" marker-end="url(#curve-arrow)"/>
+  <circle cx="700" cy="342" r="8" fill="#007a65"/><text x="700" y="370" text-anchor="middle" class="small">0</text>
+  <circle cx="813" cy="342" r="7" fill="#8b5cf6"/><text x="813" y="370" text-anchor="middle" class="small">nearby keys</text>
+  <circle cx="926" cy="342" r="7" fill="#8b5cf6"/><text x="1038" y="370" text-anchor="middle" class="small">15</text>
+  <text x="684" y="405" class="caption">Consecutive addresses always occupy adjacent grid cells.</text>
+  <text x="684" y="427" class="caption">Sorting by the returned value therefore tends to keep spatially</text>
+  <text x="684" y="449" class="caption">nearby records together without turning it into a distance metric.</text>
+
+  <rect x="660" y="480" width="435" height="172" rx="10" fill="#fffbeb" stroke="#d6a838" stroke-width="1.5"/>
+  <text x="684" y="512" class="panel-title">Read the result as an address</text>
+  <text x="684" y="546" class="caption">The curve preserves locality approximately, not perfectly:</text>
+  <text x="684" y="570" class="caption">two nearby cells can be far apart along the curve.</text>
+  <text x="684" y="606" class="caption">Use the key for ordering, clustering, or partitioning.</text>
+  <text x="684" y="630" class="caption">Use spatial predicates for exact geometric relationships.</text>
+</svg>

--- a/docs/image/ST_HilbertDistance/ST_HilbertDistance_workflow.svg
+++ b/docs/image/ST_HilbertDistance/ST_HilbertDistance_workflow.svg
@@ -1,0 +1,145 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 760" width="1200" height="760" role="img" aria-labelledby="hilbert-workflow-title hilbert-workflow-description">
+  <title id="hilbert-workflow-title">How geometry envelopes become Hilbert sort keys</title>
+  <desc id="hilbert-workflow-description">A three-stage diagram. Five geometries labeled A through E are shown inside or beside the supplied extent from zero to one hundred. Dashed rectangles identify each geometry envelope, and crosshairs identify envelope midpoints. The midpoints are normalized onto a level-two four-by-four grid; the outside point E is clipped to the nearest edge. The resulting rows sort by Hilbert addresses zero, two, four, thirteen, and fifteen.</desc>
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+      text:not([fill]) { fill: #172033; }
+      .panel { fill: #f8fafc; stroke: #b8c3d1; stroke-width: 1.5; }
+      .panel-title { font-size: 16px; font-weight: 700; }
+      .caption { font-size: 12px; fill: #475569; }
+      .small { font-size: 11px; fill: #475569; }
+      .axis { font-size: 11px; fill: #475569; }
+      .grid { stroke: #cbd5e1; stroke-width: 1; }
+      .envelope { fill: none; stroke-width: 1.7; stroke-dasharray: 7 5; }
+      .row { fill: #ffffff; stroke: #d4dbe5; stroke-width: 1; }
+      .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    </style>
+    <marker id="flow-arrow" markerWidth="10" markerHeight="10" refX="9" refY="5" orient="auto" markerUnits="userSpaceOnUse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#64748b"/>
+    </marker>
+    <marker id="clip-arrow" markerWidth="9" markerHeight="9" refX="8" refY="4.5" orient="auto" markerUnits="userSpaceOnUse">
+      <path d="M0,0 L9,4.5 L0,9 Z" fill="#6f2da8"/>
+    </marker>
+  </defs>
+
+  <rect width="1200" height="760" fill="#ffffff"/>
+  <text x="600" y="34" text-anchor="middle" font-size="22" font-weight="700">From geometry envelope to sortable Hilbert address</text>
+  <text x="600" y="59" text-anchor="middle" class="caption">Example extent: (xmin, ymin, xmax, ymax) = (0, 0, 100, 100), level = 2</text>
+
+  <rect x="25" y="82" width="590" height="608" rx="10" class="panel"/>
+  <text x="48" y="112" class="panel-title">1 · Find each envelope midpoint</text>
+  <text x="48" y="134" class="caption">Dashed boxes are envelopes; circled crosses are their midpoints, not centroids.</text>
+
+  <rect x="105" y="160" width="400" height="400" fill="#ffffff" stroke="#475569" stroke-width="2"/>
+  <path d="M205 160 V560 M305 160 V560 M405 160 V560 M105 260 H505 M105 360 H505 M105 460 H505" class="grid"/>
+  <text x="105" y="582" text-anchor="middle" class="axis">0</text><text x="205" y="582" text-anchor="middle" class="axis">25</text><text x="305" y="582" text-anchor="middle" class="axis">50</text><text x="405" y="582" text-anchor="middle" class="axis">75</text><text x="505" y="582" text-anchor="middle" class="axis">100</text>
+  <text x="92" y="564" text-anchor="end" class="axis">0</text><text x="92" y="464" text-anchor="end" class="axis">25</text><text x="92" y="364" text-anchor="end" class="axis">50</text><text x="92" y="264" text-anchor="end" class="axis">75</text><text x="92" y="164" text-anchor="end" class="axis">100</text>
+  <text x="305" y="607" text-anchor="middle" class="caption">supplied X extent</text>
+  <text x="60" y="360" text-anchor="middle" class="caption" transform="rotate(-90 60 360)">supplied Y extent</text>
+
+  <!-- A: triangle, midpoint (12.5, 12.5) -->
+  <rect x="125" y="480" width="60" height="60" class="envelope" stroke="#0072b2"/>
+  <polygon points="125,540 185,540 155,480" fill="#0072b2" fill-opacity="0.16" stroke="#0072b2" stroke-width="2.5"/>
+  <circle cx="155" cy="510" r="8" fill="#ffffff" stroke="#0072b2" stroke-width="2"/><path d="M150 510 H160 M155 505 V515" stroke="#0072b2" stroke-width="2"/>
+  <text x="130" y="471" font-size="13" font-weight="700" fill="#005b8f">A</text>
+
+  <!-- B: line, midpoint (37.5, 37.5) -->
+  <rect x="225" y="380" width="60" height="60" class="envelope" stroke="#d55e00"/>
+  <path d="M225 437 L242 400 L261 424 L285 380" fill="none" stroke="#d55e00" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="255" cy="410" r="8" fill="#ffffff" stroke="#d55e00" stroke-width="2"/><path d="M250 410 H260 M255 405 V415" stroke="#d55e00" stroke-width="2"/>
+  <text x="230" y="371" font-size="13" font-weight="700" fill="#a94700">B</text>
+
+  <!-- C: polygon, midpoint (12.5, 87.5) -->
+  <rect x="125" y="180" width="60" height="60" class="envelope" stroke="#009e73"/>
+  <path d="M125 230 L137 184 L175 180 L185 220 L162 240 Z" fill="#009e73" fill-opacity="0.16" stroke="#009e73" stroke-width="2.5"/>
+  <circle cx="155" cy="210" r="8" fill="#ffffff" stroke="#009e73" stroke-width="2"/><path d="M150 210 H160 M155 205 V215" stroke="#009e73" stroke-width="2"/>
+  <text x="130" y="171" font-size="13" font-weight="700" fill="#007a58">C</text>
+
+  <!-- D: polygon, midpoint (87.5, 62.5) -->
+  <rect x="425" y="280" width="60" height="60" class="envelope" stroke="#c23b75"/>
+  <path d="M425 330 L437 286 L466 280 L485 305 L473 340 L445 329 Z" fill="#c23b75" fill-opacity="0.16" stroke="#c23b75" stroke-width="2.5"/>
+  <circle cx="455" cy="310" r="8" fill="#ffffff" stroke="#c23b75" stroke-width="2"/><path d="M450 310 H460 M455 305 V315" stroke="#c23b75" stroke-width="2"/>
+  <text x="430" y="271" font-size="13" font-weight="700" fill="#9d255c">D</text>
+
+  <!-- E: point outside the extent, midpoint (120, 12.5) -->
+  <circle cx="585" cy="510" r="9" fill="#6f2da8" stroke="#ffffff" stroke-width="3"/>
+  <path d="M575 510 H595 M585 500 V520" stroke="#6f2da8" stroke-width="2"/>
+  <text x="572" y="490" font-size="13" font-weight="700" fill="#5b238b">E</text>
+  <path d="M572 510 H508" fill="none" stroke="#6f2da8" stroke-width="2" stroke-dasharray="5 4" marker-end="url(#clip-arrow)"/>
+  <text x="545" y="535" text-anchor="middle" class="small" fill="#5b238b">outside X → clip</text>
+
+  <rect x="84" y="626" width="507" height="43" rx="7" fill="#eef6fb" stroke="#96bfd9"/>
+  <text x="337" y="644" text-anchor="middle" class="small">Envelope midpoint = ((minX + maxX) / 2, (minY + maxY) / 2)</text>
+  <text x="337" y="660" text-anchor="middle" class="small">Geometry vertices, area, and centroid do not otherwise affect the key.</text>
+
+  <path d="M623 374 H647" stroke="#64748b" stroke-width="2.5" marker-end="url(#flow-arrow)"/>
+
+  <rect x="650" y="82" width="250" height="608" rx="10" class="panel"/>
+  <text x="673" y="112" class="panel-title">2 · Normalize to the grid</text>
+  <text x="673" y="134" class="caption">Scale each axis, clip, then truncate.</text>
+
+  <rect x="680" y="170" width="180" height="180" fill="#ffffff" stroke="#475569" stroke-width="2"/>
+  <path d="M725 170 V350 M770 170 V350 M815 170 V350 M680 215 H860 M680 260 H860 M680 305 H860" class="grid"/>
+  <text x="702.5" y="366" text-anchor="middle" class="axis">x0</text><text x="747.5" y="366" text-anchor="middle" class="axis">x1</text><text x="792.5" y="366" text-anchor="middle" class="axis">x2</text><text x="837.5" y="366" text-anchor="middle" class="axis">x3</text>
+  <text x="669" y="331" text-anchor="end" class="axis">y0</text><text x="669" y="286" text-anchor="end" class="axis">y1</text><text x="669" y="241" text-anchor="end" class="axis">y2</text><text x="669" y="196" text-anchor="end" class="axis">y3</text>
+
+  <circle cx="702.5" cy="327.5" r="14" fill="#0072b2"/><text x="702.5" y="332" text-anchor="middle" font-size="12" font-weight="700" fill="#ffffff">A</text>
+  <circle cx="747.5" cy="282.5" r="14" fill="#d55e00"/><text x="747.5" y="287" text-anchor="middle" font-size="12" font-weight="700" fill="#ffffff">B</text>
+  <circle cx="702.5" cy="237.5" r="14" fill="#009e73"/><text x="702.5" y="242" text-anchor="middle" font-size="12" font-weight="700" fill="#ffffff">C</text>
+  <circle cx="792.5" cy="282.5" r="14" fill="#c23b75"/><text x="792.5" y="287" text-anchor="middle" font-size="12" font-weight="700" fill="#ffffff">D</text>
+  <circle cx="837.5" cy="327.5" r="14" fill="#6f2da8"/><text x="837.5" y="332" text-anchor="middle" font-size="12" font-weight="700" fill="#ffffff">E</text>
+  <path d="M881 327.5 H854" stroke="#6f2da8" stroke-width="2" marker-end="url(#clip-arrow)"/>
+  <text x="880" y="311" text-anchor="end" class="small" fill="#5b238b">clipped</text>
+
+  <rect x="670" y="395" width="210" height="240" rx="8" fill="#ffffff" stroke="#d4dbe5"/>
+  <text x="688" y="422" font-size="13" font-weight="700">Normalized cell → address</text>
+  <text x="690" y="454" font-size="12" fill="#005b8f">A  (0, 0)</text><text x="854" y="454" text-anchor="end" class="mono" font-size="13">0</text>
+  <text x="690" y="490" font-size="12" fill="#a94700">B  (1, 1)</text><text x="854" y="490" text-anchor="end" class="mono" font-size="13">2</text>
+  <text x="690" y="526" font-size="12" fill="#007a58">C  (0, 2)</text><text x="854" y="526" text-anchor="end" class="mono" font-size="13">4</text>
+  <text x="690" y="562" font-size="12" fill="#9d255c">D  (2, 1)</text><text x="854" y="562" text-anchor="end" class="mono" font-size="13">13</text>
+  <text x="690" y="598" font-size="12" fill="#5b238b">E  (3, 0)</text><text x="854" y="598" text-anchor="end" class="mono" font-size="13">15</text>
+  <text x="775" y="624" text-anchor="middle" class="small">Level-2 Hilbert lookup</text>
+
+  <path d="M908 374 H932" stroke="#64748b" stroke-width="2.5" marker-end="url(#flow-arrow)"/>
+
+  <rect x="935" y="82" width="240" height="608" rx="10" class="panel"/>
+  <text x="958" y="112" class="panel-title">3 · Sort by the Long key</text>
+  <text x="958" y="134" class="caption">Ascending address gives this row order.</text>
+
+  <rect x="955" y="164" width="200" height="42" rx="7" fill="#e8f3fa" stroke="#96bfd9"/>
+  <text x="977" y="190" font-size="12" font-weight="700">row</text><text x="1134" y="190" text-anchor="end" font-size="12" font-weight="700">address</text>
+
+  <rect x="955" y="216" width="200" height="62" rx="7" class="row"/><circle cx="982" cy="247" r="14" fill="#0072b2"/><text x="982" y="251" text-anchor="middle" font-size="12" font-weight="700" fill="#ffffff">A</text><text x="1134" y="252" text-anchor="end" class="mono" font-size="15">0</text>
+  <rect x="955" y="288" width="200" height="62" rx="7" class="row"/><circle cx="982" cy="319" r="14" fill="#d55e00"/><text x="982" y="323" text-anchor="middle" font-size="12" font-weight="700" fill="#ffffff">B</text><text x="1134" y="324" text-anchor="end" class="mono" font-size="15">2</text>
+  <rect x="955" y="360" width="200" height="62" rx="7" class="row"/><circle cx="982" cy="391" r="14" fill="#009e73"/><text x="982" y="395" text-anchor="middle" font-size="12" font-weight="700" fill="#ffffff">C</text><text x="1134" y="396" text-anchor="end" class="mono" font-size="15">4</text>
+  <rect x="955" y="432" width="200" height="62" rx="7" class="row"/><circle cx="982" cy="463" r="14" fill="#c23b75"/><text x="982" y="467" text-anchor="middle" font-size="12" font-weight="700" fill="#ffffff">D</text><text x="1134" y="468" text-anchor="end" class="mono" font-size="15">13</text>
+  <rect x="955" y="504" width="200" height="62" rx="7" class="row"/><circle cx="982" cy="535" r="14" fill="#6f2da8"/><text x="982" y="539" text-anchor="middle" font-size="12" font-weight="700" fill="#ffffff">E</text><text x="1134" y="540" text-anchor="end" class="mono" font-size="15">15</text>
+
+  <path d="M1119 229 V552" stroke="#64748b" stroke-width="1.8" marker-end="url(#flow-arrow)"/>
+  <rect x="955" y="595" width="200" height="70" rx="7" fill="#fffbeb" stroke="#d6a838"/>
+  <text x="1055" y="618" text-anchor="middle" class="small">Useful for distributed</text>
+  <text x="1055" y="637" text-anchor="middle" font-size="12" font-weight="700">ORDER BY · clustering</text>
+  <text x="1055" y="655" text-anchor="middle" font-size="12" font-weight="700">range partitioning</text>
+
+  <rect x="25" y="712" width="1150" height="32" rx="7" fill="#eef2ff" stroke="#b7b9e6"/>
+  <text x="600" y="733" text-anchor="middle" font-size="12" fill="#4338ca">The result orders envelope midpoints approximately by locality; it is not the distance between geometries.</text>
+</svg>

--- a/docs/setup/release-notes.md
+++ b/docs/setup/release-notes.md
@@ -37,6 +37,12 @@
   temporarily supported with a `FutureWarning`. When CRS metadata is unavailable, validation can
   require a distributed lookup of the first non-null geometry's SRID.
 
+### New Features
+
+#### GeoPandas API
+
+* [<a href='https://github.com/apache/sedona/issues/3257'>GH-3257</a>] - Implement distributed GeoSeries and GeoDataFrame Hilbert-distance spatial ordering
+
 ## Sedona 1.9.1
 
 Sedona 1.9.1 is compiled against:

--- a/docs/tutorial/geopandas-api.md
+++ b/docs/tutorial/geopandas-api.md
@@ -331,6 +331,8 @@ The GeoPandas API for Apache Sedona implements the most commonly used GeoSeries 
 - `centroid`, `envelope`, `boundary` - Geometric properties
 - `x`, `y`, `z`, `has_z` - Coordinate access
 - `total_bounds`, `estimate_utm_crs` - Bounds and CRS utilities
+- `hilbert_distance()` - Distributed spatial-ordering keys based on geometry
+  envelope midpoints
 
 ### Spatial Operations
 
@@ -348,6 +350,12 @@ The GeoPandas API for Apache Sedona implements the most commonly used GeoSeries 
 - `overlay()` - Distributed intersection, difference, identity, symmetric
   difference, and union between GeoDataFrames
 - `sindex` - Spatial indexing (limited functionality)
+
+`hilbert_distance()` keeps its per-row ordering keys distributed and uses only
+native Spark expressions. When `total_bounds` is omitted, one distributed
+aggregation derives the extent of all envelope midpoints; only that bounded
+summary reaches the driver. Spark returns the GeoPandas-compatible unsigned
+32-bit values in an `int64` Series because Spark has no unsigned integer type.
 
 `overlay()` keeps both inputs distributed. Candidate pairs are planned as a
 Sedona spatial join, and difference branches aggregate each source row's

--- a/docs/tutorial/geopandas-api.zh.md
+++ b/docs/tutorial/geopandas-api.zh.md
@@ -331,6 +331,7 @@ Apache Sedona 的 GeoPandas API 已实现最常用的 GeoSeries 与 GeoDataFrame
 - `centroid`、`envelope`、`boundary` —— 几何属性
 - `x`、`y`、`z`、`has_z` —— 坐标访问
 - `total_bounds`、`estimate_utm_crs` —— 包围盒与 CRS 工具
+- `hilbert_distance()` —— 基于几何包围盒中点生成分布式空间排序键
 
 ### 空间运算
 
@@ -346,6 +347,11 @@ Apache Sedona 的 GeoPandas API 已实现最常用的 GeoSeries 与 GeoDataFrame
 - `clip()` —— 分布式几何裁剪
 - `overlay()` —— GeoDataFrame 之间的分布式相交、差集、恒等、对称差和并集
 - `sindex` —— 空间索引（功能有限）
+
+`hilbert_distance()` 使用原生 Spark 表达式，并让逐行排序键保持分布式执行。
+未提供 `total_bounds` 时，该方法会通过一次分布式聚合计算所有包围盒中点的
+范围，只有这个有界摘要会返回 driver。由于 Spark 没有无符号整数类型，
+与 GeoPandas 无符号 32 位值相同的结果会存储在 `int64` Series 中。
 
 `overlay()` 会让两个输入始终保持分布式执行。候选对由 Sedona 空间连接
 生成，差集分支则在 executor 上按源行聚合相匹配的掩膜几何。该实现不会收集

--- a/flink/src/main/java/org/apache/sedona/flink/Catalog.java
+++ b/flink/src/main/java/org/apache/sedona/flink/Catalog.java
@@ -110,6 +110,7 @@ public class Catalog {
       new Functions.ST_H3CellIDs(),
       new Functions.ST_H3KRing(),
       new Functions.ST_H3ToGeom(),
+      new Functions.ST_HilbertDistance(),
       new Functions.ST_BingTile(),
       new Functions.ST_BingTileAt(),
       new Functions.ST_BingTilesAround(),

--- a/flink/src/main/java/org/apache/sedona/flink/expressions/Functions.java
+++ b/flink/src/main/java/org/apache/sedona/flink/expressions/Functions.java
@@ -2901,6 +2901,33 @@ public class Functions {
     }
   }
 
+  public static class ST_HilbertDistance extends ScalarFunction {
+    @DataTypeHint("BIGINT")
+    public Long eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = GeometryTypeSerializer.class,
+                bridgedTo = Geometry.class)
+            Object o,
+        @DataTypeHint("DOUBLE") Double xmin,
+        @DataTypeHint("DOUBLE") Double ymin,
+        @DataTypeHint("DOUBLE") Double xmax,
+        @DataTypeHint("DOUBLE") Double ymax,
+        @DataTypeHint("INT") Integer level) {
+      if (o == null
+          || xmin == null
+          || ymin == null
+          || xmax == null
+          || ymax == null
+          || level == null) {
+        return null;
+      }
+      Geometry geometry = (Geometry) o;
+      return org.apache.sedona.common.Functions.hilbertDistance(
+          geometry, xmin, ymin, xmax, ymax, level);
+    }
+  }
+
   public static class ST_H3KRing extends ScalarFunction {
     @DataTypeHint(value = "ARRAY<BIGINT>")
     public Long[] eval(

--- a/flink/src/main/java/org/apache/sedona/flink/expressions/Functions.java
+++ b/flink/src/main/java/org/apache/sedona/flink/expressions/Functions.java
@@ -36,6 +36,7 @@ import org.apache.flink.table.types.inference.TypeStrategy;
 import org.apache.sedona.common.S2Geography.Geography;
 import org.apache.sedona.common.geometryObjects.Box2D;
 import org.apache.sedona.common.geometryObjects.Box3D;
+import org.apache.sedona.common.utils.HilbertDistance;
 import org.apache.sedona.flink.Box2DTypeSerializer;
 import org.apache.sedona.flink.Box3DTypeSerializer;
 import org.apache.sedona.flink.GeographyTypeSerializer;
@@ -2923,8 +2924,7 @@ public class Functions {
         return null;
       }
       Geometry geometry = (Geometry) o;
-      return org.apache.sedona.common.Functions.hilbertDistance(
-          geometry, xmin, ymin, xmax, ymax, level);
+      return HilbertDistance.compute(geometry, xmin, ymin, xmax, ymax, level);
     }
   }
 

--- a/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
@@ -847,6 +847,25 @@ public class FunctionTest extends TestBase {
   }
 
   @Test
+  public void testHilbertDistance() {
+    Table result =
+        tableEnv.sqlQuery(
+            "SELECT "
+                + "ST_HilbertDistance(ST_GeomFromWKT('POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))'), 0.0, 0.0, 1.0, 1.0, 2), "
+                + "ST_HilbertDistance(ST_GeomFromWKT('POINT (1 0)'), 0.0, 0.0, 1.0, 1.0, 16), "
+                + "ST_HilbertDistance(ST_GeomFromWKT('POINT Z (1 0 42)'), 0.0, 0.0, 1.0, 1.0, 0), "
+                + "ST_HilbertDistance(ST_GeomFromText(CAST(NULL AS STRING)), 0.0, 0.0, 1.0, 1.0, 2), "
+                + "ST_HilbertDistance(ST_GeomFromWKT('POINT (1 0)'), CAST(NULL AS DOUBLE), 0.0, 1.0, 1.0, 2)");
+    Row row = first(result);
+
+    assertEquals(2L, row.getField(0));
+    assertEquals(4294967295L, row.getField(1));
+    assertEquals(0L, row.getField(2));
+    assertNull(row.getField(3));
+    assertNull(row.getField(4));
+  }
+
+  @Test
   public void testLength() {
     Table polygonTable = createLineStringTable(1);
     Table resultTable =

--- a/python/sedona/spark/geopandas/base.py
+++ b/python/sedona/spark/geopandas/base.py
@@ -3873,6 +3873,49 @@ class GeoFrame(metaclass=ABCMeta):
         """
         return _delegate_to_geometry_column("total_bounds", self)
 
+    def hilbert_distance(self, total_bounds=None, level=16):
+        """Calculate the distance along a Hilbert curve.
+
+        Distances are calculated from geometry-envelope midpoints and can be
+        used to spatially order a GeoSeries or GeoDataFrame by mapping its
+        two-dimensional geometries onto a one-dimensional curve.
+
+        Parameters
+        ----------
+        total_bounds : 4-element array-like, optional
+            The spatial extent in which the curve is constructed, used to
+            rescale geometry midpoints. By default, the extent of all
+            geometry-envelope midpoints is computed. Passing known bounds
+            avoids that metadata computation.
+        level : int, default 16
+            Determines the precision of the curve. Documented levels are 1
+            through 16, with grid coordinates in the range
+            ``[0, 2**level - 1]``.
+
+        Returns
+        -------
+        pandas-on-Spark Series
+            Distributed Series named ``"hilbert_distance"``. Spark stores
+            the unsigned 32-bit Hilbert values as signed 64-bit integers.
+
+        Notes
+        -----
+        The method performs one eager distributed validation and metadata
+        aggregation. Geometry rows and the returned values remain distributed;
+        no geometry data are collected on the driver.
+
+        Examples
+        --------
+        >>> from shapely.geometry import Point
+        >>> from sedona.spark.geopandas import GeoSeries
+        >>> s = GeoSeries([Point(0, 0), Point(1, 1), Point(1, 0)])
+        >>> s.hilbert_distance(total_bounds=(0, 0, 1, 1), level=2).to_list()
+        [0, 10, 15]
+        """
+        return _delegate_to_geometry_column(
+            "hilbert_distance", self, total_bounds, level
+        )
+
     def dwithin(self, other, distance, align=None):
         """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
         each aligned geometry that is within a set distance from ``other``.

--- a/python/sedona/spark/geopandas/geoseries.py
+++ b/python/sedona/spark/geopandas/geoseries.py
@@ -4680,6 +4680,96 @@ class GeoSeries(GeoFrame, pspd.Series):
             ]
         )
 
+    def hilbert_distance(self, total_bounds=None, level=16) -> pspd.Series:
+        try:
+            level = operator.index(level)
+        except TypeError as exc:
+            raise TypeError("level must be an integer") from exc
+        if level > 16:
+            raise ValueError("Level out of range")
+
+        explicit_bounds = None
+        if total_bounds is not None:
+            # Preserve GeoPandas' ordinary Python unpacking errors for malformed
+            # inputs instead of silently accepting the wrong extent shape.
+            xmin, ymin, xmax, ymax = total_bounds
+            # Evaluate both ranges before float coercion so invalid values such
+            # as strings fail instead of being treated as Spark column names.
+            float(xmax - xmin)
+            float(ymax - ymin)
+            explicit_bounds = tuple(float(value) for value in (xmin, ymin, xmax, ymax))
+
+        source_internal = self._internal.resolved_copy
+        source_frame = source_internal.spark_frame
+        geometry = source_internal.data_spark_columns[0]
+        x_midpoint = (stf.ST_XMin(geometry) + stf.ST_XMax(geometry)) / F.lit(2.0)
+        y_midpoint = (stf.ST_YMin(geometry) + stf.ST_YMax(geometry)) / F.lit(2.0)
+        invalid_geometry = geometry.isNull() | F.coalesce(
+            stf.ST_IsEmpty(geometry), F.lit(False)
+        )
+
+        summary_expressions = [
+            F.count(F.lit(1)).alias("row_count"),
+            F.count(F.when(invalid_geometry, F.lit(1))).alias("invalid_geometry_count"),
+        ]
+        if explicit_bounds is None:
+
+            def valid_midpoint(midpoint):
+                return F.when(
+                    midpoint.isNull() | F.isnan(midpoint),
+                    F.lit(None).cast("double"),
+                ).otherwise(midpoint)
+
+            valid_x = valid_midpoint(x_midpoint)
+            valid_y = valid_midpoint(y_midpoint)
+            summary_expressions.extend(
+                [
+                    F.min(valid_x).alias("xmin"),
+                    F.min(valid_y).alias("ymin"),
+                    F.max(valid_x).alias("xmax"),
+                    F.max(valid_y).alias("ymax"),
+                ]
+            )
+
+        # Validation is intentionally eager, matching GeoPandas. Only one
+        # aggregate row is materialized; geometry rows remain distributed.
+        summary = source_frame.agg(*summary_expressions).first()
+        if summary["invalid_geometry_count"]:
+            raise ValueError(
+                "Hilbert distance cannot be computed on a GeoSeries with empty or "
+                "missing geometries."
+            )
+
+        if explicit_bounds is None:
+            if summary["row_count"] == 0:
+                raise ValueError(
+                    "Hilbert distance cannot infer total bounds from an empty "
+                    "GeoSeries."
+                )
+            xmin, ymin, xmax, ymax = (
+                np.nan if summary[name] is None else summary[name]
+                for name in ("xmin", "ymin", "xmax", "ymax")
+            )
+        else:
+            xmin, ymin, xmax, ymax = explicit_bounds
+
+        # Keep the fixed-width encoder inside the JVM. Expressing its prefix
+        # scan with higher-order Catalyst lambdas adds per-row array/struct
+        # allocation and is substantially slower on large distributed inputs.
+        distance = stf.ST_HilbertDistance(
+            geometry,
+            xmin,
+            ymin,
+            xmax,
+            ymax,
+            level,
+        )
+        return self._query_geometry_column(
+            distance,
+            source_frame,
+            returns_geom=False,
+        ).rename("hilbert_distance")
+
     def estimate_utm_crs(self, datum_name: str = "WGS 84") -> CRS:
         """Returns the estimated UTM CRS based on the bounds of the dataset.
 

--- a/python/sedona/spark/sql/st_functions.py
+++ b/python/sedona/spark/sql/st_functions.py
@@ -896,6 +896,38 @@ def ST_GeometryType(geometry: ColumnOrName) -> Column:
 
 
 @validate_argument_types
+def ST_HilbertDistance(
+    geometry: ColumnOrName,
+    min_x: ColumnOrNameOrNumber,
+    min_y: ColumnOrNameOrNumber,
+    max_x: ColumnOrNameOrNumber,
+    max_y: ColumnOrNameOrNumber,
+    level: Union[ColumnOrName, int],
+) -> Column:
+    """Map a geometry-envelope midpoint to a Hilbert curve distance.
+
+    :param geometry: Geometry whose envelope midpoint is encoded.
+    :type geometry: ColumnOrName
+    :param min_x: Minimum X of the Hilbert curve extent.
+    :type min_x: ColumnOrNameOrNumber
+    :param min_y: Minimum Y of the Hilbert curve extent.
+    :type min_y: ColumnOrNameOrNumber
+    :param max_x: Maximum X of the Hilbert curve extent.
+    :type max_x: ColumnOrNameOrNumber
+    :param max_y: Maximum Y of the Hilbert curve extent.
+    :type max_y: ColumnOrNameOrNumber
+    :param level: Hilbert curve level, at most 16.
+    :type level: Union[ColumnOrName, int]
+    :return: Non-negative Hilbert curve distance as a long column.
+    :rtype: Column
+    """
+    return _call_st_function(
+        "ST_HilbertDistance",
+        (geometry, min_x, min_y, max_x, max_y, level),
+    )
+
+
+@validate_argument_types
 def ST_H3CellDistance(
     cell1: Union[ColumnOrName, int], cell2: Union[ColumnOrName, int]
 ) -> Column:

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -606,6 +606,178 @@ class TestGeoSeries(TestGeopandasBase):
         np.testing.assert_array_equal(all_empty_result, np.full(4, np.nan))
         assert action_count == 1
 
+    @pytest.mark.parametrize(
+        ("level", "expected"),
+        [
+            (2, [0, 10, 15, 2]),
+            (3, [0, 42, 63, 10]),
+            (16, [0, 2863311530, 4294967295, 715827882]),
+        ],
+    )
+    def test_hilbert_distance(self, level, expected):
+        geometries = [
+            Point(0, 0),
+            Point(1, 1),
+            Point(1, 0),
+            Polygon([(0, 0), (0, 1), (1, 1), (1, 0)]),
+        ]
+        index = pd.MultiIndex.from_tuples(
+            [("a", 1), ("a", 2), ("b", 1), ("b", 2)],
+            names=["group", "feature_id"],
+        )
+        source = GeoSeries(
+            geometries,
+            index=index,
+            name="source_geometry",
+            crs="EPSG:4326",
+        )
+
+        result = source.hilbert_distance(
+            total_bounds=(0, 0, 1, 1),
+            level=level,
+        )
+        pd.testing.assert_series_equal(
+            result.to_pandas(),
+            pd.Series(
+                expected,
+                index=index,
+                name="hilbert_distance",
+                dtype="int64",
+            ),
+            check_index_type=False,
+        )
+
+        # GeoDataFrame delegates to the active geometry column, not to the
+        # first geometry-typed column in the frame.
+        if level == 2:
+            frame = GeoDataFrame(
+                gpd.GeoDataFrame(
+                    {
+                        "decoy": gpd.GeoSeries(
+                            [Point(0, 0)] * len(geometries),
+                            index=index,
+                            crs="EPSG:4326",
+                        ),
+                        "active": gpd.GeoSeries(
+                            geometries,
+                            index=index,
+                            crs="EPSG:4326",
+                        ),
+                    },
+                    index=index,
+                    geometry="active",
+                    crs="EPSG:4326",
+                )
+            )
+            pd.testing.assert_series_equal(
+                frame.hilbert_distance(
+                    total_bounds=(0, 0, 1, 1),
+                    level=level,
+                ).to_pandas(),
+                pd.Series(
+                    expected,
+                    index=index,
+                    name="hilbert_distance",
+                    dtype="int64",
+                ),
+                check_index_type=False,
+            )
+
+    def test_hilbert_distance_uses_envelope_midpoint_extent(self):
+        source = GeoSeries(
+            [box(-100, -100, 100, 100), Point(10, 10)],
+            index=pd.Index(["large", "point"], name="feature"),
+        )
+
+        # The inferred extent is (0, 0, 10, 10), based on envelope
+        # midpoints. It is deliberately different from source.total_bounds.
+        expected = pd.Series(
+            [0, 2863311530],
+            index=pd.Index(["large", "point"], name="feature"),
+            name="hilbert_distance",
+            dtype="int64",
+        )
+        pd.testing.assert_series_equal(
+            source.hilbert_distance().to_pandas(),
+            expected,
+            check_index_type=False,
+        )
+
+        zero_width = GeoSeries([Point(0, 0), Point(0, 2), Point(0, 1)])
+        pd.testing.assert_series_equal(
+            zero_width.hilbert_distance(level=2).to_pandas(),
+            pd.Series([0, 5, 3], name="hilbert_distance", dtype="int64"),
+        )
+
+    @pytest.mark.parametrize("total_bounds", [None, (0, 0, 1, 1)])
+    def test_hilbert_distance_uses_one_native_summary_action(
+        self,
+        monkeypatch,
+        total_bounds,
+    ):
+        source = GeoSeries([Point(0, 0), Point(1, 1)])
+        spark_dataframe_type = type(source._internal.spark_frame)
+        original_first = spark_dataframe_type.first
+        action_count = 0
+
+        def counting_first(frame):
+            nonlocal action_count
+            action_count += 1
+            return original_first(frame)
+
+        monkeypatch.setattr(spark_dataframe_type, "first", counting_first)
+
+        result = source.hilbert_distance(total_bounds=total_bounds, level=3)
+        assert action_count == 1
+
+        spark_frame = result._internal.spark_frame
+        if hasattr(spark_frame, "_jdf"):
+            plan = spark_frame._jdf.queryExecution().optimizedPlan().toString()
+            assert "BatchEvalPython" not in plan
+            assert "ArrowEvalPython" not in plan
+            assert "PythonUDF" not in plan
+
+    def test_hilbert_distance_rejects_missing_and_empty_geometries(self):
+        source = GeoSeries(
+            [
+                Point(0, 0),
+                None,
+                Point(),
+                LineString(),
+                Polygon(),
+                MultiPoint(),
+                MultiLineString(),
+                MultiPolygon(),
+                GeometryCollection(),
+            ]
+        )
+        with pytest.raises(
+            ValueError,
+            match="cannot be computed on a GeoSeries with empty or missing",
+        ):
+            source.hilbert_distance(total_bounds=(0, 0, 1, 1))
+
+        empty = GeoSeries([], crs="EPSG:4326")
+        with pytest.raises(ValueError, match="cannot infer total bounds"):
+            empty.hilbert_distance()
+
+        explicit_empty = empty.hilbert_distance(total_bounds=(0, 0, 1, 1))
+        assert explicit_empty.name == "hilbert_distance"
+        assert explicit_empty.to_pandas().empty
+
+    def test_hilbert_distance_validates_level(self):
+        source = GeoSeries([Point(0, 0), Point(1, 1)])
+
+        with pytest.raises(ValueError, match="Level out of range"):
+            source.hilbert_distance(level=17)
+        with pytest.raises(TypeError, match="level must be an integer"):
+            source.hilbert_distance(level=1.5)
+
+        pd.testing.assert_series_equal(
+            source.hilbert_distance(level=0).to_pandas(),
+            pd.Series([0, 0], name="hilbert_distance", dtype="int64"),
+        )
+
     # These tests were taken directly from the TestEstimateUtmCrs class in the geopandas test suite
     # https://github.com/geopandas/geopandas/blob/main/geopandas/tests/test_array.py
     def test_estimate_utm_crs(self):

--- a/python/tests/geopandas/test_match_geopandas_series.py
+++ b/python/tests/geopandas/test_match_geopandas_series.py
@@ -651,6 +651,40 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
             gpd_result = gpd.GeoSeries(geometries).get_coordinates()
             pd.testing.assert_frame_equal(sgpd_result.to_pandas(), gpd_result)
 
+    @pytest.mark.skipif(
+        parse_version(gpd.__version__) < parse_version("0.13.0"),
+        reason="geopandas hilbert_distance requires version 0.13.0 or higher",
+    )
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {},
+            {"level": 2},
+            {"total_bounds": (-100, -100, 100, 100), "level": 16},
+        ],
+    )
+    def test_hilbert_distance(self, kwargs):
+        geometries = [
+            box(-100, -100, 100, 100),
+            Point(10, 10),
+            LineString([(2, 4), (4, 8)]),
+            Polygon([(1, 1), (3, 1), (3, 5), (1, 5)]),
+        ]
+        index = pd.MultiIndex.from_tuples(
+            [("a", 1), ("a", 2), ("b", 1), ("b", 2)],
+            names=["group", "feature_id"],
+        )
+        sgpd_result = GeoSeries(geometries, index=index).hilbert_distance(**kwargs)
+        gpd_result = gpd.GeoSeries(geometries, index=index).hilbert_distance(**kwargs)
+
+        # Spark has no unsigned 32-bit integer type. Sedona uses int64 so the
+        # full GeoPandas uint32 value range remains representable.
+        pd.testing.assert_series_equal(
+            sgpd_result.to_pandas(),
+            gpd_result.astype("int64"),
+            check_index_type=False,
+        )
+
     def test_count_geometries(self):
         for geom in self.geoms:
             sgpd_result = GeoSeries(geom).count_geometries()

--- a/python/tests/sql/test_dataframe_api.py
+++ b/python/tests/sql/test_dataframe_api.py
@@ -667,6 +667,13 @@ test_configurations = [
     (stf.ST_GeometryN, ("geom", 0), "multipoint", "", "POINT (0 0)"),
     (stf.ST_GeometryType, ("point",), "point_geom", "", "ST_Point"),
     (
+        stf.ST_HilbertDistance,
+        ("geom", 0.0, 0.0, 1.0, 1.0, 2),
+        "triangle_geom",
+        "",
+        2,
+    ),
+    (
         stf.ST_GeoHashNeighbors,
         ("geohash",),
         "constructor",
@@ -1524,6 +1531,9 @@ wrong_type_configurations = [
     (stf.ST_GeometryN, ("", None)),
     (stf.ST_GeometryN, ("", 0.0)),
     (stf.ST_GeometryType, (None,)),
+    (stf.ST_HilbertDistance, (None, 0.0, 0.0, 1.0, 1.0, 2)),
+    (stf.ST_HilbertDistance, ("", None, 0.0, 1.0, 1.0, 2)),
+    (stf.ST_HilbertDistance, ("", 0.0, 0.0, 1.0, 1.0, 2.0)),
     (stf.ST_GeoHashNeighbors, (None,)),
     (stf.ST_GeoHashNeighbor, (None, "n")),
     (stf.ST_GeoHashNeighbor, ("", None)),

--- a/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctions.java
+++ b/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctions.java
@@ -514,6 +514,24 @@ public class TestFunctions extends TestBase {
   }
 
   @Test
+  public void test_ST_HilbertDistance() {
+    registerUDF(
+        "ST_HilbertDistance",
+        byte[].class,
+        double.class,
+        double.class,
+        double.class,
+        double.class,
+        int.class);
+    verifySqlSingleRes(
+        "select sedona.ST_HilbertDistance(sedona.ST_GeomFromText('POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))'), 0, 0, 1, 1, 2) = 2",
+        true);
+    verifySqlSingleRes(
+        "select sedona.ST_HilbertDistance(sedona.ST_GeomFromText('POINT (1 0)'), 0, 0, 1, 1, 16) = 4294967295",
+        true);
+  }
+
+  @Test
   public void test_ST_InteriorRingN() {
     registerUDF("ST_InteriorRingN", byte[].class, int.class);
     verifySqlSingleRes(

--- a/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctionsGeography.java
+++ b/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctionsGeography.java
@@ -41,6 +41,24 @@ public class TestFunctionsGeography extends TestBase {
   }
 
   @Test
+  public void test_ST_HilbertDistance() {
+    registerUDFGeography(
+        "ST_HilbertDistance",
+        String.class,
+        double.class,
+        double.class,
+        double.class,
+        double.class,
+        int.class);
+    verifySqlSingleRes(
+        "SELECT SEDONA.ST_HilbertDistance(ST_GeographyFromWKT('POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))'), 0, 0, 1, 1, 2) = 2",
+        true);
+    verifySqlSingleRes(
+        "SELECT SEDONA.ST_HilbertDistance(ST_GeographyFromWKT('POINT (1 0)'), 0, 0, 1, 1, 16) = 4294967295",
+        true);
+  }
+
+  @Test
   public void test_ST_IsLineStringCCW() {
     registerUDFGeography("ST_IsLineStringCCW", String.class);
     verifySqlSingleRes(

--- a/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctionsV2.java
+++ b/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctionsV2.java
@@ -494,6 +494,24 @@ public class TestFunctionsV2 extends TestBase {
   }
 
   @Test
+  public void test_ST_HilbertDistance() {
+    registerUDFV2(
+        "ST_HilbertDistance",
+        String.class,
+        double.class,
+        double.class,
+        double.class,
+        double.class,
+        int.class);
+    verifySqlSingleRes(
+        "select sedona.ST_HilbertDistance(ST_GeometryFromWKT('POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))'), 0, 0, 1, 1, 2) = 2",
+        true);
+    verifySqlSingleRes(
+        "select sedona.ST_HilbertDistance(ST_GeometryFromWKT('POINT (1 0)'), 0, 0, 1, 1, 16) = 4294967295",
+        true);
+  }
+
+  @Test
   public void test_ST_InteriorRingN() {
     registerUDFV2("ST_InteriorRingN", String.class, int.class);
     verifySqlSingleRes(

--- a/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/UDFs.java
+++ b/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/UDFs.java
@@ -546,6 +546,13 @@ public class UDFs {
         GeometrySerde.deserialize(geom1), GeometrySerde.deserialize(geom2), densifyFrac);
   }
 
+  @UDFAnnotations.ParamMeta(argNames = {"geometry", "xmin", "ymin", "xmax", "ymax", "level"})
+  public static long ST_HilbertDistance(
+      byte[] geometry, double xmin, double ymin, double xmax, double ymax, int level) {
+    return Functions.hilbertDistance(
+        GeometrySerde.deserialize(geometry), xmin, ymin, xmax, ymax, level);
+  }
+
   @UDFAnnotations.ParamMeta(argNames = {"geometry", "n"})
   public static byte[] ST_InteriorRingN(byte[] geometry, int n) {
     return GeometrySerde.serialize(Functions.interiorRingN(GeometrySerde.deserialize(geometry), n));

--- a/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/UDFs.java
+++ b/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/UDFs.java
@@ -27,6 +27,7 @@ import org.apache.sedona.common.Predicates;
 import org.apache.sedona.common.enums.FileDataSplitter;
 import org.apache.sedona.common.sphere.Haversine;
 import org.apache.sedona.common.sphere.Spheroid;
+import org.apache.sedona.common.utils.HilbertDistance;
 import org.apache.sedona.snowflake.snowsql.annotations.UDFAnnotations;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Point;
@@ -549,7 +550,7 @@ public class UDFs {
   @UDFAnnotations.ParamMeta(argNames = {"geometry", "xmin", "ymin", "xmax", "ymax", "level"})
   public static long ST_HilbertDistance(
       byte[] geometry, double xmin, double ymin, double xmax, double ymax, int level) {
-    return Functions.hilbertDistance(
+    return HilbertDistance.compute(
         GeometrySerde.deserialize(geometry), xmin, ymin, xmax, ymax, level);
   }
 

--- a/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/UDFsV2.java
+++ b/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/UDFsV2.java
@@ -24,6 +24,7 @@ import org.apache.sedona.common.FunctionsProj4;
 import org.apache.sedona.common.Predicates;
 import org.apache.sedona.common.sphere.Haversine;
 import org.apache.sedona.common.sphere.Spheroid;
+import org.apache.sedona.common.utils.HilbertDistance;
 import org.apache.sedona.snowflake.snowsql.annotations.UDFAnnotations;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Point;
@@ -689,7 +690,7 @@ public class UDFsV2 {
       argTypes = {"Geometry", "double", "double", "double", "double", "int"})
   public static long ST_HilbertDistance(
       String geometry, double xmin, double ymin, double xmax, double ymax, int level) {
-    return Functions.hilbertDistance(
+    return HilbertDistance.compute(
         GeometrySerde.deserGeoJson(geometry), xmin, ymin, xmax, ymax, level);
   }
 

--- a/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/UDFsV2.java
+++ b/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/UDFsV2.java
@@ -685,6 +685,15 @@ public class UDFsV2 {
   }
 
   @UDFAnnotations.ParamMeta(
+      argNames = {"geometry", "xmin", "ymin", "xmax", "ymax", "level"},
+      argTypes = {"Geometry", "double", "double", "double", "double", "int"})
+  public static long ST_HilbertDistance(
+      String geometry, double xmin, double ymin, double xmax, double ymax, int level) {
+    return Functions.hilbertDistance(
+        GeometrySerde.deserGeoJson(geometry), xmin, ymin, xmax, ymax, level);
+  }
+
+  @UDFAnnotations.ParamMeta(
       argNames = {"geometry", "n"},
       argTypes = {"Geometry", "int"},
       returnTypes = "Geometry")

--- a/snowflake/src/test/java/org/apache/sedona/snowflake/snowsql/HilbertDistanceTest.java
+++ b/snowflake/src/test/java/org/apache/sedona/snowflake/snowsql/HilbertDistanceTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.snowflake.snowsql;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.sedona.common.Constructors;
+import org.junit.Test;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
+
+public class HilbertDistanceTest {
+
+  @Test
+  public void binaryAndNativeGeometryWrappersPreserveUnsignedAddresses() throws ParseException {
+    Geometry unitSquare = Constructors.geomFromWKT("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))", 0);
+    Geometry lowerRight = Constructors.geomFromWKT("POINT (1 0)", 0);
+
+    assertEquals(
+        2L, UDFs.ST_HilbertDistance(GeometrySerde.serialize(unitSquare), 0.0, 0.0, 1.0, 1.0, 2));
+    assertEquals(
+        2L, UDFsV2.ST_HilbertDistance(GeometrySerde.serGeoJson(unitSquare), 0.0, 0.0, 1.0, 1.0, 2));
+
+    assertEquals(
+        4294967295L,
+        UDFs.ST_HilbertDistance(GeometrySerde.serialize(lowerRight), 0.0, 0.0, 1.0, 1.0, 16));
+    assertEquals(
+        4294967295L,
+        UDFsV2.ST_HilbertDistance(GeometrySerde.serGeoJson(lowerRight), 0.0, 0.0, 1.0, 1.0, 16));
+  }
+}

--- a/spark/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
+++ b/spark/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
@@ -316,6 +316,7 @@ object Catalog extends AbstractCatalog with Logging {
     function[ST_H3CellIDs](),
     function[ST_H3KRing](),
     function[ST_H3ToGeom](),
+    function[ST_HilbertDistance](),
     function[ST_S2CellIDs](),
     function[ST_S2ToGeom](),
     function[ST_KNN]())

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
@@ -21,7 +21,7 @@ package org.apache.spark.sql.sedona_sql.expressions
 import org.apache.sedona.common.{Functions, FunctionsGeoTools, FunctionsProj4}
 import org.apache.sedona.common.geometryObjects.{Box2D, Box3D}
 import org.apache.sedona.common.sphere.{Haversine, Spheroid}
-import org.apache.sedona.common.utils.{InscribedCircle, ValidDetail}
+import org.apache.sedona.common.utils.{HilbertDistance, InscribedCircle, ValidDetail}
 import org.apache.sedona.core.utils.SedonaConf
 import org.apache.sedona.sql.utils.GeometrySerializer
 import org.apache.spark.sql.catalyst.InternalRow
@@ -1675,7 +1675,7 @@ private[apache] case class ST_S2ToGeom(inputExpressions: Seq[Expression])
 }
 
 private[apache] case class ST_HilbertDistance(inputExpressions: Seq[Expression])
-    extends InferredExpression(Functions.hilbertDistance _) {
+    extends InferredExpression(HilbertDistance.compute _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
@@ -1674,6 +1674,14 @@ private[apache] case class ST_S2ToGeom(inputExpressions: Seq[Expression])
   }
 }
 
+private[apache] case class ST_HilbertDistance(inputExpressions: Seq[Expression])
+    extends InferredExpression(Functions.hilbertDistance _) {
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
+}
+
 private[apache] case class ST_H3CellIDs(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.h3CellIDs _) {
 

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/st_functions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/st_functions.scala
@@ -300,6 +300,24 @@ object st_functions {
 
   def ST_H3ToGeom(cellIds: Array[Long]): Column = wrapExpression[ST_H3ToGeom](cellIds)
 
+  def ST_HilbertDistance(
+      geometry: Column,
+      xmin: Column,
+      ymin: Column,
+      xmax: Column,
+      ymax: Column,
+      level: Column): Column =
+    wrapExpression[ST_HilbertDistance](geometry, xmin, ymin, xmax, ymax, level)
+
+  def ST_HilbertDistance(
+      geometry: String,
+      xmin: Double,
+      ymin: Double,
+      xmax: Double,
+      ymax: Double,
+      level: Int): Column =
+    wrapExpression[ST_HilbertDistance](geometry, xmin, ymin, xmax, ymax, level)
+
   // Bing Tile functions
   def ST_BingTile(tileX: Column, tileY: Column, zoomLevel: Column): Column =
     wrapExpression[ST_BingTile](tileX, tileY, zoomLevel)

--- a/spark/common/src/test/scala/org/apache/sedona/sql/functions/STHilbertDistanceFunctions.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/functions/STHilbertDistanceFunctions.scala
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.sql.functions
+
+import org.apache.sedona.sql.TestBaseScala
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.sedona_sql.expressions.st_functions.ST_HilbertDistance
+import org.apache.spark.sql.types.LongType
+import org.scalatest.Matchers
+
+class STHilbertDistanceFunctions extends TestBaseScala with Matchers {
+
+  describe("ST_HilbertDistance") {
+
+    it("encodes geometry midpoints as unsigned Hilbert addresses") {
+      val row = sparkSession
+        .sql("""
+          |SELECT
+          |  ST_HilbertDistance(ST_GeomFromWKT('POINT (0 0)'), 0.0, 0.0, 1.0, 1.0, 2),
+          |  ST_HilbertDistance(ST_GeomFromWKT('POINT (0 1)'), 0.0, 0.0, 1.0, 1.0, 2),
+          |  ST_HilbertDistance(ST_GeomFromWKT('POINT (1 1)'), 0.0, 0.0, 1.0, 1.0, 2),
+          |  ST_HilbertDistance(ST_GeomFromWKT('POINT (1 0)'), 0.0, 0.0, 1.0, 1.0, 16)
+          |""".stripMargin)
+        .first()
+
+      row.getLong(0) should equal(0L)
+      row.getLong(1) should equal(5L)
+      row.getLong(2) should equal(10L)
+      row.getLong(3) should equal(4294967295L)
+    }
+
+    it("supports Column and String DataFrame API overloads") {
+      val source = sparkSession.sql("""
+          |SELECT
+          |  ST_GeomFromWKT('LINESTRING (0 0, 2 2)') AS geom,
+          |  0.0 AS xmin,
+          |  0.0 AS ymin,
+          |  2.0 AS xmax,
+          |  2.0 AS ymax,
+          |  2 AS level
+          |""".stripMargin)
+
+      val columnResult = source.select(
+        ST_HilbertDistance(
+          col("geom"),
+          col("xmin"),
+          col("ymin"),
+          col("xmax"),
+          col("ymax"),
+          col("level")))
+      columnResult.schema.head.dataType should equal(LongType)
+      columnResult.first().getLong(0) should equal(2L)
+
+      source
+        .select(ST_HilbertDistance("geom", 0.0, 0.0, 2.0, 2.0, 2))
+        .first()
+        .getLong(0) should equal(2L)
+    }
+
+    it("propagates null inputs") {
+      val row = sparkSession
+        .sql("""
+          |SELECT
+          |  ST_HilbertDistance(ST_GeomFromWKT(CAST(NULL AS STRING)), 0.0, 0.0, 1.0, 1.0, 2),
+          |  ST_HilbertDistance(ST_GeomFromWKT('POINT (0 0)'), CAST(NULL AS DOUBLE), 0.0, 1.0, 1.0, 2)
+          |""".stripMargin)
+        .first()
+
+      row.isNullAt(0) should be(true)
+      row.isNullAt(1) should be(true)
+    }
+
+    it("rejects empty geometries before collapsing non-positive levels") {
+      val exception = intercept[Exception] {
+        sparkSession
+          .sql("""
+            |SELECT ST_HilbertDistance(
+            |  ST_GeomFromWKT('POINT EMPTY'), 0.0, 0.0, 1.0, 1.0, 0)
+            |""".stripMargin)
+          .collect()
+      }
+
+      val expected = "Hilbert distance cannot be computed for an empty geometry"
+      val hasExpectedMessage = Iterator
+        .iterate(exception: Throwable)(_.getCause)
+        .takeWhile(_ != null)
+        .exists(error => Option(error.getMessage).exists(_.contains(expected)))
+      hasExpectedMessage should be(true)
+    }
+  }
+}


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/).

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`.

Closes #3257.
Part of #2230.

## What changes were proposed in this PR?

- Add a native `ST_HilbertDistance(geometry, xmin, ymin, xmax, ymax, level)` implementation that maps a geometry-envelope midpoint onto a Hilbert curve over a supplied extent.
- Represent the unsigned 32-bit Hilbert address as a non-negative `Long`, including the level-16 maximum value `4294967295`.
- Clip midpoint coordinates outside the supplied extent, map zero-width axes to grid coordinate zero, propagate null SQL inputs, reject empty geometries, and preserve GeoPandas-compatible level behavior.
- Register and expose `ST_HilbertDistance` through Spark SQL and DataFrame APIs, Flink SQL, Snowflake WKB and GeoJSON UDF paths, and the Python Spark SQL API.
- Implement distributed `GeoSeries.hilbert_distance` and `GeoDataFrame.hilbert_distance` through the active geometry column.
- Use one eager distributed aggregate to validate geometries and, when `total_bounds` is omitted, derive the extent of all envelope midpoints. Only the single aggregate row reaches the driver; geometry rows and returned keys remain distributed.
- Preserve duplicate and MultiIndex indexes, the `hilbert_distance` result name, explicit-bound behavior, empty-series behavior, and GeoPandas parity without Python UDF execution.
- Document the SQL function for Spark, Flink, and Snowflake and add the distributed method to the English and Chinese GeoPandas tutorials.

## How was this patch tested?

- Full common test suite: 1,292 tests passed.
- Focused Spark `ST_HilbertDistance` suite: 4 tests passed.
- Focused Flink function test: passed.
- Snowflake native-function and DDL suites: 4 tests passed.
- Focused Python GeoPandas, parity, and DataFrame API coverage: 15 tests passed.
- Regression coverage includes Hilbert-address goldens at levels 2, 3, and 16; the unsigned level-16 maximum; envelope-midpoint bounds; zero-width axes; clipping; null and typed-empty geometries; empty sources; explicit and inferred bounds; level validation; named duplicate and MultiIndex indexes; active-geometry delegation; exactly one metadata action; and the absence of Python execution nodes.
- The full documentation build, repository formatting checks, and `git diff --check` passed.
- The commit passed the repository pre-commit suite.

## Did this PR include necessary documentation updates?

- Yes, I am adding a new API. I used the current SNAPSHOT version, `v2.0.0`.
- Yes, I added Spark, Flink, and Snowflake SQL function documentation, release notes, and English and Chinese GeoPandas tutorial updates.
