### PR TITLE
[GH-3281] GeoPandas: implement from_features

### DIFF
--- a/docs/setup/release-notes.md
+++ b/docs/setup/release-notes.md
@@ -50,6 +50,7 @@
 * [<a href='https://github.com/apache/sedona/issues/3257'>GH-3257</a>] - Implement distributed GeoSeries and GeoDataFrame Hilbert-distance spatial ordering
 * [<a href='https://github.com/apache/sedona/issues/3260'>GH-3260</a>] - Implement distributed GeoSeries and GeoDataFrame identical-geometry equality
 * [<a href='https://github.com/apache/sedona/issues/3273'>GH-3273</a>] - Implement distributed GeoSeries and GeoDataFrame polygonal coverage validation and invalid-edge diagnostics
+* [<a href='https://github.com/apache/sedona/issues/3281'>GH-3281</a>] - Implement `GeoDataFrame.from_features` for in-memory GeoJSON-like features
 
 ### Bug Fixes
 

--- a/python/sedona/spark/geopandas/geodataframe.py
+++ b/python/sedona/spark/geopandas/geodataframe.py
@@ -1485,9 +1485,103 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
 
     @classmethod
     def from_features(
-        cls, features, crs: Any | None = None, columns: Iterable[str] | None = None
+        cls,
+        features,
+        crs: Any | None = None,
+        columns: typing.Iterable[str] | None = None,
     ) -> GeoDataFrame:
-        raise NotImplementedError("from_features() is not implemented yet.")
+        """Construct a GeoDataFrame from GeoJSON-like features.
+
+        .. versionadded:: 2.0.0
+
+        Parameters
+        ----------
+        features
+            An iterable of feature mappings or objects implementing
+            ``__geo_interface__``; a FeatureCollection dictionary; or an object
+            whose ``__geo_interface__`` is a FeatureCollection.
+        crs : str, dict, pyproj.CRS, optional
+            Coordinate reference system to assign to the resulting frame. The
+            coordinates are not transformed.
+        columns : iterable of str, optional
+            Column names to include and their order in the resulting frame.
+
+        Returns
+        -------
+        GeoDataFrame
+
+        Notes
+        -----
+        This constructor first materializes all features in a local GeoPandas
+        GeoDataFrame on the driver. It is intended for small in-memory feature
+        collections. For large datasets, use Sedona's distributed GeoJSON or
+        GeoParquet Spark data source instead.
+
+        GeoPandas controls feature parsing and column selection; feature ``id``,
+        ``bbox``, and collection metadata are not added as columns. Once the
+        result is distributed, property values follow Spark schema inference:
+        nested mappings become structs, and columns with incompatible mixed
+        types are not supported.
+
+        Examples
+        --------
+        >>> from sedona.spark.geopandas import GeoDataFrame
+        >>> feature_collection = {
+        ...     "type": "FeatureCollection",
+        ...     "features": [
+        ...         {
+        ...             "type": "Feature",
+        ...             "properties": {"name": "first"},
+        ...             "geometry": {
+        ...                 "type": "Point",
+        ...                 "coordinates": (1.0, 2.0),
+        ...             },
+        ...         },
+        ...         {
+        ...             "type": "Feature",
+        ...             "properties": {"name": "second"},
+        ...             "geometry": {
+        ...                 "type": "Point",
+        ...                 "coordinates": (2.0, 1.0),
+        ...             },
+        ...         },
+        ...     ],
+        ... }
+        >>> GeoDataFrame.from_features(feature_collection)
+              geometry    name
+        0  POINT (1 2)   first
+        1  POINT (2 1)  second
+        """
+        local = gpd.GeoDataFrame.from_features(
+            features,
+            crs=crs,
+            columns=columns,
+        )
+
+        # Spark 3 pandas-on-Spark only checks the first object value when
+        # looking for a user-defined type. Move one geometry forward for
+        # schema inference, then restore the GeoPandas RangeIndex order.
+        restore_order = False
+        geometry_name = local._geometry_column_name
+        if geometry_name is not None and len(local) > 0:
+            missing = local[geometry_name].isna().to_numpy()
+            non_missing = np.flatnonzero(~missing)
+            if missing[0] and len(non_missing) > 0:
+                first_geometry = non_missing[0]
+                order = np.concatenate(
+                    (
+                        [first_geometry],
+                        np.arange(first_geometry),
+                        np.arange(first_geometry + 1, len(local)),
+                    )
+                )
+                local = local.iloc[order]
+                restore_order = True
+
+        result = cls(local)
+        if restore_order:
+            result.sort_index(inplace=True)
+        return result
 
     @classmethod
     def from_postgis(

--- a/python/tests/geopandas/test_geodataframe.py
+++ b/python/tests/geopandas/test_geodataframe.py
@@ -43,6 +43,103 @@ from pandas.testing import assert_frame_equal
 from packaging.version import parse as parse_version
 
 
+class TestGeoDataFrameFromFeatures(TestGeopandasBase):
+    def test_input_forms(self):
+        feature_collection = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "properties": {"name": "first"},
+                    "geometry": {"type": "Point", "coordinates": (1.0, 2.0)},
+                },
+                {
+                    "type": "Feature",
+                    "properties": {"name": "second"},
+                    "geometry": {"type": "Point", "coordinates": (2.0, 1.0)},
+                },
+            ],
+        }
+
+        class FeatureCollection:
+            __geo_interface__ = feature_collection
+
+        class Feature:
+            def __init__(self, mapping):
+                self.__geo_interface__ = mapping
+
+        expected = gpd.GeoDataFrame.from_features(feature_collection)
+        inputs = [
+            feature_collection,
+            (feature for feature in feature_collection["features"]),
+            FeatureCollection(),
+            [Feature(feature) for feature in feature_collection["features"]],
+        ]
+
+        for features in inputs:
+            result = GeoDataFrame.from_features(features)
+            self.check_sgpd_df_equals_gpd_df(result, expected)
+
+    def test_columns_crs_and_nulls_match_geopandas(self):
+        from geopandas.testing import assert_geodataframe_equal
+
+        features = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "id": "first",
+                    "type": "Feature",
+                    "properties": {"other": 2},
+                    "geometry": None,
+                },
+                {
+                    "id": "second",
+                    "type": "Feature",
+                    "properties": {"value": 1},
+                    "geometry": {"type": "Point", "coordinates": (1.0, 2.0)},
+                },
+                {
+                    "id": "third",
+                    "type": "Feature",
+                    "properties": None,
+                    "geometry": {
+                        "type": "LineString",
+                        "coordinates": ((0.0, 0.0), (1.0, 1.0)),
+                    },
+                },
+            ],
+        }
+        kwargs = {
+            "crs": "EPSG:4326",
+            "columns": ["other", "geometry", "value"],
+        }
+
+        result = GeoDataFrame.from_features(features, **kwargs)
+        expected = gpd.GeoDataFrame.from_features(features, **kwargs)
+        materialized = result.to_geopandas()
+
+        assert list(result.columns) == list(expected.columns)
+        assert result.crs == expected.crs
+        assert materialized.index.tolist() == expected.index.tolist()
+        assert_geodataframe_equal(materialized, expected)
+
+    def test_empty_with_schema(self):
+        expected = gpd.GeoDataFrame.from_features(
+            [],
+            crs="EPSG:4326",
+            columns=["geometry", "name"],
+        )
+        result = GeoDataFrame.from_features(
+            [],
+            crs="EPSG:4326",
+            columns=["geometry", "name"],
+        )
+
+        assert list(result.columns) == list(expected.columns)
+        assert result.crs == expected.crs
+        assert len(result) == 0
+
+
 @pytest.mark.skipif(
     parse_version(shapely.__version__) < parse_version("2.0.0"),
     reason=f"Tests require shapely>=2.0.0, but found v{shapely.__version__}",


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/).

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`.

Closes #3281.
Part of #2230.

## What changes were proposed in this PR?

This PR implements `GeoDataFrame.from_features` for small, in-memory GeoJSON-like feature collections.

It:

- delegates feature parsing to the installed GeoPandas version and wraps the resulting frame in Sedona;
- accepts feature iterables and generators, FeatureCollection dictionaries, and objects implementing `__geo_interface__`;
- preserves column selection and ordering, CRS assignment, null geometries, uneven or null property sets, and empty inputs with explicit columns;
- preserves leading-null geometry order on Spark 3, where pandas-on-Spark otherwise fails Geometry UDT inference; and
- documents driver materialization, Spark property-schema constraints, and the distributed GeoJSON and GeoParquet alternatives for large datasets.

Malformed inputs continue to use GeoPandas validation and error behavior. Property values must be representable by a consistent Spark-inferred schema after parsing.

## How was this patch tested?

- Spark 3.4.0 / Python 3.8 / GeoPandas 0.13.2: 3 focused tests passed.
- Spark 3.4.0 / Python 3.8 / Shapely 1.8.5.post1: 3 focused tests passed.
- Spark 4.1.1 / Python 3.11 / GeoPandas 1.1.3: 3 focused tests passed.
- All commit hooks passed.

The tests cover supported input forms, generators, `__geo_interface__`, leading-null geometries, uneven and null properties, column ordering, CRS preservation, restored row order, and empty inputs with an explicit geometry schema.

## Did this PR include necessary documentation updates?

- Yes, I am adding a new API. I am using the [current SNAPSHOT version number](https://github.com/apache/sedona/blob/99239524f17389fc4ae9548ea88756f8ea538bb9/pom.xml#L29) in `vX.Y.Z` format.

The method documentation marks the API as added in `2.0.0`, and the release notes are updated.
