### PR TITLE
[GH-3283] Honor max_items in STAC client searches with bbox/datetime filters

### DIFF
--- a/docs/tutorial/files/stac-sedona-spark.md
+++ b/docs/tutorial/files/stac-sedona-spark.md
@@ -459,7 +459,7 @@ Returns:
 
 ---
 
-**`search(*ids: Union[str, list], collection_id: str, bbox: Optional[list] = None, datetime: Optional[Union[str, datetime.datetime, list]] = None, max_items: Optional[int] = None, return_dataframe: bool = True) -> Union[Iterator[PyStacItem], DataFrame]`**
+**`search(*ids: Union[str, list], collection_id: str, bbox: Optional[list] = None, geometry: Optional[Union[str, BaseGeometry, list]] = None, datetime: Optional[Union[str, datetime.datetime, list]] = None, max_items: Optional[int] = None, return_dataframe: bool = True) -> Union[Iterator[PyStacItem], DataFrame]`**
 Searches for items in the specified collection with optional filters.
 
 Parameters:
@@ -467,6 +467,7 @@ Parameters:
 * `ids` (*Union[str, list]*): A variable number of item IDs to filter the items. Example: `"item_id1"` or `["item_id1", "item_id2"]`
 * `collection_id` (*str*): The ID of the collection to search in. Example: `"aster-l1t"`
 * `bbox` (*Optional[list]*): A list of bounding boxes for filtering the items, represented as `[min_lon, min_lat, max_lon, max_lat]`. Example: `[[ -180.0, -90.0, 180.0, 90.0 ]]`
+* `geometry` (*Optional[Union[str, BaseGeometry, list]]*): Shapely geometry object(s) or WKT string(s) for spatial filtering; a single geometry, a WKT string, or a list of either. If both `bbox` and `geometry` are provided, `geometry` takes precedence. Geometry filtering is evaluated by Spark, not by the STAC API. Example: `"POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))"`
 * `datetime` (*Optional[Union[str, datetime.datetime, list]]*): A single datetime, RFC 3339-compliant timestamp, or a list of date-time ranges. Example: `"2020-01-01T00:00:00Z"`, `datetime.datetime(2020, 1, 1)`, `[["2020-01-01T00:00:00Z", "2021-01-01T00:00:00Z"]]`
 * `max_items` (*Optional[int]*): The maximum number of items to return. Example: `100`
 * `return_dataframe` (*bool*): If `True` (default), return the result as a Spark DataFrame instead of an iterator of `PyStacItem` objects. Example: `True`

--- a/docs/tutorial/files/stac-sedona-spark.md
+++ b/docs/tutorial/files/stac-sedona-spark.md
@@ -240,6 +240,8 @@ items = client.search(
 )
 ```
 
+`max_items` follows pystac-client semantics: it is the total number of Items returned by the STAC API, while `itemsLimitPerRequest` is only the requested page size. For a named collection with at most one `bbox` and one `datetime` interval (and no ID or geometry filter), Sedona sends those constraints to the Collection's advertised Items endpoint, trusts the conforming STAC API's spatial and temporal matching semantics, and stops enumeration after `max_items` server results. Multiple bounding boxes or datetime intervals, ID filters, and geometry filters are Sedona extensions evaluated by Spark; those shapes are fully enumerated before Spark applies the filters and final limit.
+
 #### Search Items with Bounding Box and Interval
 
 ```python

--- a/docs/tutorial/files/stac-sedona-spark.md
+++ b/docs/tutorial/files/stac-sedona-spark.md
@@ -240,7 +240,7 @@ items = client.search(
 )
 ```
 
-`max_items` follows pystac-client semantics: it is the total number of Items returned by the STAC API, while `itemsLimitPerRequest` is only the requested page size. For a named collection with at most one `bbox` and one `datetime` interval (and no ID or geometry filter), Sedona sends those constraints to the Collection's advertised Items endpoint, trusts the conforming STAC API's spatial and temporal matching semantics, and stops enumeration after `max_items` server results. Multiple bounding boxes or datetime intervals, ID filters, and geometry filters are Sedona extensions evaluated by Spark; those shapes are fully enumerated before Spark applies the filters and final limit.
+`max_items` follows pystac-client semantics: it is the total number of Items returned by the STAC API, while `itemsLimitPerRequest` is only the requested page size. For a named collection with at most one `bbox` and one `datetime` interval (and no ID or geometry filter), Sedona sends those constraints to the Collection's advertised Items endpoint, trusts the conforming STAC API's spatial and temporal matching semantics, and stops enumeration after `max_items` server results. Multiple bounding boxes or datetime intervals, ID filters, and `search()`'s `geometry` parameter are Sedona extensions evaluated by Spark; those shapes are fully enumerated before Spark applies the filters and final limit.
 
 #### Search Items with Bounding Box and Interval
 

--- a/docs/tutorial/files/stac-sedona-spark.zh.md
+++ b/docs/tutorial/files/stac-sedona-spark.zh.md
@@ -240,7 +240,7 @@ items = client.search(
 )
 ```
 
-`max_items` 遵循 pystac-client 的语义：它限制 STAC API 返回的 Item 总数，而 `itemsLimitPerRequest` 仅控制建议的单页大小。对于指定 collection、最多包含一个 `bbox` 和一个 `datetime` 区间（且没有 ID 或 geometry 过滤）的搜索，Sedona 会把这些约束发送到 collection 公告的 Items 端点，信任符合规范的 STAC API 的空间和时间匹配语义，并在服务端返回 `max_items` 个结果后停止枚举。多个 bbox 或 datetime 区间、ID 过滤和 geometry 过滤属于由 Spark 执行的 Sedona 扩展；这些搜索会先完整枚举，再由 Spark 应用过滤条件和最终 limit。
+`max_items` 遵循 pystac-client 的语义：它限制 STAC API 返回的 Item 总数，而 `itemsLimitPerRequest` 仅控制建议的单页大小。对于指定 collection、最多包含一个 `bbox` 和一个 `datetime` 区间（且没有 ID 或 geometry 过滤）的搜索，Sedona 会把这些约束发送到 collection 公告的 Items 端点，信任符合规范的 STAC API 的空间和时间匹配语义，并在服务端返回 `max_items` 个结果后停止枚举。多个 bbox 或 datetime 区间、ID 过滤以及 `search()` 的 `geometry` 参数属于由 Spark 执行的 Sedona 扩展；这些搜索会先完整枚举，再由 Spark 应用过滤条件和最终 limit。
 
 #### 按 bbox 与时间区间搜索
 

--- a/docs/tutorial/files/stac-sedona-spark.zh.md
+++ b/docs/tutorial/files/stac-sedona-spark.zh.md
@@ -459,7 +459,7 @@ df.show()
 
 ---
 
-**`search(*ids: Union[str, list], collection_id: str, bbox: Optional[list] = None, datetime: Optional[Union[str, datetime.datetime, list]] = None, max_items: Optional[int] = None, return_dataframe: bool = True) -> Union[Iterator[PyStacItem], DataFrame]`**
+**`search(*ids: Union[str, list], collection_id: str, bbox: Optional[list] = None, geometry: Optional[Union[str, BaseGeometry, list]] = None, datetime: Optional[Union[str, datetime.datetime, list]] = None, max_items: Optional[int] = None, return_dataframe: bool = True) -> Union[Iterator[PyStacItem], DataFrame]`**
 在指定 collection 中按可选过滤条件搜索 item。
 
 参数：
@@ -467,6 +467,7 @@ df.show()
 * `ids` (*Union[str, list]*)：可变数量的 item ID，用于过滤。例如 `"item_id1"` 或 `["item_id1", "item_id2"]`。
 * `collection_id` (*str*)：要搜索的 collection ID。例如 `"aster-l1t"`。
 * `bbox` (*Optional[list]*)：用于过滤 item 的边界框列表，每项形如 `[min_lon, min_lat, max_lon, max_lat]`。例如 `[[ -180.0, -90.0, 180.0, 90.0 ]]`。
+* `geometry` (*Optional[Union[str, BaseGeometry, list]]*)：用于空间过滤的 Shapely 几何对象或 WKT 字符串；可以是单个几何、WKT 字符串或它们的列表。同时提供 `bbox` 和 `geometry` 时以 `geometry` 为准。geometry 过滤由 Spark 执行，而非 STAC API。例如 `"POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))"`。
 * `datetime` (*Optional[Union[str, datetime.datetime, list]]*)：单个日期时间、符合 RFC 3339 的时间戳，或一组时间区间。例如 `"2020-01-01T00:00:00Z"`、`datetime.datetime(2020, 1, 1)`、`[["2020-01-01T00:00:00Z", "2021-01-01T00:00:00Z"]]`。
 * `max_items` (*Optional[int]*)：返回 item 的最大数量。例如 `100`。
 * `return_dataframe` (*bool*)：若为 `True`（默认），返回 Spark DataFrame，而不是 `PyStacItem` 迭代器。例如 `True`。

--- a/docs/tutorial/files/stac-sedona-spark.zh.md
+++ b/docs/tutorial/files/stac-sedona-spark.zh.md
@@ -240,6 +240,8 @@ items = client.search(
 )
 ```
 
+`max_items` 遵循 pystac-client 的语义：它限制 STAC API 返回的 Item 总数，而 `itemsLimitPerRequest` 仅控制建议的单页大小。对于指定 collection、最多包含一个 `bbox` 和一个 `datetime` 区间（且没有 ID 或 geometry 过滤）的搜索，Sedona 会把这些约束发送到 collection 公告的 Items 端点，信任符合规范的 STAC API 的空间和时间匹配语义，并在服务端返回 `max_items` 个结果后停止枚举。多个 bbox 或 datetime 区间、ID 过滤和 geometry 过滤属于由 Spark 执行的 Sedona 扩展；这些搜索会先完整枚举，再由 Spark 应用过滤条件和最终 limit。
+
 #### 按 bbox 与时间区间搜索
 
 ```python

--- a/python/sedona/spark/stac/client.py
+++ b/python/sedona/spark/stac/client.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
 from typing import Union, Optional, Iterator, List
 
 from sedona.spark.stac.collection_client import CollectionClient
@@ -175,8 +176,10 @@ class Client:
             - A list of date-time ranges can be provided for multiple intervals.
 
             Example: "2020-01-01T00:00:00Z" or python_datetime.datetime(2020, 1, 1) or [["2020-01-01T00:00:00Z", "2021-01-01T00:00:00Z"]]
-        :param max_items: The maximum number of items to return from the search, even if there are more matching results.
-            Example: 100
+        :param max_items: The maximum number of STAC API results to return. Supported
+            single-collection bbox/datetime searches follow pystac-client semantics and
+            trust the API's matching behavior; extended Spark-side filters are applied
+            before the final result limit. Example: 100
         :param return_dataframe: If True, return the result as a Spark DataFrame instead of an iterator of PyStacItem objects.
             Example: True
         :return: An iterator of PyStacItem objects or a Spark DataFrame that match the specified filters.

--- a/python/sedona/spark/stac/collection_client.py
+++ b/python/sedona/spark/stac/collection_client.py
@@ -17,8 +17,11 @@
 
 import calendar
 import logging
+import math
+from numbers import Real
 from typing import Iterator, Union, List
 from typing import Optional
+from urllib.parse import urlsplit
 
 import datetime as python_datetime
 from pyspark.sql import DataFrame, SparkSession
@@ -108,7 +111,13 @@ class CollectionClient:
         # Move the specified attributes to 'properties'
         for attr in attributes_to_move:
             if attr in item_dict:
-                item_dict["properties"][attr] = str(item_dict.pop(attr))
+                value = item_dict.pop(attr)
+                if isinstance(value, python_datetime.datetime):
+                    # PySpark materializes TimestampType with datetime.fromtimestamp(),
+                    # so a naïve value is in the Python process's local timezone.
+                    value = value.astimezone(python_datetime.timezone.utc)
+                    value = value.isoformat().replace("+00:00", "Z")
+                item_dict["properties"][attr] = value if value is None else str(value)
 
         return item_dict
 
@@ -359,7 +368,10 @@ class CollectionClient:
             If both bbox and geometry are provided, geometry takes precedence.
         :param datetime: A single datetime, RFC 3339-compliant timestamp,
             or a list of date-time ranges for filtering the items.
-        :param max_items: The maximum number of items to return from the search, even if there are more matching results.
+        :param max_items: The maximum number of STAC API results to return. Supported
+            single-collection bbox/datetime searches follow pystac-client semantics and
+            trust the API's matching behavior; extended Spark-side filters are applied
+            before the final result limit.
         :return: An iterator of PyStacItem objects that match the specified filters.
             If no filters are provided, the iterator contains all items in the collection.
         :raises RuntimeError: If there is an error loading the data or applying the filters, a RuntimeError
@@ -419,7 +431,10 @@ class CollectionClient:
         :param datetime: A single datetime, RFC 3339-compliant timestamp,
             or a list of date-time ranges for filtering the items.
             Example: "2020-01-01T00:00:00Z" or python_datetime.datetime(2020, 1, 1) or [["2020-01-01T00:00:00Z", "2021-01-01T00:00:00Z"]]
-        :param max_items: The maximum number of items to return from the search.
+        :param max_items: The maximum number of STAC API results to return. Supported
+            single-collection bbox/datetime searches follow pystac-client semantics and
+            trust the API's matching behavior; extended Spark-side filters are applied
+            before the final result limit.
         :return: A Spark DataFrame containing the filtered items. If no filters are provided,
             the DataFrame contains all items in the collection.
         :raises RuntimeError: If there is an error loading the data or applying the filters, a RuntimeError
@@ -508,6 +523,90 @@ class CollectionClient:
 
         return df
 
+    @staticmethod
+    def _enumeration_cap_options(max_items):
+        """
+        Reader options for a request whose filtering is owned by the STAC API.
+
+        This mirrors pystac-client: ``itemsLimitMax`` is the total number of
+        server-returned Items to enumerate, while ``itemsLimitPerRequest`` is
+        only the requested page size. Callers must not use these options when a
+        Spark-side predicate can still reject rows before the user's limit.
+        """
+        if max_items is None or max_items <= 0:
+            return {}
+        return {
+            "itemsLimitMax": str(max_items),
+            "itemsLimitPerRequest": str(min(200, max_items)),
+        }
+
+    def _api_search_options(self, bbox, geometry, datetime, ids, max_items):
+        """Build a PySTAC-compatible Collection Items search when representable.
+
+        A single bbox and a single datetime interval map directly to STAC API
+        Collection Items parameters. Their semantics are owned by the API, including
+        interval-valued Items. Multiple bboxes/intervals and geometry filters
+        are Sedona extensions implemented with Spark predicates, so they keep
+        the uncapped fallback instead of applying a raw reader cap too early.
+
+        The datasource applies these private options to the Collection's advertised
+        JSON ``rel=items`` link. Keeping endpoint discovery in the datasource preserves
+        custom, cross-origin, and query-bearing Item endpoint URLs.
+        """
+        if (
+            max_items is None
+            or max_items <= 0
+            or not self.collection_id
+            or ids
+            or geometry
+            or (not bbox and not datetime)
+        ):
+            return None
+
+        parsed_base = urlsplit(self.collection_url)
+        if (
+            parsed_base.scheme not in ("http", "https")
+            or not parsed_base.netloc
+            or parsed_base.query
+            or parsed_base.fragment
+        ):
+            return None
+
+        options = {}
+
+        if bbox:
+            if len(bbox) != 1 or not isinstance(bbox[0], (list, tuple)):
+                return None
+            coordinates = bbox[0]
+            if len(coordinates) != 4 or any(
+                not isinstance(value, Real)
+                or isinstance(value, bool)
+                or not math.isfinite(float(value))
+                for value in coordinates
+            ):
+                return None
+            min_lon, min_lat, max_lon, max_lat = coordinates
+            # Longitudes may wrap across the antimeridian (min_lon > max_lon).
+            if not (-180 <= min_lon <= 180 and -180 <= max_lon <= 180) or not (
+                -90 <= min_lat <= max_lat <= 90
+            ):
+                return None
+            options["__stacApiSearchBbox"] = ",".join(
+                str(value) for value in coordinates
+            )
+
+        if datetime:
+            if len(datetime) != 1 or not isinstance(datetime[0], (list, tuple)):
+                return None
+            interval = datetime[0]
+            if len(interval) != 2 or not all(
+                isinstance(value, str) and value for value in interval
+            ):
+                return None
+            options["__stacApiSearchDatetime"] = f"{interval[0]}/{interval[1]}"
+
+        return options
+
     def load_items_df(self, bbox, geometry, datetime, ids, max_items):
         """
         Loads items from the STAC collection as a Spark DataFrame.
@@ -517,49 +616,65 @@ class CollectionClient:
         """
         import json
 
+        # Ensure bbox is a list of lists
+        if bbox and isinstance(bbox, (list, tuple)) and isinstance(bbox[0], Real):
+            bbox = [list(bbox)]
+        # Handle geometry parameter
+        if geometry:
+            if not isinstance(geometry, list):
+                geometry = [geometry]
+        # Handle datetime parameter
+        if datetime:
+            if isinstance(datetime, python_datetime.datetime):
+                normalized_datetime = datetime
+                if normalized_datetime.tzinfo is None:
+                    normalized_datetime = normalized_datetime.replace(
+                        tzinfo=python_datetime.timezone.utc
+                    )
+                else:
+                    normalized_datetime = normalized_datetime.astimezone(
+                        python_datetime.timezone.utc
+                    )
+                datetime_string = normalized_datetime.isoformat().replace("+00:00", "Z")
+                datetime = [[datetime_string, datetime_string]]
+            elif isinstance(datetime, str):
+                datetime = [self._expand_date(str(datetime))]
+            elif isinstance(datetime, (list, tuple)) and isinstance(datetime[0], str):
+                datetime = [list(datetime)]
+
+        api_search_options = self._api_search_options(
+            bbox, geometry, datetime, ids, max_items
+        )
+
         # Prepare Spark DataFrameReader with headers if present
         reader = self.spark.read.format("stac")
-
-        # Encode headers as JSON string for passing to Spark
         if self.headers:
-            headers_json = json.dumps(self.headers)
-            reader = reader.option("headers", headers_json)
+            reader = reader.option("headers", json.dumps(self.headers))
 
-        # Load the collection data from the specified collection URL
-        if (
-            not ids
-            and not bbox
-            and not geometry
-            and not datetime
-            and max_items is not None
-        ):
-            df = reader.option("itemsLimitMax", max_items).load(self.collection_url)
-        else:
-            df = reader.load(self.collection_url)
-            # Apply ID filters if provided
+        # In the PySTAC-compatible path, the datasource puts every search predicate
+        # on the advertised endpoint and itemsLimitMax counts exactly what the API returns.
+        has_client_side_filters = bool(ids or bbox or geometry or datetime)
+        if api_search_options is not None or not has_client_side_filters:
+            for key, value in self._enumeration_cap_options(max_items).items():
+                reader = reader.option(key, value)
+        if api_search_options is not None:
+            for key, value in api_search_options.items():
+                reader = reader.option(key, value)
+
+        df = reader.load(self.collection_url)
+
+        if api_search_options is None:
+            # These extended shapes are evaluated by Spark. They deliberately
+            # stay uncapped in the reader so a residual cannot exhaust the cap
+            # before a later matching Item is reached.
             if ids:
                 if isinstance(ids, tuple):
                     ids = list(ids)
                 if isinstance(ids, str):
                     ids = [ids]
                 df = df.filter(df.id.isin(ids))
-            # Ensure bbox is a list of lists
-            if bbox and isinstance(bbox[0], float):
-                bbox = [bbox]
-            # Handle geometry parameter
-            if geometry:
-                if not isinstance(geometry, list):
-                    geometry = [geometry]
-            # Handle datetime parameter
-            if datetime:
-                if isinstance(datetime, (str, python_datetime.datetime)):
-                    datetime = [self._expand_date(str(datetime))]
-                elif isinstance(datetime, (list, tuple)) and isinstance(
-                    datetime[0], str
-                ):
-                    datetime = [list(datetime)]
-            # Apply spatial and temporal filters
             df = self._apply_spatial_temporal_filters(df, bbox, geometry, datetime)
+
         # Limit the number of items if max_items is specified
         if max_items is not None:
             df = df.limit(max_items)

--- a/python/tests/stac/test_collection_client.py
+++ b/python/tests/stac/test_collection_client.py
@@ -477,3 +477,296 @@ class TestStacReader(TestBase):
         assert matches("2020-05-15") == {"day-edge"}
         # The first instant of the next period is never pulled in.
         assert "next-period" not in matches("2020")
+
+    def test_enumeration_cap_uses_total_and_per_request_limits(self) -> None:
+        assert CollectionClient._enumeration_cap_options(100) == {
+            "itemsLimitMax": "100",
+            "itemsLimitPerRequest": "100",
+        }
+
+        options = CollectionClient._enumeration_cap_options(1000)
+        assert options["itemsLimitMax"] == "1000"
+        assert options["itemsLimitPerRequest"] == "200"
+
+    def test_enumeration_cap_requires_max_items(self) -> None:
+        assert CollectionClient._enumeration_cap_options(None) == {}
+        assert CollectionClient._enumeration_cap_options(0) == {}
+
+    def test_get_items_preserves_interval_item_datetime_values(self) -> None:
+        import datetime as python_datetime
+        import sys
+        from types import SimpleNamespace
+
+        start_datetime = python_datetime.datetime(2025, 3, 1)
+        end_datetime = python_datetime.datetime(2025, 3, 4)
+
+        def utc_text(value):
+            return (
+                value.astimezone(python_datetime.timezone.utc)
+                .isoformat()
+                .replace("+00:00", "Z")
+            )
+
+        class FakeRow:
+            def asDict(self, recursive):
+                assert recursive
+                return {
+                    "type": "Feature",
+                    "stac_version": "1.0.0",
+                    "id": "interval-item",
+                    "collection": "c",
+                    "geometry": None,
+                    "bbox": None,
+                    "properties": {},
+                    "links": [],
+                    "assets": {},
+                    "datetime": None,
+                    "start_datetime": start_datetime,
+                    "end_datetime": end_datetime,
+                }
+
+        class FakeDataFrame:
+            def collect(self):
+                return [FakeRow()]
+
+        class FakePyStacItem:
+            @staticmethod
+            def from_dict(item_dict):
+                return item_dict
+
+        client = CollectionClient.__new__(CollectionClient)
+        with patch.dict(
+            sys.modules, {"pystac": SimpleNamespace(Item=FakePyStacItem)}
+        ), patch.object(
+            client, "load_items_df", return_value=FakeDataFrame()
+        ) as load_items:
+            items = list(
+                client.get_items(
+                    datetime=[["2025-03-01T00:00:00Z", "2025-03-04T00:00:00Z"]],
+                    max_items=1,
+                )
+            )
+
+        load_items.assert_called_once()
+        assert len(items) == 1
+        assert items[0]["properties"]["datetime"] is None
+        assert items[0]["properties"]["start_datetime"] == utc_text(start_datetime)
+        assert items[0]["properties"]["end_datetime"] == utc_text(end_datetime)
+
+    def test_api_search_options_carry_single_bbox_and_datetime(self) -> None:
+        client = CollectionClient.__new__(CollectionClient)
+        client.url = "https://stac.example.test/api/v1"
+        client.collection_id = "sentinel-2"
+        client.collection_url = (
+            "https://stac.example.test/api/v1/collections/sentinel-2"
+        )
+
+        options = client._api_search_options(
+            bbox=[[-10.0, -5.0, 20.0, 30.0]],
+            geometry=None,
+            datetime=[["2025-01-01T00:00:00Z", "2025-02-01T00:00:00+00:00"]],
+            ids=(),
+            max_items=100,
+        )
+
+        assert options == {
+            "__stacApiSearchBbox": "-10.0,-5.0,20.0,30.0",
+            "__stacApiSearchDatetime": (
+                "2025-01-01T00:00:00Z/2025-02-01T00:00:00+00:00"
+            ),
+        }
+
+        antimeridian_options = client._api_search_options(
+            bbox=[[160.0, -10.0, -170.0, 10.0]],
+            geometry=None,
+            datetime=None,
+            ids=(),
+            max_items=100,
+        )
+        assert antimeridian_options["__stacApiSearchBbox"] == (
+            "160.0,-10.0,-170.0,10.0"
+        )
+
+    def test_api_search_options_fall_back_for_extended_search_shapes(self) -> None:
+        client = CollectionClient.__new__(CollectionClient)
+        client.url = "https://stac.example.test/api/v1"
+        client.collection_id = "sentinel-2"
+        client.collection_url = (
+            "https://stac.example.test/api/v1/collections/sentinel-2"
+        )
+        one_bbox = [[-10.0, -5.0, 20.0, 30.0]]
+        one_interval = [["2025-01-01T00:00:00Z", "2025-02-01T00:00:00Z"]]
+
+        unsupported = [
+            (one_bbox * 2, None, one_interval, ()),
+            (one_bbox, None, one_interval * 2, ()),
+            (one_bbox, "POINT (0 0)", one_interval, ()),
+            (one_bbox, None, one_interval, ("item-1",)),
+            ([[20.0, 20.0, -10.0, 10.0]], None, one_interval, ()),
+        ]
+        for bbox, geometry, datetime, ids in unsupported:
+            assert (
+                client._api_search_options(bbox, geometry, datetime, ids, max_items=100)
+                is None
+            )
+
+        client.collection_id = None
+        assert (
+            client._api_search_options(one_bbox, None, one_interval, (), max_items=100)
+            is None
+        )
+
+    def test_load_items_df_wires_pystac_compatible_request(self) -> None:
+        import datetime as python_datetime
+
+        class FakeDataFrame:
+            def __init__(self):
+                self.limits = []
+
+            def limit(self, value):
+                self.limits.append(value)
+                return self
+
+        class RecordingReader:
+            def __init__(self, dataframe):
+                self.dataframe = dataframe
+                self.options = {}
+                self.loaded_url = None
+
+            def format(self, value):
+                assert value == "stac"
+                return self
+
+            def option(self, key, value):
+                self.options[key] = str(value)
+                return self
+
+            def load(self, url):
+                self.loaded_url = url
+                return self.dataframe
+
+        class FakeSpark:
+            def __init__(self, reader):
+                self.read = reader
+
+        dataframe = FakeDataFrame()
+        reader = RecordingReader(dataframe)
+        client = CollectionClient.__new__(CollectionClient)
+        client.url = "https://stac.example.test/api/v1"
+        client.collection_id = "sentinel-2"
+        client.collection_url = (
+            "https://stac.example.test/api/v1/collections/sentinel-2"
+        )
+        client.headers = {"Authorization": "Bearer secret"}
+        client.spark = FakeSpark(reader)
+
+        with patch.object(
+            CollectionClient,
+            "_apply_spatial_temporal_filters",
+            side_effect=AssertionError("trusted API filters must not be reinterpreted"),
+        ):
+            result = client.load_items_df(
+                bbox=[-10.0, -5.0, 20.0, 30.0],
+                geometry=None,
+                datetime=python_datetime.datetime(
+                    2025,
+                    1,
+                    1,
+                    2,
+                    tzinfo=python_datetime.timezone(python_datetime.timedelta(hours=2)),
+                ),
+                ids=(),
+                max_items=100,
+            )
+
+        assert result is dataframe
+        assert dataframe.limits == [100]
+        assert reader.options["itemsLimitMax"] == "100"
+        assert reader.options["itemsLimitPerRequest"] == "100"
+        assert reader.options["__stacApiSearchBbox"] == "-10.0,-5.0,20.0,30.0"
+        assert reader.options["__stacApiSearchDatetime"] == (
+            "2025-01-01T00:00:00Z/2025-01-01T00:00:00Z"
+        )
+        assert "secret" in reader.options["headers"]
+        assert reader.loaded_url == client.collection_url
+
+    def test_load_items_df_fallback_keeps_spark_filter_and_limit(self) -> None:
+        class FakeDataFrame:
+            def __init__(self):
+                self.limits = []
+
+            def limit(self, value):
+                self.limits.append(value)
+                return self
+
+        class RecordingReader:
+            def __init__(self, dataframe):
+                self.dataframe = dataframe
+                self.options = {}
+                self.loaded_url = None
+
+            def format(self, value):
+                return self
+
+            def option(self, key, value):
+                self.options[key] = str(value)
+                return self
+
+            def load(self, url):
+                self.loaded_url = url
+                return self.dataframe
+
+        class FakeSpark:
+            def __init__(self, reader):
+                self.read = reader
+
+        dataframe = FakeDataFrame()
+        reader = RecordingReader(dataframe)
+        client = CollectionClient.__new__(CollectionClient)
+        client.url = "https://stac.example.test/api/v1"
+        client.collection_id = "sentinel-2"
+        client.collection_url = (
+            "https://stac.example.test/api/v1/collections/sentinel-2"
+        )
+        client.headers = {}
+        client.spark = FakeSpark(reader)
+        intervals = [
+            ["2025-01-01T00:00:00Z", "2025-02-01T00:00:00Z"],
+            ["2025-03-01T00:00:00Z", "2025-04-01T00:00:00Z"],
+        ]
+
+        with patch.object(
+            CollectionClient,
+            "_apply_spatial_temporal_filters",
+            return_value=dataframe,
+        ) as apply_filters:
+            result = client.load_items_df(
+                bbox=None,
+                geometry=None,
+                datetime=intervals,
+                ids=(),
+                max_items=5,
+            )
+
+        assert result is dataframe
+        assert reader.loaded_url == client.collection_url
+        assert "itemsLimitMax" not in reader.options
+        assert "itemsLimitPerRequest" not in reader.options
+        apply_filters.assert_called_once_with(dataframe, None, None, intervals)
+        assert dataframe.limits == [5]
+
+        # An unfiltered max_items request retains the existing Collection walk
+        # and raw reader cap; it does not require an Item Search endpoint.
+        unfiltered_dataframe = FakeDataFrame()
+        unfiltered_reader = RecordingReader(unfiltered_dataframe)
+        client.spark = FakeSpark(unfiltered_reader)
+        with patch.object(
+            CollectionClient,
+            "_apply_spatial_temporal_filters",
+            return_value=unfiltered_dataframe,
+        ):
+            client.load_items_df(None, None, None, (), 5)
+        assert unfiltered_reader.loaded_url == client.collection_url
+        assert unfiltered_reader.options["itemsLimitMax"] == "5"
+        assert unfiltered_reader.options["itemsLimitPerRequest"] == "5"
+        assert unfiltered_dataframe.limits == [5]

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacBatch.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/io/stac/StacBatch.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.sedona_sql.io.stac.StacUtils.getNumPartitions
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.SerializableConfiguration
 
-import java.net.URI
+import java.net.{URI, URLDecoder, URLEncoder}
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatterBuilder
 import java.time.temporal.ChronoField
@@ -72,6 +72,12 @@ case class StacBatch(
   }
   private val itemsLoadProcessReportThreshold =
     opts.getOrElse("itemsLoadProcessReportThreshold", "1000000").toInt
+  private val clientApiSearchBBox =
+    opts.get(StacBatch.ApiSearchBBoxOption).map(_.trim).filter(_.nonEmpty)
+  private val clientApiSearchDatetime =
+    opts.get(StacBatch.ApiSearchDatetimeOption).map(_.trim).filter(_.nonEmpty)
+  private val clientApiSearchRequested =
+    clientApiSearchBBox.isDefined || clientApiSearchDatetime.isDefined
   private var itemMaxLeft: Int = -1
   private var lastReportCount: Int = 0
 
@@ -248,6 +254,43 @@ case class StacBatch(
         }
       }
       false
+    }
+
+    // CollectionClient's PySTAC-compatible search mode deliberately trusts the API's bbox and
+    // datetime semantics: apply those parameters to the collection's advertised items endpoint
+    // and count the raw API results. Do not crawl child or direct item links and never combine
+    // this mode with Spark-pushed predicates, whose retained Filter would discard rows the cap
+    // already counted — this mode represents one Collection Items request, like pystac-client.
+    if (clientApiSearchRequested) {
+      require(needCountNextItems, "Client API search options require a positive itemsLimitMax")
+      require(
+        spatialFilter.isEmpty && temporalFilter.isEmpty,
+        "Client API search options cannot be combined with Spark-pushed filters")
+      val itemsEndpoint = linksNode
+        .elements()
+        .asScala
+        .find { link =>
+          link.path("rel").asText() == "items" && {
+            val hrefNode = link.get("href")
+            hrefNode != null && hrefNode.isTextual && hrefNode.asText().trim.nonEmpty &&
+            resolveLink(collectionUrl, hrefNode.asText()).startsWith("http")
+          }
+        }
+        .getOrElse(throw new IllegalArgumentException(
+          "Client API search requires a remote HTTP(S) items endpoint"))
+      val itemUrl = resolveLink(collectionUrl, itemsEndpoint.get("href").asText())
+      val searchUrl = StacBatch.applyClientApiSearchParameters(
+        itemUrl,
+        clientApiSearchBBox,
+        clientApiSearchDatetime)
+      val firstPageUrl = getItemLink(
+        searchUrl,
+        defaultItemsLimitPerRequest,
+        spatialFilter = None,
+        temporalFilter = None)
+      itemLinks += firstPageUrl
+      iterateItemsWithLimit(firstPageUrl, needCountNextItems)
+      return
     }
 
     while (iterator.hasNext) {
@@ -449,5 +492,53 @@ case class StacBatch(
         spatialFilter,
         temporalFilter)
     }
+  }
+}
+
+object StacBatch {
+
+  private[stac] val ApiSearchBBoxOption = "__stacApiSearchBbox"
+  private[stac] val ApiSearchDatetimeOption = "__stacApiSearchDatetime"
+
+  /**
+   * Adds CollectionClient's API-owned search parameters to an advertised items endpoint. Existing
+   * query bytes and the fragment are retained. A source-owned spatial or datetime constraint
+   * cannot be combined generically with another constraint of the same kind, so reject that
+   * ambiguous endpoint instead of widening, narrowing, or duplicating its source relation.
+   */
+  private[stac] def applyClientApiSearchParameters(
+      endpointUrl: String,
+      bbox: Option[String],
+      datetime: Option[String]): String = {
+    require(bbox.isDefined || datetime.isDefined, "At least one API search parameter is required")
+    val fragmentIndex = endpointUrl.indexOf('#')
+    val (urlWithoutFragment, fragment) = if (fragmentIndex >= 0) {
+      (endpointUrl.substring(0, fragmentIndex), endpointUrl.substring(fragmentIndex))
+    } else (endpointUrl, "")
+    val queryIndex = urlWithoutFragment.indexOf('?')
+    val (path, existingQuery) = if (queryIndex >= 0) {
+      (urlWithoutFragment.substring(0, queryIndex), urlWithoutFragment.substring(queryIndex + 1))
+    } else (urlWithoutFragment, "")
+    val existingParameters = existingQuery.split("&", -1).filter(_.nonEmpty).toVector
+    val existingNames = existingParameters.flatMap(decodedQueryParameterName).toSet
+
+    if (bbox.isDefined && existingNames.exists(Set("bbox", "bbox-crs", "intersects"))) {
+      throw new IllegalArgumentException(
+        "The advertised items endpoint already owns a spatial search constraint")
+    }
+    if (datetime.isDefined && existingNames.contains("datetime")) {
+      throw new IllegalArgumentException(
+        "The advertised items endpoint already owns a datetime search constraint")
+    }
+
+    val searchParameters = bbox.map(value => "bbox=" + URLEncoder.encode(value, "UTF-8")) ++
+      datetime.map(value => "datetime=" + URLEncoder.encode(value, "UTF-8"))
+    val query = (existingParameters ++ searchParameters).mkString("&")
+    s"$path?$query$fragment"
+  }
+
+  private def decodedQueryParameterName(parameter: String): Option[String] = {
+    val rawName = parameter.takeWhile(_ != '=')
+    Try(URLDecoder.decode(rawName, "UTF-8")).toOption
   }
 }

--- a/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacBatchTest.scala
+++ b/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacBatchTest.scala
@@ -169,6 +169,57 @@ class StacBatchTest extends TestBaseScala {
     }
   }
 
+  it("collectItemLinks should apply client search to the advertised items endpoint") {
+    val requests = mutable.ArrayBuffer[String]()
+    withHttpServer(exchange => {
+      val request = exchange.getRequestURI.toString
+      requests.synchronized(requests += request)
+      val nextCursor = if (request.contains("cursor=page-2")) "page-3" else "page-2"
+      s"""{"features":[{}],
+         |"links":[{"rel":"next","href":"?cursor=$nextCursor"}]}""".stripMargin
+    }) { serverUrl =>
+      val collectionJson =
+        s"""{"id":"c","links":[
+           |{"rel":"child","href":"should-not-be-read"},
+           |{"rel":"items","href":"$serverUrl/custom/items?token=secret#results",
+           | "type":"application/geo+json"}]}""".stripMargin
+      val stacBatch = StacBatch(
+        null,
+        s"$serverUrl/api/collections/c",
+        collectionJson,
+        StructType(Seq()),
+        Map(
+          "itemsLimitMax" -> "2",
+          "itemsLimitPerRequest" -> "1",
+          StacBatch.ApiSearchBBoxOption -> "-10.0,-5.0,20.0,30.0",
+          StacBatch.ApiSearchDatetimeOption ->
+            "2025-01-01T00:00:00Z/2025-02-01T00:00:00Z"),
+        None,
+        None,
+        None)
+      stacBatch.setItemMaxLeft(2)
+      val itemLinks = mutable.ArrayBuffer[String]()
+
+      stacBatch.collectItemLinks(
+        s"$serverUrl/api/collections/c",
+        collectionJson,
+        itemLinks,
+        needCountNextItems = true)
+
+      val expected = s"$serverUrl/custom/items?token=secret" +
+        "&bbox=-10.0%2C-5.0%2C20.0%2C30.0" +
+        "&datetime=2025-01-01T00%3A00%3A00Z%2F2025-02-01T00%3A00%3A00Z" +
+        "&limit=1#results"
+      val secondPage = s"$serverUrl/custom/items?cursor=page-2"
+      assert(itemLinks == Seq(expected, secondPage))
+      assert(
+        requests == Seq(
+          new URI(expected).getRawPath + "?" + new URI(expected).getRawQuery,
+          "/custom/items?cursor=page-2"))
+      assert(!requests.exists(_.contains("page-3")))
+    }
+  }
+
   it("collectItemLinks should stop at the direct item limit without adding an extra link") {
     val collectionJson =
       """{"links":[{"rel":"item","href":"file:/one.json"},{"rel":"item","href":"two.json"}]}"""

--- a/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacBatchUrlTest.scala
+++ b/spark/common/src/test/scala/org/apache/spark/sql/sedona_sql/io/stac/StacBatchUrlTest.scala
@@ -53,4 +53,30 @@ class StacBatchUrlTest extends AnyFunSuite {
       assert(batch.getItemLink(input, 2, None, temporalFilter) == expected)
     }
   }
+  test("applyClientApiSearchParameters should append encoded search parameters") {
+    val url = StacBatch.applyClientApiSearchParameters(
+      "https://example.test/items?token=x#results",
+      Some("-10.0,-5.0,20.0,30.0"),
+      Some("2025-01-01T00:00:00Z/2025-02-01T00:00:00Z"))
+    assert(
+      url == "https://example.test/items?token=x" +
+        "&bbox=-10.0%2C-5.0%2C20.0%2C30.0" +
+        "&datetime=2025-01-01T00%3A00%3A00Z%2F2025-02-01T00%3A00%3A00Z#results")
+  }
+
+  test("applyClientApiSearchParameters should reject conflicting endpoint constraints") {
+    intercept[IllegalArgumentException] {
+      StacBatch.applyClientApiSearchParameters(
+        "https://example.test/items?bbox=0,0,1,1",
+        Some("2,2,3,3"),
+        None)
+    }
+    intercept[IllegalArgumentException] {
+      StacBatch.applyClientApiSearchParameters(
+        "https://example.test/items?dat%65time=2025-01-01T00:00:00Z",
+        None,
+        Some("2025-02-01T00:00:00Z/2025-03-01T00:00:00Z"))
+    }
+  }
+
 }


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #3283

## What changes were proposed in this PR?

`CollectionClient.load_items_df` only passed `max_items` to the reader as `itemsLimitMax` when no filters were provided. With a `bbox` or `datetime` filter it fell back to `df.limit(max_items)` behind the filters — which cannot bound the scan — so `client.search(collection_id="sentinel-2-c1-l2a", datetime="2025", max_items=100)` sequentially enumerated every matching result page (hundreds of thousands of items at 10 per request) before Spark trimmed to 100. In our integration environment this ran to a 1-hour timeout.

Searches the STAC API can represent directly now follow **pystac-client semantics**:

- When a search against a named collection uses at most one `bbox` and one `datetime` interval, no ID or geometry filter, and a positive `max_items`, the Python client forwards the constraints through internal reader options.
- The datasource applies them as parameters of the collection's advertised JSON `rel=items` endpoint (preserving custom, cross-origin, and query-bearing hrefs), trusts the conforming API's spatial and temporal matching, and stops enumeration after `max_items` server results via the existing counting walk, paging at `min(200, max_items)`. The motivating search becomes ~1 request.
- Endpoints that already own a same-kind constraint (`bbox`/`bbox-crs`/`intersects`/`datetime`, matched on percent-decoded parameter names) are rejected rather than widened or duplicated, and this mode refuses to combine with Spark-pushed predicates, whose retained Filter would discard rows the cap already counted.
- Multiple bounding boxes or datetime intervals, ID filters, and geometry filters are Sedona extensions evaluated by Spark; those shapes keep the current behavior (full enumeration, then Spark filters and the final limit) because a raw fetch cap before Spark-side predicates could return fewer matching items than requested.

Note this makes the representable searches API-owned in semantics: e.g. an interval-valued Item a conforming server returns for a datetime search is kept rather than re-filtered against its nominal `datetime` — which matches what pystac-client users expect.

Also fixes a timezone bug in `_move_attributes_to_properties`: PySpark materializes timestamps in the local timezone, so item round-trips previously produced naive local-time strings; datetime values are now normalized to UTC RFC 3339 (`Z`) strings.

## How was this patch tested?

- New Scala tests: the API-mode request chain against a local HTTP server (cursor pagination stops at the cap, child links never fetched, custom query-bearing href preserved) in `StacBatchTest`, plus `applyClientApiSearchParameters` unit tests (encoding, fragment placement, conflicting-constraint rejection incl. percent-encoded names) in `StacBatchUrlTest`. All STAC suites pass under `-Dspark=3.5`: 73 passed.
- New Python tests: API-search option matrix (single vs multiple bbox/datetime, geometry/ids fallback, URL validation incl. antimeridian bbox), production reader-option wiring, Spark-filtered fallback, and UTC round-trip of interval item datetimes. 31 passed.

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation. The STAC tutorial (EN/ZH) now documents the pystac-client `max_items` semantics and which search shapes are API-owned vs Spark-evaluated.