### PR TITLE
[GH-3260] Add ST_EqualsIdentical across Sedona SQL engines

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/Predicates.java
+++ b/common/src/main/java/org/apache/sedona/common/Predicates.java
@@ -21,6 +21,7 @@ package org.apache.sedona.common;
 import org.apache.sedona.common.geometryObjects.Box2D;
 import org.apache.sedona.common.geometryObjects.Box3D;
 import org.apache.sedona.common.sphere.Spheroid;
+import org.apache.sedona.common.utils.GeometryEquality;
 import org.locationtech.jts.geom.*;
 import org.locationtech.jts.operation.distance3d.Distance3DOp;
 import org.locationtech.jts.operation.relate.RelateOp;
@@ -161,6 +162,10 @@ public class Predicates {
   public static boolean equalsExact(
       Geometry leftGeometry, Geometry rightGeometry, double tolerance) {
     return leftGeometry.equalsExact(rightGeometry, tolerance);
+  }
+
+  public static boolean equalsIdentical(Geometry leftGeometry, Geometry rightGeometry) {
+    return GeometryEquality.equalsIdentical(leftGeometry, rightGeometry);
   }
 
   public static boolean disjoint(Geometry leftGeometry, Geometry rightGeometry) {

--- a/common/src/main/java/org/apache/sedona/common/utils/GeometryEquality.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/GeometryEquality.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.common.utils;
+
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.CoordinateSequences;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryCollection;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
+
+/** Structural geometry equality including every coordinate dimension. */
+public final class GeometryEquality {
+
+  private GeometryEquality() {}
+
+  /**
+   * Tests whether two geometries have identical types, structure, component ordering, coordinate
+   * ordering, dimensionality, and ordinate values. NaN ordinates in corresponding positions are
+   * considered equal. Geometry metadata such as SRID, precision model, and user data is ignored.
+   */
+  public static boolean equalsIdentical(Geometry left, Geometry right) {
+    if (left == null || right == null) {
+      return false;
+    }
+    if (left == right) {
+      return true;
+    }
+    if (!left.getGeometryType().equals(right.getGeometryType())) {
+      return false;
+    }
+
+    if (left instanceof Point && right instanceof Point) {
+      return coordinateSequencesEqual(
+          ((Point) left).getCoordinateSequence(), ((Point) right).getCoordinateSequence());
+    }
+    if (left instanceof LineString && right instanceof LineString) {
+      return coordinateSequencesEqual(
+          ((LineString) left).getCoordinateSequence(),
+          ((LineString) right).getCoordinateSequence());
+    }
+    if (left instanceof Polygon && right instanceof Polygon) {
+      return polygonsEqual((Polygon) left, (Polygon) right);
+    }
+    if (left instanceof GeometryCollection && right instanceof GeometryCollection) {
+      return collectionsEqual((GeometryCollection) left, (GeometryCollection) right);
+    }
+    return false;
+  }
+
+  private static boolean polygonsEqual(Polygon left, Polygon right) {
+    if (left.getNumInteriorRing() != right.getNumInteriorRing()
+        || !equalsIdentical(left.getExteriorRing(), right.getExteriorRing())) {
+      return false;
+    }
+    for (int i = 0; i < left.getNumInteriorRing(); i++) {
+      if (!equalsIdentical(left.getInteriorRingN(i), right.getInteriorRingN(i))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean collectionsEqual(GeometryCollection left, GeometryCollection right) {
+    if (left.getNumGeometries() != right.getNumGeometries()) {
+      return false;
+    }
+    for (int i = 0; i < left.getNumGeometries(); i++) {
+      if (!equalsIdentical(left.getGeometryN(i), right.getGeometryN(i))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean coordinateSequencesEqual(
+      CoordinateSequence left, CoordinateSequence right) {
+    return left.getDimension() == right.getDimension()
+        && left.getMeasures() == right.getMeasures()
+        && CoordinateSequences.isEqual(left, right);
+  }
+}

--- a/common/src/test/java/org/apache/sedona/common/PredicatesTest.java
+++ b/common/src/test/java/org/apache/sedona/common/PredicatesTest.java
@@ -26,8 +26,14 @@ import org.apache.sedona.common.geometryObjects.Box2D;
 import org.apache.sedona.common.geometryObjects.Box3D;
 import org.junit.Test;
 import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateSequence;
 import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryCollection;
 import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.locationtech.jts.geom.impl.CoordinateArraySequenceFactory;
+import org.locationtech.jts.geom.impl.PackedCoordinateSequenceFactory;
 import org.locationtech.jts.io.ParseException;
 
 public class PredicatesTest extends TestBase {
@@ -375,6 +381,141 @@ public class PredicatesTest extends TestBase {
   }
 
   @Test
+  public void testEqualsIdenticalDimensionsAndOrdinateValues() {
+    GeometryFactory factory = coordinateArrayFactory(0);
+    Point xy = point(factory, false, false, 1, 2, Double.NaN, Double.NaN);
+    Point xyz = point(factory, true, false, 1, 2, 3, Double.NaN);
+    Point xym = point(factory, false, true, 1, 2, Double.NaN, 3);
+    Point xyzm = point(factory, true, true, 1, 2, 3, 4);
+
+    assertTrue(Predicates.equalsIdentical(xy, xy.copy()));
+    assertFalse(Predicates.equalsIdentical(xy, xyz));
+    assertFalse(Predicates.equalsIdentical(xyz, xym));
+    Point xyzNaN = point(factory, true, false, 1, 2, Double.NaN, Double.NaN);
+    assertTrue(Predicates.equalsIdentical(xyzNaN, xyzNaN.copy()));
+    assertFalse(Predicates.equalsIdentical(xy, xyzNaN));
+    assertFalse(Predicates.equalsIdentical(xyz, point(factory, true, false, 1, 2, 4, Double.NaN)));
+    assertFalse(Predicates.equalsIdentical(xym, point(factory, false, true, 1, 2, Double.NaN, 4)));
+    assertTrue(Predicates.equalsIdentical(xyzm, xyzm.copy()));
+    assertFalse(Predicates.equalsIdentical(xyzm, point(factory, true, true, 1, 2, 3, 5)));
+
+    Point nan = point(factory, false, false, Double.NaN, 2, Double.NaN, Double.NaN);
+    assertTrue(Predicates.equalsIdentical(nan, nan.copy()));
+    assertTrue(
+        Predicates.equalsIdentical(
+            point(factory, false, false, 1, 0.0, Double.NaN, Double.NaN),
+            point(factory, false, false, 1, -0.0, Double.NaN, Double.NaN)));
+    assertTrue(
+        Predicates.equalsIdentical(
+            point(factory, false, false, 1, Double.POSITIVE_INFINITY, Double.NaN, Double.NaN),
+            point(factory, false, false, 1, Double.POSITIVE_INFINITY, Double.NaN, Double.NaN)));
+    assertFalse(
+        Predicates.equalsIdentical(
+            point(factory, false, false, 1, Double.POSITIVE_INFINITY, Double.NaN, Double.NaN),
+            point(factory, false, false, 1, Double.NEGATIVE_INFINITY, Double.NaN, Double.NaN)));
+
+    Point wgs84 = point(coordinateArrayFactory(4326), false, false, 1, 2, 0, 0);
+    Point webMercator = point(coordinateArrayFactory(3857), false, false, 1, 2, 0, 0);
+    assertTrue(Predicates.equalsIdentical(wgs84, webMercator));
+    assertFalse(Predicates.equalsIdentical(null, null));
+    assertFalse(Predicates.equalsIdentical(xy, null));
+  }
+
+  @Test
+  public void testEqualsIdenticalPreservesEmptyDimensions() {
+    GeometryFactory factory = coordinateArrayFactory(0);
+    Point emptyXY = emptyPoint(factory, false, false);
+    Point emptyXYZ = emptyPoint(factory, true, false);
+    Point emptyXYM = emptyPoint(factory, false, true);
+
+    assertTrue(Predicates.equalsIdentical(emptyXY, emptyXY.copy()));
+    assertTrue(Predicates.equalsIdentical(emptyXYZ, emptyXYZ.copy()));
+    assertFalse(Predicates.equalsIdentical(emptyXY, emptyXYZ));
+    assertFalse(Predicates.equalsIdentical(emptyXYZ, emptyXYM));
+    assertFalse(
+        Predicates.equalsIdentical(
+            emptyXY,
+            factory.createLineString(factory.getCoordinateSequenceFactory().create(0, 2, 0))));
+    assertFalse(
+        Predicates.equalsIdentical(
+            factory.createLineString(coordinateSequence(factory, 0, false, false)),
+            factory.createLineString(coordinateSequence(factory, 0, true, false))));
+    assertFalse(
+        Predicates.equalsIdentical(
+            factory.createPolygon(
+                factory.createLinearRing(coordinateSequence(factory, 0, false, false))),
+            factory.createPolygon(
+                factory.createLinearRing(coordinateSequence(factory, 0, true, false)))));
+  }
+
+  @Test
+  public void testEqualsIdenticalRequiresMatchingStructureAndOrder() throws ParseException {
+    Geometry line = geomFromEWKT("LINESTRING(0 0, 1 1, 2 0)");
+    assertTrue(Predicates.equalsIdentical(line, line.copy()));
+    assertFalse(Predicates.equalsIdentical(line, geomFromEWKT("LINESTRING(2 0, 1 1, 0 0)")));
+    assertFalse(Predicates.equalsIdentical(line, geomFromEWKT("LINESTRING(0 0, 1 1, 1 1, 2 0)")));
+    assertFalse(
+        Predicates.equalsIdentical(
+            GEOMETRY_FACTORY.createLinearRing(coordArray(0, 0, 1, 1, 2, 0, 0, 0)),
+            GEOMETRY_FACTORY.createLineString(coordArray(0, 0, 1, 1, 2, 0, 0, 0))));
+
+    Geometry polygon =
+        geomFromEWKT(
+            "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0),"
+                + "(1 1, 2 1, 1 2, 1 1),(3 3, 4 3, 3 4, 3 3))");
+    Geometry holesReordered =
+        geomFromEWKT(
+            "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0),"
+                + "(3 3, 4 3, 3 4, 3 3),(1 1, 2 1, 1 2, 1 1))");
+    Geometry shellRotated =
+        geomFromEWKT(
+            "POLYGON((10 0, 10 10, 0 10, 0 0, 10 0),"
+                + "(1 1, 2 1, 1 2, 1 1),(3 3, 4 3, 3 4, 3 3))");
+    assertTrue(Predicates.equalsIdentical(polygon, polygon.copy()));
+    assertFalse(Predicates.equalsIdentical(polygon, holesReordered));
+    assertFalse(Predicates.equalsIdentical(polygon, shellRotated));
+  }
+
+  @Test
+  public void testEqualsIdenticalCollectionsAndMixedDimensions() throws ParseException {
+    GeometryFactory factory = coordinateArrayFactory(0);
+    Geometry xy = point(factory, false, false, 0, 0, 0, 0);
+    Geometry xyz = point(factory, true, false, 1, 1, 2, 0);
+    Geometry xym = point(factory, false, true, 2, 2, 0, 3);
+    GeometryCollection mixed = factory.createGeometryCollection(new Geometry[] {xy, xyz, xym});
+    GeometryCollection same =
+        factory.createGeometryCollection(new Geometry[] {xy.copy(), xyz.copy(), xym.copy()});
+    GeometryCollection dimensionChanged =
+        factory.createGeometryCollection(
+            new Geometry[] {xy.copy(), point(factory, false, true, 1, 1, 0, 2), xym.copy()});
+
+    assertTrue(Predicates.equalsIdentical(mixed, same));
+    assertFalse(Predicates.equalsIdentical(mixed, dimensionChanged));
+    assertFalse(
+        Predicates.equalsIdentical(
+            mixed,
+            factory.createGeometryCollection(new Geometry[] {xym.copy(), xyz.copy(), xy.copy()})));
+    assertFalse(
+        Predicates.equalsIdentical(
+            geomFromEWKT("MULTIPOINT((0 0))"), geomFromEWKT("GEOMETRYCOLLECTION(POINT(0 0))")));
+  }
+
+  @Test
+  public void testEqualsIdenticalIgnoresCoordinateSequenceImplementation() {
+    GeometryFactory arrayFactory = coordinateArrayFactory(0);
+    GeometryFactory packedFactory =
+        new GeometryFactory(
+            new PrecisionModel(), 0, PackedCoordinateSequenceFactory.DOUBLE_FACTORY);
+
+    Point arrayPoint = point(arrayFactory, true, true, 1, 2, 3, 4);
+    Point packedPoint = point(packedFactory, true, true, 1, 2, 3, 4);
+    assertNotEquals(
+        arrayPoint.getCoordinateSequence().getClass(),
+        packedPoint.getCoordinateSequence().getClass());
+    assertTrue(Predicates.equalsIdentical(arrayPoint, packedPoint));
+  }
+
+  @Test
   public void testRelateBoolean() throws ParseException {
     Geometry geom1 = geomFromEWKT("POINT(1 2)");
     Geometry geom2 = Functions.buffer(geomFromEWKT("POINT(1 2)"), 2);
@@ -450,5 +591,35 @@ public class PredicatesTest extends TestBase {
     assertEquals(true, crossesDateLine(multiGeom2));
     assertEquals(false, crossesDateLine(multiGeom3));
     assertEquals(false, crossesDateLine(multiGeom4));
+  }
+
+  private static GeometryFactory coordinateArrayFactory(int srid) {
+    return new GeometryFactory(
+        new PrecisionModel(), srid, CoordinateArraySequenceFactory.instance());
+  }
+
+  private static Point point(
+      GeometryFactory factory, boolean hasZ, boolean hasM, double x, double y, double z, double m) {
+    CoordinateSequence coordinates = coordinateSequence(factory, 1, hasZ, hasM);
+    coordinates.setOrdinate(0, CoordinateSequence.X, x);
+    coordinates.setOrdinate(0, CoordinateSequence.Y, y);
+    if (hasZ) {
+      coordinates.setOrdinate(0, CoordinateSequence.Z, z);
+    }
+    if (hasM) {
+      coordinates.setOrdinate(0, coordinates.getDimension() - coordinates.getMeasures(), m);
+    }
+    return factory.createPoint(coordinates);
+  }
+
+  private static Point emptyPoint(GeometryFactory factory, boolean hasZ, boolean hasM) {
+    return factory.createPoint(coordinateSequence(factory, 0, hasZ, hasM));
+  }
+
+  private static CoordinateSequence coordinateSequence(
+      GeometryFactory factory, int size, boolean hasZ, boolean hasM) {
+    int measures = hasM ? 1 : 0;
+    int dimension = 2 + (hasZ ? 1 : 0) + measures;
+    return factory.getCoordinateSequenceFactory().create(size, dimension, measures);
   }
 }

--- a/common/src/test/java/org/apache/sedona/common/PredicatesTest.java
+++ b/common/src/test/java/org/apache/sedona/common/PredicatesTest.java
@@ -382,6 +382,9 @@ public class PredicatesTest extends TestBase {
 
   @Test
   public void testEqualsIdenticalDimensionsAndOrdinateValues() {
+    // Construct explicit coordinate sequences here so the predicate receives the dimensional
+    // metadata being compared. Default JTS sequences cannot distinguish ordinary XY from declared
+    // XYZ when every Z ordinate is NaN after some serialization boundaries.
     GeometryFactory factory = coordinateArrayFactory(0);
     Point xy = point(factory, false, false, 1, 2, Double.NaN, Double.NaN);
     Point xyz = point(factory, true, false, 1, 2, 3, Double.NaN);
@@ -422,7 +425,9 @@ public class PredicatesTest extends TestBase {
   }
 
   @Test
-  public void testEqualsIdenticalPreservesEmptyDimensions() {
+  public void testEqualsIdenticalComparesRepresentedEmptyDimensions() {
+    // These empty geometries retain explicit sequence dimensions in memory. Some empty and
+    // zero-member values do not retain that declaration after serialization.
     GeometryFactory factory = coordinateArrayFactory(0);
     Point emptyXY = emptyPoint(factory, false, false);
     Point emptyXYZ = emptyPoint(factory, true, false);

--- a/docs/api/flink/Geometry-Functions.md
+++ b/docs/api/flink/Geometry-Functions.md
@@ -168,6 +168,7 @@ These functions test spatial relationships between geometries, returning boolean
 | [ST_DWithin](Predicates/ST_DWithin.md) | Boolean | Returns true if 'leftGeometry' and 'rightGeometry' are within a specified 'distance'. | v1.5.1 |
 | [ST_Equals](Predicates/ST_Equals.md) | Boolean | Return true if A equals to B | v1.5.0 |
 | [ST_EqualsExact](Predicates/ST_EqualsExact.md) | Boolean | Return true if A and B have matching structures and corresponding coordinates within a tolerance | v1.9.1 |
+| [ST_EqualsIdentical](Predicates/ST_EqualsIdentical.md) | Boolean | Return true if A and B have identical structures, dimensions, and coordinate values | v2.0.0 |
 | [ST_Intersects](Predicates/ST_Intersects.md) | Boolean | Return true if A intersects B | v1.2.0 |
 | [ST_OrderingEquals](Predicates/ST_OrderingEquals.md) | Boolean | Returns true if the geometries are equal and the coordinates are in the same order | v1.2.1 |
 | [ST_Overlaps](Predicates/ST_Overlaps.md) | Boolean | Return true if A overlaps B | v1.5.0 |

--- a/docs/api/flink/Predicates/ST_EqualsIdentical.md
+++ b/docs/api/flink/Predicates/ST_EqualsIdentical.md
@@ -1,0 +1,62 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_EqualsIdentical
+
+Introduction: Returns true if A and B have identical geometry types, component ordering, coordinate ordering, dimensionality, and coordinate values.
+
+Unlike `ST_EqualsExact`, this predicate compares every available coordinate dimension, including Z and M, and does not accept a tolerance. NaN ordinate values are considered equal to other NaN values. The SRID and other geometry metadata are not compared.
+
+Format: `ST_EqualsIdentical(A: Geometry, B: Geometry)`
+
+Return type: `Boolean`
+
+Since: `v2.0.0`
+
+Identical geometries return true:
+
+```sql
+SELECT ST_EqualsIdentical(
+    ST_GeomFromWKT('POINT Z (1 2 3)'),
+    ST_GeomFromWKT('POINT Z (1 2 3)')
+)
+```
+
+Output:
+
+```
+true
+```
+
+All dimensions must match:
+
+```sql
+SELECT ST_EqualsIdentical(
+    ST_GeomFromWKT('POINT Z (1 2 3)'),
+    ST_GeomFromWKT('POINT Z (1 2 4)')
+)
+```
+
+Output:
+
+```
+false
+```
+
+The order of components and coordinates must also match. Use `ST_Equals` when only topological equality is required.

--- a/docs/api/flink/Predicates/ST_EqualsIdentical.md
+++ b/docs/api/flink/Predicates/ST_EqualsIdentical.md
@@ -29,6 +29,39 @@ Return type: `Boolean`
 
 Since: `v2.0.0`
 
+## Visual examples
+
+### Structure and coordinate order
+
+The inputs are shown separately so their traversal direction and container structure are easy to
+compare. Geometries can occupy the same locations and still be non-identical when their vertex
+order, geometry type, or nesting differs.
+
+![ST_EqualsIdentical compares geometry structure and coordinate order](../../../image/ST_EqualsIdentical/ST_EqualsIdentical_structure.svg "Structure and coordinate-order comparisons")
+
+### Z, M, and ZM dimensions
+
+The coordinate layout is part of a geometry's identity. `POINT Z (1 2 3)` and
+`POINT M (1 2 3)` contain the same numeric values, but the third ordinate has a different role.
+For ZM geometries, both the Z and M values participate in the comparison.
+
+![ST_EqualsIdentical compares every X, Y, Z, and M ordinate](../../../image/ST_EqualsIdentical/ST_EqualsIdentical_dimensions.svg "Z, M, and ZM comparisons")
+
+## Choosing an equality predicate
+
+| Predicate | Comparison | Typical use |
+| --- | --- | --- |
+| `ST_Equals` | Same two-dimensional topology; representation and ordering may differ | Find geometries that describe the same shape |
+| `ST_EqualsExact` | Same structure and order, with corresponding X/Y coordinates within a tolerance; Z/M are ignored | Accept small X/Y representation differences |
+| `ST_EqualsIdentical` | Same type, structure, order, dimensional layout, and exact X/Y/Z/M ordinate values | Verify that a geometry representation was preserved |
+
+`ST_EqualsIdentical` does not compare SRID, precision model, user data, or the coordinate-sequence
+implementation. Compare SRIDs separately when CRS identity is also required.
+
+## SQL examples
+
+### Identical XYZ geometries
+
 Identical geometries return true:
 
 ```sql
@@ -44,19 +77,135 @@ Output:
 true
 ```
 
-All dimensions must match:
+### Topological equality versus identity
+
+These paths occupy the same locations, so `ST_Equals` returns true. Their coordinate sequences
+run in opposite directions, so `ST_EqualsIdentical` returns false.
 
 ```sql
-SELECT ST_EqualsIdentical(
-    ST_GeomFromWKT('POINT Z (1 2 3)'),
-    ST_GeomFromWKT('POINT Z (1 2 4)')
+WITH paths AS (
+    SELECT
+        ST_GeomFromWKT('LINESTRING (0 0, 1 1, 2 0)') AS forward_path,
+        ST_GeomFromWKT('LINESTRING (2 0, 1 1, 0 0)') AS reverse_path
 )
+SELECT
+    ST_Equals(forward_path, reverse_path) AS same_shape,
+    ST_EqualsIdentical(forward_path, reverse_path) AS identical
+FROM paths;
 ```
 
 Output:
 
-```
-false
+```text
+same_shape | identical
+-----------+----------
+true       | false
 ```
 
-The order of components and coordinates must also match. Use `ST_Equals` when only topological equality is required.
+### Z, M, and ZM dimensions
+
+Every ordinate value and its dimensional role must match:
+
+```sql
+SELECT
+    ST_EqualsIdentical(
+        ST_GeomFromWKT('POINT Z (1 2 3)'),
+        ST_GeomFromWKT('POINT Z (1 2 4)')
+    ) AS changed_z,
+    ST_EqualsIdentical(
+        ST_GeomFromWKT('POINT M (1 2 3)'),
+        ST_GeomFromWKT('POINT M (1 2 4)')
+    ) AS changed_m,
+    ST_EqualsIdentical(
+        ST_GeomFromWKT('POINT Z (1 2 3)'),
+        ST_GeomFromWKT('POINT M (1 2 3)')
+    ) AS z_is_not_m,
+    ST_EqualsIdentical(
+        ST_GeomFromWKT('POINT ZM (1 2 3 4)'),
+        ST_GeomFromWKT('POINT ZM (1 2 3 4)')
+    ) AS same_xyzm;
+```
+
+Output:
+
+```text
+changed_z | changed_m | z_is_not_m | same_xyzm
+----------+-----------+------------+----------
+false     | false     | false      | true
+```
+
+### Geometry structure and SRID
+
+Geometry type and nesting are compared. SRID is intentionally ignored.
+
+```sql
+SELECT
+    ST_EqualsIdentical(
+        ST_GeomFromWKT('MULTIPOINT ((0 0))'),
+        ST_GeomFromWKT('GEOMETRYCOLLECTION (POINT (0 0))')
+    ) AS different_types,
+    ST_EqualsIdentical(
+        ST_SetSRID(ST_GeomFromWKT('POINT (1 2)'), 4326),
+        ST_SetSRID(ST_GeomFromWKT('POINT (1 2)'), 3857)
+    ) AS srid_is_ignored;
+```
+
+Output:
+
+```text
+different_types | srid_is_ignored
+----------------+----------------
+false           | true
+```
+
+Identity does not imply CRS compatibility. Validate or transform SRIDs before using the
+geometries together.
+
+### NaN and NULL
+
+NaN ordinates compare equal to NaN ordinates in the corresponding position. A SQL NULL operand
+produces NULL. The example constructs a typed null geometry for Flink's type inference.
+
+```sql
+SELECT
+    ST_EqualsIdentical(
+        ST_GeomFromWKT('POINT (NaN 2)'),
+        ST_GeomFromWKT('POINT (NaN 2)')
+    ) AS matching_nan,
+    ST_EqualsIdentical(
+        ST_GeomFromWKT(CAST(NULL AS STRING)),
+        ST_GeomFromWKT('POINT (1 2)')
+    ) AS null_result;
+```
+
+Output:
+
+```text
+matching_nan | null_result
+-------------+------------
+true         | NULL
+```
+
+## Practical use: lossless geometry validation
+
+Use `ST_EqualsIdentical` for deterministic change detection after serialization, storage, or an
+ETL rewrite. It can reveal a reversed coordinate sequence, a changed geometry container, or a
+lost Z/M ordinate even when `ST_Equals` reports the same shape.
+
+The following query flags rows whose geometry representation changed:
+
+```sql
+SELECT
+    record_id,
+    CASE
+        WHEN source_geometry IS NULL OR reloaded_geometry IS NULL THEN 'missing_geometry'
+        WHEN ST_EqualsIdentical(source_geometry, reloaded_geometry) THEN 'unchanged'
+        ELSE 'changed'
+    END AS validation_result
+FROM geometry_round_trip;
+```
+
+This predicate checks geometric content, not a byte-for-byte encoding. Compare SRID and any
+application metadata separately when those fields are part of the validation contract. Where the
+input geometry types support topological equality, use `ST_Equals` in a separate comparison to
+distinguish representation-only changes from changed topology.

--- a/docs/api/flink/Predicates/ST_EqualsIdentical.md
+++ b/docs/api/flink/Predicates/ST_EqualsIdentical.md
@@ -58,6 +58,12 @@ For ZM geometries, both the Z and M values participate in the comparison.
 `ST_EqualsIdentical` does not compare SRID, precision model, user data, or the coordinate-sequence
 implementation. Compare SRIDs separately when CRS identity is also required.
 
+The predicate compares the dimensions retained by the geometry value it receives. At Spark and
+Flink serialization boundaries, JTS cannot distinguish ordinary XY coordinates from declared XYZ
+coordinates when every Z ordinate is NaN; those values may normalize to XY. Empty XYZ values and
+zero-member collections have the same limitation. Mixed layouts within a Polygon or multi-geometry
+are rejected by the serializer; use a GeometryCollection when members need independent layouts.
+
 ## SQL examples
 
 ### Identical XYZ geometries
@@ -186,7 +192,7 @@ matching_nan | null_result
 true         | NULL
 ```
 
-## Practical use: lossless geometry validation
+## Practical use: geometry round-trip validation
 
 Use `ST_EqualsIdentical` for deterministic change detection after serialization, storage, or an
 ETL rewrite. It can reveal a reversed coordinate sequence, a changed geometry container, or a

--- a/docs/api/snowflake/vector-data/Geometry-Functions.md
+++ b/docs/api/snowflake/vector-data/Geometry-Functions.md
@@ -160,6 +160,7 @@ These functions test spatial relationships between geometries, returning boolean
 | [ST_DWithin](Predicates/ST_DWithin.md) | Returns true if 'leftGeometry' and 'rightGeometry' are within a specified 'distance'. This function essentially checks if the shortest distance between the envelope of the two geometries is <= the ... |
 | [ST_Equals](Predicates/ST_Equals.md) | Return true if A equals to B |
 | [ST_EqualsExact](Predicates/ST_EqualsExact.md) | Return true if A and B have matching structures and corresponding coordinates within a tolerance |
+| [ST_EqualsIdentical](Predicates/ST_EqualsIdentical.md) | Return true if A and B have identical structures, dimensions, and coordinate values |
 | [ST_Intersects](Predicates/ST_Intersects.md) | Return true if A intersects B |
 | [ST_OrderingEquals](Predicates/ST_OrderingEquals.md) | Returns true if the geometries are equal and the coordinates are in the same order |
 | [ST_Overlaps](Predicates/ST_Overlaps.md) | Return true if A overlaps B |

--- a/docs/api/snowflake/vector-data/Predicates/ST_EqualsIdentical.md
+++ b/docs/api/snowflake/vector-data/Predicates/ST_EqualsIdentical.md
@@ -27,7 +27,36 @@ Format: `ST_EqualsIdentical(A: Geometry, B: Geometry)`
 
 Return type: `Boolean`
 
+Since: `v2.0.0`
+
 This function supports Snowflake `GEOMETRY` values. It is not available for `GEOGRAPHY` values. Snowflake currently stores native `GEOMETRY` values as two-dimensional coordinates with 14 decimal places, so identity is evaluated on those stored 2D values.
+
+## Visual example
+
+The inputs are shown separately so their traversal direction and container structure are easy to
+compare. Geometries can occupy the same locations and still be non-identical when their vertex
+order, geometry type, or nesting differs.
+
+![ST_EqualsIdentical compares geometry structure and coordinate order](../../../../image/ST_EqualsIdentical/ST_EqualsIdentical_structure.svg "Structure and coordinate-order comparisons")
+
+The Z/M visual used by the Spark and Flink pages does not apply to native Snowflake `GEOMETRY`
+values because Snowflake stores those values in two dimensions.
+
+## Choosing an equality predicate
+
+| Predicate | Comparison | Typical use |
+| --- | --- | --- |
+| `ST_Equals` | Same two-dimensional topology; representation and ordering may differ | Find geometries that describe the same shape |
+| `ST_EqualsExact` | Same structure and order, with corresponding stored coordinates within a tolerance | Accept small representation differences |
+| `ST_EqualsIdentical` | Same type, structure, order, and exact stored coordinate values | Verify that a stored 2D geometry representation was preserved |
+
+`ST_EqualsIdentical` does not compare SRID or other geometry metadata. The Snowflake GeoJSON UDF
+bridge also does not carry SRID into the predicate, so compare CRS metadata separately when it is
+part of the validation contract.
+
+## SQL examples
+
+### Identical geometries
 
 Identical geometries return true:
 
@@ -44,19 +73,92 @@ Output:
 true
 ```
 
-The order of components and coordinates must match:
+### Topological equality versus identity
+
+These paths occupy the same locations, so `SEDONA.ST_Equals` returns true. Their coordinate
+sequences run in opposite directions, so `SEDONA.ST_EqualsIdentical` returns false.
 
 ```sql
-SELECT SEDONA.ST_EqualsIdentical(
-    ST_GeometryFromWKT('LINESTRING (0 0, 1 1)'),
-    ST_GeometryFromWKT('LINESTRING (1 1, 0 0)')
+WITH paths AS (
+    SELECT
+        ST_GeometryFromWKT('LINESTRING (0 0, 1 1, 2 0)') AS forward_path,
+        ST_GeometryFromWKT('LINESTRING (2 0, 1 1, 0 0)') AS reverse_path
 )
+SELECT
+    SEDONA.ST_Equals(forward_path, reverse_path) AS same_shape,
+    SEDONA.ST_EqualsIdentical(forward_path, reverse_path) AS identical
+FROM paths;
 ```
 
 Output:
 
+```text
+same_shape | identical
+-----------+----------
+true       | false
 ```
+
+### Geometry type and nesting
+
+The same visible points are not identical when their geometry types and nesting differ.
+
+```sql
+SELECT SEDONA.ST_EqualsIdentical(
+    ST_GeometryFromWKT('MULTIPOINT ((0 0), (4 0))'),
+    ST_GeometryFromWKT(
+        'GEOMETRYCOLLECTION (POINT (0 0), POINT (4 0))'
+    )
+) AS identical;
+```
+
+Output:
+
+```text
+identical
+---------
 false
 ```
 
-Use `ST_Equals` when only topological equality is required.
+### NULL input
+
+The generated UDF uses Snowflake's `RETURNS NULL ON NULL INPUT` behavior, so a NULL operand
+produces NULL.
+
+```sql
+SELECT SEDONA.ST_EqualsIdentical(
+    NULL,
+    ST_GeometryFromWKT('POINT (1 2)')
+) AS identical;
+```
+
+Output:
+
+```text
+identical
+---------
+NULL
+```
+
+## Practical use: lossless geometry validation
+
+Use `ST_EqualsIdentical` for deterministic change detection after serialization, storage, or an
+ETL rewrite. It can reveal a reversed coordinate sequence or changed geometry container even
+when `ST_Equals` reports the same shape.
+
+The following query flags rows whose geometry representation changed:
+
+```sql
+SELECT
+    record_id,
+    CASE
+        WHEN source_geometry IS NULL OR reloaded_geometry IS NULL THEN 'missing_geometry'
+        WHEN SEDONA.ST_EqualsIdentical(source_geometry, reloaded_geometry) THEN 'unchanged'
+        ELSE 'changed'
+    END AS validation_result
+FROM geometry_round_trip;
+```
+
+This predicate checks geometric content, not a byte-for-byte encoding. Compare CRS and application
+metadata separately when those fields are part of the validation contract. Where the input
+geometry types support topological equality, use `SEDONA.ST_Equals` in a separate comparison to
+distinguish representation-only changes from changed topology.

--- a/docs/api/snowflake/vector-data/Predicates/ST_EqualsIdentical.md
+++ b/docs/api/snowflake/vector-data/Predicates/ST_EqualsIdentical.md
@@ -139,7 +139,7 @@ identical
 NULL
 ```
 
-## Practical use: lossless geometry validation
+## Practical use: geometry round-trip validation
 
 Use `ST_EqualsIdentical` for deterministic change detection after serialization, storage, or an
 ETL rewrite. It can reveal a reversed coordinate sequence or changed geometry container even

--- a/docs/api/snowflake/vector-data/Predicates/ST_EqualsIdentical.md
+++ b/docs/api/snowflake/vector-data/Predicates/ST_EqualsIdentical.md
@@ -1,0 +1,62 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_EqualsIdentical
+
+Introduction: Returns true if A and B have identical geometry types, component ordering, coordinate ordering, dimensionality, and coordinate values.
+
+Unlike `ST_EqualsExact`, this predicate does not accept a tolerance. NaN ordinate values are considered equal to other NaN values. The SRID and other geometry metadata are not compared.
+
+Format: `ST_EqualsIdentical(A: Geometry, B: Geometry)`
+
+Return type: `Boolean`
+
+This function supports Snowflake `GEOMETRY` values. It is not available for `GEOGRAPHY` values. Snowflake currently stores native `GEOMETRY` values as two-dimensional coordinates with 14 decimal places, so identity is evaluated on those stored 2D values.
+
+Identical geometries return true:
+
+```sql
+SELECT SEDONA.ST_EqualsIdentical(
+    ST_GeometryFromWKT('LINESTRING (0 0, 1 1)'),
+    ST_GeometryFromWKT('LINESTRING (0 0, 1 1)')
+)
+```
+
+Output:
+
+```
+true
+```
+
+The order of components and coordinates must match:
+
+```sql
+SELECT SEDONA.ST_EqualsIdentical(
+    ST_GeometryFromWKT('LINESTRING (0 0, 1 1)'),
+    ST_GeometryFromWKT('LINESTRING (1 1, 0 0)')
+)
+```
+
+Output:
+
+```
+false
+```
+
+Use `ST_Equals` when only topological equality is required.

--- a/docs/api/sql/Geometry-Functions.md
+++ b/docs/api/sql/Geometry-Functions.md
@@ -170,6 +170,7 @@ These functions test spatial relationships between geometries, returning boolean
 | [ST_3DDWithin](Predicates/ST_3DDWithin.md) | Boolean | Returns true if A and B are within a specified 3D Euclidean 'distance'. Accepts Geometry or Box3D inputs. | v1.9.1 |
 | [ST_Equals](Predicates/ST_Equals.md) | Boolean | Return true if A equals to B | v1.0.0 |
 | [ST_EqualsExact](Predicates/ST_EqualsExact.md) | Boolean | Return true if A and B have matching structures and corresponding coordinates within a tolerance | v1.9.1 |
+| [ST_EqualsIdentical](Predicates/ST_EqualsIdentical.md) | Boolean | Return true if A and B have identical structures, dimensions, and coordinate values | v2.0.0 |
 | [ST_Intersects](Predicates/ST_Intersects.md) | Boolean | Return true if A intersects B | v1.0.0 |
 | [ST_OrderingEquals](Predicates/ST_OrderingEquals.md) | Boolean | Returns true if the geometries are equal and the coordinates are in the same order | v1.2.1 |
 | [ST_Overlaps](Predicates/ST_Overlaps.md) | Boolean | Return true if A overlaps B | v1.0.0 |

--- a/docs/api/sql/Predicates/ST_EqualsIdentical.md
+++ b/docs/api/sql/Predicates/ST_EqualsIdentical.md
@@ -1,0 +1,62 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_EqualsIdentical
+
+Introduction: Returns true if A and B have identical geometry types, component ordering, coordinate ordering, dimensionality, and coordinate values.
+
+Unlike `ST_EqualsExact`, this predicate compares every available coordinate dimension, including Z and M, and does not accept a tolerance. NaN ordinate values are considered equal to other NaN values. The SRID and other geometry metadata are not compared.
+
+Format: `ST_EqualsIdentical(A: Geometry, B: Geometry)`
+
+Return type: `Boolean`
+
+Since: `v2.0.0`
+
+Identical geometries return true:
+
+```sql
+SELECT ST_EqualsIdentical(
+    ST_GeomFromWKT('POINT Z (1 2 3)'),
+    ST_GeomFromWKT('POINT Z (1 2 3)')
+)
+```
+
+Output:
+
+```
+true
+```
+
+All dimensions must match:
+
+```sql
+SELECT ST_EqualsIdentical(
+    ST_GeomFromWKT('POINT Z (1 2 3)'),
+    ST_GeomFromWKT('POINT Z (1 2 4)')
+)
+```
+
+Output:
+
+```
+false
+```
+
+The order of components and coordinates must also match. Use `ST_Equals` when only topological equality is required.

--- a/docs/api/sql/Predicates/ST_EqualsIdentical.md
+++ b/docs/api/sql/Predicates/ST_EqualsIdentical.md
@@ -29,6 +29,39 @@ Return type: `Boolean`
 
 Since: `v2.0.0`
 
+## Visual examples
+
+### Structure and coordinate order
+
+The inputs are shown separately so their traversal direction and container structure are easy to
+compare. Geometries can occupy the same locations and still be non-identical when their vertex
+order, geometry type, or nesting differs.
+
+![ST_EqualsIdentical compares geometry structure and coordinate order](../../../image/ST_EqualsIdentical/ST_EqualsIdentical_structure.svg "Structure and coordinate-order comparisons")
+
+### Z, M, and ZM dimensions
+
+The coordinate layout is part of a geometry's identity. `POINT Z (1 2 3)` and
+`POINT M (1 2 3)` contain the same numeric values, but the third ordinate has a different role.
+For ZM geometries, both the Z and M values participate in the comparison.
+
+![ST_EqualsIdentical compares every X, Y, Z, and M ordinate](../../../image/ST_EqualsIdentical/ST_EqualsIdentical_dimensions.svg "Z, M, and ZM comparisons")
+
+## Choosing an equality predicate
+
+| Predicate | Comparison | Typical use |
+| --- | --- | --- |
+| `ST_Equals` | Same two-dimensional topology; representation and ordering may differ | Find geometries that describe the same shape |
+| `ST_EqualsExact` | Same structure and order, with corresponding X/Y coordinates within a tolerance; Z/M are ignored | Accept small X/Y representation differences |
+| `ST_EqualsIdentical` | Same type, structure, order, dimensional layout, and exact X/Y/Z/M ordinate values | Verify that a geometry representation was preserved |
+
+`ST_EqualsIdentical` does not compare SRID, precision model, user data, or the coordinate-sequence
+implementation. Compare SRIDs separately when CRS identity is also required.
+
+## SQL examples
+
+### Identical XYZ geometries
+
 Identical geometries return true:
 
 ```sql
@@ -44,19 +77,135 @@ Output:
 true
 ```
 
-All dimensions must match:
+### Topological equality versus identity
+
+These paths occupy the same locations, so `ST_Equals` returns true. Their coordinate sequences
+run in opposite directions, so `ST_EqualsIdentical` returns false.
 
 ```sql
-SELECT ST_EqualsIdentical(
-    ST_GeomFromWKT('POINT Z (1 2 3)'),
-    ST_GeomFromWKT('POINT Z (1 2 4)')
+WITH paths AS (
+    SELECT
+        ST_GeomFromWKT('LINESTRING (0 0, 1 1, 2 0)') AS forward_path,
+        ST_GeomFromWKT('LINESTRING (2 0, 1 1, 0 0)') AS reverse_path
 )
+SELECT
+    ST_Equals(forward_path, reverse_path) AS same_shape,
+    ST_EqualsIdentical(forward_path, reverse_path) AS identical
+FROM paths;
 ```
 
 Output:
 
-```
-false
+```text
+same_shape | identical
+-----------+----------
+true       | false
 ```
 
-The order of components and coordinates must also match. Use `ST_Equals` when only topological equality is required.
+### Z, M, and ZM dimensions
+
+Every ordinate value and its dimensional role must match:
+
+```sql
+SELECT
+    ST_EqualsIdentical(
+        ST_GeomFromWKT('POINT Z (1 2 3)'),
+        ST_GeomFromWKT('POINT Z (1 2 4)')
+    ) AS changed_z,
+    ST_EqualsIdentical(
+        ST_GeomFromWKT('POINT M (1 2 3)'),
+        ST_GeomFromWKT('POINT M (1 2 4)')
+    ) AS changed_m,
+    ST_EqualsIdentical(
+        ST_GeomFromWKT('POINT Z (1 2 3)'),
+        ST_GeomFromWKT('POINT M (1 2 3)')
+    ) AS z_is_not_m,
+    ST_EqualsIdentical(
+        ST_GeomFromWKT('POINT ZM (1 2 3 4)'),
+        ST_GeomFromWKT('POINT ZM (1 2 3 4)')
+    ) AS same_xyzm;
+```
+
+Output:
+
+```text
+changed_z | changed_m | z_is_not_m | same_xyzm
+----------+-----------+------------+----------
+false     | false     | false      | true
+```
+
+### Geometry structure and SRID
+
+Geometry type and nesting are compared. SRID is intentionally ignored.
+
+```sql
+SELECT
+    ST_EqualsIdentical(
+        ST_GeomFromWKT('MULTIPOINT ((0 0))'),
+        ST_GeomFromWKT('GEOMETRYCOLLECTION (POINT (0 0))')
+    ) AS different_types,
+    ST_EqualsIdentical(
+        ST_SetSRID(ST_GeomFromWKT('POINT (1 2)'), 4326),
+        ST_SetSRID(ST_GeomFromWKT('POINT (1 2)'), 3857)
+    ) AS srid_is_ignored;
+```
+
+Output:
+
+```text
+different_types | srid_is_ignored
+----------------+----------------
+false           | true
+```
+
+Identity does not imply CRS compatibility. Validate or transform SRIDs before using the
+geometries together.
+
+### NaN and NULL
+
+NaN ordinates compare equal to NaN ordinates in the corresponding position. A SQL NULL operand
+produces NULL.
+
+```sql
+SELECT
+    ST_EqualsIdentical(
+        ST_GeomFromWKT('POINT (NaN 2)'),
+        ST_GeomFromWKT('POINT (NaN 2)')
+    ) AS matching_nan,
+    ST_EqualsIdentical(
+        NULL,
+        ST_GeomFromWKT('POINT (1 2)')
+    ) AS null_result;
+```
+
+Output:
+
+```text
+matching_nan | null_result
+-------------+------------
+true         | NULL
+```
+
+## Practical use: lossless geometry validation
+
+Use `ST_EqualsIdentical` for deterministic change detection after serialization, storage, or an
+ETL rewrite. It can reveal a reversed coordinate sequence, a changed geometry container, or a
+lost Z/M ordinate even when `ST_Equals` reports the same shape.
+
+The following query flags rows whose geometry representation changed:
+
+```sql
+SELECT
+    record_id,
+    CASE
+        WHEN source_geometry IS NULL OR reloaded_geometry IS NULL THEN 'missing_geometry'
+        WHEN ST_EqualsIdentical(source_geometry, reloaded_geometry) THEN 'unchanged'
+        ELSE 'changed'
+    END AS validation_result
+FROM geometry_round_trip;
+```
+
+This predicate checks geometric content, not a byte-for-byte encoding. Compare SRID and any
+application metadata separately when those fields are part of the validation contract. Where the
+input geometry types support topological equality, use `ST_Equals` in a separate comparison to
+distinguish representation-only changes from changed topology.

--- a/docs/api/sql/Predicates/ST_EqualsIdentical.md
+++ b/docs/api/sql/Predicates/ST_EqualsIdentical.md
@@ -58,6 +58,12 @@ For ZM geometries, both the Z and M values participate in the comparison.
 `ST_EqualsIdentical` does not compare SRID, precision model, user data, or the coordinate-sequence
 implementation. Compare SRIDs separately when CRS identity is also required.
 
+The predicate compares the dimensions retained by the geometry value it receives. At Spark and
+Flink serialization boundaries, JTS cannot distinguish ordinary XY coordinates from declared XYZ
+coordinates when every Z ordinate is NaN; those values may normalize to XY. Empty XYZ values and
+zero-member collections have the same limitation. Mixed layouts within a Polygon or multi-geometry
+are rejected by the serializer; use a GeometryCollection when members need independent layouts.
+
 ## SQL examples
 
 ### Identical XYZ geometries
@@ -186,7 +192,7 @@ matching_nan | null_result
 true         | NULL
 ```
 
-## Practical use: lossless geometry validation
+## Practical use: geometry round-trip validation
 
 Use `ST_EqualsIdentical` for deterministic change detection after serialization, storage, or an
 ETL rewrite. It can reveal a reversed coordinate sequence, a changed geometry container, or a

--- a/docs/image/ST_EqualsIdentical/ST_EqualsIdentical_dimensions.svg
+++ b/docs/image/ST_EqualsIdentical/ST_EqualsIdentical_dimensions.svg
@@ -1,0 +1,154 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 970" width="1200" height="970" role="img" aria-labelledby="equals-identical-dimensions-title equals-identical-dimensions-description">
+  <title id="equals-identical-dimensions-title">ST_EqualsIdentical compares every coordinate dimension and ordinate value</title>
+  <desc id="equals-identical-dimensions-description">Four point comparisons with input A and input B in separate panels. Matching XYZ points return true. A different Z value returns false. Equal numeric triples interpreted as XYZ and XYM return false because Z and M are different ordinate roles. Two XYZM points with different M values return false.</desc>
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+      text:not([fill]) { fill: #172033; }
+      .comparison { fill: #f8fafc; stroke: #b8c3d1; stroke-width: 1.5; }
+      .input-card { fill: #ffffff; stroke-width: 2; }
+      .input-a-card { stroke: #005ea8; }
+      .input-b-card { stroke: #b8324a; stroke-dasharray: 8 5; }
+      .row-title { font-size: 15px; font-weight: 700; }
+      .input-title { font-size: 13px; font-weight: 700; }
+      .caption { font-size: 12px; fill: #475569; }
+      .small { font-size: 11px; fill: #475569; }
+      .wkt { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 12px; fill: #334155; }
+      .slot { fill: #eef3f8; stroke: #8291a5; stroke-width: 1.4; }
+      .slot-different { fill: #fff7ed; stroke: #a84d00; stroke-width: 2; stroke-dasharray: 5 3; }
+      .slot-name { font-size: 11px; font-weight: 700; fill: #475569; }
+      .slot-value { font-size: 16px; font-weight: 700; }
+      .signature { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 11px; font-weight: 700; }
+      .result-true { fill: #e6f5ef; stroke: #08775f; stroke-width: 2; }
+      .result-false { fill: #fff0f1; stroke: #a92e43; stroke-width: 2; }
+      .result-word { font-size: 20px; font-weight: 800; }
+    </style>
+  </defs>
+
+  <rect width="1200" height="970" fill="#ffffff"/>
+  <text x="600" y="32" text-anchor="middle" font-size="22" font-weight="700">Every coordinate dimension is part of identity</text>
+  <text x="600" y="57" text-anchor="middle" class="caption">X, Y, Z, and M roles and values must match exactly; a dashed slot identifies the stored difference.</text>
+
+  <!-- Matching XYZ points: true. -->
+  <rect x="25" y="80" width="1150" height="195" rx="10" class="comparison"/>
+  <text x="45" y="108" class="row-title">1 · Matching XYZ layout and values</text>
+
+  <rect x="45" y="124" width="420" height="130" rx="8" class="input-card input-a-card"/>
+  <text x="62" y="147" class="input-title" fill="#005ea8">Input A · POINT Z</text>
+  <rect x="330" y="133" width="115" height="23" rx="11" fill="#eef6fb" stroke="#96bfd9"/><text x="387" y="149" text-anchor="middle" class="signature" fill="#005ea8">layout XYZ</text>
+  <rect x="75" y="163" width="92" height="53" rx="7" class="slot"/><text x="121" y="181" text-anchor="middle" class="slot-name">X</text><text x="121" y="205" text-anchor="middle" class="slot-value">1</text>
+  <rect x="188" y="163" width="92" height="53" rx="7" class="slot"/><text x="234" y="181" text-anchor="middle" class="slot-name">Y</text><text x="234" y="205" text-anchor="middle" class="slot-value">2</text>
+  <rect x="301" y="163" width="92" height="53" rx="7" class="slot"/><text x="347" y="181" text-anchor="middle" class="slot-name">Z</text><text x="347" y="205" text-anchor="middle" class="slot-value">3</text>
+  <text x="255" y="241" text-anchor="middle" class="wkt">POINT Z (1 2 3)</text>
+
+  <rect x="490" y="124" width="420" height="130" rx="8" class="input-card input-b-card"/>
+  <text x="507" y="147" class="input-title" fill="#a92e43">Input B · POINT Z</text>
+  <rect x="775" y="133" width="115" height="23" rx="11" fill="#fff5f5" stroke="#e0a4ae"/><text x="832" y="149" text-anchor="middle" class="signature" fill="#a92e43">layout XYZ</text>
+  <rect x="520" y="163" width="92" height="53" rx="7" class="slot"/><text x="566" y="181" text-anchor="middle" class="slot-name">X</text><text x="566" y="205" text-anchor="middle" class="slot-value">1</text>
+  <rect x="633" y="163" width="92" height="53" rx="7" class="slot"/><text x="679" y="181" text-anchor="middle" class="slot-name">Y</text><text x="679" y="205" text-anchor="middle" class="slot-value">2</text>
+  <rect x="746" y="163" width="92" height="53" rx="7" class="slot"/><text x="792" y="181" text-anchor="middle" class="slot-name">Z</text><text x="792" y="205" text-anchor="middle" class="slot-value">3</text>
+  <text x="700" y="241" text-anchor="middle" class="wkt">POINT Z (1 2 3)</text>
+
+  <rect x="935" y="139" width="220" height="100" rx="9" class="result-true"/>
+  <text x="1045" y="166" text-anchor="middle" class="small">ST_EqualsIdentical(A, B)</text>
+  <text x="1045" y="200" text-anchor="middle" class="result-word" fill="#08775f">TRUE</text>
+  <text x="1045" y="222" text-anchor="middle" class="small">layout and values match</text>
+
+  <!-- Z value differs: false. -->
+  <rect x="25" y="290" width="1150" height="195" rx="10" class="comparison"/>
+  <text x="45" y="318" class="row-title">2 · Same XYZ layout, different Z value</text>
+
+  <rect x="45" y="334" width="420" height="130" rx="8" class="input-card input-a-card"/>
+  <text x="62" y="357" class="input-title" fill="#005ea8">Input A · POINT Z</text>
+  <rect x="330" y="343" width="115" height="23" rx="11" fill="#eef6fb" stroke="#96bfd9"/><text x="387" y="359" text-anchor="middle" class="signature" fill="#005ea8">layout XYZ</text>
+  <rect x="75" y="373" width="92" height="53" rx="7" class="slot"/><text x="121" y="391" text-anchor="middle" class="slot-name">X</text><text x="121" y="415" text-anchor="middle" class="slot-value">1</text>
+  <rect x="188" y="373" width="92" height="53" rx="7" class="slot"/><text x="234" y="391" text-anchor="middle" class="slot-name">Y</text><text x="234" y="415" text-anchor="middle" class="slot-value">2</text>
+  <rect x="301" y="373" width="92" height="53" rx="7" class="slot-different"/><text x="347" y="391" text-anchor="middle" class="slot-name">Z · differs</text><text x="347" y="415" text-anchor="middle" class="slot-value">3</text>
+  <text x="255" y="451" text-anchor="middle" class="wkt">POINT Z (1 2 3)</text>
+
+  <rect x="490" y="334" width="420" height="130" rx="8" class="input-card input-b-card"/>
+  <text x="507" y="357" class="input-title" fill="#a92e43">Input B · POINT Z</text>
+  <rect x="775" y="343" width="115" height="23" rx="11" fill="#fff5f5" stroke="#e0a4ae"/><text x="832" y="359" text-anchor="middle" class="signature" fill="#a92e43">layout XYZ</text>
+  <rect x="520" y="373" width="92" height="53" rx="7" class="slot"/><text x="566" y="391" text-anchor="middle" class="slot-name">X</text><text x="566" y="415" text-anchor="middle" class="slot-value">1</text>
+  <rect x="633" y="373" width="92" height="53" rx="7" class="slot"/><text x="679" y="391" text-anchor="middle" class="slot-name">Y</text><text x="679" y="415" text-anchor="middle" class="slot-value">2</text>
+  <rect x="746" y="373" width="92" height="53" rx="7" class="slot-different"/><text x="792" y="391" text-anchor="middle" class="slot-name">Z · differs</text><text x="792" y="415" text-anchor="middle" class="slot-value">4</text>
+  <text x="700" y="451" text-anchor="middle" class="wkt">POINT Z (1 2 4)</text>
+
+  <rect x="935" y="349" width="220" height="100" rx="9" class="result-false"/>
+  <text x="1045" y="376" text-anchor="middle" class="small">ST_EqualsIdentical(A, B)</text>
+  <text x="1045" y="410" text-anchor="middle" class="result-word" fill="#a92e43">FALSE</text>
+  <text x="1045" y="432" text-anchor="middle" class="small">Z: 3 ≠ 4</text>
+
+  <!-- Same number, different third-ordinate role: false. -->
+  <rect x="25" y="500" width="1150" height="195" rx="10" class="comparison"/>
+  <text x="45" y="528" class="row-title">3 · Same numeric triple, different third-ordinate role</text>
+
+  <rect x="45" y="544" width="420" height="130" rx="8" class="input-card input-a-card"/>
+  <text x="62" y="567" class="input-title" fill="#005ea8">Input A · elevation (Z)</text>
+  <rect x="330" y="553" width="115" height="23" rx="11" fill="#eef6fb" stroke="#96bfd9"/><text x="387" y="569" text-anchor="middle" class="signature" fill="#005ea8">layout XYZ</text>
+  <rect x="75" y="583" width="92" height="53" rx="7" class="slot"/><text x="121" y="601" text-anchor="middle" class="slot-name">X</text><text x="121" y="625" text-anchor="middle" class="slot-value">1</text>
+  <rect x="188" y="583" width="92" height="53" rx="7" class="slot"/><text x="234" y="601" text-anchor="middle" class="slot-name">Y</text><text x="234" y="625" text-anchor="middle" class="slot-value">2</text>
+  <rect x="301" y="583" width="92" height="53" rx="7" class="slot-different"/><text x="347" y="601" text-anchor="middle" class="slot-name">role Z</text><text x="347" y="625" text-anchor="middle" class="slot-value">3</text>
+  <text x="255" y="661" text-anchor="middle" class="wkt">POINT Z (1 2 3)</text>
+
+  <rect x="490" y="544" width="420" height="130" rx="8" class="input-card input-b-card"/>
+  <text x="507" y="567" class="input-title" fill="#a92e43">Input B · measure (M)</text>
+  <rect x="775" y="553" width="115" height="23" rx="11" fill="#fff5f5" stroke="#e0a4ae"/><text x="832" y="569" text-anchor="middle" class="signature" fill="#a92e43">layout XYM</text>
+  <rect x="520" y="583" width="92" height="53" rx="7" class="slot"/><text x="566" y="601" text-anchor="middle" class="slot-name">X</text><text x="566" y="625" text-anchor="middle" class="slot-value">1</text>
+  <rect x="633" y="583" width="92" height="53" rx="7" class="slot"/><text x="679" y="601" text-anchor="middle" class="slot-name">Y</text><text x="679" y="625" text-anchor="middle" class="slot-value">2</text>
+  <rect x="746" y="583" width="92" height="53" rx="7" class="slot-different"/><text x="792" y="601" text-anchor="middle" class="slot-name">role M</text><text x="792" y="625" text-anchor="middle" class="slot-value">3</text>
+  <text x="700" y="661" text-anchor="middle" class="wkt">POINT M (1 2 3)</text>
+
+  <rect x="935" y="559" width="220" height="100" rx="9" class="result-false"/>
+  <text x="1045" y="586" text-anchor="middle" class="small">ST_EqualsIdentical(A, B)</text>
+  <text x="1045" y="620" text-anchor="middle" class="result-word" fill="#a92e43">FALSE</text>
+  <text x="1045" y="642" text-anchor="middle" class="small">XYZ ≠ XYM</text>
+
+  <!-- XYZM measure differs: false. -->
+  <rect x="25" y="710" width="1150" height="195" rx="10" class="comparison"/>
+  <text x="45" y="738" class="row-title">4 · Same XYZ values, different M value</text>
+
+  <rect x="45" y="754" width="420" height="130" rx="8" class="input-card input-a-card"/>
+  <text x="62" y="777" class="input-title" fill="#005ea8">Input A · POINT ZM</text>
+  <rect x="325" y="763" width="120" height="23" rx="11" fill="#eef6fb" stroke="#96bfd9"/><text x="385" y="779" text-anchor="middle" class="signature" fill="#005ea8">layout XYZM</text>
+  <rect x="67" y="793" width="73" height="53" rx="7" class="slot"/><text x="103" y="811" text-anchor="middle" class="slot-name">X</text><text x="103" y="835" text-anchor="middle" class="slot-value">1</text>
+  <rect x="153" y="793" width="73" height="53" rx="7" class="slot"/><text x="189" y="811" text-anchor="middle" class="slot-name">Y</text><text x="189" y="835" text-anchor="middle" class="slot-value">2</text>
+  <rect x="239" y="793" width="73" height="53" rx="7" class="slot"/><text x="275" y="811" text-anchor="middle" class="slot-name">Z</text><text x="275" y="835" text-anchor="middle" class="slot-value">3</text>
+  <rect x="325" y="793" width="73" height="53" rx="7" class="slot-different"/><text x="361" y="811" text-anchor="middle" class="slot-name">M · differs</text><text x="361" y="835" text-anchor="middle" class="slot-value">4</text>
+  <text x="255" y="871" text-anchor="middle" class="wkt">POINT ZM (1 2 3 4)</text>
+
+  <rect x="490" y="754" width="420" height="130" rx="8" class="input-card input-b-card"/>
+  <text x="507" y="777" class="input-title" fill="#a92e43">Input B · POINT ZM</text>
+  <rect x="770" y="763" width="120" height="23" rx="11" fill="#fff5f5" stroke="#e0a4ae"/><text x="830" y="779" text-anchor="middle" class="signature" fill="#a92e43">layout XYZM</text>
+  <rect x="512" y="793" width="73" height="53" rx="7" class="slot"/><text x="548" y="811" text-anchor="middle" class="slot-name">X</text><text x="548" y="835" text-anchor="middle" class="slot-value">1</text>
+  <rect x="598" y="793" width="73" height="53" rx="7" class="slot"/><text x="634" y="811" text-anchor="middle" class="slot-name">Y</text><text x="634" y="835" text-anchor="middle" class="slot-value">2</text>
+  <rect x="684" y="793" width="73" height="53" rx="7" class="slot"/><text x="720" y="811" text-anchor="middle" class="slot-name">Z</text><text x="720" y="835" text-anchor="middle" class="slot-value">3</text>
+  <rect x="770" y="793" width="73" height="53" rx="7" class="slot-different"/><text x="806" y="811" text-anchor="middle" class="slot-name">M · differs</text><text x="806" y="835" text-anchor="middle" class="slot-value">9</text>
+  <text x="700" y="871" text-anchor="middle" class="wkt">POINT ZM (1 2 3 9)</text>
+
+  <rect x="935" y="769" width="220" height="100" rx="9" class="result-false"/>
+  <text x="1045" y="796" text-anchor="middle" class="small">ST_EqualsIdentical(A, B)</text>
+  <text x="1045" y="830" text-anchor="middle" class="result-word" fill="#a92e43">FALSE</text>
+  <text x="1045" y="852" text-anchor="middle" class="small">M: 4 ≠ 9</text>
+
+  <rect x="25" y="920" width="1150" height="32" rx="7" fill="#eef2ff" stroke="#b7b9e6"/>
+  <text x="600" y="941" text-anchor="middle" class="small" fill="#4338ca">Z is elevation and M is a measure; equal numbers in different ordinate roles are not identical.</text>
+</svg>

--- a/docs/image/ST_EqualsIdentical/ST_EqualsIdentical_structure.svg
+++ b/docs/image/ST_EqualsIdentical/ST_EqualsIdentical_structure.svg
@@ -1,0 +1,135 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 830" width="1200" height="830" role="img" aria-labelledby="equals-identical-structure-title equals-identical-structure-description">
+  <title id="equals-identical-structure-title">ST_EqualsIdentical compares stored geometry structure and coordinate order</title>
+  <desc id="equals-identical-structure-description">Three comparisons with input A and input B shown in separate panels. Two line strings with the same coordinate sequence return true. The same line traced in reverse order returns false. A MultiPoint and a GeometryCollection containing the same two visible points return false because their geometry types and structures differ.</desc>
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, Helvetica, sans-serif; }
+      text:not([fill]) { fill: #172033; }
+      .comparison { fill: #f8fafc; stroke: #b8c3d1; stroke-width: 1.5; }
+      .input-card { fill: #ffffff; stroke-width: 2; }
+      .input-a-card { stroke: #005ea8; }
+      .input-b-card { stroke: #b8324a; stroke-dasharray: 8 5; }
+      .row-title { font-size: 15px; font-weight: 700; }
+      .input-title { font-size: 14px; font-weight: 700; }
+      .caption { font-size: 12px; fill: #475569; }
+      .small { font-size: 11px; fill: #475569; }
+      .wkt { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 12px; fill: #334155; }
+      .a-line { fill: none; stroke: #005ea8; stroke-width: 5; stroke-linecap: round; stroke-linejoin: round; }
+      .b-line { fill: none; stroke: #b8324a; stroke-width: 5; stroke-linecap: round; stroke-linejoin: round; stroke-dasharray: 10 6; }
+      .a-vertex { fill: #ffffff; stroke: #005ea8; stroke-width: 2; }
+      .b-vertex { fill: #ffffff; stroke: #b8324a; stroke-width: 2; }
+      .vertex-label { font-size: 10px; font-weight: 700; }
+      .result-true { fill: #e6f5ef; stroke: #08775f; stroke-width: 2; }
+      .result-false { fill: #fff0f1; stroke: #a92e43; stroke-width: 2; }
+      .result-word { font-size: 20px; font-weight: 800; }
+    </style>
+    <marker id="structure-a-arrow" markerWidth="10" markerHeight="10" refX="9" refY="5" orient="auto" markerUnits="userSpaceOnUse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#005ea8"/>
+    </marker>
+    <marker id="structure-b-arrow" markerWidth="10" markerHeight="10" refX="9" refY="5" orient="auto" markerUnits="userSpaceOnUse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#b8324a"/>
+    </marker>
+  </defs>
+
+  <rect width="1200" height="830" fill="#ffffff"/>
+  <text x="600" y="32" text-anchor="middle" font-size="22" font-weight="700">Exact structure and coordinate order</text>
+  <text x="600" y="57" text-anchor="middle" class="caption">The visible shape is not enough: geometry type, nesting, component order, and vertex order must all match.</text>
+
+  <!-- Same coordinate order: true. -->
+  <rect x="25" y="80" width="1150" height="225" rx="10" class="comparison"/>
+  <text x="45" y="108" class="row-title">1 · Same type, structure, and vertex order</text>
+  <text x="45" y="128" class="caption">Both lines visit vertices 1 → 2 → 3.</text>
+
+  <rect x="45" y="143" width="435" height="142" rx="8" class="input-card input-a-card"/>
+  <text x="62" y="166" class="input-title" fill="#005ea8">Input A · solid</text>
+  <path d="M90 232 L260 187 L430 232" class="a-line" marker-end="url(#structure-a-arrow)"/>
+  <circle cx="90" cy="232" r="10" class="a-vertex"/><text x="90" y="236" text-anchor="middle" class="vertex-label" fill="#005ea8">1</text>
+  <circle cx="260" cy="187" r="10" class="a-vertex"/><text x="260" y="191" text-anchor="middle" class="vertex-label" fill="#005ea8">2</text>
+  <circle cx="430" cy="232" r="10" class="a-vertex"/><text x="430" y="236" text-anchor="middle" class="vertex-label" fill="#005ea8">3</text>
+  <text x="262" y="270" text-anchor="middle" class="wkt">LINESTRING (0 0, 2 2, 4 0)</text>
+
+  <rect x="500" y="143" width="435" height="142" rx="8" class="input-card input-b-card"/>
+  <text x="517" y="166" class="input-title" fill="#a92e43">Input B · dashed</text>
+  <path d="M545 232 L715 187 L885 232" class="b-line" marker-end="url(#structure-b-arrow)"/>
+  <circle cx="545" cy="232" r="10" class="b-vertex"/><text x="545" y="236" text-anchor="middle" class="vertex-label" fill="#a92e43">1</text>
+  <circle cx="715" cy="187" r="10" class="b-vertex"/><text x="715" y="191" text-anchor="middle" class="vertex-label" fill="#a92e43">2</text>
+  <circle cx="885" cy="232" r="10" class="b-vertex"/><text x="885" y="236" text-anchor="middle" class="vertex-label" fill="#a92e43">3</text>
+  <text x="717" y="270" text-anchor="middle" class="wkt">LINESTRING (0 0, 2 2, 4 0)</text>
+
+  <rect x="955" y="164" width="200" height="100" rx="9" class="result-true"/>
+  <text x="1055" y="191" text-anchor="middle" class="small">ST_EqualsIdentical(A, B)</text>
+  <text x="1055" y="225" text-anchor="middle" class="result-word" fill="#08775f">TRUE</text>
+  <text x="1055" y="247" text-anchor="middle" class="small">all compared details match</text>
+
+  <!-- Reverse coordinate order: false. -->
+  <rect x="25" y="320" width="1150" height="225" rx="10" class="comparison"/>
+  <text x="45" y="348" class="row-title">2 · Same trace, opposite vertex order</text>
+  <text x="45" y="368" class="caption">The paths are topologically equal, but B stores the coordinates in reverse.</text>
+
+  <rect x="45" y="383" width="435" height="142" rx="8" class="input-card input-a-card"/>
+  <text x="62" y="406" class="input-title" fill="#005ea8">Input A · solid</text>
+  <path d="M90 472 L260 427 L430 472" class="a-line" marker-end="url(#structure-a-arrow)"/>
+  <circle cx="90" cy="472" r="10" class="a-vertex"/><text x="90" y="476" text-anchor="middle" class="vertex-label" fill="#005ea8">1</text>
+  <circle cx="260" cy="427" r="10" class="a-vertex"/><text x="260" y="431" text-anchor="middle" class="vertex-label" fill="#005ea8">2</text>
+  <circle cx="430" cy="472" r="10" class="a-vertex"/><text x="430" y="476" text-anchor="middle" class="vertex-label" fill="#005ea8">3</text>
+  <text x="262" y="510" text-anchor="middle" class="wkt">LINESTRING (0 0, 2 2, 4 0)</text>
+
+  <rect x="500" y="383" width="435" height="142" rx="8" class="input-card input-b-card"/>
+  <text x="517" y="406" class="input-title" fill="#a92e43">Input B · dashed</text>
+  <path d="M885 472 L715 427 L545 472" class="b-line" marker-end="url(#structure-b-arrow)"/>
+  <circle cx="885" cy="472" r="10" class="b-vertex"/><text x="885" y="476" text-anchor="middle" class="vertex-label" fill="#a92e43">1</text>
+  <circle cx="715" cy="427" r="10" class="b-vertex"/><text x="715" y="431" text-anchor="middle" class="vertex-label" fill="#a92e43">2</text>
+  <circle cx="545" cy="472" r="10" class="b-vertex"/><text x="545" y="476" text-anchor="middle" class="vertex-label" fill="#a92e43">3</text>
+  <text x="717" y="510" text-anchor="middle" class="wkt">LINESTRING (4 0, 2 2, 0 0)</text>
+
+  <rect x="955" y="404" width="200" height="100" rx="9" class="result-false"/>
+  <text x="1055" y="431" text-anchor="middle" class="small">ST_EqualsIdentical(A, B)</text>
+  <text x="1055" y="465" text-anchor="middle" class="result-word" fill="#a92e43">FALSE</text>
+  <text x="1055" y="487" text-anchor="middle" class="small">coordinate order differs</text>
+
+  <!-- Same visible members, different structural type: false. -->
+  <rect x="25" y="560" width="1150" height="225" rx="10" class="comparison"/>
+  <text x="45" y="588" class="row-title">3 · Same visible points, different container structure</text>
+  <text x="45" y="608" class="caption">A MultiPoint and a GeometryCollection remain distinct even when their child points match.</text>
+
+  <rect x="45" y="623" width="435" height="142" rx="8" class="input-card input-a-card"/>
+  <text x="62" y="646" class="input-title" fill="#005ea8">Input A · MultiPoint</text>
+  <rect x="80" y="660" width="365" height="54" rx="20" fill="#eef6fb" stroke="#005ea8" stroke-width="1.5"/>
+  <circle cx="160" cy="687" r="11" fill="#005ea8"/><text x="160" y="691" text-anchor="middle" class="vertex-label" fill="#ffffff">1</text>
+  <circle cx="365" cy="687" r="11" fill="#005ea8"/><text x="365" y="691" text-anchor="middle" class="vertex-label" fill="#ffffff">2</text>
+  <text x="262" y="749" text-anchor="middle" class="wkt">MULTIPOINT ((0 0), (4 0))</text>
+
+  <rect x="500" y="623" width="435" height="142" rx="8" class="input-card input-b-card"/>
+  <text x="517" y="646" class="input-title" fill="#a92e43">Input B · GeometryCollection</text>
+  <rect x="530" y="660" width="375" height="54" rx="8" fill="#fff5f5" stroke="#b8324a" stroke-width="1.5" stroke-dasharray="7 4"/>
+  <rect x="555" y="669" width="125" height="36" rx="16" fill="#ffffff" stroke="#b8324a"/><circle cx="575" cy="687" r="8" fill="#b8324a"/><text x="618" y="692" text-anchor="middle" class="small">POINT 1</text>
+  <rect x="755" y="669" width="125" height="36" rx="16" fill="#ffffff" stroke="#b8324a"/><circle cx="775" cy="687" r="8" fill="#b8324a"/><text x="818" y="692" text-anchor="middle" class="small">POINT 2</text>
+  <text x="717" y="738" text-anchor="middle" class="wkt">GEOMETRYCOLLECTION (POINT (0 0),</text>
+  <text x="717" y="754" text-anchor="middle" class="wkt">POINT (4 0))</text>
+
+  <rect x="955" y="644" width="200" height="100" rx="9" class="result-false"/>
+  <text x="1055" y="671" text-anchor="middle" class="small">ST_EqualsIdentical(A, B)</text>
+  <text x="1055" y="705" text-anchor="middle" class="result-word" fill="#a92e43">FALSE</text>
+  <text x="1055" y="727" text-anchor="middle" class="small">type and nesting differ</text>
+
+  <rect x="25" y="800" width="1150" height="22" rx="6" fill="#eef2ff" stroke="#b7b9e6"/>
+  <text x="600" y="815" text-anchor="middle" class="small" fill="#4338ca">Use ST_Equals when only topology matters; use ST_EqualsIdentical to verify type, structure, order, and coordinates.</text>
+</svg>

--- a/flink/src/main/java/org/apache/sedona/flink/Catalog.java
+++ b/flink/src/main/java/org/apache/sedona/flink/Catalog.java
@@ -275,6 +275,7 @@ public class Catalog {
       new Predicates.ST_Disjoint(),
       new Predicates.ST_Equals(),
       new Predicates.ST_EqualsExact(),
+      new Predicates.ST_EqualsIdentical(),
       new Predicates.ST_OrderingEquals(),
       new Predicates.ST_Overlaps(),
       new Predicates.ST_Touches(),

--- a/flink/src/main/java/org/apache/sedona/flink/expressions/Predicates.java
+++ b/flink/src/main/java/org/apache/sedona/flink/expressions/Predicates.java
@@ -371,6 +371,29 @@ public class Predicates {
     }
   }
 
+  public static class ST_EqualsIdentical extends ScalarFunction {
+
+    public ST_EqualsIdentical() {}
+
+    @DataTypeHint("Boolean")
+    public Boolean eval(
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = GeometryTypeSerializer.class,
+                bridgedTo = Geometry.class)
+            Object o1,
+        @DataTypeHint(
+                value = "RAW",
+                rawSerializer = GeometryTypeSerializer.class,
+                bridgedTo = Geometry.class)
+            Object o2) {
+      if (o1 == null || o2 == null) return null;
+      Geometry geom1 = (Geometry) o1;
+      Geometry geom2 = (Geometry) o2;
+      return org.apache.sedona.common.Predicates.equalsIdentical(geom1, geom2);
+    }
+  }
+
   public static class ST_OrderingEquals extends ScalarFunction {
 
     /** Constructor for relation checking without duplicate removal */

--- a/flink/src/test/java/org/apache/sedona/flink/PredicateTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/PredicateTest.java
@@ -230,6 +230,30 @@ public class PredicateTest extends TestBase {
   }
 
   @Test
+  public void testEqualsIdentical() {
+    Table table =
+        tableEnv.sqlQuery(
+            "SELECT"
+                + " ST_EqualsIdentical(ST_GeomFromWKT('POINT Z (1 2 3)'),"
+                + " ST_GeomFromWKT('POINT Z (1 2 3)')) AS identical,"
+                + " ST_EqualsIdentical(ST_GeomFromWKT('POINT Z (1 2 3)'),"
+                + " ST_GeomFromWKT('POINT Z (1 2 4)')) AS different_z,"
+                + " ST_EqualsIdentical(ST_GeomFromWKT('POINT Z (1 2 3)'),"
+                + " ST_GeomFromWKT('POINT M (1 2 3)')) AS different_dimension,"
+                + " ST_EqualsIdentical("
+                + " ST_GeomFromWKT('LINESTRING (0 0, 1 1)'),"
+                + " ST_GeomFromWKT('LINESTRING (1 1, 0 0)')) AS different_order,"
+                + " ST_EqualsIdentical(ST_GeomFromWKT(CAST(NULL AS STRING)),"
+                + " ST_Point(0.0, 0.0)) AS null_left");
+    org.apache.flink.types.Row row = first(table);
+    assertEquals(true, row.getField(0));
+    assertEquals(false, row.getField(1));
+    assertEquals(false, row.getField(2));
+    assertEquals(false, row.getField(3));
+    assertNull(row.getField(4));
+  }
+
+  @Test
   public void testOrderingEquals() {
     Table lineStringTable = createLineStringTable(testDataSize);
     String lineString = createLineStringWKT(testDataSize).get(0).getField(0).toString();

--- a/python/sedona/spark/sql/st_predicates.py
+++ b/python/sedona/spark/sql/st_predicates.py
@@ -115,6 +115,24 @@ def ST_EqualsExact(
 
 
 @validate_argument_types
+def ST_EqualsIdentical(a: ColumnOrName, b: ColumnOrName) -> Column:
+    """Check whether two geometries are structurally identical in every dimension.
+
+    Geometry types, component ordering, vertex ordering, dimensionality, and all
+    coordinate values must match exactly. NaN ordinate values compare equal to
+    other NaN values.
+
+    :param a: One geometry column to check.
+    :type a: ColumnOrName
+    :param b: Other geometry column to check.
+    :type b: ColumnOrName
+    :return: True if a and b are identical, otherwise False.
+    :rtype: Column
+    """
+    return _call_predicate_function("ST_EqualsIdentical", (a, b))
+
+
+@validate_argument_types
 def ST_Intersects(a: ColumnOrName, b: ColumnOrName) -> Column:
     """Check whether a and b intersect. Polymorphic over input type:
 

--- a/python/tests/sql/test_dataframe_api.py
+++ b/python/tests/sql/test_dataframe_api.py
@@ -1287,6 +1287,16 @@ test_configurations = [
         "",
         True,
     ),
+    (
+        stp.ST_EqualsIdentical,
+        (
+            lambda: f.expr("ST_GeomFromWKT('POINT Z (1 2 3)')"),
+            lambda: f.expr("ST_GeomFromWKT('POINT Z (1 2 3)')"),
+        ),
+        "triangle_geom",
+        "",
+        True,
+    ),
     (stp.ST_Intersects, ("a", "b"), "overlapping_polys", "", True),
     (
         stp.ST_OrderingEquals,
@@ -1682,6 +1692,8 @@ wrong_type_configurations = [
     (stp.ST_EqualsExact, (None, "", 0.0)),
     (stp.ST_EqualsExact, ("", None, 0.0)),
     (stp.ST_EqualsExact, ("", "", None)),
+    (stp.ST_EqualsIdentical, (None, "")),
+    (stp.ST_EqualsIdentical, ("", None)),
     (stp.ST_Overlaps, (None, "")),
     (stp.ST_Overlaps, ("", None)),
     (stp.ST_Touches, (None, "")),

--- a/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestPredicates.java
+++ b/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestPredicates.java
@@ -79,6 +79,20 @@ public class TestPredicates extends TestBase {
   }
 
   @Test
+  public void test_ST_EqualsIdentical() {
+    registerUDF("ST_EqualsIdentical", byte[].class, byte[].class);
+    verifySqlSingleRes(
+        "SELECT SEDONA.ST_EqualsIdentical(SEDONA.ST_GeomFromWKT('POINT Z (1 2 3)'), SEDONA.ST_GeomFromWKT('POINT Z (1 2 3)'))",
+        true);
+    verifySqlSingleRes(
+        "SELECT SEDONA.ST_EqualsIdentical(SEDONA.ST_GeomFromWKT('POINT Z (1 2 3)'), SEDONA.ST_GeomFromWKT('POINT Z (1 2 4)'))",
+        false);
+    verifySqlSingleRes(
+        "SELECT SEDONA.ST_EqualsIdentical(SEDONA.ST_GeomFromWKT('POINT Z (1 2 3)'), SEDONA.ST_GeomFromWKT('POINT M (1 2 3)'))",
+        false);
+  }
+
+  @Test
   public void test_ST_Intersects() {
     registerUDF("ST_Intersects", byte[].class, byte[].class);
     verifySqlSingleRes(

--- a/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestPredicatesV2.java
+++ b/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestPredicatesV2.java
@@ -79,6 +79,17 @@ public class TestPredicatesV2 extends TestBase {
   }
 
   @Test
+  public void test_ST_EqualsIdentical() {
+    registerUDFV2("ST_EqualsIdentical", String.class, String.class);
+    verifySqlSingleRes(
+        "SELECT SEDONA.ST_EqualsIdentical(ST_GeometryFromWKT('LINESTRING (0 0, 1 1)'), ST_GeometryFromWKT('LINESTRING (0 0, 1 1)'))",
+        true);
+    verifySqlSingleRes(
+        "SELECT SEDONA.ST_EqualsIdentical(ST_GeometryFromWKT('LINESTRING (0 0, 1 1)'), ST_GeometryFromWKT('LINESTRING (1 1, 0 0)'))",
+        false);
+  }
+
+  @Test
   public void test_ST_Intersects() {
     registerUDFV2("ST_Intersects", String.class, String.class);
     verifySqlSingleRes(

--- a/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/UDFs.java
+++ b/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/UDFs.java
@@ -412,6 +412,12 @@ public class UDFs {
         tolerance);
   }
 
+  @UDFAnnotations.ParamMeta(argNames = {"leftGeometry", "rightGeometry"})
+  public static boolean ST_EqualsIdentical(byte[] leftGeometry, byte[] rightGeometry) {
+    return Predicates.equalsIdentical(
+        GeometrySerde.deserialize(leftGeometry), GeometrySerde.deserialize(rightGeometry));
+  }
+
   @UDFAnnotations.ParamMeta(argNames = {"geometry"})
   public static byte[] ST_ExteriorRing(byte[] geometry) {
     return GeometrySerde.serialize(Functions.exteriorRing(GeometrySerde.deserialize(geometry)));

--- a/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/UDFsV2.java
+++ b/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/UDFsV2.java
@@ -575,6 +575,15 @@ public class UDFsV2 {
         tolerance);
   }
 
+  @UDFAnnotations.GeometryOnly
+  @UDFAnnotations.ParamMeta(
+      argNames = {"leftGeometry", "rightGeometry"},
+      argTypes = {"Geometry", "Geometry"})
+  public static boolean ST_EqualsIdentical(String leftGeometry, String rightGeometry) {
+    return Predicates.equalsIdentical(
+        GeometrySerde.deserGeoJson(leftGeometry), GeometrySerde.deserGeoJson(rightGeometry));
+  }
+
   @UDFAnnotations.ParamMeta(
       argNames = {"geometry"},
       argTypes = {"Geometry"},

--- a/snowflake/src/test/java/org/apache/sedona/snowflake/snowsql/ddl/UDFDDLGeneratorTest.java
+++ b/snowflake/src/test/java/org/apache/sedona/snowflake/snowsql/ddl/UDFDDLGeneratorTest.java
@@ -37,7 +37,9 @@ public class UDFDDLGeneratorTest {
     String originalGeometryType = Constants.snowflakeTypeMap.put("Geometry", "GEOMETRY");
 
     try {
-      assertSharedPathsTargets(UDFDDLGenerator.buildAll(configs(), "@ApacheSedona", false, ""));
+      List<String> ddls = UDFDDLGenerator.buildAll(configs(), "@ApacheSedona", false, "");
+      assertGeometryOnlyTargets(ddls, "ST_SharedPaths");
+      assertGeometryOnlyTargets(ddls, "ST_EqualsIdentical");
     } finally {
       restoreGeometryType(originalGeometryType);
     }
@@ -48,20 +50,8 @@ public class UDFDDLGeneratorTest {
     String originalGeometryType = Constants.snowflakeTypeMap.put("Geometry", "GEOGRAPHY");
 
     try {
-      IllegalArgumentException error =
-          assertThrows(
-              IllegalArgumentException.class,
-              () ->
-                  UDFDDLGenerator.buildUDFDDL(
-                      UDFsV2.class.getMethod("ST_SharedPaths", String.class, String.class),
-                      configs(),
-                      "@ApacheSedona",
-                      false,
-                      ""));
-
-      assertEquals(
-          "Cannot generate GEOGRAPHY DDL for @GeometryOnly method: ST_SharedPaths",
-          error.getMessage());
+      assertGeographyGenerationRejected("ST_SharedPaths", String.class, String.class);
+      assertGeographyGenerationRejected("ST_EqualsIdentical", String.class, String.class);
     } finally {
       restoreGeometryType(originalGeometryType);
     }
@@ -72,10 +62,14 @@ public class UDFDDLGeneratorTest {
     String originalGeometryType = Constants.snowflakeTypeMap.put("Geometry", "GEOMETRY");
 
     try {
-      assertSharedPathsTargets(UDFDDLGenerator.buildAll(configs(), "@ApacheSedona", false, ""));
+      List<String> firstDdls = UDFDDLGenerator.buildAll(configs(), "@ApacheSedona", false, "");
+      assertGeometryOnlyTargets(firstDdls, "ST_SharedPaths");
+      assertGeometryOnlyTargets(firstDdls, "ST_EqualsIdentical");
       assertEquals("GEOMETRY", Constants.snowflakeTypeMap.get("Geometry"));
 
-      assertSharedPathsTargets(UDFDDLGenerator.buildAll(configs(), "@ApacheSedona", false, ""));
+      List<String> secondDdls = UDFDDLGenerator.buildAll(configs(), "@ApacheSedona", false, "");
+      assertGeometryOnlyTargets(secondDdls, "ST_SharedPaths");
+      assertGeometryOnlyTargets(secondDdls, "ST_EqualsIdentical");
       assertEquals("GEOMETRY", Constants.snowflakeTypeMap.get("Geometry"));
     } finally {
       restoreGeometryType(originalGeometryType);
@@ -89,13 +83,33 @@ public class UDFDDLGeneratorTest {
     return configs;
   }
 
-  private static void assertSharedPathsTargets(List<String> ddls) {
-    List<String> sharedPathsDdls =
-        ddls.stream().filter(ddl -> ddl.contains(".ST_SharedPaths ")).collect(Collectors.toList());
+  private static void assertGeographyGenerationRejected(
+      String functionName, Class<?>... parameterTypes) throws NoSuchMethodException {
+    IllegalArgumentException error =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                UDFDDLGenerator.buildUDFDDL(
+                    UDFsV2.class.getMethod(functionName, parameterTypes),
+                    configs(),
+                    "@ApacheSedona",
+                    false,
+                    ""));
 
-    assertEquals(2, sharedPathsDdls.size());
-    assertTrue(sharedPathsDdls.stream().anyMatch(ddl -> ddl.contains(" GEOMETRY")));
-    assertFalse(sharedPathsDdls.stream().anyMatch(ddl -> ddl.contains(" GEOGRAPHY")));
+    assertEquals(
+        "Cannot generate GEOGRAPHY DDL for @GeometryOnly method: " + functionName,
+        error.getMessage());
+  }
+
+  private static void assertGeometryOnlyTargets(List<String> ddls, String functionName) {
+    List<String> functionDdls =
+        ddls.stream()
+            .filter(ddl -> ddl.contains("." + functionName + " "))
+            .collect(Collectors.toList());
+
+    assertEquals(2, functionDdls.size());
+    assertTrue(functionDdls.stream().anyMatch(ddl -> ddl.contains(" GEOMETRY")));
+    assertFalse(functionDdls.stream().anyMatch(ddl -> ddl.contains(" GEOGRAPHY")));
   }
 
   private static void restoreGeometryType(String geometryType) {

--- a/spark/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
+++ b/spark/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
@@ -174,6 +174,7 @@ object Catalog extends AbstractCatalog with Logging {
     function[ST_3DDWithin](),
     function[ST_Equals](),
     function[ST_EqualsExact](),
+    function[ST_EqualsIdentical](),
     function[ST_Intersects](),
     function[ST_OrderingEquals](),
     function[ST_Overlaps](),

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Predicates.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Predicates.scala
@@ -276,6 +276,20 @@ private[apache] case class ST_EqualsExact(inputExpressions: Seq[Expression])
 }
 
 /**
+ * Test if two geometries have identical structure, coordinate ordering, dimensions, and ordinate
+ * values.
+ *
+ * @param inputExpressions
+ */
+private[apache] case class ST_EqualsIdentical(inputExpressions: Seq[Expression])
+    extends InferredExpression(inferrableFunction2(Predicates.equalsIdentical)) {
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
+}
+
+/**
  * Test if leftGeometry is disjoint from rightGeometry
  *
  * @param inputExpressions

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/st_predicates.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/st_predicates.scala
@@ -41,6 +41,11 @@ object st_predicates {
   def ST_EqualsExact(a: String, b: String, tolerance: Double): Column =
     wrapExpression[ST_EqualsExact](a, b, tolerance)
 
+  def ST_EqualsIdentical(a: Column, b: Column): Column =
+    wrapExpression[ST_EqualsIdentical](a, b)
+  def ST_EqualsIdentical(a: String, b: String): Column =
+    wrapExpression[ST_EqualsIdentical](a, b)
+
   def ST_Intersects(a: Column, b: Column): Column = wrapExpression[ST_Intersects](a, b)
   def ST_Intersects(a: String, b: String): Column = wrapExpression[ST_Intersects](a, b)
 

--- a/spark/common/src/test/scala/org/apache/sedona/sql/dataFrameAPITestScala.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/dataFrameAPITestScala.scala
@@ -1915,6 +1915,22 @@ class dataFrameAPITestScala extends TestBaseScala {
       assert(!result.getBoolean(1))
     }
 
+    it("Passed ST_EqualsIdentical") {
+      val baseDf = sparkSession.sql("""
+        SELECT
+          ST_GeomFromWKT('POINT Z (1 2 3)') AS a,
+          ST_GeomFromWKT('POINT Z (1 2 3)') AS identical,
+          ST_GeomFromWKT('POINT M (1 2 3)') AS different_dimension
+      """)
+      val result = baseDf
+        .select(
+          ST_EqualsIdentical("a", "identical").alias("identical"),
+          ST_EqualsIdentical(col("a"), col("different_dimension")).alias("different"))
+        .first()
+      assert(result.getBoolean(0))
+      assert(!result.getBoolean(1))
+    }
+
     it("Passed ST_Covers") {
       val baseDf = sparkSession.sql(
         "SELECT ST_GeomFromWKT('POLYGON ((0 0, 1 0, 1 1, 0 0))') AS a, ST_Point(1.0, 0.0) AS b, ST_Point(0.0, 1.0) AS c")

--- a/spark/common/src/test/scala/org/apache/sedona/sql/predicateTestScala.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/predicateTestScala.scala
@@ -19,7 +19,7 @@
 package org.apache.sedona.sql
 
 import org.apache.spark.sql.catalyst.expressions.{EmptyRow, Literal}
-import org.apache.spark.sql.sedona_sql.expressions.{ST_Contains, ST_CoveredBy, ST_Covers, ST_Crosses, ST_DWithin, ST_Disjoint, ST_Equals, ST_EqualsExact, ST_Intersects, ST_OrderingEquals, ST_Overlaps, ST_Point, ST_Touches, ST_Within}
+import org.apache.spark.sql.sedona_sql.expressions.{ST_Contains, ST_CoveredBy, ST_Covers, ST_Crosses, ST_DWithin, ST_Disjoint, ST_Equals, ST_EqualsExact, ST_EqualsIdentical, ST_Intersects, ST_OrderingEquals, ST_Overlaps, ST_Point, ST_Touches, ST_Within}
 
 class predicateTestScala extends TestBaseScala {
 
@@ -374,6 +374,32 @@ class predicateTestScala extends TestBaseScala {
       assert(result.isNullAt(3))
     }
 
+    it("Passed ST_EqualsIdentical") {
+      val result = sparkSession
+        .sql("""
+          SELECT
+            ST_EqualsIdentical(
+              ST_GeomFromWKT('POINT Z (1 2 3)'),
+              ST_GeomFromWKT('POINT Z (1 2 3)')),
+            ST_EqualsIdentical(
+              ST_GeomFromWKT('POINT Z (1 2 3)'),
+              ST_GeomFromWKT('POINT Z (1 2 4)')),
+            ST_EqualsIdentical(
+              ST_GeomFromWKT('POINT Z (1 2 3)'),
+              ST_GeomFromWKT('POINT M (1 2 3)')),
+            ST_EqualsIdentical(
+              ST_GeomFromWKT('GEOMETRYCOLLECTION (POINT (0 0), POINT (1 1))'),
+              ST_GeomFromWKT('GEOMETRYCOLLECTION (POINT (1 1), POINT (0 0))')),
+            ST_EqualsIdentical(NULL, ST_Point(0.0, 0.0))
+        """)
+        .first()
+      assert(result.getBoolean(0))
+      assert(!result.getBoolean(1))
+      assert(!result.getBoolean(2))
+      assert(!result.getBoolean(3))
+      assert(result.isNullAt(4))
+    }
+
     it("Passed edge cases of ST_Contains and ST_Covers") {
       val testtable = sparkSession.sql(
         "select ST_GeomFromWKT('POLYGON((2 0, 0 2, -2 0, 2 0))') AS a, ST_GeomFromWKT('POINT(2 0)') AS b")
@@ -426,6 +452,7 @@ class predicateTestScala extends TestBaseScala {
       ST_Overlaps,
       ST_Touches,
       ST_Equals,
+      ST_EqualsIdentical,
       ST_Disjoint,
       ST_OrderingEquals).foreach { predicate =>
       it(s"Passed null handling in $predicate") {


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/).

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`.

Part of #3260.

The serialization prerequisites #3265 and #3268 have merged into `master`.

## What changes were proposed in this PR?

- Add a common `ST_EqualsIdentical` implementation that compares exact geometry type, nested structure, component and coordinate order, dimensionality, and every XY/Z/M ordinate.
- Treat corresponding NaN ordinates as equal, treat positive and negative zero as equal, and ignore SRID and other geometry metadata.
- Register and expose the predicate through:
  - Spark SQL, DataFrame APIs, Spark Connect, and the Python Spark SQL API
  - Flink SQL
  - Snowflake WKB and native `GEOMETRY` UDF paths
- Add SQL documentation for Spark, Flink, and Snowflake, including each engine's stored-geometry dimensionality boundary and practical round-trip validation examples.

This is the second PR in the #3260 stack and is now based directly on `master`. Its two serialization prerequisites are merged:

- #3265 preserves M and ZM when Shapely geometries cross the Python GeometryUDT boundary.
- #3268 preserves every recoverable coordinate layout when geometries cross Sedona's compact Java SerDe boundary, and rejects mixed layouts that its single-layout container encoding cannot represent losslessly.

`ST_EqualsIdentical` compares the geometry representation it receives; it cannot reconstruct dimensional information already discarded by an upstream representation. JTS 1.20's default coordinate-sequence factory still makes ordinary XY indistinguishable from declared XYZ whose Z ordinates are all NaN, while Snowflake native `GEOMETRY` stores normalized 2D coordinates. The engine-specific documentation calls out these boundaries.

The final stacked PR is #3262, which adds distributed GeoPandas `geom_equals_identical` on top of this predicate.

## How was this patch tested?

- Full common test suite: 1,304 tests passed.
- Spark predicate suite: 37 tests passed.
- Spark DataFrame API suite: 261 tests passed.
- Flink predicate suite: 24 tests passed.
- Snowflake DDL suite: 3 tests passed; both modified Snowflake tester suites compiled successfully.
- Regression coverage includes XY/Z/M/ZM distinctions, NaN and infinity handling, represented typed empties, component and ring ordering, SRID independence, null propagation, API argument validation, and SerDe-preserved dimensional layouts.
- The repository commit-hook suite, Spotless, documentation build, Markdown linting, and `git diff --check` passed.

## Did this PR include necessary documentation updates?

- Yes, I am adding a new API. I am using the current SNAPSHOT version, `v2.0.0`.
- Yes, I added Spark, Flink, and Snowflake SQL documentation.
