### PR TITLE
[GH-2068] GeoPandas: implement GeoSeries fillna limit

### DIFF
--- a/docs/setup/release-notes.md
+++ b/docs/setup/release-notes.md
@@ -52,6 +52,7 @@
 
 #### GeoPandas API
 
+* [<a href='https://github.com/apache/sedona/issues/2068'>GH-2068</a>] - Implement the `limit` parameter for `GeoSeries.fillna`
 * [<a href='https://github.com/apache/sedona/issues/3257'>GH-3257</a>] - Implement distributed GeoSeries and GeoDataFrame Hilbert-distance spatial ordering
 * [<a href='https://github.com/apache/sedona/issues/3260'>GH-3260</a>] - Implement distributed GeoSeries and GeoDataFrame identical-geometry equality
 * [<a href='https://github.com/apache/sedona/issues/3273'>GH-3273</a>] - Implement distributed GeoSeries and GeoDataFrame polygonal coverage validation and invalid-edge diagnostics

--- a/python/sedona/spark/geopandas/geoseries.py
+++ b/python/sedona/spark/geopandas/geoseries.py
@@ -5003,26 +5003,18 @@ class GeoSeries(GeoFrame, pspd.Series):
                 scol_for(source_frame, NATURAL_ORDER_COLUMN_NAME),
             )
 
-        ranked_missing = _attach_ordered_sequence_column(
-            aligned_frame.where(F.col("L").isNull()),
-            F.col(NATURAL_ORDER_COLUMN_NAME),
+        # Rank missing rows first, avoiding separate branches that repeat alignment.
+        ranked_frame = _attach_ordered_sequence_column(
+            aligned_frame,
+            F.struct(F.col("L").isNotNull(), F.col(NATURAL_ORDER_COLUMN_NAME)),
             fill_rank,
-        )
-        nonmissing = aligned_frame.where(F.col("L").isNotNull()).withColumn(
-            fill_rank, F.lit(-1).cast(LongType())
-        )
-        ranked_frame = nonmissing.unionByName(ranked_missing).orderBy(
-            NATURAL_ORDER_COLUMN_NAME
-        )
+        ).orderBy(NATURAL_ORDER_COLUMN_NAME)
 
         left_crs = self.crs
         left_srid = (left_crs.to_epsg() or 0) if left_crs is not None else 0
         result_expression = F.when(
-            (F.col(fill_rank) >= F.lit(0)) & (F.col(fill_rank) < F.lit(limit)),
-            F.coalesce(
-                F.col("L"),
-                stf.ST_SetSRID(F.col("R"), left_srid),
-            ),
+            F.col("L").isNull() & (F.col(fill_rank) < F.lit(limit)),
+            stf.ST_SetSRID(F.col("R"), left_srid),
         ).otherwise(F.col("L"))
         return self._result_preserving_index(
             result_expression,
@@ -5064,8 +5056,8 @@ class GeoSeries(GeoFrame, pspd.Series):
         before returning. Filling from another column of the same ``GeoDataFrame``
         remains lazy.
 
-        Using ``limit`` requires a distributed global ordering of the missing
-        geometries and can be expensive for large GeoSeries.
+        Using ``limit`` requires distributed global ordering and can be expensive
+        for large GeoSeries.
 
         Examples
         --------

--- a/python/sedona/spark/geopandas/geoseries.py
+++ b/python/sedona/spark/geopandas/geoseries.py
@@ -4975,6 +4975,65 @@ class GeoSeries(GeoFrame, pspd.Series):
         ).orderBy(NATURAL_ORDER_COLUMN_NAME)
         return aligned_frame, left_indexes
 
+    def _fillna_with_limit(
+        self,
+        replacement: Union[PySparkColumn, "GeoSeries"],
+        limit: int,
+    ) -> "GeoSeries":
+        """Fill the first missing rows while preserving the exact left axis."""
+        fill_rank = "__fillna_rank__"
+
+        if isinstance(replacement, GeoSeries):
+            aligned_frame, left_indexes = self._align_fillna_series(replacement)
+        else:
+            source_frame = self._internal.spark_frame
+            left_indexes = [
+                f"__fillna_left_index_{level}__"
+                for level in range(len(self._internal.index_spark_columns))
+            ]
+            aligned_frame = source_frame.select(
+                self.spark.column.alias("L"),
+                replacement.alias("R"),
+                *[
+                    column.alias(alias)
+                    for column, alias in zip(
+                        self._internal.index_spark_columns, left_indexes
+                    )
+                ],
+                scol_for(source_frame, NATURAL_ORDER_COLUMN_NAME),
+            )
+
+        ranked_missing = _attach_ordered_sequence_column(
+            aligned_frame.where(F.col("L").isNull()),
+            F.col(NATURAL_ORDER_COLUMN_NAME),
+            fill_rank,
+        )
+        nonmissing = aligned_frame.where(F.col("L").isNotNull()).withColumn(
+            fill_rank, F.lit(-1).cast(LongType())
+        )
+        ranked_frame = nonmissing.unionByName(ranked_missing).orderBy(
+            NATURAL_ORDER_COLUMN_NAME
+        )
+
+        left_crs = self.crs
+        left_srid = (left_crs.to_epsg() or 0) if left_crs is not None else 0
+        result_expression = F.when(
+            (F.col(fill_rank) >= F.lit(0)) & (F.col(fill_rank) < F.lit(limit)),
+            F.coalesce(
+                F.col("L"),
+                stf.ST_SetSRID(F.col("R"), left_srid),
+            ),
+        ).otherwise(F.col("L"))
+        return self._result_preserving_index(
+            result_expression,
+            ranked_frame,
+            [scol_for(ranked_frame, name) for name in left_indexes],
+            self._internal.index_fields,
+            self._internal.index_names,
+            returns_geom=True,
+            keep_name=True,
+        )
+
     # GeoSeries-only (not in GeoDataFrame)
     def fillna(
         self, value=None, inplace: bool = False, limit=None, **kwargs
@@ -5004,6 +5063,9 @@ class GeoSeries(GeoFrame, pspd.Series):
         Filling from an independent ``GeoSeries`` validates its distributed index
         before returning. Filling from another column of the same ``GeoDataFrame``
         remains lazy.
+
+        Using ``limit`` requires a distributed global ordering of the missing
+        geometries and can be expensive for large GeoSeries.
 
         Examples
         --------
@@ -5061,11 +5123,13 @@ class GeoSeries(GeoFrame, pspd.Series):
         """
         from shapely.geometry.base import BaseGeometry
 
-        # TODO: Implement limit https://github.com/apache/sedona/issues/2068
-        if limit:
-            raise NotImplementedError(
-                "GeoSeries.fillna() with limit is not implemented yet."
-            )
+        if limit is not None:
+            if type(limit) is not int:
+                raise ValueError("Limit must be an integer")
+            if limit <= 0:
+                raise ValueError("Limit must be greater than 0")
+            # Distributed sequence positions use Spark LongType.
+            limit = min(limit, 9_223_372_036_854_775_807)
 
         align = True
 
@@ -5083,21 +5147,24 @@ class GeoSeries(GeoFrame, pspd.Series):
                     crs=value_crs,
                 )
 
-            aligned_frame, left_indexes = self._align_fillna_series(value)
-            left_crs = self.crs
-            left_srid = (left_crs.to_epsg() or 0) if left_crs is not None else 0
-            result = self._result_preserving_index(
-                F.coalesce(
-                    F.col("L"),
-                    stf.ST_SetSRID(F.col("R"), left_srid),
-                ),
-                aligned_frame,
-                [scol_for(aligned_frame, name) for name in left_indexes],
-                self._internal.index_fields,
-                self._internal.index_names,
-                returns_geom=True,
-                keep_name=True,
-            )
+            if limit is not None:
+                result = self._fillna_with_limit(value, limit)
+            else:
+                aligned_frame, left_indexes = self._align_fillna_series(value)
+                left_crs = self.crs
+                left_srid = (left_crs.to_epsg() or 0) if left_crs is not None else 0
+                result = self._result_preserving_index(
+                    F.coalesce(
+                        F.col("L"),
+                        stf.ST_SetSRID(F.col("R"), left_srid),
+                    ),
+                    aligned_frame,
+                    [scol_for(aligned_frame, name) for name in left_indexes],
+                    self._internal.index_fields,
+                    self._internal.index_names,
+                    returns_geom=True,
+                    keep_name=True,
+                )
 
         elif pd.isna(value) == True or isinstance(value, BaseGeometry):
             if (
@@ -5110,19 +5177,25 @@ class GeoSeries(GeoFrame, pspd.Series):
 
                     value = GeometryCollection()
 
-            other, extended = self._make_series_of_val(value)
-            align = False if extended else align
+            if limit is not None:
+                replacement = stc.ST_GeomFromWKB(
+                    F.lit(value.wkb if value is not None else None).cast("binary")
+                )
+                result = self._fillna_with_limit(replacement, limit)
+            else:
+                other, extended = self._make_series_of_val(value)
+                align = False if extended else align
 
-            # Coalesce: If the value in L is null, use the corresponding value in R for that row
-            spark_expr = F.coalesce(F.col("L"), F.col("R"))
-            result = self._row_wise_operation(
-                spark_expr,
-                other,
-                align=align,
-                returns_geom=True,
-                default_val=None,
-                keep_name=True,
-            )
+                # Coalesce: If the value in L is null, use the corresponding value in R for that row
+                spark_expr = F.coalesce(F.col("L"), F.col("R"))
+                result = self._row_wise_operation(
+                    spark_expr,
+                    other,
+                    align=align,
+                    returns_geom=True,
+                    default_val=None,
+                    keep_name=True,
+                )
 
         else:
             raise ValueError(f"Invalid value type: {type(value)}")

--- a/python/sedona/spark/geopandas/geoseries.py
+++ b/python/sedona/spark/geopandas/geoseries.py
@@ -4777,7 +4777,7 @@ class GeoSeries(GeoFrame, pspd.Series):
         return self.notna()
 
     def _align_fillna_series(self, replacement: "GeoSeries"):
-        """Align a replacement GeoSeries to the exact left axis."""
+        """Align to the exact left axis; callers restore natural row order."""
         position = "__fillna_position__"
         left_order = "__fillna_left_order__"
         right_order = "__fillna_right_order__"
@@ -4807,7 +4807,7 @@ class GeoSeries(GeoFrame, pspd.Series):
             )
             aligned_frame = aligned_frame.withColumnRenamed(
                 left_order, NATURAL_ORDER_COLUMN_NAME
-            ).orderBy(NATURAL_ORDER_COLUMN_NAME)
+            )
             return aligned_frame, left_indexes
 
         left_frame = left_source.select(
@@ -4876,7 +4876,7 @@ class GeoSeries(GeoFrame, pspd.Series):
             )
             aligned_frame = aligned_frame.withColumnRenamed(
                 left_order, NATURAL_ORDER_COLUMN_NAME
-            ).orderBy(NATURAL_ORDER_COLUMN_NAME)
+            )
             return aligned_frame, left_indexes
 
         positioned_left = _attach_ordered_sequence_column(
@@ -4972,7 +4972,7 @@ class GeoSeries(GeoFrame, pspd.Series):
 
         aligned_frame = aligned_frame.withColumnRenamed(
             left_order, NATURAL_ORDER_COLUMN_NAME
-        ).orderBy(NATURAL_ORDER_COLUMN_NAME)
+        )
         return aligned_frame, left_indexes
 
     def _fillna_with_limit(
@@ -5124,8 +5124,12 @@ class GeoSeries(GeoFrame, pspd.Series):
         from shapely.geometry.base import BaseGeometry
 
         if limit is not None:
-            if type(limit) is not int:
+            if isinstance(limit, (bool, np.bool_)):
                 raise ValueError("Limit must be an integer")
+            try:
+                limit = operator.index(limit)
+            except TypeError as exc:
+                raise ValueError("Limit must be an integer") from exc
             if limit <= 0:
                 raise ValueError("Limit must be greater than 0")
             # Distributed sequence positions use Spark LongType.
@@ -5151,6 +5155,7 @@ class GeoSeries(GeoFrame, pspd.Series):
                 result = self._fillna_with_limit(value, limit)
             else:
                 aligned_frame, left_indexes = self._align_fillna_series(value)
+                aligned_frame = aligned_frame.orderBy(NATURAL_ORDER_COLUMN_NAME)
                 left_crs = self.crs
                 left_srid = (left_crs.to_epsg() or 0) if left_crs is not None else 0
                 result = self._result_preserving_index(
@@ -5186,8 +5191,11 @@ class GeoSeries(GeoFrame, pspd.Series):
                 other, extended = self._make_series_of_val(value)
                 align = False if extended else align
 
-                # Coalesce: If the value in L is null, use the corresponding value in R for that row
-                spark_expr = F.coalesce(F.col("L"), F.col("R"))
+                left_crs = self.crs
+                left_srid = (left_crs.to_epsg() or 0) if left_crs is not None else 0
+                spark_expr = F.coalesce(
+                    F.col("L"), stf.ST_SetSRID(F.col("R"), left_srid)
+                )
                 result = self._row_wise_operation(
                     spark_expr,
                     other,

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -1485,6 +1485,22 @@ class TestGeoSeries(TestGeopandasBase):
         assert embedded_srid == 4326
         self.check_sgpd_equals_gpd(result.to_crs(3857), expected)
 
+    @pytest.mark.parametrize("limit", [None, 1])
+    def test_fillna_scalar_replacement_uses_left_crs_for_embedded_srid(self, limit):
+        source = GeoSeries([Point(0, 0), None], crs="EPSG:4326")
+
+        result = source.fillna(Point(1, 1), limit=limit)
+        embedded_srids = result._internal.spark_frame.select(
+            stf.ST_SRID(result.spark.column).alias("srid")
+        ).collect()
+        expected = gpd.GeoSeries([Point(0, 0), Point(1, 1)], crs="EPSG:4326").to_crs(
+            3857
+        )
+
+        assert result.crs.to_epsg() == 4326
+        assert [row["srid"] for row in embedded_srids] == [4326, 4326]
+        self.check_sgpd_equals_gpd(result.to_crs(3857), expected)
+
     def test_fillna_limit_pairs_equal_duplicate_indexes_positionally(self):
         from geopandas.testing import assert_geoseries_equal
 
@@ -1673,7 +1689,7 @@ class TestGeoSeries(TestGeopandasBase):
         assert return_value is None
         assert_geoseries_equal(result.to_geopandas(), expected, check_index_type=False)
 
-    @pytest.mark.parametrize("limit", [0, -1, 1.5, "1", True])
+    @pytest.mark.parametrize("limit", [0, -1, 1.5, "1", True, np.bool_(True)])
     def test_fillna_limit_validation(self, limit):
         message = (
             "Limit must be greater than 0"
@@ -1684,10 +1700,20 @@ class TestGeoSeries(TestGeopandasBase):
         with pytest.raises(ValueError, match=message):
             GeoSeries([None]).fillna(Point(1, 1), limit=limit)
 
-    def test_fillna_limit_accepts_large_python_integer(self):
+    @pytest.mark.parametrize("limit", [np.int32(1), np.int64(1), np.uint64(1)])
+    def test_fillna_limit_accepts_numpy_integer(self, limit):
         from geopandas.testing import assert_geoseries_equal
 
-        result = GeoSeries([None, None]).fillna(Point(1, 1), limit=2**63)
+        result = GeoSeries([None, None]).fillna(Point(1, 1), limit=limit)
+        expected = gpd.GeoSeries([Point(1, 1), None])
+
+        assert_geoseries_equal(result.to_geopandas(), expected, check_index_type=False)
+
+    @pytest.mark.parametrize("limit", [2**63, np.uint64(2**64 - 1)])
+    def test_fillna_limit_accepts_large_integer(self, limit):
+        from geopandas.testing import assert_geoseries_equal
+
+        result = GeoSeries([None, None]).fillna(Point(1, 1), limit=limit)
         expected = gpd.GeoSeries([Point(1, 1), Point(1, 1)])
 
         assert_geoseries_equal(result.to_geopandas(), expected, check_index_type=False)

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -1718,6 +1718,56 @@ class TestGeoSeries(TestGeopandasBase):
 
         assert_geoseries_equal(result.to_geopandas(), expected, check_index_type=False)
 
+    @pytest.mark.parametrize(
+        "replacement_kind", ["scalar", "same_anchor", "independent"]
+    )
+    def test_fillna_limit_does_not_duplicate_input_plan(self, replacement_kind):
+        from geopandas.testing import assert_geoseries_equal
+
+        row_id = F.col("id")
+        replacement_column = F.when(row_id != 4, stc.ST_Point(row_id + 100, F.lit(1)))
+        rows = self.spark.range(24, numPartitions=4).select(
+            row_id,
+            F.when(row_id % 3 == 0, stc.ST_Point(row_id, F.lit(0))).alias("geometry"),
+            replacement_column.alias("replacement"),
+        )
+        frame = GeoDataFrame(rows.pandas_api(index_col="id"), geometry="geometry")
+        expected = gpd.GeoSeries(
+            [Point(i, 0) if i % 3 == 0 else None for i in range(24)],
+            index=pd.Index(range(24), name="id"),
+            name="geometry",
+        )
+        if replacement_kind == "scalar":
+            replacement = expected_replacement = Point(99, 1)
+        else:
+            expected_replacement = gpd.GeoSeries(
+                [Point(i + 100, 1) if i != 4 else None for i in range(24)],
+                index=expected.index,
+            )
+            if replacement_kind == "same_anchor":
+                replacement = frame["replacement"]
+            else:
+                replacement_rows = self.spark.range(24, numPartitions=3).select(
+                    row_id, replacement_column.alias("replacement")
+                )
+                replacement = GeoSeries(
+                    replacement_rows.pandas_api(index_col="id")["replacement"]
+                )
+
+        result = frame.geometry.fillna(replacement, limit=5)
+        query = result._internal.spark_frame._jdf.queryExecution()
+        plan = query.optimizedPlan().toString()
+        expected_inputs = 2 if replacement_kind == "independent" else 1
+
+        assert plan.count("Range (") == expected_inputs
+        assert "Union" not in plan
+        assert "SinglePartition" not in query.executedPlan().toString()
+        assert_geoseries_equal(
+            result.to_geopandas(),
+            expected.fillna(expected_replacement, limit=5),
+            check_index_type=False,
+        )
+
     def test_fillna_limit_scalar_plan_is_distributed_and_lazy(self, monkeypatch):
         from pyspark.sql import DataFrame
 

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -105,6 +105,25 @@ class TestGeoSeriesFillnaCompatibility(TestGeopandasBase):
 
         assert_geoseries_equal(result.to_geopandas(), expected, check_index_type=False)
 
+    def test_fillna_limit_scalar_wkb_literal(self):
+        from geopandas.testing import assert_geoseries_equal
+
+        _ = self.spark
+        result = GeoSeries([Point(0, 0), None, None]).fillna(Point(1, 1), limit=1)
+        expected = gpd.GeoSeries([Point(0, 0), Point(1, 1), None])
+
+        assert_geoseries_equal(result.to_geopandas(), expected, check_index_type=False)
+
+    @pytest.mark.parametrize("values", [[], [Point(0, 0), Point(2, 2)]])
+    def test_fillna_limit_without_missing_rows(self, values):
+        from geopandas.testing import assert_geoseries_equal
+
+        _ = self.spark
+        result = GeoSeries(values).fillna(Point(1, 1), limit=1)
+        expected = gpd.GeoSeries(values)
+
+        assert_geoseries_equal(result.to_geopandas(), expected, check_index_type=False)
+
 
 @pytest.mark.skipif(
     parse_version(shapely.__version__) < parse_version("2.0.0"),
@@ -1394,6 +1413,303 @@ class TestGeoSeries(TestGeopandasBase):
 
         assert "Join" not in plan
         assert_geoseries_equal(result.to_geopandas(), expected, check_index_type=False)
+
+    @pytest.mark.parametrize("value", [Point(9, 9), None])
+    def test_fillna_limit_scalar_uses_natural_order(self, value):
+        from geopandas.testing import assert_geoseries_equal
+
+        polygon = Polygon([(0, 0), (1, 0), (0, 1)])
+        source = GeoSeries(
+            GeoSeries(
+                [polygon, None, None, GeometryCollection(), None],
+                name="geometry",
+                crs="EPSG:4326",
+            ).sort_index(ascending=False)
+        )
+        result = source.fillna(value, limit=2).to_geopandas()
+        replacement = Point(9, 9) if value is not None else GeometryCollection()
+        expected = gpd.GeoSeries(
+            [replacement, GeometryCollection(), replacement, None, polygon],
+            index=[4, 3, 2, 1, 0],
+            name="geometry",
+            crs="EPSG:4326",
+        )
+
+        assert_geoseries_equal(result, expected, check_index_type=False)
+
+    @pytest.mark.parametrize("local_fill_values", [False, True])
+    def test_fillna_limit_counts_missing_aligned_values(self, local_fill_values):
+        from geopandas.testing import assert_geoseries_equal
+
+        source = GeoSeries(
+            GeoSeries(
+                [Point(7, 7), None, None, None],
+                name="geometry",
+                crs="EPSG:4326",
+            ).sort_index(ascending=False)
+        )
+        fill_values = gpd.GeoSeries(
+            [Point(3, 3), None, Point(4, 4), Point(99, 99)],
+            index=[1, 2, 3, 99],
+            crs="EPSG:4326",
+        )
+        if not local_fill_values:
+            fill_values = GeoSeries(fill_values)
+
+        result = source.fillna(fill_values, limit=2)
+        expected = gpd.GeoSeries(
+            [Point(4, 4), None, None, Point(7, 7)],
+            index=[3, 2, 1, 0],
+            name="geometry",
+            crs="EPSG:4326",
+        )
+
+        assert_geoseries_equal(result.to_geopandas(), expected, check_index_type=False)
+
+    @pytest.mark.parametrize("local_fill_values", [False, True])
+    def test_fillna_limit_series_replacement_uses_left_crs_for_embedded_srid(
+        self, local_fill_values
+    ):
+        source = GeoSeries([None], crs="EPSG:4326")
+        fill_values = gpd.GeoSeries([Point(1, 1)], crs="EPSG:3857")
+        if not local_fill_values:
+            fill_values = GeoSeries(fill_values)
+
+        result = source.fillna(fill_values, limit=1)
+        embedded_srid = result._internal.spark_frame.select(
+            stf.ST_SRID(result.spark.column).alias("srid")
+        ).first()["srid"]
+        expected = gpd.GeoSeries([Point(1, 1)], crs="EPSG:4326").to_crs(3857)
+
+        assert result.crs.to_epsg() == 4326
+        assert embedded_srid == 4326
+        self.check_sgpd_equals_gpd(result.to_crs(3857), expected)
+
+    def test_fillna_limit_pairs_equal_duplicate_indexes_positionally(self):
+        from geopandas.testing import assert_geoseries_equal
+
+        index = ["y", "x", "x"]
+        source = GeoSeries([Point(7, 7), None, None], index=index)
+        fill_values = GeoSeries([Point(8, 8), Point(1, 1), Point(2, 2)], index=index)
+
+        result = source.fillna(fill_values, limit=1)
+        expected = gpd.GeoSeries([Point(7, 7), Point(1, 1), None], index=index)
+
+        assert_geoseries_equal(result.to_geopandas(), expected, check_index_type=False)
+
+    @pytest.mark.parametrize("local_fill_values", [False, True])
+    def test_fillna_limit_does_not_coerce_decimal_to_float_index(
+        self, local_fill_values
+    ):
+        source = GeoSeries([None], index=pd.Index([Decimal("0.1")], dtype=object))
+        fill_values = gpd.GeoSeries([Point(1, 1)], index=pd.Index([0.1]))
+        if not local_fill_values:
+            fill_values = GeoSeries(fill_values)
+
+        result = source.fillna(fill_values, limit=1).to_geopandas()
+
+        assert result.iloc[0] is None
+
+    def test_fillna_limit_matches_null_keys_positionally(self):
+        from geopandas.testing import assert_geoseries_equal
+
+        left_index = pd.Index([None], dtype=object, name="feature_id")
+        right_index = pd.Index([np.nan], dtype="float64", name="replacement_id")
+        source = GeoSeries([None], index=left_index, name="geometry")
+        fill_values = GeoSeries([Point(1, 1)], index=right_index)
+        expected = gpd.GeoSeries([Point(1, 1)], index=left_index, name="geometry")
+
+        assert_geoseries_equal(
+            source.fillna(fill_values, limit=1).to_geopandas(),
+            expected,
+            check_index_type=False,
+        )
+
+    def test_fillna_limit_does_not_reindex_null_keys_across_dtypes(self):
+        from geopandas.testing import assert_geoseries_equal
+
+        left_index = pd.Index([None, "left-only"], dtype=object, name="feature_id")
+        right_index = pd.Index([1.0, np.nan], dtype="float64", name="replacement_id")
+        source_values = [None, None]
+        replacement_values = [Point(1, 1), Point(2, 2)]
+        source = GeoSeries(source_values, index=left_index, name="geometry")
+        fill_values = GeoSeries(replacement_values, index=right_index)
+        expected = gpd.GeoSeries(source_values, index=left_index, name="geometry")
+
+        assert expected.isna().all()
+        assert_geoseries_equal(
+            source.fillna(fill_values, limit=1).to_geopandas(),
+            expected,
+            check_index_type=False,
+        )
+
+    def test_fillna_limit_uses_left_order_with_multiindex(self):
+        from geopandas.testing import assert_geoseries_equal
+
+        source_index = pd.MultiIndex.from_tuples(
+            [("z", 0), ("b", 0), ("a", 0)], names=["group", "row"]
+        )
+        fill_index = pd.MultiIndex.from_tuples(
+            [("a", 0), ("b", 0), ("z", 0)], names=["other_group", "other_row"]
+        )
+        source = GeoSeries([Point(7, 7), None, None], index=source_index)
+        fill_values = GeoSeries(
+            [Point(1, 1), Point(2, 2), Point(8, 8)], index=fill_index
+        )
+
+        result = source.fillna(fill_values, limit=1)
+        expected = gpd.GeoSeries([Point(7, 7), Point(2, 2), None], index=source_index)
+
+        assert_geoseries_equal(result.to_geopandas(), expected, check_index_type=False)
+
+    @pytest.mark.parametrize("left_is_multiindex", [False, True])
+    def test_fillna_limit_requires_full_index_shape(self, left_is_multiindex):
+        from geopandas.testing import assert_geoseries_equal
+
+        single_index = pd.Index(["a", "b"], name="id")
+        multi_index = pd.MultiIndex.from_tuples(
+            [("a", "x"), ("b", "y")], names=["id", "kind"]
+        )
+        left_index = multi_index if left_is_multiindex else single_index
+        right_index = single_index if left_is_multiindex else multi_index
+        source = GeoSeries([None, None], index=left_index)
+        fill_values = GeoSeries([Point(1, 1), Point(2, 2)], index=right_index)
+
+        result = source.fillna(fill_values, limit=1)
+        expected = gpd.GeoSeries([None, None], index=left_index)
+
+        assert_geoseries_equal(result.to_geopandas(), expected, check_index_type=False)
+
+    @pytest.mark.parametrize(
+        ("left_index", "right_index", "message"),
+        [
+            (
+                pd.Index([1, 2]),
+                pd.Index([1, 1]),
+                "cannot reindex on an axis with duplicate labels",
+            ),
+            (
+                pd.Index(
+                    [Decimal("0.1"), Decimal("0.1")],
+                    dtype=object,
+                ),
+                pd.Index([0.1, 0.1], dtype="float64"),
+                "cannot reindex on an axis with duplicate labels",
+            ),
+            (
+                pd.MultiIndex.from_tuples([("a", 1), ("b", 2)]),
+                pd.MultiIndex.from_tuples([("a", 1), ("a", 1)]),
+                "cannot handle a non-unique multi-index!",
+            ),
+        ],
+    )
+    def test_fillna_limit_rejects_nonidentical_duplicate_fill_index(
+        self, left_index, right_index, message
+    ):
+        source = GeoSeries([None, None], index=left_index)
+        fill_values = GeoSeries([Point(1, 1), Point(2, 2)], index=right_index)
+
+        with pytest.raises(ValueError, match=message):
+            source.fillna(fill_values, limit=1)
+
+    def test_fillna_limit_broadcasts_unique_value_to_duplicate_left_index(self):
+        from geopandas.testing import assert_geoseries_equal
+
+        source = GeoSeries([None, None, None], index=[1, 1, 2])
+        fill_values = GeoSeries([Point(1, 1), Point(2, 2)], index=[1, 2])
+
+        result = source.fillna(fill_values, limit=1)
+        expected = gpd.GeoSeries([Point(1, 1), None, None], index=[1, 1, 2])
+
+        assert_geoseries_equal(result.to_geopandas(), expected, check_index_type=False)
+
+    def test_fillna_limit_same_anchor_series_is_lazy_and_positional(self, monkeypatch):
+        from geopandas.testing import assert_geoseries_equal
+        from pyspark.sql import DataFrame
+
+        index = pd.Index(["x", "x", "y"], name="feature_id")
+        frame = GeoDataFrame(
+            gpd.GeoDataFrame(
+                {
+                    "geometry": gpd.GeoSeries([Point(7, 7), None, None], index=index),
+                    "replacement": gpd.GeoSeries(
+                        [Point(8, 8), Point(1, 1), Point(2, 2)], index=index
+                    ),
+                },
+                geometry="geometry",
+            )
+        )
+
+        def unexpected_action(*args, **kwargs):
+            raise AssertionError("same-anchor fillna(limit=...) ran a Spark action")
+
+        monkeypatch.setattr(DataFrame, "first", unexpected_action)
+
+        result = frame.geometry.fillna(frame["replacement"], limit=1)
+        plan = (
+            result._internal.spark_frame._jdf.queryExecution()
+            .optimizedPlan()
+            .toString()
+        )
+        expected = gpd.GeoSeries(
+            [Point(7, 7), Point(1, 1), None],
+            index=index,
+            name="geometry",
+        )
+
+        assert "Join" not in plan
+        assert_geoseries_equal(result.to_geopandas(), expected, check_index_type=False)
+
+    def test_fillna_limit_inplace(self):
+        from geopandas.testing import assert_geoseries_equal
+
+        result = GeoSeries([None, None, None], name="geometry", crs="EPSG:4326")
+
+        return_value = result.fillna(Point(1, 1), limit=1, inplace=True)
+        expected = gpd.GeoSeries(
+            [Point(1, 1), None, None], name="geometry", crs="EPSG:4326"
+        )
+
+        assert return_value is None
+        assert_geoseries_equal(result.to_geopandas(), expected, check_index_type=False)
+
+    @pytest.mark.parametrize("limit", [0, -1, 1.5, "1", True])
+    def test_fillna_limit_validation(self, limit):
+        message = (
+            "Limit must be greater than 0"
+            if isinstance(limit, int) and not isinstance(limit, bool)
+            else "Limit must be an integer"
+        )
+
+        with pytest.raises(ValueError, match=message):
+            GeoSeries([None]).fillna(Point(1, 1), limit=limit)
+
+    def test_fillna_limit_accepts_large_python_integer(self):
+        from geopandas.testing import assert_geoseries_equal
+
+        result = GeoSeries([None, None]).fillna(Point(1, 1), limit=2**63)
+        expected = gpd.GeoSeries([Point(1, 1), Point(1, 1)])
+
+        assert_geoseries_equal(result.to_geopandas(), expected, check_index_type=False)
+
+    def test_fillna_limit_scalar_plan_is_distributed_and_lazy(self, monkeypatch):
+        from pyspark.sql import DataFrame
+
+        source = GeoSeries([Point(0, 0), None, None])
+
+        def unexpected_action(*args, **kwargs):
+            raise AssertionError("scalar fillna(limit=...) triggered a Spark action")
+
+        for operation in ["count", "collect", "toPandas", "first"]:
+            monkeypatch.setattr(DataFrame, operation, unexpected_action)
+
+        result = source.fillna(Point(1, 1), limit=1)
+        plan = (
+            result._internal.spark_frame._jdf.queryExecution().executedPlan().toString()
+        )
+
+        assert "SinglePartition" not in plan
+        assert "PythonUDF" not in plan
 
     @pytest.mark.parametrize(
         "kwargs",


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2068

## What changes were proposed in this PR?

This PR implements the `limit` parameter for `GeoSeries.fillna`.

- Fill only the first `limit` missing geometries in the natural row order.
- Support scalar geometries, local GeoPandas GeoSeries, and distributed Sedona GeoSeries replacements.
- Preserve the left index, row order, name, and CRS while matching GeoPandas alignment and duplicate-index behavior.
- Avoid materializing a driver-sized replacement series for scalar fills.
- Document the distributed ordering cost and add a release note.

## How was this patch tested?

- Focused GeoSeries fillna and parity tests on Spark 3.5: 23 passed.
- Focused GeoSeries fillna and parity tests on Spark 4.1: 23 passed.
- Shapely 1 compatibility tests: 3 passed.
- All commit hooks passed, including Black, Bandit, codespell, gitleaks, and markdownlint.

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.