### PR TITLE
[GH-3277] Avoid duplicate STAC datetime filters

### DIFF
--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacUtils.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacUtils.scala
@@ -27,9 +27,12 @@ import org.apache.spark.sql.execution.datasources.geoparquet.GeoParquetSpatialFi
 import org.apache.spark.sql.types.{MetadataBuilder, StructField, StructType}
 import org.locationtech.jts.geom.Envelope
 
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import scala.io.Source
+import scala.util.Try
 
 object StacUtils {
 
@@ -479,10 +482,27 @@ object StacUtils {
       spatialFilter: Option[GeoParquetSpatialFilter],
       temporalFilter: Option[TemporalFilter]): String = {
     val spatialFilterStr = spatialFilter.map(StacUtils.getFilterBBox).getOrElse("")
-    val temporalFilterStr = temporalFilter.map(StacUtils.getFilterTemporal).getOrElse("")
+    val temporalFilterStr =
+      if (hasQueryParameter(baseUrl, "datetime")) ""
+      else temporalFilter.map(StacUtils.getFilterTemporal).getOrElse("")
 
     val filters = Seq(spatialFilterStr, temporalFilterStr).filter(_.nonEmpty).mkString("&")
     val urlWithFilters = if (filters.nonEmpty) s"&$filters" else ""
     s"$baseUrl$urlWithFilters"
+  }
+
+  private def hasQueryParameter(url: String, parameterName: String): Boolean = {
+    val queryStart = url.indexOf('?')
+    val fragmentStart = url.indexOf('#')
+    if (queryStart < 0 || (fragmentStart >= 0 && fragmentStart < queryStart)) return false
+
+    val queryEnd = if (fragmentStart < 0) url.length else fragmentStart
+    val query = url.substring(queryStart + 1, queryEnd)
+
+    query.split("&", -1).exists { parameter =>
+      val rawName = parameter.takeWhile(_ != '=')
+      Try(URLDecoder.decode(rawName, StandardCharsets.UTF_8.name())).getOrElse(rawName) ==
+        parameterName
+    }
   }
 }

--- a/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacBatchUrlTest.scala
+++ b/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacBatchUrlTest.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.spark.sql.sedona_sql.io.stac
+
+import org.apache.spark.sql.execution.datasource.stac.TemporalFilter
+import org.apache.spark.sql.types.StructType
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.time.LocalDateTime
+
+class StacBatchUrlTest extends AnyFunSuite {
+
+  private val batch = StacBatch(
+    null,
+    "file:///collection.json",
+    """{"links":[]}""",
+    StructType(Seq.empty),
+    Map.empty,
+    None,
+    None,
+    None)
+
+  test("getItemLink should not append datetime when the endpoint already provides it") {
+    val temporalFilter = Some(
+      TemporalFilter.GreaterThanFilter("datetime", LocalDateTime.parse("2025-03-06T00:00:00")))
+    val cases = Seq(
+      "https://example.test/items?token=x&datetime=2025-02-01/2025-02-28#results" ->
+        "https://example.test/items?token=x&datetime=2025-02-01/2025-02-28&limit=2#results",
+      "https://example.test/items?datetime=" ->
+        "https://example.test/items?datetime=&limit=2",
+      "https://example.test/items?datetime=%ZZ&datetime=also-bad" ->
+        "https://example.test/items?datetime=%ZZ&datetime=also-bad&limit=2",
+      "https://example.test/items?d%61tetime=2025-02-01/2025-02-28" ->
+        "https://example.test/items?d%61tetime=2025-02-01/2025-02-28&limit=2")
+
+    cases.foreach { case (input, expected) =>
+      assert(batch.getItemLink(input, 2, None, temporalFilter) == expected)
+    }
+  }
+}

--- a/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacUtilsTest.scala
+++ b/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacUtilsTest.scala
@@ -797,6 +797,20 @@ class StacUtilsTest extends AnyFunSuite {
     assert(result == expectedUrl)
   }
 
+  test("addFiltersToUrl preserves endpoint datetime while adding a spatial filter") {
+    val baseUrl = "http://example.com/stac?token=x&datetime=2025-02-01/2025-02-28"
+    val envelope = new Envelope(1.0, 2.0, 3.0, 4.0)
+    val queryWindow = geometryFactory.toGeometry(envelope)
+    val spatialFilter = Some(
+      GeoParquetSpatialFilter.LeafFilter("geometry", SpatialPredicate.INTERSECTS, queryWindow))
+    val temporalFilter = Some(
+      TemporalFilter.GreaterThanFilter("timestamp", LocalDateTime.parse("2025-03-06T00:00:00")))
+
+    assert(
+      StacUtils.addFiltersToUrl(baseUrl, spatialFilter, temporalFilter) ==
+        s"$baseUrl&bbox=1.0%2C3.0%2C2.0%2C4.0")
+  }
+
   // Tests for authentication headers
 
   test("parseHeaders should return empty map when no headers option provided") {


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #3277.

## What changes were proposed in this PR?

`StacUtils.addFiltersToUrl` now detects an existing decoded `datetime` query parameter name and preserves the endpoint value instead of appending a pushed temporal parameter. Other query bytes and fragments stay unchanged, and a spatial `bbox` can still be added.

Regression coverage includes valid, empty, malformed, repeated, and percent-encoded endpoint parameters.

## How was this patch tested?

- `mvn -B -ntp -Drat.skip=true -Dlog4j.version=2.19.0 -pl spark/common test-compile`
- `mvn -B -ntp -Dlog4j.version=2.19.0 -DwildcardSuites=org.apache.spark.sql.sedona_sql.io.stac.StacBatchUrlTest,org.apache.spark.sql.sedona_sql.io.stac.StacUtilsTest -pl spark/common scalatest:test` (40/40, Scala 2.12)
- `mvn -B -ntp -Drat.skip=true -Dlog4j.version=2.19.0 -Dscala=2.13 -Dspark=3.4 -pl spark/common clean test-compile`
- `mvn -B -ntp -Dlog4j.version=2.19.0 -Dscala=2.13 -Dspark=3.4 -DwildcardSuites=org.apache.spark.sql.sedona_sql.io.stac.StacBatchUrlTest,org.apache.spark.sql.sedona_sql.io.stac.StacUtilsTest -pl spark/common scalatest:test` (40/40)
- `mvn -B -ntp -pl spark/common spotless:apply`

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
