### PR TITLE
[GH-3245] Fix RS_AsCOG ArrayIndexOutOfBoundsException for byte-band rasters

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/raster/cog/ByteBandRetilingImage.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/cog/ByteBandRetilingImage.java
@@ -1,0 +1,287 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.common.raster.cog;
+
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.image.ComponentSampleModel;
+import java.awt.image.DataBuffer;
+import java.awt.image.DataBufferByte;
+import java.awt.image.Raster;
+import java.awt.image.RenderedImage;
+import java.awt.image.SampleModel;
+import java.awt.image.WritableRaster;
+import java.util.Arrays;
+import javax.media.jai.ImageLayout;
+import javax.media.jai.PlanarImage;
+
+/**
+ * A non-caching retiling view that shields the TIFF writer from unsafe byte-band tile layouts.
+ *
+ * <p>When the source tile grid already matches the output grid, concrete tiles that are safe for
+ * imageio-ext's direct-buffer path are returned by identity. All other tiles are materialized on
+ * demand into fresh rasters; the view never retains them, so it cannot accumulate a second
+ * uncompressed copy of the image as {@link javax.media.jai.TiledImage} would.
+ *
+ * <p>The source is read directly with {@link RenderedImage#getTile(int, int)} and copied with
+ * explicit {@link DataBuffer} offsets. This view never reads the source through {@link
+ * PlanarImage#getData(Rectangle)} or copies it with {@link WritableRaster#setRect(Raster)} because
+ * those bulk paths can drop a positive {@link DataBufferByte} offset. Standard byte component
+ * layouts use row-wise array copies; other layouts fall back to offset-aware {@link SampleModel}
+ * accessors.
+ */
+final class ByteBandRetilingImage extends PlanarImage {
+  private final RenderedImage source;
+  private final boolean sameTileGrid;
+
+  ByteBandRetilingImage(RenderedImage source, int tileSize) {
+    super(
+        new ImageLayout(
+            source.getMinX(),
+            source.getMinY(),
+            source.getWidth(),
+            source.getHeight(),
+            source.getMinX(),
+            source.getMinY(),
+            tileSize,
+            tileSize,
+            source.getSampleModel().createCompatibleSampleModel(tileSize, tileSize),
+            source.getColorModel()),
+        null,
+        null);
+    this.source = source;
+    this.sameTileGrid =
+        source.getTileWidth() == tileSize
+            && source.getTileHeight() == tileSize
+            && source.getTileGridXOffset() == source.getMinX()
+            && source.getTileGridYOffset() == source.getMinY();
+  }
+
+  @Override
+  public Raster getTile(int tileX, int tileY) {
+    Raster alignedSourceTile = null;
+    if (sameTileGrid) {
+      alignedSourceTile = source.getTile(tileX, tileY);
+      if (isWriterSafe(alignedSourceTile)) {
+        return alignedSourceTile;
+      }
+    }
+
+    WritableRaster tile =
+        Raster.createWritableRaster(getSampleModel(), new Point(tileXToX(tileX), tileYToY(tileY)));
+    Rectangle bounds = tile.getBounds().intersection(getBounds());
+    if (bounds.isEmpty()) {
+      return tile;
+    }
+
+    if (alignedSourceTile != null) {
+      Rectangle region = bounds.intersection(alignedSourceTile.getBounds());
+      if (!region.isEmpty()) {
+        copyPixels(alignedSourceTile, tile, region);
+      }
+      return tile;
+    }
+
+    int sourceTileWidth = source.getTileWidth();
+    int sourceTileHeight = source.getTileHeight();
+    int minTileX = Math.floorDiv(bounds.x - source.getTileGridXOffset(), sourceTileWidth);
+    int maxTileX =
+        Math.floorDiv(bounds.x + bounds.width - 1 - source.getTileGridXOffset(), sourceTileWidth);
+    int minTileY = Math.floorDiv(bounds.y - source.getTileGridYOffset(), sourceTileHeight);
+    int maxTileY =
+        Math.floorDiv(bounds.y + bounds.height - 1 - source.getTileGridYOffset(), sourceTileHeight);
+
+    for (int sourceTileY = minTileY; sourceTileY <= maxTileY; sourceTileY++) {
+      for (int sourceTileX = minTileX; sourceTileX <= maxTileX; sourceTileX++) {
+        Raster sourceTile = source.getTile(sourceTileX, sourceTileY);
+        Rectangle region = bounds.intersection(sourceTile.getBounds());
+        if (!region.isEmpty()) {
+          copyPixels(sourceTile, tile, region);
+        }
+      }
+    }
+    return tile;
+  }
+
+  /**
+   * Whether imageio-ext can consume this concrete tile through its direct-buffer path. The check is
+   * per tile because translations and buffer offsets are properties of the returned raster, not the
+   * image's declared sample model.
+   */
+  private boolean isWriterSafe(Raster tile) {
+    int tileSize = getTileWidth();
+    if (tile.getWidth() != tileSize
+        || tile.getHeight() != tileSize
+        || tile.getSampleModelTranslateX() != tile.getMinX()
+        || tile.getSampleModelTranslateY() != tile.getMinY()) {
+      return false;
+    }
+
+    SampleModel sampleModel = tile.getSampleModel();
+    if (!(sampleModel instanceof ComponentSampleModel)
+        || sampleModel.getWidth() != tileSize
+        || sampleModel.getHeight() != tileSize) {
+      return false;
+    }
+
+    ComponentSampleModel componentModel = (ComponentSampleModel) sampleModel;
+    int pixelStride = componentModel.getPixelStride();
+    int numBands = componentModel.getNumBands();
+    if (pixelStride != numBands || componentModel.getScanlineStride() != tileSize * pixelStride) {
+      return false;
+    }
+
+    int[] bandOffsets = componentModel.getBandOffsets();
+    int[] bankIndices = componentModel.getBankIndices();
+    for (int band = 0; band < numBands; band++) {
+      if (bandOffsets[band] != band || bankIndices[band] != 0) {
+        return false;
+      }
+    }
+
+    DataBuffer dataBuffer = tile.getDataBuffer();
+    if (!(dataBuffer instanceof DataBufferByte)
+        || dataBuffer.getNumBanks() != 1
+        || dataBuffer.getOffset() != 0) {
+      return false;
+    }
+    long requiredBytes = (long) tileSize * tileSize * pixelStride;
+    return ((DataBufferByte) dataBuffer).getData().length >= requiredBytes;
+  }
+
+  /** Copy a region between rasters without dropping either DataBuffer's offsets. */
+  private static void copyPixels(Raster source, WritableRaster destination, Rectangle region) {
+    if (copyRowsDirectly(source, destination, region)) {
+      return;
+    }
+
+    SampleModel sourceModel = source.getSampleModel();
+    SampleModel destinationModel = destination.getSampleModel();
+    DataBuffer sourceBuffer = source.getDataBuffer();
+    DataBuffer destinationBuffer = destination.getDataBuffer();
+    int sourceTranslateX = source.getSampleModelTranslateX();
+    int sourceTranslateY = source.getSampleModelTranslateY();
+    int destinationTranslateX = destination.getSampleModelTranslateX();
+    int destinationTranslateY = destination.getSampleModelTranslateY();
+    int[] row = new int[region.width * sourceModel.getNumBands()];
+    for (int y = region.y; y < region.y + region.height; y++) {
+      sourceModel.getPixels(
+          region.x - sourceTranslateX, y - sourceTranslateY, region.width, 1, row, sourceBuffer);
+      destinationModel.setPixels(
+          region.x - destinationTranslateX,
+          y - destinationTranslateY,
+          region.width,
+          1,
+          row,
+          destinationBuffer);
+    }
+  }
+
+  /**
+   * Copies {@code region} row by row for compatible byte component layouts, applying each side's
+   * DataBuffer bank offsets explicitly. The region must lie within both rasters. Returns {@code
+   * false} without writing when the layout pair is ineligible; indexing and copy failures propagate
+   * to the caller.
+   */
+  static boolean copyRowsDirectly(Raster source, WritableRaster destination, Rectangle region) {
+    if (!(source.getSampleModel() instanceof ComponentSampleModel)
+        || !(destination.getSampleModel() instanceof ComponentSampleModel)
+        || !(source.getDataBuffer() instanceof DataBufferByte)
+        || !(destination.getDataBuffer() instanceof DataBufferByte)) {
+      return false;
+    }
+
+    ComponentSampleModel sourceModel = (ComponentSampleModel) source.getSampleModel();
+    ComponentSampleModel destinationModel = (ComponentSampleModel) destination.getSampleModel();
+    DataBufferByte sourceBuffer = (DataBufferByte) source.getDataBuffer();
+    DataBufferByte destinationBuffer = (DataBufferByte) destination.getDataBuffer();
+    int pixelStride = sourceModel.getPixelStride();
+    if (destinationModel.getPixelStride() != pixelStride
+        || sourceModel.getNumBands() != destinationModel.getNumBands()) {
+      return false;
+    }
+
+    int sourceX = region.x - source.getSampleModelTranslateX();
+    int sourceY = region.y - source.getSampleModelTranslateY();
+    int destinationX = region.x - destination.getSampleModelTranslateX();
+    int destinationY = region.y - destination.getSampleModelTranslateY();
+    int sourceStride = sourceModel.getScanlineStride();
+    int destinationStride = destinationModel.getScanlineStride();
+
+    if (pixelStride == 1) {
+      // Each logical band uses its configured bank and offset.
+      int[] sourceBanks = sourceModel.getBankIndices();
+      int[] destinationBanks = destinationModel.getBankIndices();
+      int[] sourceBandOffsets = sourceModel.getBandOffsets();
+      int[] destinationBandOffsets = destinationModel.getBandOffsets();
+      int[] sourceBufferOffsets = sourceBuffer.getOffsets();
+      int[] destinationBufferOffsets = destinationBuffer.getOffsets();
+      for (int band = 0; band < sourceModel.getNumBands(); band++) {
+        int sourceBank = sourceBanks[band];
+        int destinationBank = destinationBanks[band];
+        byte[] sourceArray = sourceBuffer.getData(sourceBank);
+        byte[] destinationArray = destinationBuffer.getData(destinationBank);
+        int sourceBase = sourceBufferOffsets[sourceBank] + sourceBandOffsets[band];
+        int destinationBase =
+            destinationBufferOffsets[destinationBank] + destinationBandOffsets[band];
+        for (int y = 0; y < region.height; y++) {
+          System.arraycopy(
+              sourceArray,
+              sourceBase + (sourceY + y) * sourceStride + sourceX,
+              destinationArray,
+              destinationBase + (destinationY + y) * destinationStride + destinationX,
+              region.width);
+        }
+      }
+      return true;
+    }
+
+    // Interleaved rows are contiguous only when both sides use identical single-bank packing.
+    int[] bandOffsets = sourceModel.getBandOffsets();
+    if (!Arrays.equals(bandOffsets, destinationModel.getBandOffsets())
+        || sourceBuffer.getNumBanks() != 1
+        || destinationBuffer.getNumBanks() != 1) {
+      return false;
+    }
+    int minOffset = pixelStride;
+    int maxOffset = -1;
+    for (int offset : bandOffsets) {
+      minOffset = Math.min(minOffset, offset);
+      maxOffset = Math.max(maxOffset, offset);
+    }
+    if (minOffset != 0 || maxOffset != pixelStride - 1) {
+      return false;
+    }
+
+    byte[] sourceArray = sourceBuffer.getData();
+    byte[] destinationArray = destinationBuffer.getData();
+    int sourceBase = sourceBuffer.getOffset();
+    int destinationBase = destinationBuffer.getOffset();
+    int length = region.width * pixelStride;
+    for (int y = 0; y < region.height; y++) {
+      System.arraycopy(
+          sourceArray,
+          sourceBase + (sourceY + y) * sourceStride + sourceX * pixelStride,
+          destinationArray,
+          destinationBase + (destinationY + y) * destinationStride + destinationX * pixelStride,
+          length);
+    }
+    return true;
+  }
+}

--- a/common/src/main/java/org/apache/sedona/common/raster/cog/CogWriter.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/cog/CogWriter.java
@@ -20,7 +20,6 @@ package org.apache.sedona.common.raster.cog;
 
 import java.awt.Point;
 import java.awt.Rectangle;
-import java.awt.image.ComponentSampleModel;
 import java.awt.image.DataBuffer;
 import java.awt.image.Raster;
 import java.awt.image.RenderedImage;
@@ -257,23 +256,22 @@ public class CogWriter {
   }
 
   /**
-   * Retile byte-band coverages to the output tile grid before writing (GH-3245).
+   * Rebuild byte-band coverages on the output tile grid before writing (GH-3245).
    *
    * <p>imageio-ext's TIFFDeflater passes {@code (offset, height * scanlineStride)} verbatim to
    * {@link java.util.zip.Deflater#setInput(byte[], int, int)}. For 8-bit images, TIFFImageWriter's
-   * optimized path hands the compressor the raster's backing array directly; when that raster
-   * shares a buffer wider than the output tile (e.g. a JAI overview image with a single 512x512
-   * tile written as 256x256 tiles, or 256x256 tiles carrying a wider scanline stride), the computed
-   * range overruns the array and Deflater throws ArrayIndexOutOfBoundsException. Only byte-band
-   * images take the direct-buffer path, so rewrap them unless the layout is already tight: every
-   * raster the writer reads must start at offset 0 of a tile-sized, tightly-strided buffer. Pixel
-   * data and the written TIFF are unchanged; tiles are materialized one at a time and never cached,
-   * so no second copy of the raster is retained.
+   * optimized path hands the compressor the raster's backing array directly, ignoring both the
+   * layout of that array (a buffer wider than the output tile overruns and throws
+   * ArrayIndexOutOfBoundsException) and the DataBuffer's own offset (a nonzero offset silently
+   * shifts every pixel). Whether a given tile is safe depends on its DataBuffer, which cannot be
+   * verified up front, so every byte-band image is rewrapped unconditionally: the writer only ever
+   * sees freshly materialized tiles backed by tight, zero-offset buffers. Pixel data and the
+   * written TIFF are unchanged; tiles are copied one at a time and never cached, so no second copy
+   * of the raster is retained.
    */
   private static GridCoverage2D alignTileLayoutForByteBands(GridCoverage2D raster, int tileSize) {
     RenderedImage image = raster.getRenderedImage();
-    if (image.getSampleModel().getDataType() != DataBuffer.TYPE_BYTE
-        || hasTightTileLayout(image, tileSize)) {
+    if (image.getSampleModel().getDataType() != DataBuffer.TYPE_BYTE) {
       return raster;
     }
     RenderedImage retiled = new RetilingImage(image, tileSize);
@@ -281,31 +279,17 @@ public class CogWriter {
   }
 
   /**
-   * Whether the image's tiles already match the output tile grid AND are backed by tight,
-   * zero-offset buffers, so the TIFF writer's direct-buffer path cannot overrun. Declared tile
-   * dimensions alone are not enough: a 256x256 tile whose sample model carries a wider scanline
-   * stride (a legal layout for views over larger buffers) still overruns.
-   */
-  private static boolean hasTightTileLayout(RenderedImage image, int tileSize) {
-    if (image.getTileWidth() != tileSize || image.getTileHeight() != tileSize) {
-      return false;
-    }
-    SampleModel sm = image.getSampleModel();
-    if (!(sm instanceof ComponentSampleModel)
-        || sm.getWidth() != tileSize
-        || sm.getHeight() != tileSize) {
-      return false;
-    }
-    ComponentSampleModel csm = (ComponentSampleModel) sm;
-    return csm.getScanlineStride() == tileSize * csm.getPixelStride()
-        && csm.getBandOffsets()[0] == 0;
-  }
-
-  /**
    * A retiling view over a source image: each tile is materialized on demand as a tight,
    * zero-offset raster and is not cached, so writing does not retain a second copy of the raster's
    * pixel data (unlike {@link javax.media.jai.TiledImage}, which holds every realized tile
    * strongly).
+   *
+   * <p>Pixels are copied through SampleModel/DataBuffer accessors, which honor the source
+   * DataBuffer's offset. Raster bulk-copy shortcuts must not be used here: {@code
+   * WritableRaster.setRect} and the getDataElements-based cobbling inside {@code
+   * PlanarImage.getData} read the backing array directly and silently drop a nonzero DataBuffer
+   * offset, corrupting every pixel. For the same reason tiles are read straight from the source
+   * with {@code getTile} rather than through {@code getData}.
    */
   private static final class RetilingImage extends PlanarImage {
     private final RenderedImage source;
@@ -334,10 +318,42 @@ public class CogWriter {
           Raster.createWritableRaster(
               getSampleModel(), new Point(tileXToX(tileX), tileYToY(tileY)));
       Rectangle bounds = tile.getBounds().intersection(getBounds());
-      if (!bounds.isEmpty()) {
-        tile.setRect(source.getData(bounds));
+      if (bounds.isEmpty()) {
+        return tile;
+      }
+      int tw = source.getTileWidth();
+      int th = source.getTileHeight();
+      int minTx = Math.floorDiv(bounds.x - source.getTileGridXOffset(), tw);
+      int maxTx = Math.floorDiv(bounds.x + bounds.width - 1 - source.getTileGridXOffset(), tw);
+      int minTy = Math.floorDiv(bounds.y - source.getTileGridYOffset(), th);
+      int maxTy = Math.floorDiv(bounds.y + bounds.height - 1 - source.getTileGridYOffset(), th);
+      for (int ty = minTy; ty <= maxTy; ty++) {
+        for (int tx = minTx; tx <= maxTx; tx++) {
+          Raster srcTile = source.getTile(tx, ty);
+          Rectangle region = bounds.intersection(srcTile.getBounds());
+          if (!region.isEmpty()) {
+            copyPixels(srcTile, tile, region);
+          }
+        }
       }
       return tile;
+    }
+
+    /** Row-wise copy through SampleModel/DataBuffer accessors; see the class comment for why. */
+    private static void copyPixels(Raster src, WritableRaster dest, Rectangle region) {
+      SampleModel srcSm = src.getSampleModel();
+      SampleModel destSm = dest.getSampleModel();
+      DataBuffer srcDb = src.getDataBuffer();
+      DataBuffer destDb = dest.getDataBuffer();
+      int srcTx = src.getSampleModelTranslateX();
+      int srcTy = src.getSampleModelTranslateY();
+      int destTx = dest.getSampleModelTranslateX();
+      int destTy = dest.getSampleModelTranslateY();
+      int[] row = new int[region.width * srcSm.getNumBands()];
+      for (int y = region.y; y < region.y + region.height; y++) {
+        srcSm.getPixels(region.x - srcTx, y - srcTy, region.width, 1, row, srcDb);
+        destSm.setPixels(region.x - destTx, y - destTy, region.width, 1, row, destDb);
+      }
     }
   }
 

--- a/common/src/main/java/org/apache/sedona/common/raster/cog/CogWriter.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/cog/CogWriter.java
@@ -267,10 +267,11 @@ public class CogWriter {
    * layout of that array (a buffer wider than the output tile overruns and throws
    * ArrayIndexOutOfBoundsException) and the DataBuffer's own offset (a nonzero offset silently
    * shifts every pixel). Whether a given tile is safe depends on its DataBuffer, which cannot be
-   * verified up front, so every byte-band image is rewrapped unconditionally: the writer only ever
-   * sees freshly materialized tiles backed by tight, zero-offset buffers. Pixel data and the
-   * written TIFF are unchanged; tiles are copied one at a time and never cached, so no second copy
-   * of the raster is retained.
+   * verified up front, so every byte-band image is wrapped unconditionally. The wrapper vets each
+   * tile as it is requested: a tile whose concrete raster is already writer-safe passes through
+   * unchanged, and only unsafe tiles are materialized into fresh tiles backed by tight, zero-offset
+   * buffers. Pixel data and the written TIFF are unchanged; materialized tiles are copied one at a
+   * time and never cached, so no second copy of the raster is retained.
    */
   private static GridCoverage2D alignTileLayoutForByteBands(GridCoverage2D raster, int tileSize) {
     RenderedImage image = raster.getRenderedImage();
@@ -298,7 +299,8 @@ public class CogWriter {
    * concrete raster is verifiably safe for the writer (full-size, tight stride, zero buffer offset)
    * is returned as-is, so already well-tiled sources are written without any copy.
    */
-  private static final class RetilingImage extends PlanarImage {
+  // Package-private so tests can assert on tile reuse and copy behavior directly.
+  static final class RetilingImage extends PlanarImage {
     private final RenderedImage source;
     /** Source tile grid coincides with this image's grid, so source tiles can be reused. */
     private final boolean sameTileGrid;
@@ -425,7 +427,7 @@ public class CogWriter {
      * Row-wise System.arraycopy for standard byte component layouts, applying each side's
      * DataBuffer bank offsets explicitly. Returns false when the layout pair is not eligible.
      */
-    private static boolean copyRowsDirectly(Raster src, WritableRaster dest, Rectangle region) {
+    static boolean copyRowsDirectly(Raster src, WritableRaster dest, Rectangle region) {
       if (!(src.getSampleModel() instanceof ComponentSampleModel)
           || !(dest.getSampleModel() instanceof ComponentSampleModel)
           || !(src.getDataBuffer() instanceof DataBufferByte)

--- a/common/src/main/java/org/apache/sedona/common/raster/cog/CogWriter.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/cog/CogWriter.java
@@ -20,7 +20,9 @@ package org.apache.sedona.common.raster.cog;
 
 import java.awt.Point;
 import java.awt.Rectangle;
+import java.awt.image.ComponentSampleModel;
 import java.awt.image.DataBuffer;
+import java.awt.image.DataBufferByte;
 import java.awt.image.Raster;
 import java.awt.image.RenderedImage;
 import java.awt.image.SampleModel;
@@ -29,6 +31,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import javax.imageio.ImageWriteParam;
 import javax.media.jai.ImageLayout;
@@ -284,15 +287,21 @@ public class CogWriter {
    * pixel data (unlike {@link javax.media.jai.TiledImage}, which holds every realized tile
    * strongly).
    *
-   * <p>Pixels are copied through SampleModel/DataBuffer accessors, which honor the source
-   * DataBuffer's offset. Raster bulk-copy shortcuts must not be used here: {@code
+   * <p>Pixels are copied with explicit DataBuffer bank offsets (or through SampleModel/DataBuffer
+   * accessors, which honor them). Raster bulk-copy shortcuts must not be used here: {@code
    * WritableRaster.setRect} and the getDataElements-based cobbling inside {@code
    * PlanarImage.getData} read the backing array directly and silently drop a nonzero DataBuffer
    * offset, corrupting every pixel. For the same reason tiles are read straight from the source
    * with {@code getTile} rather than through {@code getData}.
+   *
+   * <p>When the source's tile grid already coincides with the output grid, each source tile whose
+   * concrete raster is verifiably safe for the writer (full-size, tight stride, zero buffer offset)
+   * is returned as-is, so already well-tiled sources are written without any copy.
    */
   private static final class RetilingImage extends PlanarImage {
     private final RenderedImage source;
+    /** Source tile grid coincides with this image's grid, so source tiles can be reused. */
+    private final boolean sameTileGrid;
 
     RetilingImage(RenderedImage source, int tileSize) {
       super(
@@ -310,10 +319,21 @@ public class CogWriter {
           null,
           null);
       this.source = source;
+      this.sameTileGrid =
+          source.getTileWidth() == tileSize
+              && source.getTileHeight() == tileSize
+              && source.getTileGridXOffset() == source.getMinX()
+              && source.getTileGridYOffset() == source.getMinY();
     }
 
     @Override
     public Raster getTile(int tileX, int tileY) {
+      if (sameTileGrid) {
+        Raster srcTile = source.getTile(tileX, tileY);
+        if (isWriterSafe(srcTile)) {
+          return srcTile;
+        }
+      }
       WritableRaster tile =
           Raster.createWritableRaster(
               getSampleModel(), new Point(tileXToX(tileX), tileYToY(tileY)));
@@ -339,8 +359,53 @@ public class CogWriter {
       return tile;
     }
 
-    /** Row-wise copy through SampleModel/DataBuffer accessors; see the class comment for why. */
+    /**
+     * Whether the writer can consume this concrete tile as-is: a full-size byte component tile
+     * whose samples fill a single-bank, zero-offset buffer exactly, with the pixel's bytes packed
+     * in [0, pixelStride). This must be judged per tile — the DataBuffer offset is a property of
+     * each tile's buffer, not of the image layout.
+     */
+    private boolean isWriterSafe(Raster tile) {
+      int tileSize = getTileWidth();
+      if (tile.getWidth() != tileSize
+          || tile.getHeight() != tileSize
+          || tile.getSampleModelTranslateX() != tile.getMinX()
+          || tile.getSampleModelTranslateY() != tile.getMinY()) {
+        return false;
+      }
+      SampleModel sm = tile.getSampleModel();
+      if (!(sm instanceof ComponentSampleModel)
+          || sm.getWidth() != tileSize
+          || sm.getHeight() != tileSize) {
+        return false;
+      }
+      ComponentSampleModel csm = (ComponentSampleModel) sm;
+      int ps = csm.getPixelStride();
+      if (csm.getScanlineStride() != tileSize * ps) {
+        return false;
+      }
+      int[] bandOffsets = csm.getBandOffsets();
+      int maxOff = 0;
+      for (int off : bandOffsets) {
+        if (off < 0 || off >= ps) {
+          return false;
+        }
+        maxOff = Math.max(maxOff, off);
+      }
+      if (bandOffsets[0] != 0 || maxOff != ps - 1) {
+        return false;
+      }
+      DataBuffer db = tile.getDataBuffer();
+      return db instanceof DataBufferByte && db.getNumBanks() == 1 && db.getOffset() == 0;
+    }
+
+    /** Copy a region between rasters without ever dropping DataBuffer offsets. */
     private static void copyPixels(Raster src, WritableRaster dest, Rectangle region) {
+      if (copyRowsDirectly(src, dest, region)) {
+        return;
+      }
+      // Fallback for layout pairs the bulk path does not cover: per-sample accessors, which
+      // are offset-aware by specification.
       SampleModel srcSm = src.getSampleModel();
       SampleModel destSm = dest.getSampleModel();
       DataBuffer srcDb = src.getDataBuffer();
@@ -354,6 +419,83 @@ public class CogWriter {
         srcSm.getPixels(region.x - srcTx, y - srcTy, region.width, 1, row, srcDb);
         destSm.setPixels(region.x - destTx, y - destTy, region.width, 1, row, destDb);
       }
+    }
+
+    /**
+     * Row-wise System.arraycopy for standard byte component layouts, applying each side's
+     * DataBuffer bank offsets explicitly. Returns false when the layout pair is not eligible.
+     */
+    private static boolean copyRowsDirectly(Raster src, WritableRaster dest, Rectangle region) {
+      if (!(src.getSampleModel() instanceof ComponentSampleModel)
+          || !(dest.getSampleModel() instanceof ComponentSampleModel)
+          || !(src.getDataBuffer() instanceof DataBufferByte)
+          || !(dest.getDataBuffer() instanceof DataBufferByte)) {
+        return false;
+      }
+      ComponentSampleModel srcSm = (ComponentSampleModel) src.getSampleModel();
+      ComponentSampleModel destSm = (ComponentSampleModel) dest.getSampleModel();
+      DataBufferByte srcDb = (DataBufferByte) src.getDataBuffer();
+      DataBufferByte destDb = (DataBufferByte) dest.getDataBuffer();
+      int ps = srcSm.getPixelStride();
+      if (destSm.getPixelStride() != ps || srcSm.getNumBands() != destSm.getNumBands()) {
+        return false;
+      }
+      int srcX = region.x - src.getSampleModelTranslateX();
+      int srcY = region.y - src.getSampleModelTranslateY();
+      int destX = region.x - dest.getSampleModelTranslateX();
+      int destY = region.y - dest.getSampleModelTranslateY();
+      int srcStride = srcSm.getScanlineStride();
+      int destStride = destSm.getScanlineStride();
+      if (ps == 1) {
+        // One byte per band sample: copy each band's rows within its own bank.
+        for (int b = 0; b < srcSm.getNumBands(); b++) {
+          byte[] srcArr = srcDb.getData(srcSm.getBankIndices()[b]);
+          byte[] destArr = destDb.getData(destSm.getBankIndices()[b]);
+          int srcBase = srcDb.getOffsets()[srcSm.getBankIndices()[b]] + srcSm.getBandOffsets()[b];
+          int destBase =
+              destDb.getOffsets()[destSm.getBankIndices()[b]] + destSm.getBandOffsets()[b];
+          for (int y = 0; y < region.height; y++) {
+            System.arraycopy(
+                srcArr,
+                srcBase + (srcY + y) * srcStride + srcX,
+                destArr,
+                destBase + (destY + y) * destStride + destX,
+                region.width);
+          }
+        }
+        return true;
+      }
+      // Interleaved pixels: rows are contiguous byte blocks only when both sides pack the
+      // pixel's bytes identically across [0, pixelStride) in a single bank.
+      int[] bandOffsets = srcSm.getBandOffsets();
+      if (!Arrays.equals(bandOffsets, destSm.getBandOffsets())
+          || srcDb.getNumBanks() != 1
+          || destDb.getNumBanks() != 1) {
+        return false;
+      }
+      int minOff = ps;
+      int maxOff = -1;
+      for (int off : bandOffsets) {
+        minOff = Math.min(minOff, off);
+        maxOff = Math.max(maxOff, off);
+      }
+      if (minOff != 0 || maxOff != ps - 1) {
+        return false;
+      }
+      byte[] srcArr = srcDb.getData();
+      byte[] destArr = destDb.getData();
+      int srcBase = srcDb.getOffset();
+      int destBase = destDb.getOffset();
+      int len = region.width * ps;
+      for (int y = 0; y < region.height; y++) {
+        System.arraycopy(
+            srcArr,
+            srcBase + (srcY + y) * srcStride + srcX * ps,
+            destArr,
+            destBase + (destY + y) * destStride + destX * ps,
+            len);
+      }
+      return true;
     }
   }
 

--- a/common/src/main/java/org/apache/sedona/common/raster/cog/CogWriter.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/cog/CogWriter.java
@@ -18,6 +18,7 @@
  */
 package org.apache.sedona.common.raster.cog;
 
+import java.awt.image.DataBuffer;
 import java.awt.image.RenderedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -29,6 +30,8 @@ import javax.media.jai.Interpolation;
 import javax.media.jai.InterpolationBicubic;
 import javax.media.jai.InterpolationBilinear;
 import javax.media.jai.InterpolationNearest;
+import javax.media.jai.TiledImage;
+import org.apache.sedona.common.utils.RasterUtils;
 import org.geotools.api.coverage.grid.GridCoverageWriter;
 import org.geotools.api.parameter.GeneralParameterValue;
 import org.geotools.api.parameter.ParameterValueGroup;
@@ -247,6 +250,29 @@ public class CogWriter {
   }
 
   /**
+   * Retile byte-band coverages to the output tile grid before writing (GH-3245).
+   *
+   * <p>imageio-ext's TIFFDeflater passes {@code (offset, height * scanlineStride)} verbatim to
+   * {@link java.util.zip.Deflater#setInput(byte[], int, int)}. For 8-bit images, TIFFImageWriter's
+   * optimized path hands the compressor the raster's backing array directly; when that raster is a
+   * child of a source tile wider than the output tile (e.g. a JAI overview image with a single
+   * 512x512 tile written as 256x256 tiles), the computed range overruns the array on the last row
+   * of tiles and Deflater throws ArrayIndexOutOfBoundsException. Only byte-band images take the
+   * direct-buffer path, so retiling them to match the output tile grid guarantees every raster the
+   * writer reads starts at offset 0 of a tile-sized buffer. Pixel data and the written TIFF are
+   * unchanged; the copy happens lazily one tile at a time.
+   */
+  private static GridCoverage2D alignTileLayoutForByteBands(GridCoverage2D raster, int tileSize) {
+    RenderedImage image = raster.getRenderedImage();
+    if (image.getSampleModel().getDataType() != DataBuffer.TYPE_BYTE
+        || (image.getTileWidth() == tileSize && image.getTileHeight() == tileSize)) {
+      return raster;
+    }
+    TiledImage retiled = new TiledImage(image, tileSize, tileSize);
+    return RasterUtils.clone(retiled, raster.getSampleDimensions(), raster, null, true);
+  }
+
+  /**
    * Write a GridCoverage2D as a tiled GeoTIFF byte array using GeoTools.
    *
    * @param raster The input raster
@@ -259,6 +285,7 @@ public class CogWriter {
   private static byte[] writeAsTiledGeoTiff(
       GridCoverage2D raster, String compressionType, double compressionQuality, int tileSize)
       throws IOException {
+    raster = alignTileLayoutForByteBands(raster, tileSize);
 
     try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
       GridCoverageWriter writer = new GeoTiffWriter(out);

--- a/common/src/main/java/org/apache/sedona/common/raster/cog/CogWriter.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/cog/CogWriter.java
@@ -18,19 +18,26 @@
  */
 package org.apache.sedona.common.raster.cog;
 
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.image.ComponentSampleModel;
 import java.awt.image.DataBuffer;
+import java.awt.image.Raster;
 import java.awt.image.RenderedImage;
+import java.awt.image.SampleModel;
+import java.awt.image.WritableRaster;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import javax.imageio.ImageWriteParam;
+import javax.media.jai.ImageLayout;
 import javax.media.jai.Interpolation;
 import javax.media.jai.InterpolationBicubic;
 import javax.media.jai.InterpolationBilinear;
 import javax.media.jai.InterpolationNearest;
-import javax.media.jai.TiledImage;
+import javax.media.jai.PlanarImage;
 import org.apache.sedona.common.utils.RasterUtils;
 import org.geotools.api.coverage.grid.GridCoverageWriter;
 import org.geotools.api.parameter.GeneralParameterValue;
@@ -254,22 +261,84 @@ public class CogWriter {
    *
    * <p>imageio-ext's TIFFDeflater passes {@code (offset, height * scanlineStride)} verbatim to
    * {@link java.util.zip.Deflater#setInput(byte[], int, int)}. For 8-bit images, TIFFImageWriter's
-   * optimized path hands the compressor the raster's backing array directly; when that raster is a
-   * child of a source tile wider than the output tile (e.g. a JAI overview image with a single
-   * 512x512 tile written as 256x256 tiles), the computed range overruns the array on the last row
-   * of tiles and Deflater throws ArrayIndexOutOfBoundsException. Only byte-band images take the
-   * direct-buffer path, so retiling them to match the output tile grid guarantees every raster the
-   * writer reads starts at offset 0 of a tile-sized buffer. Pixel data and the written TIFF are
-   * unchanged; the copy happens lazily one tile at a time.
+   * optimized path hands the compressor the raster's backing array directly; when that raster
+   * shares a buffer wider than the output tile (e.g. a JAI overview image with a single 512x512
+   * tile written as 256x256 tiles, or 256x256 tiles carrying a wider scanline stride), the computed
+   * range overruns the array and Deflater throws ArrayIndexOutOfBoundsException. Only byte-band
+   * images take the direct-buffer path, so rewrap them unless the layout is already tight: every
+   * raster the writer reads must start at offset 0 of a tile-sized, tightly-strided buffer. Pixel
+   * data and the written TIFF are unchanged; tiles are materialized one at a time and never cached,
+   * so no second copy of the raster is retained.
    */
   private static GridCoverage2D alignTileLayoutForByteBands(GridCoverage2D raster, int tileSize) {
     RenderedImage image = raster.getRenderedImage();
     if (image.getSampleModel().getDataType() != DataBuffer.TYPE_BYTE
-        || (image.getTileWidth() == tileSize && image.getTileHeight() == tileSize)) {
+        || hasTightTileLayout(image, tileSize)) {
       return raster;
     }
-    TiledImage retiled = new TiledImage(image, tileSize, tileSize);
+    RenderedImage retiled = new RetilingImage(image, tileSize);
     return RasterUtils.clone(retiled, raster.getSampleDimensions(), raster, null, true);
+  }
+
+  /**
+   * Whether the image's tiles already match the output tile grid AND are backed by tight,
+   * zero-offset buffers, so the TIFF writer's direct-buffer path cannot overrun. Declared tile
+   * dimensions alone are not enough: a 256x256 tile whose sample model carries a wider scanline
+   * stride (a legal layout for views over larger buffers) still overruns.
+   */
+  private static boolean hasTightTileLayout(RenderedImage image, int tileSize) {
+    if (image.getTileWidth() != tileSize || image.getTileHeight() != tileSize) {
+      return false;
+    }
+    SampleModel sm = image.getSampleModel();
+    if (!(sm instanceof ComponentSampleModel)
+        || sm.getWidth() != tileSize
+        || sm.getHeight() != tileSize) {
+      return false;
+    }
+    ComponentSampleModel csm = (ComponentSampleModel) sm;
+    return csm.getScanlineStride() == tileSize * csm.getPixelStride()
+        && csm.getBandOffsets()[0] == 0;
+  }
+
+  /**
+   * A retiling view over a source image: each tile is materialized on demand as a tight,
+   * zero-offset raster and is not cached, so writing does not retain a second copy of the raster's
+   * pixel data (unlike {@link javax.media.jai.TiledImage}, which holds every realized tile
+   * strongly).
+   */
+  private static final class RetilingImage extends PlanarImage {
+    private final RenderedImage source;
+
+    RetilingImage(RenderedImage source, int tileSize) {
+      super(
+          new ImageLayout(
+              source.getMinX(),
+              source.getMinY(),
+              source.getWidth(),
+              source.getHeight(),
+              source.getMinX(),
+              source.getMinY(),
+              tileSize,
+              tileSize,
+              source.getSampleModel().createCompatibleSampleModel(tileSize, tileSize),
+              source.getColorModel()),
+          null,
+          null);
+      this.source = source;
+    }
+
+    @Override
+    public Raster getTile(int tileX, int tileY) {
+      WritableRaster tile =
+          Raster.createWritableRaster(
+              getSampleModel(), new Point(tileXToX(tileX), tileYToY(tileY)));
+      Rectangle bounds = tile.getBounds().intersection(getBounds());
+      if (!bounds.isEmpty()) {
+        tile.setRect(source.getData(bounds));
+      }
+      return tile;
+    }
   }
 
   /**

--- a/common/src/main/java/org/apache/sedona/common/raster/cog/CogWriter.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/cog/CogWriter.java
@@ -18,28 +18,18 @@
  */
 package org.apache.sedona.common.raster.cog;
 
-import java.awt.Point;
-import java.awt.Rectangle;
-import java.awt.image.ComponentSampleModel;
 import java.awt.image.DataBuffer;
-import java.awt.image.DataBufferByte;
-import java.awt.image.Raster;
 import java.awt.image.RenderedImage;
-import java.awt.image.SampleModel;
-import java.awt.image.WritableRaster;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import javax.imageio.ImageWriteParam;
-import javax.media.jai.ImageLayout;
 import javax.media.jai.Interpolation;
 import javax.media.jai.InterpolationBicubic;
 import javax.media.jai.InterpolationBilinear;
 import javax.media.jai.InterpolationNearest;
-import javax.media.jai.PlanarImage;
 import org.apache.sedona.common.utils.RasterUtils;
 import org.geotools.api.coverage.grid.GridCoverageWriter;
 import org.geotools.api.parameter.GeneralParameterValue;
@@ -278,227 +268,8 @@ public class CogWriter {
     if (image.getSampleModel().getDataType() != DataBuffer.TYPE_BYTE) {
       return raster;
     }
-    RenderedImage retiled = new RetilingImage(image, tileSize);
+    RenderedImage retiled = new ByteBandRetilingImage(image, tileSize);
     return RasterUtils.clone(retiled, raster.getSampleDimensions(), raster, null, true);
-  }
-
-  /**
-   * A retiling view over a source image: each tile is materialized on demand as a tight,
-   * zero-offset raster and is not cached, so writing does not retain a second copy of the raster's
-   * pixel data (unlike {@link javax.media.jai.TiledImage}, which holds every realized tile
-   * strongly).
-   *
-   * <p>Pixels are copied with explicit DataBuffer bank offsets (or through SampleModel/DataBuffer
-   * accessors, which honor them). Raster bulk-copy shortcuts must not be used here: {@code
-   * WritableRaster.setRect} and the getDataElements-based cobbling inside {@code
-   * PlanarImage.getData} read the backing array directly and silently drop a nonzero DataBuffer
-   * offset, corrupting every pixel. For the same reason tiles are read straight from the source
-   * with {@code getTile} rather than through {@code getData}.
-   *
-   * <p>When the source's tile grid already coincides with the output grid, each source tile whose
-   * concrete raster is verifiably safe for the writer (full-size, tight stride, zero buffer offset)
-   * is returned as-is, so already well-tiled sources are written without any copy.
-   */
-  // Package-private so tests can assert on tile reuse and copy behavior directly.
-  static final class RetilingImage extends PlanarImage {
-    private final RenderedImage source;
-    /** Source tile grid coincides with this image's grid, so source tiles can be reused. */
-    private final boolean sameTileGrid;
-
-    RetilingImage(RenderedImage source, int tileSize) {
-      super(
-          new ImageLayout(
-              source.getMinX(),
-              source.getMinY(),
-              source.getWidth(),
-              source.getHeight(),
-              source.getMinX(),
-              source.getMinY(),
-              tileSize,
-              tileSize,
-              source.getSampleModel().createCompatibleSampleModel(tileSize, tileSize),
-              source.getColorModel()),
-          null,
-          null);
-      this.source = source;
-      this.sameTileGrid =
-          source.getTileWidth() == tileSize
-              && source.getTileHeight() == tileSize
-              && source.getTileGridXOffset() == source.getMinX()
-              && source.getTileGridYOffset() == source.getMinY();
-    }
-
-    @Override
-    public Raster getTile(int tileX, int tileY) {
-      if (sameTileGrid) {
-        Raster srcTile = source.getTile(tileX, tileY);
-        if (isWriterSafe(srcTile)) {
-          return srcTile;
-        }
-      }
-      WritableRaster tile =
-          Raster.createWritableRaster(
-              getSampleModel(), new Point(tileXToX(tileX), tileYToY(tileY)));
-      Rectangle bounds = tile.getBounds().intersection(getBounds());
-      if (bounds.isEmpty()) {
-        return tile;
-      }
-      int tw = source.getTileWidth();
-      int th = source.getTileHeight();
-      int minTx = Math.floorDiv(bounds.x - source.getTileGridXOffset(), tw);
-      int maxTx = Math.floorDiv(bounds.x + bounds.width - 1 - source.getTileGridXOffset(), tw);
-      int minTy = Math.floorDiv(bounds.y - source.getTileGridYOffset(), th);
-      int maxTy = Math.floorDiv(bounds.y + bounds.height - 1 - source.getTileGridYOffset(), th);
-      for (int ty = minTy; ty <= maxTy; ty++) {
-        for (int tx = minTx; tx <= maxTx; tx++) {
-          Raster srcTile = source.getTile(tx, ty);
-          Rectangle region = bounds.intersection(srcTile.getBounds());
-          if (!region.isEmpty()) {
-            copyPixels(srcTile, tile, region);
-          }
-        }
-      }
-      return tile;
-    }
-
-    /**
-     * Whether the writer can consume this concrete tile as-is: a full-size byte component tile
-     * whose samples fill a single-bank, zero-offset buffer exactly, with the pixel's bytes packed
-     * in [0, pixelStride). This must be judged per tile — the DataBuffer offset is a property of
-     * each tile's buffer, not of the image layout.
-     */
-    private boolean isWriterSafe(Raster tile) {
-      int tileSize = getTileWidth();
-      if (tile.getWidth() != tileSize
-          || tile.getHeight() != tileSize
-          || tile.getSampleModelTranslateX() != tile.getMinX()
-          || tile.getSampleModelTranslateY() != tile.getMinY()) {
-        return false;
-      }
-      SampleModel sm = tile.getSampleModel();
-      if (!(sm instanceof ComponentSampleModel)
-          || sm.getWidth() != tileSize
-          || sm.getHeight() != tileSize) {
-        return false;
-      }
-      ComponentSampleModel csm = (ComponentSampleModel) sm;
-      int ps = csm.getPixelStride();
-      if (csm.getScanlineStride() != tileSize * ps) {
-        return false;
-      }
-      int[] bandOffsets = csm.getBandOffsets();
-      int maxOff = 0;
-      for (int off : bandOffsets) {
-        if (off < 0 || off >= ps) {
-          return false;
-        }
-        maxOff = Math.max(maxOff, off);
-      }
-      if (bandOffsets[0] != 0 || maxOff != ps - 1) {
-        return false;
-      }
-      DataBuffer db = tile.getDataBuffer();
-      return db instanceof DataBufferByte && db.getNumBanks() == 1 && db.getOffset() == 0;
-    }
-
-    /** Copy a region between rasters without ever dropping DataBuffer offsets. */
-    private static void copyPixels(Raster src, WritableRaster dest, Rectangle region) {
-      if (copyRowsDirectly(src, dest, region)) {
-        return;
-      }
-      // Fallback for layout pairs the bulk path does not cover: per-sample accessors, which
-      // are offset-aware by specification.
-      SampleModel srcSm = src.getSampleModel();
-      SampleModel destSm = dest.getSampleModel();
-      DataBuffer srcDb = src.getDataBuffer();
-      DataBuffer destDb = dest.getDataBuffer();
-      int srcTx = src.getSampleModelTranslateX();
-      int srcTy = src.getSampleModelTranslateY();
-      int destTx = dest.getSampleModelTranslateX();
-      int destTy = dest.getSampleModelTranslateY();
-      int[] row = new int[region.width * srcSm.getNumBands()];
-      for (int y = region.y; y < region.y + region.height; y++) {
-        srcSm.getPixels(region.x - srcTx, y - srcTy, region.width, 1, row, srcDb);
-        destSm.setPixels(region.x - destTx, y - destTy, region.width, 1, row, destDb);
-      }
-    }
-
-    /**
-     * Row-wise System.arraycopy for standard byte component layouts, applying each side's
-     * DataBuffer bank offsets explicitly. Returns false when the layout pair is not eligible.
-     */
-    static boolean copyRowsDirectly(Raster src, WritableRaster dest, Rectangle region) {
-      if (!(src.getSampleModel() instanceof ComponentSampleModel)
-          || !(dest.getSampleModel() instanceof ComponentSampleModel)
-          || !(src.getDataBuffer() instanceof DataBufferByte)
-          || !(dest.getDataBuffer() instanceof DataBufferByte)) {
-        return false;
-      }
-      ComponentSampleModel srcSm = (ComponentSampleModel) src.getSampleModel();
-      ComponentSampleModel destSm = (ComponentSampleModel) dest.getSampleModel();
-      DataBufferByte srcDb = (DataBufferByte) src.getDataBuffer();
-      DataBufferByte destDb = (DataBufferByte) dest.getDataBuffer();
-      int ps = srcSm.getPixelStride();
-      if (destSm.getPixelStride() != ps || srcSm.getNumBands() != destSm.getNumBands()) {
-        return false;
-      }
-      int srcX = region.x - src.getSampleModelTranslateX();
-      int srcY = region.y - src.getSampleModelTranslateY();
-      int destX = region.x - dest.getSampleModelTranslateX();
-      int destY = region.y - dest.getSampleModelTranslateY();
-      int srcStride = srcSm.getScanlineStride();
-      int destStride = destSm.getScanlineStride();
-      if (ps == 1) {
-        // One byte per band sample: copy each band's rows within its own bank.
-        for (int b = 0; b < srcSm.getNumBands(); b++) {
-          byte[] srcArr = srcDb.getData(srcSm.getBankIndices()[b]);
-          byte[] destArr = destDb.getData(destSm.getBankIndices()[b]);
-          int srcBase = srcDb.getOffsets()[srcSm.getBankIndices()[b]] + srcSm.getBandOffsets()[b];
-          int destBase =
-              destDb.getOffsets()[destSm.getBankIndices()[b]] + destSm.getBandOffsets()[b];
-          for (int y = 0; y < region.height; y++) {
-            System.arraycopy(
-                srcArr,
-                srcBase + (srcY + y) * srcStride + srcX,
-                destArr,
-                destBase + (destY + y) * destStride + destX,
-                region.width);
-          }
-        }
-        return true;
-      }
-      // Interleaved pixels: rows are contiguous byte blocks only when both sides pack the
-      // pixel's bytes identically across [0, pixelStride) in a single bank.
-      int[] bandOffsets = srcSm.getBandOffsets();
-      if (!Arrays.equals(bandOffsets, destSm.getBandOffsets())
-          || srcDb.getNumBanks() != 1
-          || destDb.getNumBanks() != 1) {
-        return false;
-      }
-      int minOff = ps;
-      int maxOff = -1;
-      for (int off : bandOffsets) {
-        minOff = Math.min(minOff, off);
-        maxOff = Math.max(maxOff, off);
-      }
-      if (minOff != 0 || maxOff != ps - 1) {
-        return false;
-      }
-      byte[] srcArr = srcDb.getData();
-      byte[] destArr = destDb.getData();
-      int srcBase = srcDb.getOffset();
-      int destBase = destDb.getOffset();
-      int len = region.width * ps;
-      for (int y = 0; y < region.height; y++) {
-        System.arraycopy(
-            srcArr,
-            srcBase + (srcY + y) * srcStride + srcX * ps,
-            destArr,
-            destBase + (destY + y) * destStride + destX * ps,
-            len);
-      }
-      return true;
-    }
   }
 
   /**

--- a/common/src/test/java/org/apache/sedona/common/raster/cog/ByteBandRetilingImageTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/cog/ByteBandRetilingImageTest.java
@@ -1,0 +1,405 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.common.raster.cog;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.image.ColorModel;
+import java.awt.image.ComponentSampleModel;
+import java.awt.image.DataBuffer;
+import java.awt.image.DataBufferByte;
+import java.awt.image.MultiPixelPackedSampleModel;
+import java.awt.image.PixelInterleavedSampleModel;
+import java.awt.image.Raster;
+import java.awt.image.SampleModel;
+import java.awt.image.WritableRaster;
+import java.util.Arrays;
+import javax.media.jai.ImageLayout;
+import javax.media.jai.PlanarImage;
+import javax.media.jai.TiledImage;
+import org.junit.Test;
+
+public class ByteBandRetilingImageTest {
+
+  @Test
+  public void alignedWriterSafeTilesAreReturnedByIdentity() {
+    SampleModel grayModel =
+        new PixelInterleavedSampleModel(DataBuffer.TYPE_BYTE, 32, 32, 1, 32, new int[] {0});
+    TiledImage graySource = tiledImage(64, 64, grayModel);
+    ByteBandRetilingImage grayView = new ByteBandRetilingImage(graySource, 32);
+    assertSame(graySource.getTile(0, 0), grayView.getTile(0, 0));
+    assertSame(graySource.getTile(1, 1), grayView.getTile(1, 1));
+
+    SampleModel rgbModel =
+        new PixelInterleavedSampleModel(
+            DataBuffer.TYPE_BYTE, 32, 32, 3, 32 * 3, new int[] {0, 1, 2});
+    TiledImage rgbSource = tiledImage(64, 64, rgbModel);
+    ByteBandRetilingImage rgbView = new ByteBandRetilingImage(rgbSource, 32);
+    assertSame(rgbSource.getTile(0, 1), rgbView.getTile(0, 1));
+  }
+
+  @Test
+  public void nonCanonicalAlignedTilesAreMaterialized() {
+    int tileSize = 32;
+    SampleModel paddedPixelModel =
+        new PixelInterleavedSampleModel(
+            DataBuffer.TYPE_BYTE, tileSize, tileSize, 4, tileSize * 4, new int[] {0, 1, 2});
+    DataBufferByte paddedPixelBuffer =
+        new DataBufferByte(new byte[tileSize * tileSize * 4], tileSize * tileSize * 4);
+    WritableRaster paddedPixelRaster =
+        Raster.createWritableRaster(paddedPixelModel, paddedPixelBuffer, null);
+    fillPattern(paddedPixelRaster);
+    CountingSingleTileImage paddedPixelSource =
+        new CountingSingleTileImage(
+            paddedPixelRaster, PlanarImage.createColorModel(paddedPixelModel));
+
+    Raster normalizedPaddedPixel =
+        new ByteBandRetilingImage(paddedPixelSource, tileSize).getTile(0, 0);
+
+    assertNotSame(paddedPixelRaster, normalizedPaddedPixel);
+    assertPattern(normalizedPaddedPixel);
+
+    SampleModel reorderedBandModel =
+        new PixelInterleavedSampleModel(
+            DataBuffer.TYPE_BYTE, tileSize, tileSize, 3, tileSize * 3, new int[] {0, 2, 1});
+    WritableRaster reorderedBandRaster = Raster.createWritableRaster(reorderedBandModel, null);
+    fillPattern(reorderedBandRaster);
+    CountingSingleTileImage reorderedBandSource =
+        new CountingSingleTileImage(
+            reorderedBandRaster, PlanarImage.createColorModel(reorderedBandModel));
+
+    Raster normalizedReorderedBand =
+        new ByteBandRetilingImage(reorderedBandSource, tileSize).getTile(0, 0);
+
+    assertNotSame(reorderedBandRaster, normalizedReorderedBand);
+    assertPattern(normalizedReorderedBand);
+  }
+
+  @Test
+  public void unsafeTilesAreMaterializedOnEveryRequest() {
+    SampleModel wideModel =
+        new PixelInterleavedSampleModel(DataBuffer.TYPE_BYTE, 32, 32, 1, 64, new int[] {0});
+    WritableRaster wideRaster = Raster.createWritableRaster(wideModel, null);
+    fillPattern(wideRaster);
+    CountingSingleTileImage source =
+        new CountingSingleTileImage(wideRaster, PlanarImage.createColorModel(wideModel));
+    ByteBandRetilingImage view = new ByteBandRetilingImage(source, 32);
+
+    Raster first = view.getTile(0, 0);
+    Raster second = view.getTile(0, 0);
+
+    assertNotSame(wideRaster, first);
+    assertNotSame(first, second);
+    assertEquals(2, source.getTileRequestCount());
+    assertEquals(32, ((ComponentSampleModel) first.getSampleModel()).getScanlineStride());
+    assertEquals(0, first.getDataBuffer().getOffset());
+    assertPattern(first);
+    assertPattern(second);
+  }
+
+  @Test
+  public void offsetBackedRgbTileIsMaterializedWithoutPixelShift() {
+    int width = 32;
+    int height = 32;
+    SampleModel model =
+        new PixelInterleavedSampleModel(
+            DataBuffer.TYPE_BYTE, width, height, 3, width * 3, new int[] {0, 1, 2});
+    int dataSize = width * height * 3;
+    DataBufferByte buffer = new DataBufferByte(new byte[17 + dataSize], dataSize, 17);
+    WritableRaster offsetRaster = Raster.createWritableRaster(model, buffer, null);
+    fillPattern(offsetRaster);
+    CountingSingleTileImage source =
+        new CountingSingleTileImage(offsetRaster, PlanarImage.createColorModel(model));
+
+    Raster normalized = new ByteBandRetilingImage(source, width).getTile(0, 0);
+
+    assertNotSame(offsetRaster, normalized);
+    assertEquals(0, normalized.getDataBuffer().getOffset());
+    assertEquals(1, source.getTileRequestCount());
+    assertPattern(normalized);
+  }
+
+  @Test
+  public void interleavedBulkCopyHonorsBufferOffsetsAndPadding() {
+    int width = 7;
+    int height = 5;
+    Point origin = new Point(10, -7);
+    PixelInterleavedSampleModel sourceModel =
+        new PixelInterleavedSampleModel(
+            DataBuffer.TYPE_BYTE, width, height, 3, 26, new int[] {0, 1, 2});
+    PixelInterleavedSampleModel destinationModel =
+        new PixelInterleavedSampleModel(
+            DataBuffer.TYPE_BYTE, width, height, 3, 29, new int[] {0, 1, 2});
+    DataBufferByte sourceBuffer = offsetBuffer(13, requiredSize(sourceModel));
+    DataBufferByte destinationBuffer = offsetBuffer(19, requiredSize(destinationModel));
+    Arrays.fill(destinationBuffer.getData(), (byte) 0xff);
+    WritableRaster source = Raster.createWritableRaster(sourceModel, sourceBuffer, origin);
+    WritableRaster destination =
+        Raster.createWritableRaster(destinationModel, destinationBuffer, origin);
+    fillPattern(source);
+    Rectangle region = new Rectangle(12, -6, 3, 3);
+
+    assertTrue(ByteBandRetilingImage.copyRowsDirectly(source, destination, region));
+
+    assertRegionCopied(source, destination, region, 0xff);
+  }
+
+  @Test
+  public void perBandBulkCopyHonorsBankMappingsAndOffsets() {
+    int width = 7;
+    int height = 5;
+    Point origin = new Point(10, -7);
+    ComponentSampleModel sourceModel =
+        new ComponentSampleModel(
+            DataBuffer.TYPE_BYTE, width, height, 1, 11, new int[] {2, 0, 1}, new int[] {3, 5, 7});
+    ComponentSampleModel destinationModel =
+        new ComponentSampleModel(
+            DataBuffer.TYPE_BYTE, width, height, 1, 13, new int[] {1, 2, 0}, new int[] {9, 4, 6});
+    DataBufferByte sourceBuffer = bankedBuffer(new int[] {11, 13, 17});
+    DataBufferByte destinationBuffer = bankedBuffer(new int[] {19, 23, 29});
+    for (byte[] bank : destinationBuffer.getBankData()) {
+      Arrays.fill(bank, (byte) 0xff);
+    }
+    WritableRaster source = Raster.createWritableRaster(sourceModel, sourceBuffer, origin);
+    WritableRaster destination =
+        Raster.createWritableRaster(destinationModel, destinationBuffer, origin);
+    fillPattern(source);
+    Rectangle region = new Rectangle(11, -5, 4, 2);
+
+    assertTrue(ByteBandRetilingImage.copyRowsDirectly(source, destination, region));
+
+    assertRegionCopied(source, destination, region, 0xff);
+  }
+
+  @Test
+  public void incompatibleInterleavedPackingIsRejected() {
+    int width = 8;
+    int height = 4;
+    SampleModel sourceModel =
+        new PixelInterleavedSampleModel(
+            DataBuffer.TYPE_BYTE, width, height, 3, width * 3, new int[] {0, 1, 2});
+    WritableRaster source = Raster.createWritableRaster(sourceModel, null);
+    fillPattern(source);
+    Rectangle region = new Rectangle(0, 0, width, height);
+
+    SampleModel widerPixelModel =
+        new PixelInterleavedSampleModel(
+            DataBuffer.TYPE_BYTE, width, height, 4, width * 4, new int[] {0, 1, 2});
+    WritableRaster widerPixelDestination = Raster.createWritableRaster(widerPixelModel, null);
+    fillValue(widerPixelDestination, 0xff);
+    assertFalse(ByteBandRetilingImage.copyRowsDirectly(source, widerPixelDestination, region));
+    assertValue(widerPixelDestination, 0xff);
+
+    SampleModel reorderedModel =
+        new PixelInterleavedSampleModel(
+            DataBuffer.TYPE_BYTE, width, height, 3, width * 3, new int[] {2, 1, 0});
+    WritableRaster reorderedDestination = Raster.createWritableRaster(reorderedModel, null);
+    fillValue(reorderedDestination, 0xff);
+    assertFalse(ByteBandRetilingImage.copyRowsDirectly(source, reorderedDestination, region));
+    assertValue(reorderedDestination, 0xff);
+  }
+
+  @Test
+  public void packedByteTilesUseTheAccessorFallback() {
+    int width = 32;
+    int height = 32;
+    SampleModel packedModel =
+        new MultiPixelPackedSampleModel(DataBuffer.TYPE_BYTE, width, height, 1);
+    WritableRaster sourceRaster = Raster.createWritableRaster(packedModel, null);
+    for (int y = 0; y < height; y++) {
+      for (int x = 0; x < width; x++) {
+        sourceRaster.setSample(x, y, 0, (x + y) & 1);
+      }
+    }
+    CountingSingleTileImage source =
+        new CountingSingleTileImage(sourceRaster, PlanarImage.createColorModel(packedModel));
+
+    Raster normalized = new ByteBandRetilingImage(source, width).getTile(0, 0);
+
+    assertNotSame(sourceRaster, normalized);
+    assertEquals(1, source.getTileRequestCount());
+    for (int y = 0; y < height; y++) {
+      for (int x = 0; x < width; x++) {
+        assertEquals(sourceRaster.getSample(x, y, 0), normalized.getSample(x, y, 0));
+      }
+    }
+  }
+
+  @Test
+  public void translatedCrossGridTilesCopyPixelsAndZeroPadEdges() {
+    int minX = -37;
+    int minY = 23;
+    int width = 91;
+    int height = 73;
+    SampleModel sourceModel =
+        new PixelInterleavedSampleModel(DataBuffer.TYPE_BYTE, 17, 13, 1, 17, new int[] {0});
+    TiledImage source =
+        new TiledImage(
+            minX,
+            minY,
+            width,
+            height,
+            -29,
+            30,
+            sourceModel,
+            PlanarImage.createColorModel(sourceModel));
+    WritableRaster sourceValues =
+        Raster.createWritableRaster(
+            sourceModel.createCompatibleSampleModel(width, height), new Point(minX, minY));
+    fillPattern(sourceValues);
+    source.setData(sourceValues);
+    ByteBandRetilingImage view = new ByteBandRetilingImage(source, 32);
+    Rectangle imageBounds = new Rectangle(minX, minY, width, height);
+
+    for (int tileY = view.getMinTileY(); tileY <= view.getMaxTileY(); tileY++) {
+      for (int tileX = view.getMinTileX(); tileX <= view.getMaxTileX(); tileX++) {
+        Raster tile = view.getTile(tileX, tileY);
+        assertEquals(view.tileXToX(tileX), tile.getMinX());
+        assertEquals(view.tileYToY(tileY), tile.getMinY());
+        assertEquals(32, tile.getWidth());
+        assertEquals(32, tile.getHeight());
+        Rectangle tileBounds = tile.getBounds();
+        for (int y = tileBounds.y; y < tileBounds.y + tileBounds.height; y++) {
+          for (int x = tileBounds.x; x < tileBounds.x + tileBounds.width; x++) {
+            int expected = imageBounds.contains(x, y) ? expected(x, y, 0) : 0;
+            assertEquals(expected, tile.getSample(x, y, 0));
+          }
+        }
+      }
+    }
+  }
+
+  private static TiledImage tiledImage(int width, int height, SampleModel model) {
+    return new TiledImage(0, 0, width, height, 0, 0, model, PlanarImage.createColorModel(model));
+  }
+
+  private static DataBufferByte offsetBuffer(int offset, int size) {
+    return new DataBufferByte(new byte[offset + size], size, offset);
+  }
+
+  private static DataBufferByte bankedBuffer(int[] offsets) {
+    byte[][] banks = new byte[offsets.length][256];
+    return new DataBufferByte(banks, 200, offsets);
+  }
+
+  private static int requiredSize(ComponentSampleModel model) {
+    return model.getScanlineStride() * (model.getHeight() - 1)
+        + model.getPixelStride() * model.getWidth();
+  }
+
+  private static void fillPattern(WritableRaster raster) {
+    Rectangle bounds = raster.getBounds();
+    for (int y = bounds.y; y < bounds.y + bounds.height; y++) {
+      for (int x = bounds.x; x < bounds.x + bounds.width; x++) {
+        for (int band = 0; band < raster.getNumBands(); band++) {
+          raster.setSample(x, y, band, expected(x, y, band));
+        }
+      }
+    }
+  }
+
+  private static void fillValue(WritableRaster raster, int value) {
+    Rectangle bounds = raster.getBounds();
+    for (int y = bounds.y; y < bounds.y + bounds.height; y++) {
+      for (int x = bounds.x; x < bounds.x + bounds.width; x++) {
+        for (int band = 0; band < raster.getNumBands(); band++) {
+          raster.setSample(x, y, band, value);
+        }
+      }
+    }
+  }
+
+  private static void assertPattern(Raster raster) {
+    Rectangle bounds = raster.getBounds();
+    for (int y = bounds.y; y < bounds.y + bounds.height; y++) {
+      for (int x = bounds.x; x < bounds.x + bounds.width; x++) {
+        for (int band = 0; band < raster.getNumBands(); band++) {
+          assertEquals(expected(x, y, band), raster.getSample(x, y, band));
+        }
+      }
+    }
+  }
+
+  private static void assertValue(Raster raster, int expected) {
+    Rectangle bounds = raster.getBounds();
+    for (int y = bounds.y; y < bounds.y + bounds.height; y++) {
+      for (int x = bounds.x; x < bounds.x + bounds.width; x++) {
+        for (int band = 0; band < raster.getNumBands(); band++) {
+          assertEquals(expected, raster.getSample(x, y, band));
+        }
+      }
+    }
+  }
+
+  private static void assertRegionCopied(
+      Raster source, Raster destination, Rectangle region, int outsideValue) {
+    Rectangle bounds = destination.getBounds();
+    for (int y = bounds.y; y < bounds.y + bounds.height; y++) {
+      for (int x = bounds.x; x < bounds.x + bounds.width; x++) {
+        for (int band = 0; band < destination.getNumBands(); band++) {
+          int expected = region.contains(x, y) ? source.getSample(x, y, band) : outsideValue;
+          assertEquals(expected, destination.getSample(x, y, band));
+        }
+      }
+    }
+  }
+
+  private static int expected(int x, int y, int band) {
+    return Math.floorMod(31 * x + 17 * y + 73 * band, 251);
+  }
+
+  private static final class CountingSingleTileImage extends PlanarImage {
+    private final Raster tile;
+    private int tileRequestCount;
+
+    CountingSingleTileImage(Raster tile, ColorModel colorModel) {
+      super(
+          new ImageLayout(
+              tile.getMinX(),
+              tile.getMinY(),
+              tile.getWidth(),
+              tile.getHeight(),
+              tile.getMinX(),
+              tile.getMinY(),
+              tile.getWidth(),
+              tile.getHeight(),
+              tile.getSampleModel(),
+              colorModel),
+          null,
+          null);
+      this.tile = tile;
+    }
+
+    @Override
+    public Raster getTile(int tileX, int tileY) {
+      tileRequestCount++;
+      return tile;
+    }
+
+    int getTileRequestCount() {
+      return tileRequestCount;
+    }
+  }
+}

--- a/common/src/test/java/org/apache/sedona/common/raster/cog/CogWriterTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/cog/CogWriterTest.java
@@ -20,9 +20,7 @@ package org.apache.sedona.common.raster.cog;
 
 import static org.junit.Assert.*;
 
-import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
-import java.awt.image.ComponentSampleModel;
 import java.awt.image.DataBuffer;
 import java.awt.image.DataBufferByte;
 import java.awt.image.PixelInterleavedSampleModel;
@@ -379,8 +377,8 @@ public class CogWriterTest {
   public void testWriteOffsetBufferByteSourceAsCog() throws Exception {
     // GH-3245: a DataBufferByte may carry a positive array offset independent of the
     // sample model. The TIFF writer's direct-buffer path and Raster bulk-copy shortcuts
-    // (WritableRaster.setRect) both ignore it, silently shifting every pixel, so the
-    // per-tile copy must go through SampleModel/DataBuffer accessors.
+    // (WritableRaster.setRect) both ignore it, silently shifting every pixel, so tile
+    // normalization must apply the buffer offset explicitly.
     int size = 256;
     SampleModel sm =
         new PixelInterleavedSampleModel(DataBuffer.TYPE_BYTE, size, size, 1, size, new int[] {0});
@@ -443,94 +441,6 @@ public class CogWriterTest {
     GridCoverage2D readBack = RasterConstructors.fromGeoTiff(cogBytes);
     double[] readValues = MapAlgebra.bandAsArray(readBack, 1);
     assertArrayEquals(bandValues, readValues, 0.0);
-  }
-
-  @Test
-  public void testRetilingViewReturnsEligibleTilesByIdentity() {
-    // GH-3245 performance guard: a source already tiled on the output grid with tight,
-    // zero-offset tiles must be passed through without copying — assert tile identity,
-    // not timing.
-    SampleModel tightSm =
-        new PixelInterleavedSampleModel(DataBuffer.TYPE_BYTE, 256, 256, 1, 256, new int[] {0});
-    TiledImage tightSrc =
-        new TiledImage(0, 0, 512, 512, 0, 0, tightSm, PlanarImage.createColorModel(tightSm));
-    CogWriter.RetilingImage tightView = new CogWriter.RetilingImage(tightSrc, 256);
-    assertSame(tightSrc.getTile(0, 0), tightView.getTile(0, 0));
-    assertSame(tightSrc.getTile(1, 1), tightView.getTile(1, 1));
-
-    // Wide-stride tiles are NOT eligible: they must be materialized into tight rasters.
-    SampleModel wideSm =
-        new PixelInterleavedSampleModel(DataBuffer.TYPE_BYTE, 256, 256, 1, 512, new int[] {0});
-    TiledImage wideSrc =
-        new TiledImage(0, 0, 512, 512, 0, 0, wideSm, PlanarImage.createColorModel(wideSm));
-    CogWriter.RetilingImage wideView = new CogWriter.RetilingImage(wideSrc, 256);
-    Raster wideTile = wideView.getTile(0, 0);
-    assertNotSame(wideSrc.getTile(0, 0), wideTile);
-    assertEquals(256, ((ComponentSampleModel) wideTile.getSampleModel()).getScanlineStride());
-
-    // Offset-backed tiles are NOT eligible: the copy must land in a zero-offset buffer
-    // with the pixel values preserved.
-    SampleModel sm =
-        new PixelInterleavedSampleModel(DataBuffer.TYPE_BYTE, 256, 256, 1, 256, new int[] {0});
-    DataBufferByte db = new DataBufferByte(new byte[17 + 256 * 256], 256 * 256, 17);
-    WritableRaster offsetRaster = Raster.createWritableRaster(sm, db, null);
-    offsetRaster.setSample(1, 0, 0, 42);
-    SingleTileImage offsetSrc = new SingleTileImage(offsetRaster, PlanarImage.createColorModel(sm));
-    CogWriter.RetilingImage offsetView = new CogWriter.RetilingImage(offsetSrc, 256);
-    Raster offsetTile = offsetView.getTile(0, 0);
-    assertNotSame(offsetRaster, offsetTile);
-    assertEquals(0, offsetTile.getDataBuffer().getOffset());
-    assertEquals(42, offsetTile.getSample(1, 0, 0));
-  }
-
-  @Test
-  public void testBulkRowCopyEligibility() {
-    // GH-3245 performance guard: standard byte layouts must take the arraycopy path
-    // (return true) with correct values, including offset-backed sources; ineligible
-    // pairs must be refused so the accessor fallback handles them.
-    Rectangle region = new Rectangle(0, 0, 64, 64);
-
-    // Grayscale pair, offset-backed source: eligible, and the offset must be applied.
-    SampleModel graySm =
-        new PixelInterleavedSampleModel(DataBuffer.TYPE_BYTE, 64, 64, 1, 64, new int[] {0});
-    DataBufferByte offsetDb = new DataBufferByte(new byte[17 + 64 * 64], 64 * 64, 17);
-    WritableRaster offsetSrc = Raster.createWritableRaster(graySm, offsetDb, null);
-    for (int y = 0; y < 64; y++) {
-      for (int x = 0; x < 64; x++) {
-        offsetSrc.setSample(x, y, 0, (x + 2 * y) % 251);
-      }
-    }
-    WritableRaster grayDest =
-        Raster.createWritableRaster(graySm.createCompatibleSampleModel(64, 64), null);
-    assertTrue(CogWriter.RetilingImage.copyRowsDirectly(offsetSrc, grayDest, region));
-    for (int y = 0; y < 64; y++) {
-      for (int x = 0; x < 64; x++) {
-        assertEquals((x + 2 * y) % 251, grayDest.getSample(x, y, 0));
-      }
-    }
-
-    // Interleaved RGB pair with identical packing: eligible.
-    SampleModel rgbSm =
-        new PixelInterleavedSampleModel(
-            DataBuffer.TYPE_BYTE, 64, 64, 3, 64 * 3, new int[] {0, 1, 2});
-    WritableRaster rgbSrc = Raster.createWritableRaster(rgbSm, null);
-    rgbSrc.setSample(5, 7, 2, 99);
-    WritableRaster rgbDest =
-        Raster.createWritableRaster(rgbSm.createCompatibleSampleModel(64, 64), null);
-    assertTrue(CogWriter.RetilingImage.copyRowsDirectly(rgbSrc, rgbDest, region));
-    assertEquals(99, rgbDest.getSample(5, 7, 2));
-
-    // Banded multiband pair: eligible via the per-band path.
-    WritableRaster bandedSrc = Raster.createBandedRaster(DataBuffer.TYPE_BYTE, 64, 64, 3, null);
-    bandedSrc.setSample(9, 11, 1, 77);
-    WritableRaster bandedDest =
-        Raster.createWritableRaster(
-            bandedSrc.getSampleModel().createCompatibleSampleModel(64, 64), null);
-    assertTrue(CogWriter.RetilingImage.copyRowsDirectly(bandedSrc, bandedDest, region));
-    assertEquals(77, bandedDest.getSample(9, 11, 1));
-
-    // Mismatched pixel strides: not eligible, must fall back to accessors.
-    assertFalse(CogWriter.RetilingImage.copyRowsDirectly(rgbSrc, grayDest, region));
   }
 
   /** Minimal image exposing a single tile as-is, preserving its DataBuffer offset. */

--- a/common/src/test/java/org/apache/sedona/common/raster/cog/CogWriterTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/cog/CogWriterTest.java
@@ -21,7 +21,13 @@ package org.apache.sedona.common.raster.cog;
 import static org.junit.Assert.*;
 
 import java.awt.image.BufferedImage;
+import java.awt.image.DataBuffer;
+import java.awt.image.PixelInterleavedSampleModel;
+import java.awt.image.Raster;
+import java.awt.image.SampleModel;
+import java.awt.image.WritableRaster;
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -30,13 +36,20 @@ import java.nio.file.Paths;
 import java.util.List;
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
+import javax.imageio.ImageWriteParam;
 import javax.imageio.stream.ImageInputStream;
+import javax.media.jai.PlanarImage;
 import javax.media.jai.TiledImage;
 import org.apache.sedona.common.raster.MapAlgebra;
 import org.apache.sedona.common.raster.RasterConstructors;
 import org.apache.sedona.common.raster.RasterOutputs;
 import org.apache.sedona.common.utils.RasterUtils;
+import org.geotools.api.parameter.GeneralParameterValue;
+import org.geotools.api.parameter.ParameterValueGroup;
 import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.coverage.grid.io.AbstractGridFormat;
+import org.geotools.gce.geotiff.GeoTiffWriteParams;
+import org.geotools.gce.geotiff.GeoTiffWriter;
 import org.junit.Test;
 
 public class CogWriterTest {
@@ -278,8 +291,9 @@ public class CogWriterTest {
 
   @Test
   public void testWriteTiledByteSourceAsCog() throws IOException {
-    // GH-3245 variant on the full-res path: a byte-band coverage whose own image is
-    // tiled wider than the COG tile size fed the same overrunning encode path.
+    // GH-3245 variant on the full-res path: a byte-band coverage read from a 512-tiled
+    // GeoTIFF is backed by a deferred JAI image with 512x512 tiles, which fed the same
+    // overrunning encode path when written as 256x256 COG tiles.
     int size = 1024;
     double[] bandValues = new double[size * size];
     for (int i = 0; i < bandValues.length; i++) {
@@ -288,17 +302,69 @@ public class CogWriterTest {
     GridCoverage2D raster =
         RasterConstructors.makeNonEmptyRaster(
             1, "b", size, size, 0, 0, 1, -1, 0, 0, 4326, new double[][] {bandValues});
-    TiledImage tiled = new TiledImage(raster.getRenderedImage(), 512, 512);
-    GridCoverage2D tiledRaster =
-        RasterUtils.clone(tiled, raster.getSampleDimensions(), raster, null, false);
+    GridCoverage2D fromFile = RasterConstructors.fromGeoTiff(writeTiledGeoTiff(raster, 512));
+    // The regression relies on the reader exposing the file's 512px tile grid
+    assertEquals(512, fromFile.getRenderedImage().getTileWidth());
+    assertEquals(512, fromFile.getRenderedImage().getTileHeight());
 
-    byte[] cogBytes =
-        RasterOutputs.asCloudOptimizedGeoTiff(
-            tiledRaster, CogOptions.builder().overviewCount(0).build());
+    byte[] cogBytes = RasterOutputs.asCloudOptimizedGeoTiff(fromFile, CogOptions.defaults());
 
     GridCoverage2D readBack = RasterConstructors.fromGeoTiff(cogBytes);
     double[] readValues = MapAlgebra.bandAsArray(readBack, 1);
     assertArrayEquals(bandValues, readValues, 0.0);
+  }
+
+  @Test
+  public void testWriteWideStrideByteSourceAsCog() throws Exception {
+    // GH-3245: matching 256x256 tile dimensions are not sufficient — a legal byte sample
+    // model whose scanline stride is wider than the tile still overruns in the writer's
+    // direct-buffer path, so the layout check must validate the backing stride too.
+    int size = 512;
+    SampleModel wideSm =
+        new PixelInterleavedSampleModel(DataBuffer.TYPE_BYTE, 256, 256, 1, 512, new int[] {0});
+    TiledImage image =
+        new TiledImage(0, 0, size, size, 0, 0, wideSm, PlanarImage.createColorModel(wideSm));
+    double[] bandValues = new double[size * size];
+    WritableRaster values =
+        Raster.createWritableRaster(wideSm.createCompatibleSampleModel(size, size), null);
+    for (int y = 0; y < size; y++) {
+      for (int x = 0; x < size; x++) {
+        bandValues[y * size + x] = (x + y) % 256;
+        values.setSample(x, y, 0, (x + y) % 256);
+      }
+    }
+    image.setData(values);
+
+    GridCoverage2D reference =
+        RasterConstructors.makeEmptyRaster(
+            1, "B", size, size, 10.0, 52.0, 0.001, -0.001, 0, 0, 4326);
+    GridCoverage2D coverage =
+        RasterUtils.clone(image, reference.getSampleDimensions(), reference, null, false);
+
+    byte[] cogBytes = RasterOutputs.asCloudOptimizedGeoTiff(coverage, CogOptions.defaults());
+
+    GridCoverage2D readBack = RasterConstructors.fromGeoTiff(cogBytes);
+    double[] readValues = MapAlgebra.bandAsArray(readBack, 1);
+    assertArrayEquals(bandValues, readValues, 0.0);
+  }
+
+  private static byte[] writeTiledGeoTiff(GridCoverage2D raster, int tileSize) throws IOException {
+    try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+      GeoTiffWriter writer = new GeoTiffWriter(out);
+      try {
+        ParameterValueGroup params = writer.getFormat().getWriteParameters();
+        GeoTiffWriteParams wp = new GeoTiffWriteParams();
+        wp.setTilingMode(ImageWriteParam.MODE_EXPLICIT);
+        wp.setTiling(tileSize, tileSize);
+        params
+            .parameter(AbstractGridFormat.GEOTOOLS_WRITE_PARAMS.getName().toString())
+            .setValue(wp);
+        writer.write(raster, params.values().toArray(new GeneralParameterValue[0]));
+      } finally {
+        writer.dispose();
+      }
+      return out.toByteArray();
+    }
   }
 
   @Test

--- a/common/src/test/java/org/apache/sedona/common/raster/cog/CogWriterTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/cog/CogWriterTest.java
@@ -351,6 +351,29 @@ public class CogWriterTest {
   }
 
   @Test
+  public void testWriteAlignedTiledByteSourceAsCog() throws Exception {
+    // GH-3245: a source already tiled on the output grid with tight, zero-offset buffers
+    // takes the zero-copy fast path — verify that path produces identical pixels too.
+    int size = 1024;
+    double[] bandValues = new double[size * size];
+    for (int i = 0; i < bandValues.length; i++) {
+      bandValues[i] = (i * 13) % 256;
+    }
+    GridCoverage2D raster =
+        RasterConstructors.makeNonEmptyRaster(
+            1, "b", size, size, 0, 0, 1, -1, 0, 0, 4326, new double[][] {bandValues});
+    GridCoverage2D fromFile = RasterConstructors.fromGeoTiff(writeTiledGeoTiff(raster, 256));
+    assertEquals(256, fromFile.getRenderedImage().getTileWidth());
+    assertEquals(256, fromFile.getRenderedImage().getTileHeight());
+
+    byte[] cogBytes = RasterOutputs.asCloudOptimizedGeoTiff(fromFile, CogOptions.defaults());
+
+    GridCoverage2D readBack = RasterConstructors.fromGeoTiff(cogBytes);
+    double[] readValues = MapAlgebra.bandAsArray(readBack, 1);
+    assertArrayEquals(bandValues, readValues, 0.0);
+  }
+
+  @Test
   public void testWriteOffsetBufferByteSourceAsCog() throws Exception {
     // GH-3245: a DataBufferByte may carry a positive array offset independent of the
     // sample model. The TIFF writer's direct-buffer path and Raster bulk-copy shortcuts
@@ -448,7 +471,7 @@ public class CogWriterTest {
     }
   }
 
-  private static byte[] writeTiledGeoTiff(GridCoverage2D raster, int tileSize) throws IOException {
+  static byte[] writeTiledGeoTiff(GridCoverage2D raster, int tileSize) throws IOException {
     try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
       GeoTiffWriter writer = new GeoTiffWriter(out);
       try {

--- a/common/src/test/java/org/apache/sedona/common/raster/cog/CogWriterTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/cog/CogWriterTest.java
@@ -20,15 +20,22 @@ package org.apache.sedona.common.raster.cog;
 
 import static org.junit.Assert.*;
 
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
+import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
+import javax.imageio.stream.ImageInputStream;
+import javax.media.jai.TiledImage;
 import org.apache.sedona.common.raster.MapAlgebra;
 import org.apache.sedona.common.raster.RasterConstructors;
 import org.apache.sedona.common.raster.RasterOutputs;
+import org.apache.sedona.common.utils.RasterUtils;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.junit.Test;
 
@@ -204,6 +211,94 @@ public class CogWriterTest {
     assertNotNull(readBack);
     assertEquals(width, readBack.getRenderedImage().getWidth());
     assertEquals(height, readBack.getRenderedImage().getHeight());
+  }
+
+  @Test
+  public void testWriteByteBandRasterAsCog() throws IOException {
+    // GH-3245: byte-band rasters whose overview images end up JAI-tiled wider than the
+    // COG tile size crashed with ArrayIndexOutOfBoundsException in Deflater.setInput
+    // (e.g. any 1024x1024 byte raster with default options).
+    for (int size : new int[] {512, 768, 1024, 1536}) {
+      double[] bandValues = new double[size * size];
+      for (int y = 0; y < size; y++) {
+        for (int x = 0; x < size; x++) {
+          bandValues[y * size + x] = 10 + 20 * (x * 4 / size);
+        }
+      }
+      GridCoverage2D raster =
+          RasterConstructors.makeNonEmptyRaster(
+              1, "b", size, size, 0, 0, 1, -1, 0, 0, 4326, new double[][] {bandValues});
+
+      byte[] cogBytes = RasterOutputs.asCloudOptimizedGeoTiff(raster, CogOptions.defaults());
+
+      GridCoverage2D readBack = RasterConstructors.fromGeoTiff(cogBytes);
+      assertEquals(size, readBack.getRenderedImage().getWidth());
+      assertEquals(size, readBack.getRenderedImage().getHeight());
+      double[] readValues = MapAlgebra.bandAsArray(readBack, 1);
+      assertArrayEquals("size=" + size, bandValues, readValues, 0.0);
+    }
+  }
+
+  @Test
+  public void testByteBandOverviewPixelsSurviveCogEncoding() throws IOException {
+    // GH-3245: besides the overrun crash, the shared-buffer encode path compressed the
+    // inter-row slack of wide source tiles, corrupting overview pixels. Verify overview
+    // content, not just the full-res IFD.
+    int size = 1024;
+    double[] bandValues = new double[size * size];
+    for (int y = 0; y < size; y++) {
+      for (int x = 0; x < size; x++) {
+        // Four constant 256px-wide column bands: 10, 30, 50, 70
+        bandValues[y * size + x] = 10 + 20 * (x / 256);
+      }
+    }
+    GridCoverage2D raster =
+        RasterConstructors.makeNonEmptyRaster(
+            1, "b", size, size, 0, 0, 1, -1, 0, 0, 4326, new double[][] {bandValues});
+
+    byte[] cogBytes = RasterOutputs.asCloudOptimizedGeoTiff(raster, CogOptions.defaults());
+
+    ImageReader reader = ImageIO.getImageReadersByFormatName("tiff").next();
+    try (ImageInputStream iis =
+        ImageIO.createImageInputStream(new ByteArrayInputStream(cogBytes))) {
+      reader.setInput(iis);
+      assertTrue("Expected at least one overview", reader.getNumImages(true) >= 2);
+      BufferedImage overview = reader.read(1);
+      assertEquals(512, overview.getWidth());
+      assertEquals(512, overview.getHeight());
+      // Sample the middle of each column band, away from the downsampled boundaries
+      assertEquals(10, overview.getRaster().getSample(64, 256, 0));
+      assertEquals(30, overview.getRaster().getSample(192, 256, 0));
+      assertEquals(50, overview.getRaster().getSample(320, 256, 0));
+      assertEquals(70, overview.getRaster().getSample(448, 256, 0));
+    } finally {
+      reader.dispose();
+    }
+  }
+
+  @Test
+  public void testWriteTiledByteSourceAsCog() throws IOException {
+    // GH-3245 variant on the full-res path: a byte-band coverage whose own image is
+    // tiled wider than the COG tile size fed the same overrunning encode path.
+    int size = 1024;
+    double[] bandValues = new double[size * size];
+    for (int i = 0; i < bandValues.length; i++) {
+      bandValues[i] = (i * 7) % 256;
+    }
+    GridCoverage2D raster =
+        RasterConstructors.makeNonEmptyRaster(
+            1, "b", size, size, 0, 0, 1, -1, 0, 0, 4326, new double[][] {bandValues});
+    TiledImage tiled = new TiledImage(raster.getRenderedImage(), 512, 512);
+    GridCoverage2D tiledRaster =
+        RasterUtils.clone(tiled, raster.getSampleDimensions(), raster, null, false);
+
+    byte[] cogBytes =
+        RasterOutputs.asCloudOptimizedGeoTiff(
+            tiledRaster, CogOptions.builder().overviewCount(0).build());
+
+    GridCoverage2D readBack = RasterConstructors.fromGeoTiff(cogBytes);
+    double[] readValues = MapAlgebra.bandAsArray(readBack, 1);
+    assertArrayEquals(bandValues, readValues, 0.0);
   }
 
   @Test

--- a/common/src/test/java/org/apache/sedona/common/raster/cog/CogWriterTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/cog/CogWriterTest.java
@@ -20,7 +20,9 @@ package org.apache.sedona.common.raster.cog;
 
 import static org.junit.Assert.*;
 
+import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
+import java.awt.image.ComponentSampleModel;
 import java.awt.image.DataBuffer;
 import java.awt.image.DataBufferByte;
 import java.awt.image.PixelInterleavedSampleModel;
@@ -441,6 +443,94 @@ public class CogWriterTest {
     GridCoverage2D readBack = RasterConstructors.fromGeoTiff(cogBytes);
     double[] readValues = MapAlgebra.bandAsArray(readBack, 1);
     assertArrayEquals(bandValues, readValues, 0.0);
+  }
+
+  @Test
+  public void testRetilingViewReturnsEligibleTilesByIdentity() {
+    // GH-3245 performance guard: a source already tiled on the output grid with tight,
+    // zero-offset tiles must be passed through without copying — assert tile identity,
+    // not timing.
+    SampleModel tightSm =
+        new PixelInterleavedSampleModel(DataBuffer.TYPE_BYTE, 256, 256, 1, 256, new int[] {0});
+    TiledImage tightSrc =
+        new TiledImage(0, 0, 512, 512, 0, 0, tightSm, PlanarImage.createColorModel(tightSm));
+    CogWriter.RetilingImage tightView = new CogWriter.RetilingImage(tightSrc, 256);
+    assertSame(tightSrc.getTile(0, 0), tightView.getTile(0, 0));
+    assertSame(tightSrc.getTile(1, 1), tightView.getTile(1, 1));
+
+    // Wide-stride tiles are NOT eligible: they must be materialized into tight rasters.
+    SampleModel wideSm =
+        new PixelInterleavedSampleModel(DataBuffer.TYPE_BYTE, 256, 256, 1, 512, new int[] {0});
+    TiledImage wideSrc =
+        new TiledImage(0, 0, 512, 512, 0, 0, wideSm, PlanarImage.createColorModel(wideSm));
+    CogWriter.RetilingImage wideView = new CogWriter.RetilingImage(wideSrc, 256);
+    Raster wideTile = wideView.getTile(0, 0);
+    assertNotSame(wideSrc.getTile(0, 0), wideTile);
+    assertEquals(256, ((ComponentSampleModel) wideTile.getSampleModel()).getScanlineStride());
+
+    // Offset-backed tiles are NOT eligible: the copy must land in a zero-offset buffer
+    // with the pixel values preserved.
+    SampleModel sm =
+        new PixelInterleavedSampleModel(DataBuffer.TYPE_BYTE, 256, 256, 1, 256, new int[] {0});
+    DataBufferByte db = new DataBufferByte(new byte[17 + 256 * 256], 256 * 256, 17);
+    WritableRaster offsetRaster = Raster.createWritableRaster(sm, db, null);
+    offsetRaster.setSample(1, 0, 0, 42);
+    SingleTileImage offsetSrc = new SingleTileImage(offsetRaster, PlanarImage.createColorModel(sm));
+    CogWriter.RetilingImage offsetView = new CogWriter.RetilingImage(offsetSrc, 256);
+    Raster offsetTile = offsetView.getTile(0, 0);
+    assertNotSame(offsetRaster, offsetTile);
+    assertEquals(0, offsetTile.getDataBuffer().getOffset());
+    assertEquals(42, offsetTile.getSample(1, 0, 0));
+  }
+
+  @Test
+  public void testBulkRowCopyEligibility() {
+    // GH-3245 performance guard: standard byte layouts must take the arraycopy path
+    // (return true) with correct values, including offset-backed sources; ineligible
+    // pairs must be refused so the accessor fallback handles them.
+    Rectangle region = new Rectangle(0, 0, 64, 64);
+
+    // Grayscale pair, offset-backed source: eligible, and the offset must be applied.
+    SampleModel graySm =
+        new PixelInterleavedSampleModel(DataBuffer.TYPE_BYTE, 64, 64, 1, 64, new int[] {0});
+    DataBufferByte offsetDb = new DataBufferByte(new byte[17 + 64 * 64], 64 * 64, 17);
+    WritableRaster offsetSrc = Raster.createWritableRaster(graySm, offsetDb, null);
+    for (int y = 0; y < 64; y++) {
+      for (int x = 0; x < 64; x++) {
+        offsetSrc.setSample(x, y, 0, (x + 2 * y) % 251);
+      }
+    }
+    WritableRaster grayDest =
+        Raster.createWritableRaster(graySm.createCompatibleSampleModel(64, 64), null);
+    assertTrue(CogWriter.RetilingImage.copyRowsDirectly(offsetSrc, grayDest, region));
+    for (int y = 0; y < 64; y++) {
+      for (int x = 0; x < 64; x++) {
+        assertEquals((x + 2 * y) % 251, grayDest.getSample(x, y, 0));
+      }
+    }
+
+    // Interleaved RGB pair with identical packing: eligible.
+    SampleModel rgbSm =
+        new PixelInterleavedSampleModel(
+            DataBuffer.TYPE_BYTE, 64, 64, 3, 64 * 3, new int[] {0, 1, 2});
+    WritableRaster rgbSrc = Raster.createWritableRaster(rgbSm, null);
+    rgbSrc.setSample(5, 7, 2, 99);
+    WritableRaster rgbDest =
+        Raster.createWritableRaster(rgbSm.createCompatibleSampleModel(64, 64), null);
+    assertTrue(CogWriter.RetilingImage.copyRowsDirectly(rgbSrc, rgbDest, region));
+    assertEquals(99, rgbDest.getSample(5, 7, 2));
+
+    // Banded multiband pair: eligible via the per-band path.
+    WritableRaster bandedSrc = Raster.createBandedRaster(DataBuffer.TYPE_BYTE, 64, 64, 3, null);
+    bandedSrc.setSample(9, 11, 1, 77);
+    WritableRaster bandedDest =
+        Raster.createWritableRaster(
+            bandedSrc.getSampleModel().createCompatibleSampleModel(64, 64), null);
+    assertTrue(CogWriter.RetilingImage.copyRowsDirectly(bandedSrc, bandedDest, region));
+    assertEquals(77, bandedDest.getSample(9, 11, 1));
+
+    // Mismatched pixel strides: not eligible, must fall back to accessors.
+    assertFalse(CogWriter.RetilingImage.copyRowsDirectly(rgbSrc, grayDest, region));
   }
 
   /** Minimal image exposing a single tile as-is, preserving its DataBuffer offset. */

--- a/common/src/test/java/org/apache/sedona/common/raster/cog/CogWriterTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/cog/CogWriterTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.*;
 
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBuffer;
+import java.awt.image.DataBufferByte;
 import java.awt.image.PixelInterleavedSampleModel;
 import java.awt.image.Raster;
 import java.awt.image.SampleModel;
@@ -38,6 +39,7 @@ import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
 import javax.imageio.ImageWriteParam;
 import javax.imageio.stream.ImageInputStream;
+import javax.media.jai.ImageLayout;
 import javax.media.jai.PlanarImage;
 import javax.media.jai.TiledImage;
 import org.apache.sedona.common.raster.MapAlgebra;
@@ -318,7 +320,7 @@ public class CogWriterTest {
   public void testWriteWideStrideByteSourceAsCog() throws Exception {
     // GH-3245: matching 256x256 tile dimensions are not sufficient — a legal byte sample
     // model whose scanline stride is wider than the tile still overruns in the writer's
-    // direct-buffer path, so the layout check must validate the backing stride too.
+    // direct-buffer path, so byte sources are normalized regardless of declared layout.
     int size = 512;
     SampleModel wideSm =
         new PixelInterleavedSampleModel(DataBuffer.TYPE_BYTE, 256, 256, 1, 512, new int[] {0});
@@ -346,6 +348,104 @@ public class CogWriterTest {
     GridCoverage2D readBack = RasterConstructors.fromGeoTiff(cogBytes);
     double[] readValues = MapAlgebra.bandAsArray(readBack, 1);
     assertArrayEquals(bandValues, readValues, 0.0);
+  }
+
+  @Test
+  public void testWriteOffsetBufferByteSourceAsCog() throws Exception {
+    // GH-3245: a DataBufferByte may carry a positive array offset independent of the
+    // sample model. The TIFF writer's direct-buffer path and Raster bulk-copy shortcuts
+    // (WritableRaster.setRect) both ignore it, silently shifting every pixel, so the
+    // per-tile copy must go through SampleModel/DataBuffer accessors.
+    int size = 256;
+    SampleModel sm =
+        new PixelInterleavedSampleModel(DataBuffer.TYPE_BYTE, size, size, 1, size, new int[] {0});
+    DataBufferByte db = new DataBufferByte(new byte[17 + size * size], size * size, 17);
+    WritableRaster raster = Raster.createWritableRaster(sm, db, null);
+    double[] bandValues = new double[size * size];
+    for (int y = 0; y < size; y++) {
+      for (int x = 0; x < size; x++) {
+        int v = (x + 3 * y) % 251;
+        bandValues[y * size + x] = v;
+        raster.setSample(x, y, 0, v);
+      }
+    }
+    // Fixture sanity: the pattern really lives at the offset positions
+    assertEquals(1, db.getData()[18] & 0xff);
+    assertEquals(1, raster.getSample(1, 0, 0));
+
+    SingleTileImage image = new SingleTileImage(raster, PlanarImage.createColorModel(sm));
+    GridCoverage2D reference =
+        RasterConstructors.makeEmptyRaster(
+            1, "B", size, size, 10.0, 52.0, 0.001, -0.001, 0, 0, 4326);
+    GridCoverage2D coverage =
+        RasterUtils.clone(image, reference.getSampleDimensions(), reference, null, false);
+
+    byte[] cogBytes = RasterOutputs.asCloudOptimizedGeoTiff(coverage, CogOptions.defaults());
+
+    GridCoverage2D readBack = RasterConstructors.fromGeoTiff(cogBytes);
+    double[] readValues = MapAlgebra.bandAsArray(readBack, 1);
+    assertArrayEquals(bandValues, readValues, 0.0);
+  }
+
+  @Test
+  public void testWriteSmallTiledByteSourceAsCog() throws Exception {
+    // GH-3245: source tiles smaller than the COG tile size make each output tile span
+    // several source tiles, exercising the multi-tile copy in the retiling view.
+    int size = 512;
+    SampleModel sm =
+        new PixelInterleavedSampleModel(DataBuffer.TYPE_BYTE, 128, 128, 1, 128, new int[] {0});
+    TiledImage image = new TiledImage(0, 0, size, size, 0, 0, sm, PlanarImage.createColorModel(sm));
+    double[] bandValues = new double[size * size];
+    WritableRaster values =
+        Raster.createWritableRaster(sm.createCompatibleSampleModel(size, size), null);
+    for (int y = 0; y < size; y++) {
+      for (int x = 0; x < size; x++) {
+        int v = (3 * x + y) % 253;
+        bandValues[y * size + x] = v;
+        values.setSample(x, y, 0, v);
+      }
+    }
+    image.setData(values);
+
+    GridCoverage2D reference =
+        RasterConstructors.makeEmptyRaster(
+            1, "B", size, size, 10.0, 52.0, 0.001, -0.001, 0, 0, 4326);
+    GridCoverage2D coverage =
+        RasterUtils.clone(image, reference.getSampleDimensions(), reference, null, false);
+
+    byte[] cogBytes = RasterOutputs.asCloudOptimizedGeoTiff(coverage, CogOptions.defaults());
+
+    GridCoverage2D readBack = RasterConstructors.fromGeoTiff(cogBytes);
+    double[] readValues = MapAlgebra.bandAsArray(readBack, 1);
+    assertArrayEquals(bandValues, readValues, 0.0);
+  }
+
+  /** Minimal image exposing a single tile as-is, preserving its DataBuffer offset. */
+  private static final class SingleTileImage extends PlanarImage {
+    private final WritableRaster raster;
+
+    SingleTileImage(WritableRaster raster, java.awt.image.ColorModel cm) {
+      super(
+          new ImageLayout(
+              0,
+              0,
+              raster.getWidth(),
+              raster.getHeight(),
+              0,
+              0,
+              raster.getWidth(),
+              raster.getHeight(),
+              raster.getSampleModel(),
+              cm),
+          null,
+          null);
+      this.raster = raster;
+    }
+
+    @Override
+    public Raster getTile(int tileX, int tileY) {
+      return raster;
+    }
   }
 
   private static byte[] writeTiledGeoTiff(GridCoverage2D raster, int tileSize) throws IOException {


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #3245

## What changes were proposed in this PR?

`RS_AsCOG` threw `ArrayIndexOutOfBoundsException` in `Deflater.setInput` for byte-band rasters whose backing scanline was wider than the requested COG tile. imageio-ext's optimized 8-bit TIFF path passes a tile's backing byte array, sample-model offset, and full scanline stride directly to the compressor; for these layouts, the computed range can overrun the array. The same path could also compress inter-row padding and silently corrupt pixels.

A separate variant occurred when a legal `DataBufferByte` used a positive array offset. The TIFF path and common raster bulk-copy shortcuts ignore that buffer offset, shifting every output pixel even when the declared sample-model layout is otherwise tight.

The fix wraps every byte-band image in a package-private, non-caching `ByteBandRetilingImage` before writing:

- Tiles already aligned to the output grid are returned by identity when their concrete raster is safe for imageio-ext's direct-buffer path.
- Misaligned or unsafe tiles are materialized lazily into fresh, zero-offset output tiles and are not cached, so the writer does not retain a second uncompressed copy of the raster.
- Standard byte component layouts use row-wise array copies with explicit per-bank `DataBuffer` offsets. Other layouts use offset-aware `SampleModel` accessors.
- Source tiles are read directly with `getTile`; bulk raster operations that can drop buffer offsets are avoided.

Pixel values, georeferencing, sample dimensions, and metadata are preserved. Non-byte images are unchanged, and the extracted implementation does not add a public API.

## How was this patch tested?

End-to-end COG regression coverage verifies:

- byte rasters at 512, 768, 1024, and 1536 pixels, including overview pixels;
- 512-tiled input written to the default 256-pixel COG grid;
- already aligned 256-tiled input;
- legal wide-scanline and positive-`DataBufferByte`-offset sources;
- source tiles smaller than the output tile.

Focused `ByteBandRetilingImageTest` coverage verifies:

- safe grayscale and RGB tiles are reused by identity;
- aligned but non-canonical pixel/band packing is normalized instead of reused;
- unsafe tiles are materialized per request and never cached;
- offset-backed RGB, padded interleaved, permuted-bank, and packed-byte layouts preserve every logical sample;
- incompatible pixel strides and band packing are rejected by the bulk-copy path;
- translated, nonaligned source grids with negative tile indices and partial edges copy and pad correctly.

The full `common` module suite passed 1,299 tests before the final two test-only boundary fixtures were added; the final focused COG suite passes 41 tests with 0 failures. The 512-tiled regression also passes in a 64 MB test JVM.

## Did this PR include necessary documentation updates?

- No public documentation changes are needed because this patch does not change a public API.
