### PR TITLE
[GH-2800] Fix Snowflake tester failures for empty geometries

### DIFF
--- a/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctions.java
+++ b/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctions.java
@@ -1378,7 +1378,7 @@ public class TestFunctions extends TestBase {
     registerUDF("ST_Translate", byte[].class, double.class, double.class, double.class);
     verifySqlSingleRes(
         "SELECT sedona.ST_AsText(sedona.ST_Translate(sedona.ST_GeomFromText('GEOMETRYCOLLECTION(MULTIPOLYGON (((1 0 0, 1 1 0, 2 1 0, 2 0 0, 1 0 0)), ((1 2 0, 3 4 0, 3 5 0, 1 2 0))), POINT(1 1 1), LINESTRING EMPTY))'), 2, 2, 3))",
-        "GEOMETRYCOLLECTION Z(MULTIPOLYGON Z(((3 2 3, 3 3 3, 4 3 3, 4 2 3, 3 2 3)), ((3 4 3, 5 6 3, 5 7 3, 3 4 3))), POINT Z(3 3 4), LINESTRING ZEMPTY)");
+        "GEOMETRYCOLLECTION Z(MULTIPOLYGON Z(((3 2 3, 3 3 3, 4 3 3, 4 2 3, 3 2 3)), ((3 4 3, 5 6 3, 5 7 3, 3 4 3))), POINT Z(3 3 4), LINESTRING Z EMPTY)");
   }
 
   @Test

--- a/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctionsV2.java
+++ b/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctionsV2.java
@@ -530,9 +530,11 @@ public class TestFunctionsV2 extends TestBase {
   @Test
   public void test_ST_SharedPaths() {
     registerUDFV2("ST_SharedPaths", String.class, String.class);
+    // Snowflake's GEOMETRY type rejects GeoJSON with empty coordinates, so use inputs
+    // that produce shared paths in both directions (no empty collection element).
     verifySqlSingleRes(
-        "select ST_AsText(sedona.ST_SharedPaths(ST_GeometryFromWKT('LINESTRING(0 0, 10 0)'), ST_GeometryFromWKT('LINESTRING(15 0, 5 0)')))",
-        "GEOMETRYCOLLECTION(MULTILINESTRING EMPTY,MULTILINESTRING((5 0,10 0)))");
+        "select ST_AsText(sedona.ST_SharedPaths(ST_GeometryFromWKT('LINESTRING(0 0, 100 0)'), ST_GeometryFromWKT('LINESTRING(20 0, 30 0, 30 50, 80 0, 70 0)')))",
+        "GEOMETRYCOLLECTION(MULTILINESTRING((20 0,30 0)),MULTILINESTRING((70 0,80 0)))");
   }
 
   @Test


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Follow-up to #3250 (GH-2800).

## What changes were proposed in this PR?

Running the Snowflake tester against a real Snowflake environment surfaced two failures introduced by #3250:

- `TestFunctions.test_ST_Translate`: #3250 fixed the WKT writer to emit `LINESTRING Z EMPTY` instead of JTS's malformed `LINESTRING ZEMPTY`, but this test still expected the old output. Updated the expectation.
- `TestFunctionsV2.test_ST_SharedPaths`: the result contained `MULTILINESTRING EMPTY`, and V2 UDFs return Snowflake-native GEOMETRY via GeoJSON, which Snowflake rejects ("Invalid GeoJSON. 'coordinates' must not be empty."). Switched to inputs that share paths in both directions so no collection element is empty; the V1 test keeps the empty-element coverage since it round-trips through Sedona's own serialization.

## How was this patch tested?

Verified against a real Snowflake environment: the full `snowflake-tester` suite passes with this change (wherobots/sedona-cloud-vendor-tester#73, run https://github.com/wherobots/sedona-cloud-vendor-tester/actions/runs/32258418019).

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.