### PR TITLE
[GH-3260] GeoPandas: Implement distributed geom_equals_identical

### DIFF
--- a/docs/setup/release-notes.md
+++ b/docs/setup/release-notes.md
@@ -48,6 +48,7 @@
 #### GeoPandas API
 
 * [<a href='https://github.com/apache/sedona/issues/3257'>GH-3257</a>] - Implement distributed GeoSeries and GeoDataFrame Hilbert-distance spatial ordering
+* [<a href='https://github.com/apache/sedona/issues/3260'>GH-3260</a>] - Implement distributed GeoSeries and GeoDataFrame identical-geometry equality
 
 ## Sedona 1.9.1
 

--- a/docs/tutorial/geopandas-api.md
+++ b/docs/tutorial/geopandas-api.md
@@ -316,6 +316,8 @@ The GeoPandas API for Apache Sedona implements the most commonly used GeoSeries 
 - `buffer()` - Geometric buffering
 - `distance()` - Distance calculations
 - `intersects()`, `contains()`, `within()` - Spatial predicates
+- `geom_equals_identical()` - Exact structural equality across every stored
+  coordinate dimension
 - `sindex` - Spatial indexing (limited functionality)
 
 ### CRS Operations

--- a/docs/tutorial/geopandas-api.zh.md
+++ b/docs/tutorial/geopandas-api.zh.md
@@ -316,6 +316,7 @@ Apache Sedona 的 GeoPandas API 已实现最常用的 GeoSeries 与 GeoDataFrame
 - `buffer()` —— 几何缓冲
 - `distance()` —— 距离计算
 - `intersects()`、`contains()`、`within()` —— 空间谓词
+- `geom_equals_identical()` —— 对所有已存储坐标维度执行精确的结构相等性比较
 - `sindex` —— 空间索引（功能有限）
 
 ### CRS 操作

--- a/python/sedona/spark/geopandas/base.py
+++ b/python/sedona/spark/geopandas/base.py
@@ -3425,6 +3425,77 @@ class GeoFrame(metaclass=ABCMeta):
             "geom_equals_exact", self, other, tolerance, align
         )
 
+    def geom_equals_identical(self, other, align=None):
+        """Return ``True`` for geometries that are identical to aligned
+        `other`, otherwise ``False``.
+
+        Equality is structural: geometry types, component ordering, ring
+        ordering, vertex ordering, coordinate dimensions, and every ordinate
+        value must match. Unlike :meth:`geom_equals_exact`, this method checks
+        Z and M coordinates and does not accept a tolerance. NaN ordinates in
+        the same position are considered equal.
+
+        The operation works in a 1-to-1 row-wise manner.
+
+        Parameters
+        ----------
+        other : GeoSeries or geometric object
+            The GeoSeries (elementwise) or geometric object to compare to.
+        align : bool | None (default None)
+            If True, automatically align GeoSeries based on their indices.
+            If False, compare values in their existing order. None defaults
+            to True.
+
+        Returns
+        -------
+        Series (bool)
+
+        Examples
+        --------
+        >>> from sedona.spark.geopandas import GeoSeries
+        >>> from shapely.geometry import Point
+        >>> s = GeoSeries(
+        ...     [
+        ...         Point(0, 1.1),
+        ...         Point(0, 1.0),
+        ...         Point(0, 1.2),
+        ...     ]
+        ... )
+        >>> s.geom_equals_identical(Point(0, 1))
+        0    False
+        1     True
+        2    False
+        dtype: bool
+
+        Notes
+        -----
+        This method checks geometries row by row; it does not compare each
+        geometry with every value in `other`.
+
+        As elsewhere in Sedona's GeoPandas compatibility layer, standalone
+        ``LinearRing`` geometries are serialized as ``LineString`` geometries.
+        Consequently, this method cannot distinguish those two standalone
+        input types when their coordinates match.
+
+        Values are compared using the representation stored in Spark. JTS
+        cannot distinguish ordinary XY from declared XYZ when every Z
+        ordinate is NaN, including empty XYZ values and zero-member
+        collections. Shapely inputs with mixed coordinate layouts inside a
+        Polygon or same-type multi-geometry may be normalized to one layout
+        by Python GeometryUDT serialization; JVM-created mixed layouts are
+        rejected when their layouts remain distinguishable in JTS. Use a
+        GeometryCollection when members need independent layouts. Passing
+        Shapely M and ZM objects through GeometryUDT requires Sedona's native
+        geometry serializer with GEOS 3.12 or newer; the pure-Python fallback
+        rejects them instead of silently discarding measures.
+
+        See also
+        --------
+        GeoSeries.geom_equals
+        GeoSeries.geom_equals_exact
+        """
+        return _delegate_to_geometry_column("geom_equals_identical", self, other, align)
+
     def interpolate(self, distance, normalized=False):
         """Return a point at the specified distance along each geometry.
 

--- a/python/sedona/spark/geopandas/geoseries.py
+++ b/python/sedona/spark/geopandas/geoseries.py
@@ -2849,6 +2849,44 @@ class GeoSeries(GeoFrame, pspd.Series):
             align,
         )
 
+    def geom_equals_identical(self, other, align=None) -> pspd.Series:
+        if isinstance(other, BaseGeometry):
+            # JTS's WKB reader loses measure metadata on typed empty values,
+            # while its WKT reader retains the explicit M/ZM layout tags.
+            if other.is_empty:
+                other_wkt = other.wkt
+                if other.geom_type == "LinearRing":
+                    # GeometryUDT stores standalone rings as LineStrings.
+                    other_wkt = other_wkt.replace("LINEARRING", "LINESTRING", 1)
+                other_geometry = stc.ST_GeomFromWKT(F.lit(other_wkt))
+            else:
+                other_geometry = stc.ST_GeomFromWKB(F.lit(other.wkb))
+            spark_expr = stp.ST_EqualsIdentical(
+                self.spark.column,
+                other_geometry,
+            )
+            result = self._boolean_result_preserving_index(
+                F.coalesce(spark_expr, F.lit(False)),
+                self._internal.spark_frame,
+                self._internal.index_spark_columns,
+                self._internal.index_fields,
+                self._internal.index_names,
+            )
+            return _to_bool(result)
+
+        if not isinstance(other, (GeoSeries, GeoDataFrame, PandasOnSparkSeries)):
+            raise TypeError(
+                "'other' must be a GeoSeries, GeoDataFrame, "
+                "pandas-on-Spark Series, or geometry"
+            )
+
+        other_series, extended = self._make_series_of_val(other)
+        align = False if extended else align
+        if isinstance(other_series, GeoSeries):
+            warn_crs_mismatch(self.crs, other_series.crs)
+
+        return self._geom_equals_identical_series(other_series, align)
+
     def interpolate(self, distance, normalized=False) -> "GeoSeries":
         other_series, extended = self._make_series_of_val(distance)
         align = not extended
@@ -3423,6 +3461,25 @@ class GeoSeries(GeoFrame, pspd.Series):
         align: Union[bool, None],
     ) -> pspd.Series:
         """Execute exact equality with GeoPandas-compatible row alignment."""
+        spark_expr = stp.ST_EqualsExact(F.col("L"), F.col("R"), tolerance)
+        return self._boolean_result_with_alignment(other, align, spark_expr)
+
+    def _geom_equals_identical_series(
+        self,
+        other: pspd.Series,
+        align: Union[bool, None],
+    ) -> pspd.Series:
+        """Execute identical equality with GeoPandas-compatible row alignment."""
+        spark_expr = stp.ST_EqualsIdentical(F.col("L"), F.col("R"))
+        return self._boolean_result_with_alignment(other, align, spark_expr)
+
+    def _boolean_result_with_alignment(
+        self,
+        other: pspd.Series,
+        align: Union[bool, None],
+        spark_expr: PySparkColumn,
+    ) -> pspd.Series:
+        """Evaluate a native boolean expression after binary row alignment."""
         (
             aligned_frame,
             result_index_columns,
@@ -3431,18 +3488,18 @@ class GeoSeries(GeoFrame, pspd.Series):
         ) = self._align_binary_geometry_series(
             other,
             align,
-            warning_stacklevel=4,
+            warning_stacklevel=5,
         )
 
-        spark_expr = stp.ST_EqualsExact(F.col("L"), F.col("R"), tolerance)
-        result = self._boolean_result_preserving_index(
-            F.coalesce(spark_expr, F.lit(False)),
-            aligned_frame,
-            [scol_for(aligned_frame, name) for name in result_index_columns],
-            result_index_fields,
-            result_index_names,
+        return _to_bool(
+            self._boolean_result_preserving_index(
+                F.coalesce(spark_expr, F.lit(False)),
+                aligned_frame,
+                [scol_for(aligned_frame, name) for name in result_index_columns],
+                result_index_fields,
+                result_index_names,
+            )
         )
-        return _to_bool(result)
 
     def _align_single_index_series_lazily(
         self,

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -52,6 +52,25 @@ requires_geopandas_shared_paths = pytest.mark.skipif(
     reason=f"Tests require geopandas>=1.0.0, but found v{gpd.__version__}",
 )
 
+requires_geopandas_geom_equals_identical = pytest.mark.skipif(
+    parse_version(gpd.__version__) < parse_version("1.1.0")
+    or parse_version(shapely.__version__) < parse_version("2.1.0"),
+    reason=(
+        "Tests require geopandas>=1.1.0 and shapely>=2.1.0, but found "
+        f"geopandas {gpd.__version__} and shapely {shapely.__version__}"
+    ),
+)
+
+requires_shapely_m_support = pytest.mark.skipif(
+    parse_version(shapely.__version__) < parse_version("2.1.0")
+    or getattr(shapely, "geos_version", (0, 0, 0)) < (3, 12, 0),
+    reason=(
+        "M and ZM geometry tests require shapely>=2.1.0 and GEOS>=3.12.0, "
+        f"but found shapely {shapely.__version__} and GEOS "
+        f"{getattr(shapely, 'geos_version_string', 'unknown')}"
+    ),
+)
+
 
 @pytest.mark.skipif(
     parse_version(shapely.__version__) < parse_version("2.0.0"),
@@ -5977,6 +5996,378 @@ e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3
         s = GeoSeries([Point(0, 0)])
         with pytest.raises(TypeError, match="'other' must be"):
             s.geom_equals_exact(other, tolerance=0)
+
+    @requires_shapely_m_support
+    def test_geom_equals_identical_structure_dimensions_and_nan(self):
+        left_wkts = [
+            "POINT Z (1 2 3)",
+            "POINT Z (1 2 3)",
+            "POINT M (1 2 3)",
+            "POINT M (1 2 3)",
+            "POINT Z (1 2 3)",
+            "POINT ZM (1 2 3 4)",
+            "POINT ZM (1 2 3 4)",
+            "LINESTRING Z (0 0 1, 1 1 NaN)",
+            "LINESTRING Z (0 0 1, 1 1 NaN)",
+            "LINESTRING (0 0, 1 1)",
+            "POLYGON ((0 0, 2 0, 0 2, 0 0))",
+            "GEOMETRYCOLLECTION (POINT (0 0), LINESTRING (0 0, 1 1))",
+            "POINT EMPTY",
+            "POINT EMPTY",
+            None,
+        ]
+        right_wkts = [
+            "POINT Z (1 2 3)",
+            "POINT Z (1 2 4)",
+            "POINT M (1 2 3)",
+            "POINT M (1 2 4)",
+            "POINT M (1 2 3)",
+            "POINT ZM (1 2 3 4)",
+            "POINT ZM (1 2 3 5)",
+            "LINESTRING Z (0 0 1, 1 1 NaN)",
+            "LINESTRING Z (0 0 1, 1 1 2)",
+            "LINESTRING (1 1, 0 0)",
+            "POLYGON ((2 0, 0 2, 0 0, 2 0))",
+            "GEOMETRYCOLLECTION (LINESTRING (0 0, 1 1), POINT (0 0))",
+            "POINT EMPTY",
+            "LINESTRING EMPTY",
+            None,
+        ]
+        index = pd.Index(
+            [
+                "z-same",
+                "z-different",
+                "m-same",
+                "m-different",
+                "z-versus-m",
+                "zm-same",
+                "zm-different",
+                "nan-same",
+                "nan-different",
+                "line-order",
+                "ring-order",
+                "part-order",
+                "empty-same",
+                "empty-type",
+                "missing",
+            ],
+            name="case",
+        )
+        left = GeoSeries(shapely.from_wkt(left_wkts), index=index, name="left")
+        right = GeoSeries(shapely.from_wkt(right_wkts), index=index, name="right")
+
+        result = left.geom_equals_identical(right, align=False)
+
+        self.check_pd_series_equal(
+            result,
+            pd.Series(
+                [
+                    True,
+                    False,
+                    True,
+                    False,
+                    False,
+                    True,
+                    False,
+                    True,
+                    False,
+                    False,
+                    False,
+                    False,
+                    True,
+                    False,
+                    False,
+                ],
+                index=index,
+                dtype=bool,
+            ),
+        )
+        assert result.name is None
+
+    def test_geom_equals_identical_scalar_multiindex_geodataframe_and_plan(self):
+        index = pd.MultiIndex.from_tuples(
+            [("a", 1), ("b", 2), ("c", 3)], names=["group", "row"]
+        )
+        source = GeoSeries(
+            [Point(1, 2, 3), Point(1, 2), None],
+            index=index,
+            name="source",
+        )
+
+        result = source.geom_equals_identical(Point(1, 2, 3))
+        self.check_pd_series_equal(
+            result,
+            pd.Series([True, False, False], index=index, dtype=bool),
+        )
+        assert result.name is None
+
+        if hasattr(result._internal.spark_frame, "_jdf"):
+            plan = (
+                result._internal.spark_frame._jdf.queryExecution()
+                .optimizedPlan()
+                .toString()
+            )
+            assert "BatchEvalPython" not in plan
+            assert "ArrowEvalPython" not in plan
+            assert "PythonUDF" not in plan
+
+        frame_source = GeoSeries(
+            [Point(1, 2, 3), Point(1, 2), None],
+            index=pd.Index(["z", "xy", "missing"], name="kind"),
+        )
+        frame_result = frame_source.to_geoframe().geom_equals_identical(Point(1, 2, 3))
+        self.check_pd_series_equal(
+            frame_result,
+            pd.Series(
+                [True, False, False],
+                index=pd.Index(["z", "xy", "missing"], name="kind"),
+                dtype=bool,
+            ),
+        )
+
+    @requires_shapely_m_support
+    @pytest.mark.parametrize(
+        ("other_wkt", "expected"),
+        [
+            ("POINT M (1 2 3)", [True, False, False, False, False]),
+            ("POINT ZM (1 2 3 4)", [False, False, False, True, False]),
+        ],
+    )
+    def test_geom_equals_identical_scalar_m_and_zm(self, other_wkt, expected):
+        source = GeoSeries(
+            shapely.from_wkt(
+                [
+                    "POINT M (1 2 3)",
+                    "POINT M (1 2 4)",
+                    "POINT Z (1 2 3)",
+                    "POINT ZM (1 2 3 4)",
+                    "POINT ZM (1 2 3 5)",
+                ]
+            )
+        )
+
+        result = source.geom_equals_identical(shapely.from_wkt(other_wkt))
+
+        self.check_pd_series_equal(result, pd.Series(expected, dtype=bool))
+
+    @requires_shapely_m_support
+    @pytest.mark.parametrize(
+        ("dimensional_wkt", "xy_wkt"),
+        [
+            ("POINT M EMPTY", "POINT EMPTY"),
+            ("LINESTRING M EMPTY", "LINESTRING EMPTY"),
+            ("POLYGON M EMPTY", "POLYGON EMPTY"),
+            ("POINT ZM EMPTY", "POINT EMPTY"),
+            ("LINESTRING ZM EMPTY", "LINESTRING EMPTY"),
+            ("POLYGON ZM EMPTY", "POLYGON EMPTY"),
+            ("LINEARRING M EMPTY", "LINEARRING EMPTY"),
+            ("LINEARRING ZM EMPTY", "LINEARRING EMPTY"),
+        ],
+    )
+    def test_geom_equals_identical_scalar_typed_empty(self, dimensional_wkt, xy_wkt):
+        source = GeoSeries(shapely.from_wkt([dimensional_wkt, xy_wkt]))
+
+        result = source.geom_equals_identical(shapely.from_wkt(dimensional_wkt))
+
+        self.check_pd_series_equal(result, pd.Series([True, False], dtype=bool))
+
+    def test_geom_equals_identical_alignment_and_duplicates(self):
+        left_geometries = [Point(0, 0), Point(1, 1), None]
+        right_geometries = [Point(1, 1), Point(0, 0), Point(9, 9)]
+        left = GeoSeries(left_geometries, index=["a", "b", "c"])
+        right = GeoSeries(right_geometries, index=["b", "a", "d"])
+
+        with pytest.warns(
+            UserWarning,
+            match="The indices of the left and right GeoSeries' are not equal",
+        ) as warning_records:
+            default_result = left.geom_equals_identical(right)
+        alignment_warning = next(
+            warning
+            for warning in warning_records
+            if "indices of the left and right GeoSeries" in str(warning.message)
+        )
+        assert alignment_warning.filename == __file__
+        aligned_expected = pd.Series(
+            [True, True, False, False],
+            index=pd.Index(["a", "b", "c", "d"]),
+            dtype=bool,
+        )
+        self.check_pd_series_equal(default_result, aligned_expected)
+        self.check_pd_series_equal(
+            left.geom_equals_identical(right, align=True), aligned_expected
+        )
+        self.check_pd_series_equal(
+            left.geom_equals_identical(right, align=False),
+            pd.Series(
+                [False, False, False],
+                index=pd.Index(["a", "b", "c"]),
+                dtype=bool,
+            ),
+        )
+
+        duplicate_index = ["a", "a"]
+        equal_duplicate_result = GeoSeries(
+            [Point(0, 0), Point(1, 1)], index=duplicate_index
+        ).geom_equals_identical(
+            GeoSeries([Point(0, 0), Point(9, 9)], index=duplicate_index),
+            align=True,
+        )
+        self.check_pd_series_equal(
+            equal_duplicate_result,
+            pd.Series([True, False], index=duplicate_index, dtype=bool),
+        )
+
+        unequal_duplicate_result = GeoSeries(
+            [Point(0, 0), Point(1, 1), Point(2, 2)], index=["a", "a", "c"]
+        ).geom_equals_identical(
+            GeoSeries(
+                [Point(0, 0), Point(9, 9), Point(3, 3)],
+                index=["a", "a", "b"],
+            ),
+            align=True,
+        )
+        self.check_pd_series_equal(
+            unequal_duplicate_result,
+            pd.Series(
+                [True, False, False, False, False, False],
+                index=pd.Index(["a", "a", "a", "a", "b", "c"]),
+                dtype=bool,
+            ),
+        )
+
+        with pytest.raises(
+            ValueError,
+            match=r"Lengths of inputs do not match\. Left: 1, Right: 2",
+        ):
+            GeoSeries([Point(0, 0)]).geom_equals_identical(
+                GeoSeries([Point(0, 0), Point(1, 1)]), align=False
+            )
+
+    def test_geom_equals_identical_preserves_named_multiindex(self):
+        left_index = pd.MultiIndex.from_tuples(
+            [("b", 2), ("a", 1)], names=["group", "row"]
+        )
+        right_index = pd.MultiIndex.from_tuples(
+            [("a", 1), ("c", 3)], names=["group", "row"]
+        )
+        result = GeoSeries(
+            [Point(2, 2), Point(1, 1)], index=left_index
+        ).geom_equals_identical(
+            GeoSeries([Point(1, 1), Point(3, 3)], index=right_index),
+            align=True,
+        )
+        self.check_pd_series_equal(
+            result,
+            pd.Series(
+                [True, False, False],
+                index=pd.MultiIndex.from_tuples(
+                    [("a", 1), ("b", 2), ("c", 3)], names=["group", "row"]
+                ),
+                dtype=bool,
+            ),
+        )
+
+        unrelated_left = pd.MultiIndex.from_tuples(
+            [("a", 1)], names=["left_group", "left_row"]
+        )
+        unrelated_right = pd.MultiIndex.from_tuples(
+            [("b", 2)], names=["right_group", "right_row"]
+        )
+        with pytest.raises(
+            ValueError, match="cannot join with no overlapping index names"
+        ):
+            GeoSeries([Point(0, 0)], index=unrelated_left).geom_equals_identical(
+                GeoSeries([Point(0, 0)], index=unrelated_right), align=True
+            )
+
+    @requires_geopandas_geom_equals_identical
+    def test_geom_equals_identical_warns_on_crs_mismatch(self):
+        left = GeoSeries([Point(0, 0)], crs="EPSG:4326")
+        right = GeoSeries([Point(0, 0)], crs="EPSG:3857")
+
+        with pytest.warns(UserWarning, match="CRS mismatch"):
+            result = left.geom_equals_identical(right, align=False)
+        with pytest.warns(UserWarning, match="CRS mismatch"):
+            expected = gpd.GeoSeries(
+                [Point(0, 0)], crs="EPSG:4326"
+            ).geom_equals_identical(
+                gpd.GeoSeries([Point(0, 0)], crs="EPSG:3857"), align=False
+            )
+        self.check_pd_series_equal(result, expected)
+
+    def test_geom_equals_identical_serialization_boundaries(self):
+        empty_2d = GeoSeries.from_wkt(
+            [
+                "POINT EMPTY",
+                "LINESTRING EMPTY",
+                "POLYGON EMPTY",
+                "POINT EMPTY",
+                "POINT EMPTY",
+            ]
+        )
+        empty_dimensional = GeoSeries.from_wkt(
+            [
+                "POINT Z EMPTY",
+                "LINESTRING Z EMPTY",
+                "POLYGON Z EMPTY",
+                "POINT M EMPTY",
+                "POINT ZM EMPTY",
+            ]
+        )
+
+        # JTS cannot distinguish empty XY and XYZ sequences. M and ZM sequence
+        # metadata is explicit, so the GeometryUDT serializers retain it.
+        self.check_pd_series_equal(
+            empty_2d.geom_equals_identical(empty_dimensional, align=False),
+            pd.Series([True, True, True, False, False], dtype=bool),
+        )
+
+        nan_first_z = GeoSeries.from_wkt(["LINESTRING Z (0 0 NaN, 1 1 2)"])
+        two_dimensional = GeoSeries.from_wkt(["LINESTRING (0 0, 1 1)"])
+
+        # A later non-NaN Z now establishes and preserves the XYZ layout.
+        self.check_pd_series_equal(
+            nan_first_z.geom_equals_identical(two_dimensional, align=False),
+            pd.Series([False], dtype=bool),
+        )
+
+        all_nan_z = GeoSeries.from_wkt(["LINESTRING Z (0 0 NaN, 1 1 NaN)"])
+
+        # An all-NaN Z sequence remains indistinguishable from ordinary XY in JTS.
+        self.check_pd_series_equal(
+            all_nan_z.geom_equals_identical(two_dimensional, align=False),
+            pd.Series([True], dtype=bool),
+        )
+
+        mixed_dimension = GeoSeries([MultiPoint([Point(0, 0), Point(1, 1, 2)])])
+        normalized_dimension = GeoSeries(
+            [shapely.from_wkt("MULTIPOINT Z ((0 0 NaN), (1 1 2))")]
+        )
+
+        # Shapely's homogeneous multi-geometry encoding selects one layout
+        # before the value reaches the JVM, promoting the XY child to XYZ/NaN.
+        self.check_pd_series_equal(
+            mixed_dimension.geom_equals_identical(normalized_dimension, align=False),
+            pd.Series([True], dtype=bool),
+        )
+
+        ring = LinearRing([(0, 0), (1, 0), (1, 1), (0, 0)])
+        line = LineString(ring.coords)
+        # Standalone LinearRings use the LineString representation in this layer.
+        self.check_pd_series_equal(
+            GeoSeries([ring]).geom_equals_identical(line),
+            pd.Series([True], dtype=bool),
+        )
+        self.check_pd_series_equal(
+            GeoSeries([LinearRing()]).geom_equals_identical(LinearRing()),
+            pd.Series([True], dtype=bool),
+        )
+
+    @pytest.mark.parametrize("other", [None, 1, "POINT (0 0)", [Point(0, 0)]])
+    def test_geom_equals_identical_rejects_non_geometry_other(self, other):
+        with pytest.raises(TypeError, match="'other' must be"):
+            GeoSeries([Point(0, 0)]).geom_equals_identical(other)
 
     def test_interpolate(self):
         s = GeoSeries(

--- a/python/tests/geopandas/test_match_geopandas_series.py
+++ b/python/tests/geopandas/test_match_geopandas_series.py
@@ -42,6 +42,27 @@ from tests.geopandas.test_geopandas_base import TestGeopandasBase
 import pyspark.pandas as ps
 from packaging.version import parse as parse_version
 
+requires_geopandas_geom_equals_identical = pytest.mark.skipif(
+    parse_version(gpd.__version__) < parse_version("1.1.0")
+    or parse_version(shapely.__version__) < parse_version("2.1.0"),
+    reason=(
+        "Tests require geopandas>=1.1.0 and shapely>=2.1.0, but found "
+        f"geopandas {gpd.__version__} and shapely {shapely.__version__}"
+    ),
+)
+
+requires_geopandas_geom_equals_identical_m = pytest.mark.skipif(
+    parse_version(gpd.__version__) < parse_version("1.1.0")
+    or parse_version(shapely.__version__) < parse_version("2.1.0")
+    or getattr(shapely, "geos_version", (0, 0, 0)) < (3, 12, 0),
+    reason=(
+        "M/ZM parity requires geopandas>=1.1.0, shapely>=2.1.0, and "
+        "GEOS>=3.12.0, but found "
+        f"geopandas {gpd.__version__}, shapely {shapely.__version__}, and "
+        f"GEOS {getattr(shapely, 'geos_version_string', 'unknown')}"
+    ),
+)
+
 
 @pytest.mark.skipif(
     parse_version(shapely.__version__) < parse_version("2.0.0"),
@@ -2284,6 +2305,97 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
         gpd_result = gpd.GeoSeries(geometries).geom_equals_exact(
             gpd.GeoSeries(geometries), tolerance=tolerance, align=False
         )
+        self.check_pd_series_equal(sgpd_result, gpd_result)
+
+    @requires_geopandas_geom_equals_identical_m
+    def test_geom_equals_identical(self):
+        left_wkts = [
+            "POINT (0 0)",
+            "POINT Z (1 2 3)",
+            "POINT M (1 2 3)",
+            "POINT ZM (1 2 3 4)",
+            "LINESTRING Z (0 0 1, 1 1 NaN)",
+            "LINESTRING (0 0, 1 1)",
+            "POLYGON ((0 0, 2 0, 0 2, 0 0))",
+            "GEOMETRYCOLLECTION (POINT (0 0), LINESTRING (0 0, 1 1))",
+            "POINT EMPTY",
+            None,
+        ]
+        right_wkts = [
+            "POINT (0 0)",
+            "POINT Z (1 2 4)",
+            "POINT M (1 2 3)",
+            "POINT ZM (1 2 3 4)",
+            "LINESTRING Z (0 0 1, 1 1 NaN)",
+            "LINESTRING (1 1, 0 0)",
+            "POLYGON ((2 0, 0 2, 0 0, 2 0))",
+            "GEOMETRYCOLLECTION (LINESTRING (0 0, 1 1), POINT (0 0))",
+            "LINESTRING EMPTY",
+            None,
+        ]
+        index = pd.Index(
+            [
+                "xy",
+                "z",
+                "m",
+                "zm",
+                "nan",
+                "line-order",
+                "ring-order",
+                "part-order",
+                "empty-type",
+                "missing",
+            ],
+            name="case",
+        )
+
+        left_geometries = shapely.from_wkt(left_wkts)
+        right_geometries = shapely.from_wkt(right_wkts)
+        sgpd_result = GeoSeries(
+            left_geometries, index=index, name="left"
+        ).geom_equals_identical(
+            GeoSeries(right_geometries, index=index, name="right"),
+            align=False,
+        )
+        gpd_result = gpd.GeoSeries(
+            left_geometries, index=index, name="left"
+        ).geom_equals_identical(
+            gpd.GeoSeries(right_geometries, index=index, name="right"),
+            align=False,
+        )
+
+        self.check_pd_series_equal(sgpd_result, gpd_result)
+
+    @requires_geopandas_geom_equals_identical
+    def test_geom_equals_identical_duplicate_multiindex_alignment(self):
+        left_index = pd.MultiIndex.from_tuples(
+            [("a", 1), ("a", 1), ("b", 2)], names=["group", "row"]
+        )
+        right_index = pd.MultiIndex.from_tuples(
+            [("a", 1), ("a", 1), ("c", 3)], names=["group", "row"]
+        )
+        left_wkts = ["POINT Z (0 0 1)", "POINT Z (1 1 2)", None]
+        right_wkts = ["POINT Z (0 0 1)", "POINT Z (9 9 9)", None]
+
+        with pytest.warns(
+            UserWarning,
+            match="The indices of the left and right GeoSeries' are not equal",
+        ):
+            sgpd_result = GeoSeries(
+                shapely.from_wkt(left_wkts), index=left_index
+            ).geom_equals_identical(
+                GeoSeries(shapely.from_wkt(right_wkts), index=right_index)
+            )
+        with pytest.warns(
+            UserWarning,
+            match="The indices of the left and right GeoSeries' are not equal",
+        ):
+            gpd_result = gpd.GeoSeries(
+                shapely.from_wkt(left_wkts), index=left_index
+            ).geom_equals_identical(
+                gpd.GeoSeries(shapely.from_wkt(right_wkts), index=right_index)
+            )
+
         self.check_pd_series_equal(sgpd_result, gpd_result)
 
     def test_interpolate(self):


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/).

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`.

Closes #3260.
Part of #2230.

## What changes were proposed in this PR?

GeoPandas 1.1 added `geom_equals_identical` for exact structural comparison of
geometry values. Unlike topological equality or tolerance-based
`geom_equals_exact`, it compares geometry type, nesting, component and vertex
order, coordinate dimensionality, and every represented XY/Z/M ordinate. NaN
ordinates at the same position compare equal.

This PR adds the distributed GeoPandas API layer on top of the native
`ST_EqualsIdentical` predicate merged in #3266:

- Implement `GeoSeries.geom_equals_identical(other, align=None)` and delegate
  `GeoDataFrame.geom_equals_identical` through the active geometry column.
- Support scalar Shapely geometries, GeoSeries, GeoDataFrame, and
  pandas-on-Spark Series inputs.
- Preserve GeoPandas-compatible index alignment, including duplicate and
  MultiIndex values, positional comparison with `align=False`, result naming,
  non-nullable boolean output, null-to-false behavior, and CRS mismatch
  warnings.
- Execute comparisons with native Spark expressions; geometry rows and results
  remain distributed, and the plan contains no Python UDF execution.
- Preserve Z/M/ZM metadata for typed empty scalar values and retain Sedona's
  standalone `LinearRing`-to-`LineString` representation.
- Document the remaining representation boundaries and update the English and
  Chinese GeoPandas tutorials and release notes.

This is the final PR in the #3260 stack and is based directly on `master`. Its
prerequisites are merged:

- #3265 preserves M and ZM when Shapely geometries cross the Python
  GeometryUDT boundary.
- #3268 preserves every coordinate layout recoverable by JTS at the compact
  Java SerDe boundary and rejects mixed layouts that a single-layout container
  cannot represent losslessly.
- #3266 provides `ST_EqualsIdentical` across Sedona's SQL engines.

The predicate compares the geometry representation it receives. JTS still
cannot distinguish ordinary XY from declared XYZ when every Z ordinate is NaN,
including empty XYZ values and zero-member collections. Direct Shapely inputs
with mixed layouts inside a Polygon or same-type multi-geometry may also be
normalized by Python GeometryUDT serialization before reaching the JVM. These
boundaries are documented in the public method.

## How was this patch tested?

- Built the Spark 4.1.1 / Scala 2.13 shaded artifact with Java 17.
- GeoPandas 1.1.3 / Shapely 2.1.2 / GEOS 3.13.1 focused identity matrix:
  `22` tests passed.
- GeoPandas 1.0.1 compatibility matrix: `19` tests passed and
  `3` upstream-version-dependent tests skipped.
- Full affected GeoSeries and GeoPandas parity files: `427 tests passed and 1 skipped`.
- Coverage includes scalar and Series inputs, XY/Z/M/ZM distinctions, typed
  empties, NaN ordinates, standalone rings, aligned and positional comparison,
  duplicate and MultiIndex values, CRS warnings, nulls, and serialization
  boundaries.
- Execution-plan coverage verifies that no Python execution nodes are added.
- Black, AST parsing, Markdown linting, the documentation build, repository
  hooks, and `git diff --check` passed.

## Did this PR include necessary documentation updates?

- Yes, I am adding a new API. I am using the current SNAPSHOT version,
  `v2.0.0`.
- Yes, I updated the English and Chinese GeoPandas tutorials, public API
  documentation, and release notes.
