### PR TITLE
[GH-3267] Preserve recoverable geometry dimensions

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/geometrySerde/GeometrySerializer.java
+++ b/common/src/main/java/org/apache/sedona/common/geometrySerde/GeometrySerializer.java
@@ -113,10 +113,10 @@ public class GeometrySerializer {
 
   private static GeometryBuffer serializePoint(Point point) {
     Coordinate coordinate = point.getCoordinate();
+    CoordinateType coordType = getCoordinateType(point);
     if (coordinate == null) {
-      return createGeometryBuffer(WKBConstants.wkbPoint, CoordinateType.XY, point.getSRID(), 8, 0);
+      return createGeometryBuffer(WKBConstants.wkbPoint, coordType, point.getSRID(), 8, 0);
     }
-    CoordinateType coordType = getCoordinateType(coordinate);
     int bufferSize = 8 + coordType.bytes;
     GeometryBuffer buffer =
         createGeometryBuffer(WKBConstants.wkbPoint, coordType, point.getSRID(), bufferSize, 1);
@@ -129,7 +129,7 @@ public class GeometrySerializer {
     int numCoordinates = getBoundedInt(buffer, 4);
     Point point;
     if (numCoordinates == 0) {
-      point = factory.createPoint();
+      point = factory.createPoint(buffer.getCoordinates(8, 0));
       buffer.mark(8);
     } else {
       int bufferSize = 8 + coordType.bytes;
@@ -175,7 +175,7 @@ public class GeometrySerializer {
       CoordinateSequence coordinates = buffer.getCoordinate(8 + i * coordType.bytes);
       Coordinate coordinate = coordinates.getCoordinate(0);
       if (Double.isNaN(coordinate.x)) {
-        points[i] = factory.createPoint();
+        points[i] = factory.createPoint(buffer.getCoordinates(8 + i * coordType.bytes, 0));
       } else {
         points[i] = factory.createPoint(coordinates);
       }
@@ -187,11 +187,7 @@ public class GeometrySerializer {
   private static GeometryBuffer serializeLineString(LineString lineString) {
     CoordinateSequence coordinates = lineString.getCoordinateSequence();
     int numCoordinates = coordinates.size();
-    if (numCoordinates == 0) {
-      return createGeometryBuffer(
-          WKBConstants.wkbLineString, CoordinateType.XY, lineString.getSRID(), 8, 0);
-    }
-    CoordinateType coordType = getCoordinateType(coordinates.getCoordinate(0));
+    CoordinateType coordType = getCoordinateType(lineString);
     int bufferSize = 8 + numCoordinates * coordType.bytes;
     GeometryBuffer buffer =
         createGeometryBuffer(
@@ -260,12 +256,10 @@ public class GeometrySerializer {
 
   private static GeometryBuffer serializePolygon(Polygon polygon) {
     LinearRing exteriorRing = polygon.getExteriorRing();
+    CoordinateType coordType = getCoordinateType(polygon);
     if (exteriorRing == null || exteriorRing.isEmpty()) {
-      return createGeometryBuffer(
-          WKBConstants.wkbPolygon, CoordinateType.XY, polygon.getSRID(), 8, 0);
+      return createGeometryBuffer(WKBConstants.wkbPolygon, coordType, polygon.getSRID(), 8, 0);
     }
-    CoordinateSequence coordinates = exteriorRing.getCoordinateSequence();
-    CoordinateType coordType = getCoordinateType(coordinates.getCoordinate(0));
     int numCoordinates = polygon.getNumPoints();
     int numInteriorRings = polygon.getNumInteriorRing();
     int coordsOffset = 8;
@@ -286,7 +280,7 @@ public class GeometrySerializer {
     int numCoordinates = getBoundedInt(buffer, 4);
     if (numCoordinates == 0) {
       buffer.mark(8);
-      return factory.createPolygon();
+      return createEmptyPolygon(buffer, 8, factory);
     }
     int coordsOffset = 8;
     int numRingsOffset = 8 + numCoordinates * coordType.bytes;
@@ -441,31 +435,64 @@ public class GeometrySerializer {
     return value;
   }
 
-  private static CoordinateType getCoordinateType(Coordinate coordinate) {
-    boolean hasZ = !Double.isNaN(coordinate.getZ());
-    boolean hasM = !Double.isNaN(coordinate.getM());
-    return getCoordinateType(hasZ, hasM);
-  }
-
   private static CoordinateType getCoordinateType(Geometry geometry) {
-    Coordinate coord = geometry.getCoordinate();
-    if (coord != null) {
-      return getCoordinateType(coord);
-    } else {
-      return CoordinateType.XY;
+    CoordinateDimensions dimensions = new CoordinateDimensions();
+    collectCoordinateDimensions(geometry, dimensions);
+    return dimensions.coordinateType == null ? CoordinateType.XY : dimensions.coordinateType;
+  }
+
+  private static void collectCoordinateDimensions(
+      Geometry geometry, CoordinateDimensions dimensions) {
+    if (geometry instanceof Point) {
+      collectCoordinateDimensions(((Point) geometry).getCoordinateSequence(), dimensions);
+    } else if (geometry instanceof LineString) {
+      collectCoordinateDimensions(((LineString) geometry).getCoordinateSequence(), dimensions);
+    } else if (geometry instanceof Polygon) {
+      Polygon polygon = (Polygon) geometry;
+      collectCoordinateDimensions(polygon.getExteriorRing().getCoordinateSequence(), dimensions);
+      for (int i = 0; i < polygon.getNumInteriorRing(); i++) {
+        collectCoordinateDimensions(
+            polygon.getInteriorRingN(i).getCoordinateSequence(), dimensions);
+      }
+    } else if (geometry instanceof GeometryCollection) {
+      GeometryCollection collection = (GeometryCollection) geometry;
+      for (int i = 0; i < collection.getNumGeometries(); i++) {
+        collectCoordinateDimensions(collection.getGeometryN(i), dimensions);
+      }
     }
   }
 
-  private static CoordinateType getCoordinateType(boolean hasZ, boolean hasM) {
-    if (hasZ && hasM) {
-      return CoordinateType.XYZM;
-    } else if (hasZ) {
-      return CoordinateType.XYZ;
-    } else if (hasM) {
-      return CoordinateType.XYM;
-    } else {
-      return CoordinateType.XY;
+  private static void collectCoordinateDimensions(
+      CoordinateSequence coordinates, CoordinateDimensions dimensions) {
+    int measures = coordinates.getMeasures();
+    int spatialDimensions = coordinates.getDimension() - measures;
+    if (measures < 0 || measures > 1 || spatialDimensions < 2 || spatialDimensions > 3) {
+      throw new IllegalArgumentException(
+          "Unsupported coordinate sequence layout: dimension="
+              + coordinates.getDimension()
+              + ", measures="
+              + measures);
     }
+
+    // Measures are explicit CoordinateSequence metadata. A Z dimension is not always explicit:
+    // JTS's default sequence factory represents ordinary XY coordinates as dimension 3 with NaN Z.
+    // XYZM is unambiguous, while XYZ is recoverable only when at least one Z value is finite. An
+    // ambiguous sequence does not constrain a multipart geometry whose other members establish the
+    // shared layout.
+    CoordinateType coordinateType = null;
+    if (measures > 0) {
+      coordinateType = spatialDimensions > 2 ? CoordinateType.XYZM : CoordinateType.XYM;
+    } else if (spatialDimensions == 2) {
+      coordinateType = CoordinateType.XY;
+    } else {
+      for (int i = 0; i < coordinates.size(); i++) {
+        if (!Double.isNaN(coordinates.getZ(i))) {
+          coordinateType = CoordinateType.XYZ;
+          break;
+        }
+      }
+    }
+    dimensions.add(coordinateType);
   }
 
   private static int alignedOffset(int offset) {
@@ -474,6 +501,29 @@ public class GeometrySerializer {
 
   private static GeometryFactory createGeometryFactory(int srid) {
     return new GeometryFactory(PRECISION_MODEL, srid);
+  }
+
+  private static Polygon createEmptyPolygon(
+      GeometryBuffer buffer, int coordinatesOffset, GeometryFactory factory) {
+    CoordinateSequence coordinates = buffer.getCoordinates(coordinatesOffset, 0);
+    return factory.createPolygon(factory.createLinearRing(coordinates));
+  }
+
+  private static class CoordinateDimensions {
+    CoordinateType coordinateType;
+
+    void add(CoordinateType candidate) {
+      if (candidate == null) {
+        return;
+      }
+      if (coordinateType == null) {
+        coordinateType = candidate;
+      } else if (coordinateType != candidate) {
+        throw new IllegalArgumentException(
+            "GeometrySerializer cannot encode heterogeneous dimensional layouts in one Polygon "
+                + "or multipart geometry. Use homogeneous components or a GeometryCollection.");
+      }
+    }
   }
 
   static class GeomPartSerializer {
@@ -505,7 +555,7 @@ public class GeometrySerializer {
     Polygon readPolygon() {
       int numRings = checkedReadBoundedInt();
       if (numRings == 0) {
-        return factory.createPolygon();
+        return createEmptyPolygon(buffer, coordsOffset, factory);
       }
       checkRemainingIntsAtLeast(numRings);
       int numInteriorRings = numRings - 1;

--- a/common/src/test/java/org/apache/sedona/common/geometrySerde/GeometryDimensionSerdeTest.java
+++ b/common/src/test/java/org/apache/sedona/common/geometrySerde/GeometryDimensionSerdeTest.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.common.geometrySerde;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.CoordinateXY;
+import org.locationtech.jts.geom.CoordinateXYM;
+import org.locationtech.jts.geom.CoordinateXYZM;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryCollection;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.geom.MultiLineString;
+import org.locationtech.jts.geom.MultiPoint;
+import org.locationtech.jts.geom.MultiPolygon;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.geom.impl.CoordinateArraySequence;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
+
+public class GeometryDimensionSerdeTest {
+  private static final GeometryFactory FACTORY = new GeometryFactory();
+
+  @Test
+  public void leadingNaNDoesNotDropLaterOrdinates() {
+    LineString xyz =
+        FACTORY.createLineString(
+            new Coordinate[] {new Coordinate(0, 0, Double.NaN), new Coordinate(1, 1, 3)});
+    LineString xym =
+        FACTORY.createLineString(
+            new Coordinate[] {new CoordinateXYM(0, 0, Double.NaN), new CoordinateXYM(1, 1, 4)});
+    LineString xyzm =
+        FACTORY.createLineString(
+            new Coordinate[] {
+              new CoordinateXYZM(0, 0, Double.NaN, Double.NaN), new CoordinateXYZM(1, 1, 3, 4)
+            });
+
+    assertLineRoundTrip(xyz, CoordinateType.XYZ, 3, 0, 3, Double.NaN);
+    assertLineRoundTrip(xym, CoordinateType.XYM, 3, 1, Double.NaN, 4);
+    assertLineRoundTrip(xyzm, CoordinateType.XYZM, 4, 1, 3, 4);
+  }
+
+  @Test
+  public void dimensionDetectionTraversesMultipartMembers() {
+    LineString first =
+        FACTORY.createLineString(
+            new Coordinate[] {new Coordinate(0, 0, Double.NaN), new Coordinate(1, 1, Double.NaN)});
+    LineString second =
+        FACTORY.createLineString(
+            new Coordinate[] {new Coordinate(2, 2, 7), new Coordinate(3, 3, 8)});
+    MultiLineString input = FACTORY.createMultiLineString(new LineString[] {first, second});
+
+    byte[] bytes = GeometrySerializer.serialize(input);
+    MultiLineString output = (MultiLineString) GeometrySerializer.deserialize(bytes);
+
+    assertEquals(CoordinateType.XYZ, coordinateType(bytes));
+    assertSequenceLayout(((LineString) output.getGeometryN(0)).getCoordinateSequence(), 3, 0);
+    assertSequenceLayout(((LineString) output.getGeometryN(1)).getCoordinateSequence(), 3, 0);
+    assertEquals(7, output.getGeometryN(1).getCoordinate().getZ(), 0);
+  }
+
+  @Test
+  public void measureMetadataAndTypedEmptyMembersKeepTheirLayout() {
+    Point allNaNMeasure = FACTORY.createPoint(new CoordinateXYM(1, 2, Double.NaN));
+    Point allNaNZM = FACTORY.createPoint(new CoordinateXYZM(1, 2, Double.NaN, Double.NaN));
+    assertSequenceLayout(((Point) roundTrip(allNaNMeasure)).getCoordinateSequence(), 3, 1);
+    assertSequenceLayout(((Point) roundTrip(allNaNZM)).getCoordinateSequence(), 4, 1);
+
+    Point emptyM = FACTORY.createPoint(emptySequence(3, 1));
+    Point emptyZM = FACTORY.createPoint(emptySequence(4, 1));
+    assertSequenceLayout(((Point) roundTrip(emptyM)).getCoordinateSequence(), 3, 1);
+    assertSequenceLayout(((Point) roundTrip(emptyZM)).getCoordinateSequence(), 4, 1);
+
+    Point measuredPoint = FACTORY.createPoint(new CoordinateXYM(1, 2, 8));
+    MultiPoint multiPoint = FACTORY.createMultiPoint(new Point[] {emptyM, measuredPoint});
+    MultiPoint multiPointOutput = (MultiPoint) roundTrip(multiPoint);
+    assertSequenceLayout(((Point) multiPointOutput.getGeometryN(0)).getCoordinateSequence(), 3, 1);
+    assertEquals(8, multiPointOutput.getGeometryN(1).getCoordinate().getM(), 0);
+
+    LineString emptyZMLine = FACTORY.createLineString(emptySequence(4, 1));
+    LineString xyzmLine =
+        FACTORY.createLineString(
+            new Coordinate[] {new CoordinateXYZM(0, 0, 1, 2), new CoordinateXYZM(1, 1, 3, 4)});
+    MultiLineString multiLine =
+        FACTORY.createMultiLineString(new LineString[] {emptyZMLine, xyzmLine});
+    MultiLineString multiLineOutput = (MultiLineString) roundTrip(multiLine);
+    assertSequenceLayout(
+        ((LineString) multiLineOutput.getGeometryN(0)).getCoordinateSequence(), 4, 1);
+
+    Polygon emptyMPolygon = emptyPolygon(3, 1);
+    assertSequenceLayout(
+        ((Polygon) roundTrip(emptyMPolygon)).getExteriorRing().getCoordinateSequence(), 3, 1);
+    Polygon measuredPolygon = measuredPolygon();
+    MultiPolygon multiPolygon =
+        FACTORY.createMultiPolygon(new Polygon[] {emptyMPolygon, measuredPolygon});
+    MultiPolygon multiPolygonOutput = (MultiPolygon) roundTrip(multiPolygon);
+    assertSequenceLayout(
+        ((Polygon) multiPolygonOutput.getGeometryN(0)).getExteriorRing().getCoordinateSequence(),
+        3,
+        1);
+    assertEquals(9, multiPolygonOutput.getGeometryN(1).getCoordinates()[0].getM(), 0);
+  }
+
+  @Test
+  public void geometryCollectionPreservesChildLayoutsIndependently() {
+    LineString xyz =
+        FACTORY.createLineString(
+            new Coordinate[] {new Coordinate(0, 0, Double.NaN), new Coordinate(1, 1, 3)});
+    Point xym = FACTORY.createPoint(new CoordinateXYM(2, 2, 4));
+    Polygon xyzm =
+        FACTORY.createPolygon(
+            FACTORY.createLinearRing(
+                new Coordinate[] {
+                  new CoordinateXYZM(0, 0, 1, 5),
+                  new CoordinateXYZM(1, 0, 2, 6),
+                  new CoordinateXYZM(0, 1, 3, 7),
+                  new CoordinateXYZM(0, 0, 1, 5)
+                }));
+    GeometryCollection input = FACTORY.createGeometryCollection(new Geometry[] {xyz, xym, xyzm});
+
+    GeometryCollection output = (GeometryCollection) roundTrip(input);
+
+    assertSequenceLayout(((LineString) output.getGeometryN(0)).getCoordinateSequence(), 3, 0);
+    assertSequenceLayout(((Point) output.getGeometryN(1)).getCoordinateSequence(), 3, 1);
+    assertSequenceLayout(
+        ((Polygon) output.getGeometryN(2)).getExteriorRing().getCoordinateSequence(), 4, 1);
+  }
+
+  @Test
+  public void ordinaryJtsXyRemainsXy() throws ParseException {
+    LineString input = (LineString) new WKTReader().read("LINESTRING (0 0, 1 1)");
+    assertEquals(3, input.getCoordinateSequence().getDimension());
+
+    byte[] bytes = GeometrySerializer.serialize(input);
+    LineString output = (LineString) GeometrySerializer.deserialize(bytes);
+
+    assertEquals(CoordinateType.XY, coordinateType(bytes));
+    assertSequenceLayout(output.getCoordinateSequence(), 2, 0);
+  }
+
+  @Test
+  public void rejectsRecoverablyHeterogeneousMultipartLayouts() {
+    LineString xy =
+        FACTORY.createLineString(new Coordinate[] {new CoordinateXY(0, 0), new CoordinateXY(1, 1)});
+    LineString xyz =
+        FACTORY.createLineString(
+            new Coordinate[] {new Coordinate(2, 2, 3), new Coordinate(3, 3, 4)});
+    MultiLineString mixedZ = FACTORY.createMultiLineString(new LineString[] {xy, xyz});
+
+    LineString xym =
+        FACTORY.createLineString(
+            new Coordinate[] {new CoordinateXYM(0, 0, 1), new CoordinateXYM(1, 1, 2)});
+    MultiLineString mixedM = FACTORY.createMultiLineString(new LineString[] {xym, xyz});
+
+    assertThrows(IllegalArgumentException.class, () -> GeometrySerializer.serialize(mixedZ));
+    assertThrows(IllegalArgumentException.class, () -> GeometrySerializer.serialize(mixedM));
+  }
+
+  private static void assertLineRoundTrip(
+      LineString input,
+      CoordinateType expectedType,
+      int expectedDimension,
+      int expectedMeasures,
+      double expectedZ,
+      double expectedM) {
+    byte[] bytes = GeometrySerializer.serialize(input);
+    LineString output = (LineString) GeometrySerializer.deserialize(bytes);
+    CoordinateSequence sequence = output.getCoordinateSequence();
+
+    assertEquals(expectedType, coordinateType(bytes));
+    assertSequenceLayout(sequence, expectedDimension, expectedMeasures);
+    assertOrdinate(expectedZ, sequence.getCoordinate(1).getZ());
+    assertOrdinate(expectedM, sequence.getCoordinate(1).getM());
+    assertTrue(Double.isNaN(sequence.getCoordinate(0).getZ()));
+  }
+
+  private static void assertSequenceLayout(
+      CoordinateSequence sequence, int expectedDimension, int expectedMeasures) {
+    assertEquals(expectedDimension, sequence.getDimension());
+    assertEquals(expectedMeasures, sequence.getMeasures());
+  }
+
+  private static void assertOrdinate(double expected, double actual) {
+    if (Double.isNaN(expected)) {
+      assertTrue(Double.isNaN(actual));
+    } else {
+      assertEquals(expected, actual, 0);
+    }
+  }
+
+  private static CoordinateType coordinateType(byte[] bytes) {
+    return CoordinateType.valueOf(((bytes[0] & 0xFF) & 0x0F) >> 1);
+  }
+
+  private static Geometry roundTrip(Geometry geometry) {
+    return GeometrySerializer.deserialize(GeometrySerializer.serialize(geometry));
+  }
+
+  private static CoordinateSequence emptySequence(int dimension, int measures) {
+    return new CoordinateArraySequence(new Coordinate[0], dimension, measures);
+  }
+
+  private static Polygon emptyPolygon(int dimension, int measures) {
+    return FACTORY.createPolygon(FACTORY.createLinearRing(emptySequence(dimension, measures)));
+  }
+
+  private static Polygon measuredPolygon() {
+    LinearRing shell =
+        FACTORY.createLinearRing(
+            new Coordinate[] {
+              new CoordinateXYM(0, 0, 9),
+              new CoordinateXYM(1, 0, 10),
+              new CoordinateXYM(0, 1, 11),
+              new CoordinateXYM(0, 0, 9)
+            });
+    return FACTORY.createPolygon(shell);
+  }
+}

--- a/common/src/test/java/org/apache/sedona/common/geometrySerde/GeometryDimensionSerdeTest.java
+++ b/common/src/test/java/org/apache/sedona/common/geometrySerde/GeometryDimensionSerdeTest.java
@@ -180,6 +180,35 @@ public class GeometryDimensionSerdeTest {
     assertThrows(IllegalArgumentException.class, () -> GeometrySerializer.serialize(mixedM));
   }
 
+  @Test
+  public void rejectsHeterogeneousPolygonRingLayouts() {
+    LinearRing shell =
+        FACTORY.createLinearRing(
+            new Coordinate[] {
+              new Coordinate(0, 0, 1),
+              new Coordinate(10, 0, 1),
+              new Coordinate(0, 10, 1),
+              new Coordinate(0, 0, 1)
+            });
+    LinearRing hole =
+        FACTORY.createLinearRing(
+            new Coordinate[] {
+              new CoordinateXY(1, 1),
+              new CoordinateXY(2, 1),
+              new CoordinateXY(1, 2),
+              new CoordinateXY(1, 1)
+            });
+    Polygon polygon = FACTORY.createPolygon(shell, new LinearRing[] {hole});
+
+    IllegalArgumentException error =
+        assertThrows(IllegalArgumentException.class, () -> GeometrySerializer.serialize(polygon));
+
+    assertEquals(
+        "GeometrySerializer cannot encode heterogeneous dimensional layouts in one Polygon "
+            + "or multipart geometry. Use homogeneous components or a GeometryCollection.",
+        error.getMessage());
+  }
+
   private static void assertLineRoundTrip(
       LineString input,
       CoordinateType expectedType,

--- a/docs/setup/release-notes.md
+++ b/docs/setup/release-notes.md
@@ -36,6 +36,12 @@
   former positional `GeoDataFrame.set_crs(crs, inplace, allow_override)` signature remain
   temporarily supported with a `FutureWarning`. When CRS metadata is unavailable, validation can
   require a distributed lookup of the first non-null geometry's SRID.
+* **Mixed coordinate layouts in polygons and multi-geometries**: Serializing a `Polygon`,
+  `MultiPoint`, `MultiLineString`, or `MultiPolygon` whose parts mix XY, XYZ, XYM, or XYZM layouts
+  now raises `IllegalArgumentException` instead of silently losing or corrupting ordinates based on
+  part order. This can affect `ST_Collect` when same-type inputs use different layouts. Normalize
+  all parts to one layout, or use a `GeometryCollection`, whose members are serialized
+  independently.
 
 ### New Features
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/).

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`.

Closes #3267.

## What changes were proposed in this PR?

Sedona's compact Java geometry format already supports XY, XYZ, XYM, and XYZM coordinate-layout tags. However, `GeometrySerializer` selected one of those tags by inspecting only a geometry's first coordinate and checking whether its Z and M values were finite. This could silently discard recoverable ordinates before a geometry crossed a Spark `GeometryUDT` or Flink serializer boundary. For example, `LINESTRING Z (0 0 NaN, 1 1 3)` was encoded as XY because its first Z value is NaN, so the later finite Z value was lost.

This PR makes dimensional inference and empty reconstruction loss-aware:

- Inspect every coordinate sequence, including all polygon rings and multipart members, instead of only the first coordinate.
- Use `CoordinateSequence` measure metadata to preserve XYM and XYZM layouts even when measure values are NaN.
- Scan ambiguous three-spatial-dimension sequences for a finite Z beyond the first coordinate.
- Preserve recoverable M and ZM metadata when empty Point and Polygon values, and their multipart children, are deserialized.
- Reject recoverably heterogeneous layouts inside one Polygon or multipart geometry. The compact format has one coordinate-layout header for the entire value, so silently selecting or promoting a layout cannot preserve every component's identity. Heterogeneous layouts remain representable with a `GeometryCollection`.
- Reject coordinate-sequence layouts wider than the format's existing XYZM model instead of silently truncating them.

The wire format and its four existing coordinate-layout tag values do not change, so previously serialized data remains readable.

There is one deliberate JTS boundary. JTS 1.20's default sequence factory represents both ordinary XY coordinates and declared XYZ coordinates whose Z values are all NaN as `dimension=3, measures=0`. Once JTS has made those representations identical, the serializer cannot recover the original declaration. This PR keeps the existing XY normalization for that ambiguous case instead of promoting ordinary XY payloads to XYZ. Consequently, an XYZ buffer produced by Python/GEOS whose Z ordinates are all NaN is indistinguishable after JTS reconstruction and normalizes to XY if it is serialized again on the JVM. Zero-member multipart and geometry-collection values similarly expose no child sequence from which to recover a declared dimension.

This is a pre-existing GeometrySerde issue identified while reviewing #3266, and is intentionally separate from the new equality predicate.

## How was this patch tested?

- `mvn -pl common test`: 1,299 tests passed.
- Focused `GeometryDimensionSerdeTest`: 7 tests passed.
- Spotless, Markdown lint, repository commit hooks, and `git diff --check` passed.

The new regression suite covers leading-NaN XYZ/XYM/XYZM values, later multipart members establishing a layout, all-NaN measure metadata, recoverable typed empty values and children, heterogeneous GeometryCollection children, mixed multipart and Polygon-ring layout rejection, and ordinary default-JTS XY normalization.

### SerDe performance

The compact format was introduced to avoid the coordinate-by-coordinate byte conversion and stream growth costs of WKB. This PR adds one extra coordinate scan only for JTS's ambiguous `dimension=3, measures=0` representation, so that path was benchmarked directly against the previous implementation and JTS WKB.

The table reports median-of-three-fork operation latency. “Full SerDe” is the sum of separately measured serialization and deserialization medians.

| Geometry | Coordinates | Previous custom SerDe | This PR | Change | JTS WKB | This PR vs. WKB |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| LineString | 1,000 | 4.173 µs | 4.742 µs | +13.6% | 41.277 µs | 8.7× faster |
| LineString | 10,000 | 39.020 µs | 45.036 µs | +15.4% | 404.198 µs | 9.0× faster |
| Polygon | 1,000 | 4.245 µs | 4.896 µs | +15.3% | 45.392 µs | 9.3× faster |
| Polygon | 10,000 | 37.857 µs | 45.880 µs | +21.2% | 416.244 µs | 9.1× faster |

The scan affects serialization only. For 1,000-coordinate default-JTS XY inputs, serialization changed from 1.043 to 1.541 µs for a LineString and from 1.244 to 1.787 µs for a Polygon. Non-empty deserialization is unchanged and showed no repeatable regression. Canonical `CoordinateXY`, XYZ, XYM, and XYZM paths were also effectively unchanged.

The benchmark used Corretto 17.0.13, JTS 1.20.0, Sedona's default Unsafe-backed geometry buffer, a fixed 512 MB G1 heap, prebuilt geometry/input objects, warmup followed by recalibration, nine samples per fork, and three fresh JVM forks. Every returned byte array or geometry escaped through a volatile sink, and all decoded dimensions and ordinates were validated outside the timed region. The WKB writer and reader were reused and preconfigured with the intended coordinate layout outside timing, which favors WKB. These are operation-level microbenchmarks; they do not include Spark SQL execution, parsing, network, or storage costs.

The result is a measurable cost on the ambiguous JTS representation, but it does not remove the compact format's performance advantage: the corrected implementation remains approximately 9× faster than generously configured WKB over full SerDe for these workloads. The format's fast deserialization path, which motivated the original [geometry SerDe optimization](https://kontinuation.one/posts/2022/12/improving-geometry-serde-performance-of-apache-sedona/), is unchanged.

## Did this PR include necessary documentation updates?

- Yes. The Sedona 2.0.0 release notes document the new mixed-layout rejection, its potential effect on `ST_Collect`, and the `GeometryCollection` workaround.
