### PR TITLE
[GH-3298] Bump GraphFrames from 0.11.0 to 0.12.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <spark.compat.version>3.4</spark.compat.version>
         <spark.major.version>3</spark.major.version>
         <log4j.version>2.25.4</log4j.version>
-        <graphframes.version>0.11.0</graphframes.version>
+        <graphframes.version>0.12.2</graphframes.version>
         <flink.version>1.19.0</flink.version>
         <slf4j.version>1.7.36</slf4j.version>
         <googles2.version>20250620-rc1</googles2.version>


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #3298

## What changes were proposed in this PR?

Bumps `<graphframes.version>` in the root `pom.xml` from 0.11.0 to 0.12.2.

Sedona's only GraphFrames usage is `GraphFrame(...).connectedComponents` in `DBSCAN.scala`. The one breaking change in the 0.12.x line is the low-level Pregel edge-attribute contract (edge columns must now be requested via `requiredEdgeColumns`), which Sedona does not use. Artifact coordinates are unchanged and 0.12.2 is published for all three combinations Sedona builds against: `graphframes-spark3_2.12`, `graphframes-spark3_2.13`, `graphframes-spark4_2.13`.

### Scope reduced

This PR originally also switched DBSCAN's connected components to `randomized_contraction`, as proposed in #3298. **That part has been dropped**, because the algorithm cannot run on Sedona's DBSCAN at all.

`RandomizedContraction` maps results back with `coalesce(col(COMPONENT), col(ID))`, where `COMPONENT` is a `Long` and `ID` is the original vertex id. `DBSCAN.dbscan` always sets `id` to `sha2(to_json(struct("*")), 256)` — a hex `String` — even when the input already has an `id` column (which is renamed to `__id`). Spark coerces the two branches to a common type, casts the hash to `BIGINT`, and fails:

```
org.apache.spark.SparkNumberFormatException: [CAST_INVALID_INPUT] The value
'36e53dd410ea44fd0f989eac55c1d9f90118dbf637374aa4e8733be40f3128f5' of the type
"STRING" cannot be cast to "BIGINT" because it is malformed. SQLSTATE: 22018
```

Every DBSCAN case in `GeoStatsSuite` failed on Spark 4.0.2 with this. Upstream, `randomized_contraction` is only exercised by `TestLDBCCases`, whose graphs are explicitly `LongType`, so non-integral vertex IDs are untested there. Reported upstream; the algorithm switch can be revisited once that is fixed and released.

I have left #3298 open to track the switch. Happy to close it instead if you would rather track only the bump.

## How was this patch tested?

Full CI matrix. No source changes — dependency version only.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
