### PR TITLE
[GH-3269] GeoPandas: warn on CRS mismatch in geometry equality

### DIFF
--- a/docs/setup/release-notes.md
+++ b/docs/setup/release-notes.md
@@ -50,6 +50,12 @@
 * [<a href='https://github.com/apache/sedona/issues/3257'>GH-3257</a>] - Implement distributed GeoSeries and GeoDataFrame Hilbert-distance spatial ordering
 * [<a href='https://github.com/apache/sedona/issues/3260'>GH-3260</a>] - Implement distributed GeoSeries and GeoDataFrame identical-geometry equality
 
+### Bug Fixes
+
+#### GeoPandas API
+
+* [<a href='https://github.com/apache/sedona/issues/3269'>GH-3269</a>] - Warn when `geom_equals` or `geom_equals_exact` compares geometry operands with mismatched CRSs
+
 ## Sedona 1.9.1
 
 Sedona 1.9.1 is compiled against:

--- a/python/sedona/spark/geopandas/base.py
+++ b/python/sedona/spark/geopandas/base.py
@@ -3356,7 +3356,11 @@ class GeoFrame(metaclass=ABCMeta):
         --------
         GeoSeries.geom_equals_exact
         """
-        return _delegate_to_geometry_column("geom_equals", self, other, align)
+        return self.geometry._geom_equals_impl(
+            other,
+            align,
+            warning_stacklevel=4,
+        )
 
     def geom_equals_exact(self, other, tolerance, align=None):
         """Return ``True`` for geometries that equal aligned `other` to a
@@ -3421,8 +3425,11 @@ class GeoFrame(metaclass=ABCMeta):
         --------
         GeoSeries.geom_equals
         """
-        return _delegate_to_geometry_column(
-            "geom_equals_exact", self, other, tolerance, align
+        return self.geometry._geom_equals_exact_impl(
+            other,
+            tolerance,
+            align,
+            warning_stacklevel=4,
         )
 
     def geom_equals_identical(self, other, align=None):

--- a/python/sedona/spark/geopandas/geoseries.py
+++ b/python/sedona/spark/geopandas/geoseries.py
@@ -2802,8 +2802,27 @@ class GeoSeries(GeoFrame, pspd.Series):
         return result
 
     def geom_equals(self, other, align=None) -> pspd.Series:
+        return self._geom_equals_impl(other, align, warning_stacklevel=4)
+
+    def _geom_equals_impl(
+        self,
+        other,
+        align,
+        *,
+        warning_stacklevel: int,
+    ) -> pspd.Series:
         other_series, extended = self._make_series_of_val(other)
         align = False if extended else align
+        other_series, other_crs = self._geometry_series_and_crs(
+            other_series,
+            extended,
+        )
+        if other_crs is not NO_CRS_OVERRIDE:
+            warn_crs_mismatch(
+                self.crs,
+                other_crs,
+                stacklevel=warning_stacklevel,
+            )
 
         spark_expr = stp.ST_Equals(F.col("L"), F.col("R"))
         result = self._row_wise_operation(
@@ -2812,10 +2831,26 @@ class GeoSeries(GeoFrame, pspd.Series):
             align,
             returns_geom=False,
             default_val=False,
+            alignment_warning_stacklevel=warning_stacklevel + 1,
         )
         return _to_bool(result)
 
     def geom_equals_exact(self, other, tolerance, align=None) -> pspd.Series:
+        return self._geom_equals_exact_impl(
+            other,
+            tolerance,
+            align,
+            warning_stacklevel=4,
+        )
+
+    def _geom_equals_exact_impl(
+        self,
+        other,
+        tolerance,
+        align,
+        *,
+        warning_stacklevel: int,
+    ) -> pspd.Series:
         tolerance = _normalize_numeric_scalar(
             tolerance, "'tolerance' must be a numeric scalar"
         )
@@ -2842,12 +2877,42 @@ class GeoSeries(GeoFrame, pspd.Series):
 
         other_series, extended = self._make_series_of_val(other)
         align = False if extended else align
+        other_series, other_crs = self._geometry_series_and_crs(
+            other_series,
+            extended,
+        )
+        if other_crs is not NO_CRS_OVERRIDE:
+            warn_crs_mismatch(
+                self.crs,
+                other_crs,
+                stacklevel=warning_stacklevel,
+            )
 
         return self._geom_equals_exact_series(
             other_series,
             tolerance,
             align,
+            alignment_warning_stacklevel=warning_stacklevel + 2,
         )
+
+    def _geometry_series_and_crs(self, other, extended):
+        """Normalize a geometry Series and return its CRS when applicable."""
+        if extended:
+            return other, NO_CRS_OVERRIDE
+        if isinstance(other, GeoSeries):
+            return other, other.crs
+        if isinstance(other, PandasOnSparkSeries):
+            internal = other._psdf._internal
+            column_label = other._column_label
+            if column_label not in internal.column_labels:
+                if len(internal.column_labels) != 1:
+                    return other, NO_CRS_OVERRIDE
+                # pandas-on-Spark may expose an unnamed Series as ``None``
+                # while its one-column InternalFrame uses ``(None,)``.
+                other = first_series(PandasOnSparkDataFrame(internal))
+            geometry_series = GeoSeries(other)
+            return geometry_series, geometry_series.crs
+        return other, NO_CRS_OVERRIDE
 
     def geom_equals_identical(self, other, align=None) -> pspd.Series:
         if isinstance(other, BaseGeometry):
@@ -3459,10 +3524,16 @@ class GeoSeries(GeoFrame, pspd.Series):
         other: pspd.Series,
         tolerance: float,
         align: Union[bool, None],
+        alignment_warning_stacklevel: int = 5,
     ) -> pspd.Series:
         """Execute exact equality with GeoPandas-compatible row alignment."""
         spark_expr = stp.ST_EqualsExact(F.col("L"), F.col("R"), tolerance)
-        return self._boolean_result_with_alignment(other, align, spark_expr)
+        return self._boolean_result_with_alignment(
+            other,
+            align,
+            spark_expr,
+            warning_stacklevel=alignment_warning_stacklevel,
+        )
 
     def _geom_equals_identical_series(
         self,
@@ -3478,6 +3549,7 @@ class GeoSeries(GeoFrame, pspd.Series):
         other: pspd.Series,
         align: Union[bool, None],
         spark_expr: PySparkColumn,
+        warning_stacklevel: int = 5,
     ) -> pspd.Series:
         """Evaluate a native boolean expression after binary row alignment."""
         (
@@ -3488,7 +3560,7 @@ class GeoSeries(GeoFrame, pspd.Series):
         ) = self._align_binary_geometry_series(
             other,
             align,
-            warning_stacklevel=5,
+            warning_stacklevel=warning_stacklevel,
         )
 
         return _to_bool(
@@ -3574,6 +3646,7 @@ class GeoSeries(GeoFrame, pspd.Series):
         default_val: Any = None,
         keep_name: bool = False,
         validate_alignment: bool = False,
+        alignment_warning_stacklevel: int = 4,
     ):
         """
         Helper function to perform a row-wise operation on two GeoSeries.
@@ -3617,7 +3690,7 @@ class GeoSeries(GeoFrame, pspd.Series):
                 other,
                 align,
                 validate_alignment=validate_alignment,
-                warning_stacklevel=4,
+                warning_stacklevel=alignment_warning_stacklevel,
             )
         (
             aligned_frame,

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -17,6 +17,7 @@
 
 from decimal import Decimal
 import typing
+import warnings
 
 import shapely
 import numpy as np
@@ -5621,6 +5622,146 @@ e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3
         df_result = s1.to_geoframe().geom_equals(s2, align=False)
         expected = pd.Series([True, False, True])
         self.check_pd_series_equal(df_result, expected)
+
+    @pytest.mark.parametrize(
+        ("method", "kwargs"),
+        [
+            ("geom_equals", {}),
+            ("geom_equals_exact", {"tolerance": 0}),
+        ],
+    )
+    def test_equality_predicates_warn_on_crs_mismatch(self, method, kwargs):
+        left = GeoSeries([Point(0, 0)], crs="EPSG:4326")
+
+        right = GeoSeries([Point(0, 0)], crs="EPSG:3857")
+        right_operands = [
+            right,
+            right.to_geoframe(),
+            right.to_spark_pandas(),
+            GeoSeries([Point(0, 0)]),
+        ]
+        for right_operand in right_operands:
+            with pytest.warns(UserWarning, match="CRS mismatch") as warning_info:
+                result = getattr(left, method)(
+                    right_operand,
+                    align=False,
+                    **kwargs,
+                )
+
+            crs_warnings = [
+                warning
+                for warning in warning_info
+                if "CRS mismatch" in str(warning.message)
+            ]
+            assert len(crs_warnings) == 1
+            assert crs_warnings[0].filename == __file__
+            self.check_pd_series_equal(result, pd.Series([True]))
+
+        with pytest.warns(UserWarning, match="CRS mismatch") as warning_info:
+            frame_result = getattr(left.to_geoframe(), method)(
+                right,
+                align=False,
+                **kwargs,
+            )
+        crs_warnings = [
+            warning
+            for warning in warning_info
+            if "CRS mismatch" in str(warning.message)
+        ]
+        assert len(crs_warnings) == 1
+        assert crs_warnings[0].filename == __file__
+        self.check_pd_series_equal(frame_result, pd.Series([True]))
+
+    @pytest.mark.parametrize(
+        ("method", "kwargs"),
+        [
+            ("geom_equals", {}),
+            ("geom_equals_exact", {"tolerance": 0}),
+        ],
+    )
+    def test_equality_predicates_avoid_spurious_crs_warnings(self, method, kwargs):
+        left = GeoSeries([Point(0, 0)], crs="EPSG:4326")
+        right = GeoSeries([Point(0, 0)], crs="EPSG:4326")
+
+        with warnings.catch_warnings(record=True) as warning_info:
+            warnings.simplefilter("always")
+            matching_result = getattr(left, method)(right, align=False, **kwargs)
+            spark_pandas_result = getattr(left, method)(
+                right.to_spark_pandas(),
+                align=False,
+                **kwargs,
+            )
+            scalar_result = getattr(left, method)(Point(0, 0), **kwargs)
+            crsless_result = getattr(GeoSeries([Point(0, 0)]), method)(
+                GeoSeries([Point(0, 0)]),
+                align=False,
+                **kwargs,
+            )
+
+        assert not any(
+            "CRS mismatch" in str(warning.message) for warning in warning_info
+        )
+        self.check_pd_series_equal(matching_result, pd.Series([True]))
+        self.check_pd_series_equal(spark_pandas_result, pd.Series([True]))
+        self.check_pd_series_equal(scalar_result, pd.Series([True]))
+        self.check_pd_series_equal(crsless_result, pd.Series([True]))
+
+    @pytest.mark.parametrize(
+        ("method", "kwargs"),
+        [
+            ("geom_equals", {}),
+            ("geom_equals_exact", {"tolerance": 0}),
+        ],
+    )
+    def test_equality_predicate_crs_warning_preserves_alignment(self, method, kwargs):
+        left = GeoSeries([Point(0, 0)], index=[1], crs="EPSG:4326")
+        right = GeoSeries([Point(0, 0)], index=[0], crs="EPSG:3857")
+
+        with pytest.warns(UserWarning, match="CRS mismatch") as warning_info:
+            result = getattr(left, method)(right, align=True, **kwargs)
+
+        crs_warnings = [
+            warning
+            for warning in warning_info
+            if "CRS mismatch" in str(warning.message)
+        ]
+        assert len(crs_warnings) == 1
+        assert crs_warnings[0].filename == __file__
+        self.check_pd_series_equal(result, pd.Series([False, False], index=[0, 1]))
+
+    @pytest.mark.parametrize(
+        ("method", "kwargs"),
+        [
+            ("geom_equals", {}),
+            ("geom_equals_exact", {"tolerance": 0}),
+        ],
+    )
+    def test_equality_predicate_alignment_warning_stays_at_user_call(
+        self, method, kwargs
+    ):
+        left_index = pd.MultiIndex.from_tuples(
+            [("left", 0)],
+            names=["side", "row"],
+        )
+        right_index = pd.MultiIndex.from_tuples(
+            [("right", 0)],
+            names=["side", "row"],
+        )
+        left = GeoSeries([Point(0, 0)], index=left_index)
+        right = GeoSeries([Point(0, 0)], index=right_index)
+
+        with pytest.warns(
+            UserWarning,
+            match="indices of the left and right GeoSeries",
+        ) as warning_info:
+            getattr(left, method)(right, **kwargs)
+
+        alignment_warning = next(
+            warning
+            for warning in warning_info
+            if "indices of the left and right GeoSeries" in str(warning.message)
+        )
+        assert alignment_warning.filename == __file__
 
     def test_binary_operation_with_projected_multiindex(self):
         index = pd.MultiIndex.from_tuples([("a", 1), ("b", 2)], names=["group", "row"])


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/).

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`.

Closes #3269.
Part of #2230.

## What changes were proposed in this PR?

GeoPandas warns when row-wise geometry predicates compare operands with different coordinate reference systems because identical coordinate values can represent different real-world locations under different CRSs. Sedona already provides that protection in newer distributed methods such as `shared_paths` and `geom_equals_identical`, but the older `geom_equals` and `geom_equals_exact` paths skipped CRS validation and silently returned boolean results.

This PR aligns those predicates with GeoPandas by:

- checking CRS metadata for GeoSeries, GeoDataFrame active-geometry, and geometry-typed pandas-on-Spark Series operands before alignment;
- emitting exactly one standard CRS mismatch warning at the user's call site while preserving the row-wise result;
- keeping matching CRS values, pairs with no CRS, and scalar Shapely operands warning-free;
- preserving the public method signatures and the existing index-alignment behavior and warning attribution;
- normalizing the one-column label representation of unnamed pandas-on-Spark geometry Series without collecting geometry rows; and
- documenting the fix in the Sedona 2.0.0 release notes.

## How was this patch tested?

- Focused CRS-warning, operand, alignment, and attribution coverage on GeoPandas 1.0.1: 8 tests passed.
- The same focused matrix on GeoPandas 1.1.3: 8 tests passed.
- Broader existing `geom_equals`, `geom_equals_exact`, `geom_equals_identical`, MultiIndex, duplicate-index, and GeoDataFrame delegation regressions: 29 tests passed.
- Repository commit hooks passed for all four changed files, including Black, AST validation, Bandit, codespell, gitleaks, Markdown linting, and whitespace checks.
- `git diff --check` passed.

## Did this PR include necessary documentation updates?

- Yes, I updated the Sedona 2.0.0 release notes.
