### PR TITLE
[GH-3288] GeoPandas: implement from_dict

### DIFF
--- a/docs/setup/release-notes.md
+++ b/docs/setup/release-notes.md
@@ -51,6 +51,7 @@
 * [<a href='https://github.com/apache/sedona/issues/3260'>GH-3260</a>] - Implement distributed GeoSeries and GeoDataFrame identical-geometry equality
 * [<a href='https://github.com/apache/sedona/issues/3273'>GH-3273</a>] - Implement distributed GeoSeries and GeoDataFrame polygonal coverage validation and invalid-edge diagnostics
 * [<a href='https://github.com/apache/sedona/issues/3281'>GH-3281</a>] - Implement `GeoDataFrame.from_features` for in-memory GeoJSON-like features
+* [<a href='https://github.com/apache/sedona/issues/3288'>GH-3288</a>] - Implement `GeoDataFrame.from_dict` for in-memory dictionaries
 
 ### Bug Fixes
 

--- a/python/sedona/spark/geopandas/geodataframe.py
+++ b/python/sedona/spark/geopandas/geodataframe.py
@@ -29,6 +29,7 @@ import geopandas as gpd
 import pandas as pd
 import pyspark.pandas as pspd
 import sedona.spark.geopandas as sgpd
+from shapely.geometry.base import BaseGeometry
 from packaging.version import parse as parse_version
 from pyproj import CRS
 from pyspark.pandas import Series as PandasOnSparkSeries
@@ -1582,7 +1583,117 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
         crs: Any | None = None,
         **kwargs,
     ) -> GeoDataFrame:
-        raise NotImplementedError("from_dict() is not implemented yet.")
+        """Construct a GeoDataFrame from a dictionary.
+
+        .. versionadded:: 2.0.0
+
+        Parameters
+        ----------
+        data : dict
+            Dictionary of the form ``{field: array-like}`` or
+            ``{field: dict}``.
+        geometry : str or array-like, optional
+            If a string, the column to use as the active geometry. If an
+            array-like, it is added as the ``"geometry"`` column.
+        crs : str, dict, pyproj.CRS, optional
+            Coordinate reference system to assign to the resulting frame. The
+            coordinates are not transformed.
+        **kwargs
+            Additional arguments passed to :meth:`pandas.DataFrame.from_dict`,
+            such as ``orient`` or ``columns``.
+
+        Returns
+        -------
+        GeoDataFrame
+
+        Notes
+        -----
+        This constructor first materializes the dictionary in a local
+        GeoPandas GeoDataFrame on the driver, then distributes it with Spark.
+        It is intended for small in-memory inputs. For large datasets, create
+        a Spark DataFrame or use a distributed Sedona data source instead.
+
+        Once distributed, dictionary values follow Spark schema inference.
+        Each column must contain values that Spark can represent with one
+        compatible type.
+
+        Examples
+        --------
+        >>> from shapely.geometry import Point
+        >>> from sedona.spark.geopandas import GeoDataFrame
+        >>> data = {
+        ...     "name": ["first", "second"],
+        ...     "geometry": [Point(1, 2), Point(2, 1)],
+        ... }
+        >>> GeoDataFrame.from_dict(data, crs="EPSG:4326")
+             name     geometry
+        0   first  POINT (1 2)
+        1  second  POINT (2 1)
+        """
+        local = gpd.GeoDataFrame.from_dict(
+            data,
+            geometry=geometry,
+            crs=crs,
+            **kwargs,
+        )
+        return cls._from_local_geopandas(local)
+
+    @classmethod
+    def _from_local_geopandas(cls, local: gpd.GeoDataFrame) -> GeoDataFrame:
+        """Distribute a locally constructed GeoPandas frame safely."""
+        geometry_name = local._geometry_column_name
+        restore_order_column = None
+
+        # Spark 3 pandas-on-Spark only checks the first object value when
+        # looking for a user-defined type. Give every geometry column that has
+        # a value a representative in a temporary first row, then remove it
+        # and restore the original positional order.
+        if len(local) > 0:
+            inference_values = {}
+            for position, dtype in enumerate(local.dtypes):
+                if not isinstance(
+                    dtype, GeometryDtype
+                ) and not pd.api.types.is_object_dtype(dtype):
+                    continue
+                missing = local.iloc[:, position].isna().to_numpy()
+                non_missing = np.flatnonzero(~missing)
+                if missing[0] and len(non_missing) > 0:
+                    value = local.iloc[non_missing[0], position]
+                    if isinstance(dtype, GeometryDtype) or isinstance(
+                        value, BaseGeometry
+                    ):
+                        inference_values[position] = value
+
+            if inference_values:
+                local = local.copy()
+
+                base_name = "__sedona_local_row_order__"
+                suffix = 0
+                while True:
+                    name = base_name if suffix == 0 else f"{base_name}_{suffix}"
+                    if isinstance(local.columns, pd.MultiIndex):
+                        candidate = (name,) + ("",) * (local.columns.nlevels - 1)
+                    else:
+                        candidate = name
+                    if candidate not in local.columns:
+                        restore_order_column = candidate
+                        break
+                    suffix += 1
+
+                local[restore_order_column] = np.arange(len(local))
+                inference_row = local.iloc[[0]].copy()
+                inference_row[restore_order_column] = -1
+                for position, value in inference_values.items():
+                    inference_row.iat[0, position] = value
+                local = pd.concat([inference_row, local])
+
+        result = cls(local)
+        if restore_order_column is not None:
+            result = result[result[restore_order_column] >= 0]
+            result.sort_values(restore_order_column, inplace=True)
+            result = cls(result.drop(columns=[restore_order_column]))
+            result._geometry_column_name = geometry_name
+        return result
 
     @classmethod
     def from_features(
@@ -1658,31 +1769,7 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
             crs=crs,
             columns=columns,
         )
-
-        # Spark 3 pandas-on-Spark only checks the first object value when
-        # looking for a user-defined type. Move one geometry forward for
-        # schema inference, then restore the GeoPandas RangeIndex order.
-        restore_order = False
-        geometry_name = local._geometry_column_name
-        if geometry_name is not None and len(local) > 0:
-            missing = local[geometry_name].isna().to_numpy()
-            non_missing = np.flatnonzero(~missing)
-            if missing[0] and len(non_missing) > 0:
-                first_geometry = non_missing[0]
-                order = np.concatenate(
-                    (
-                        [first_geometry],
-                        np.arange(first_geometry),
-                        np.arange(first_geometry + 1, len(local)),
-                    )
-                )
-                local = local.iloc[order]
-                restore_order = True
-
-        result = cls(local)
-        if restore_order:
-            result.sort_index(inplace=True)
-        return result
+        return cls._from_local_geopandas(local)
 
     @classmethod
     def from_postgis(

--- a/python/sedona/spark/geopandas/geodataframe.py
+++ b/python/sedona/spark/geopandas/geodataframe.py
@@ -1687,7 +1687,9 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
                     inference_row.iat[0, position] = value
                 local = pd.concat([inference_row, local])
 
-        result = cls(local)
+        # Avoid pandas 1.5 sharing geometry blocks with the local GeoDataFrame;
+        # the constructor casts those blocks to object dtype for Spark.
+        result = cls(local, copy=True)
         if restore_order_column is not None:
             result = result[result[restore_order_column] >= 0]
             result.sort_values(restore_order_column, inplace=True)

--- a/python/tests/geopandas/test_geodataframe.py
+++ b/python/tests/geopandas/test_geodataframe.py
@@ -101,6 +101,28 @@ class TestGeoDataFrameFromDict(TestGeopandasBase):
         assert materialized.index.tolist() == expected.index.tolist()
         assert_geodataframe_equal(materialized, expected)
 
+    def test_orient_tight_preserves_multiindex_geometry_and_crs(self):
+        from geopandas.testing import assert_geodataframe_equal
+
+        data = {
+            "index": ["row-b", "row-a"],
+            "columns": [["shape", "geometry"], ["attr", "name"]],
+            "data": [[None, "first"], [Point(1.0, 2.0), "second"]],
+            "index_names": ["row"],
+            "column_names": ["kind", "field"],
+        }
+        kwargs = {
+            "orient": "tight",
+            "geometry": ("shape", "geometry"),
+            "crs": "EPSG:4326",
+        }
+
+        expected = gpd.GeoDataFrame.from_dict(data, **kwargs)
+        result = GeoDataFrame.from_dict(data, **kwargs)
+
+        assert result._geometry_column_name == expected._geometry_column_name
+        assert_geodataframe_equal(result.to_geopandas(), expected)
+
     def test_empty_with_geometry_schema(self):
         data = {"geometry": [], "name": []}
         kwargs = {"geometry": "geometry", "crs": "EPSG:4326"}

--- a/python/tests/geopandas/test_geodataframe.py
+++ b/python/tests/geopandas/test_geodataframe.py
@@ -44,6 +44,108 @@ from pandas.testing import assert_frame_equal
 from packaging.version import parse as parse_version
 
 
+class TestGeoDataFrameFromDict(TestGeopandasBase):
+    @pytest.mark.parametrize("geometry_in_data", [False, True])
+    def test_default_orientation(self, geometry_in_data):
+        from geopandas.testing import assert_geodataframe_equal
+
+        data = {
+            "name": ["first", "second"],
+            "value": [1, 2],
+        }
+        geometry = [Point(1.0, 2.0), Point(2.0, 1.0)]
+        kwargs = {"crs": "EPSG:4326"}
+        if geometry_in_data:
+            data["geometry"] = geometry
+        else:
+            kwargs["geometry"] = geometry
+
+        expected = gpd.GeoDataFrame.from_dict(data, **kwargs)
+        result = GeoDataFrame.from_dict(data, **kwargs)
+        materialized = result.to_geopandas()
+
+        assert list(result.columns) == list(expected.columns)
+        assert result.crs == expected.crs
+        assert_geodataframe_equal(materialized, expected)
+
+    def test_orient_index_preserves_leading_null_geometry_order(self):
+        from geopandas.testing import assert_geodataframe_equal
+
+        data = {
+            "row-b": {
+                "name": "first",
+                "geometry": None,
+                "__sedona_local_row_order__": "keep-b",
+            },
+            "row-a": {
+                "name": "second",
+                "geometry": None,
+                "__sedona_local_row_order__": "keep-a",
+            },
+            "row-c": {
+                "name": "third",
+                "geometry": Point(1.0, 2.0),
+                "__sedona_local_row_order__": "keep-c",
+            },
+        }
+        kwargs = {
+            "orient": "index",
+            "geometry": "geometry",
+            "crs": "EPSG:3857",
+        }
+
+        expected = gpd.GeoDataFrame.from_dict(data, **kwargs)
+        result = GeoDataFrame.from_dict(data, **kwargs)
+        materialized = result.to_geopandas()
+
+        assert materialized.index.tolist() == expected.index.tolist()
+        assert_geodataframe_equal(materialized, expected)
+
+    def test_empty_with_geometry_schema(self):
+        data = {"geometry": [], "name": []}
+        kwargs = {"geometry": "geometry", "crs": "EPSG:4326"}
+
+        expected = gpd.GeoDataFrame.from_dict(data, **kwargs)
+        result = GeoDataFrame.from_dict(data, **kwargs)
+
+        assert list(result.columns) == list(expected.columns)
+        assert result.crs == expected.crs
+        assert len(result) == 0
+
+    def test_multiple_geometry_columns_use_independent_inference_values(self):
+        from geopandas.testing import assert_geodataframe_equal
+
+        data = {
+            "geometry": gpd.GeoSeries([None, Point(1.0, 1.0)], crs="EPSG:4326"),
+            "secondary": gpd.GeoSeries([Point(2.0, 2.0), None], crs="EPSG:3857"),
+            "name": ["first", "second"],
+        }
+        kwargs = {"geometry": "geometry"}
+
+        expected = gpd.GeoDataFrame.from_dict(data, **kwargs)
+        result = GeoDataFrame.from_dict(data, **kwargs)
+
+        assert result.crs == expected.crs
+        assert result["secondary"].crs == expected["secondary"].crs
+        assert_geodataframe_equal(result.to_geopandas(), expected)
+
+    def test_inactive_object_geometry_column_with_leading_null(self):
+        from geopandas.testing import assert_geoseries_equal
+
+        data = {
+            "geometry": [Point(0.0, 0.0), Point(1.0, 1.0)],
+            "secondary": [None, Point(2.0, 2.0)],
+        }
+
+        result = GeoDataFrame.from_dict(data, geometry="geometry")
+
+        assert isinstance(result["secondary"], GeoSeries)
+        assert_geoseries_equal(
+            result["secondary"].to_geopandas(),
+            gpd.GeoSeries(data["secondary"], name="secondary"),
+        )
+
+
 class TestGeoDataFrameFromFeatures(TestGeopandasBase):
     def test_input_forms(self):
         feature_collection = {


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/).

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`.

Closes #3288.

## What changes were proposed in this PR?

This PR implements `GeoDataFrame.from_dict` for small, in-memory dictionaries.

It:

- delegates dictionary parsing, orientation, and column selection to the installed GeoPandas version;
- preserves active geometry selection, CRS metadata, arbitrary index and row order, empty inputs, and multiple geometry columns;
- handles Spark 3 geometry-type inference when geometry-valued columns begin with missing values, including inactive object-typed geometry columns;
- shares the local GeoPandas conversion path with `GeoDataFrame.from_features`; and
- documents driver materialization, Spark schema constraints, and distributed alternatives for large datasets.

## How was this patch tested?

- Spark 3.4.0 / Python 3.8.13 / GeoPandas 0.13.2 / Shapely 1.8.5.post1: 9 focused tests passed.
- Spark 4.1.1 / Python 3.11.13 / GeoPandas 1.1.4 / Shapely 2.1.2: 9 focused tests passed.
- All commit hooks and `git diff --check` passed.

The tests cover default and index-oriented dictionaries, implicit and explicit geometry selection, CRS preservation, leading null geometries, arbitrary row order, temporary-column name collisions, multiple geometry dtypes, inactive object-typed geometry columns, empty inputs, and the existing `from_features` conversion path.

## Did this PR include necessary documentation updates?

- Yes, I am adding a new API. I am using the [current SNAPSHOT version number](https://github.com/apache/sedona/blob/99239524f17389fc4ae9548ea88756f8ea538bb9/pom.xml#L29) in `vX.Y.Z` format.

The method documentation marks the API as added in `2.0.0`, and the release notes are updated.
