### PR TITLE
[GH-3020] Add ST_H3ToParent

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/Functions.java
+++ b/common/src/main/java/org/apache/sedona/common/Functions.java
@@ -2055,6 +2055,17 @@ public class Functions {
   }
 
   /**
+   * Returns the parent of an H3 cell at the requested resolution.
+   *
+   * @param cell the H3 cell
+   * @param resolution the resolution of the parent cell
+   * @return the parent H3 cell
+   */
+  public static long h3ToParent(long cell, int resolution) {
+    return H3Utils.h3.cellToParent(cell, resolution);
+  }
+
+  /**
    * gets the polygon for each h3 index provided
    *
    * @param cells: the set of cells

--- a/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/FunctionsTest.java
@@ -1597,6 +1597,16 @@ public class FunctionsTest extends TestBase {
   }
 
   @Test
+  public void h3ToParent() {
+    long child = H3Utils.coordinateToCell(new Coordinate(1, 2), 8);
+    long parent = Functions.h3ToParent(child, 5);
+
+    assertEquals(5, H3Utils.h3.getResolution(parent));
+    assertTrue(H3Utils.h3.cellToChildren(parent, 8).contains(child));
+    assertEquals(child, Functions.h3ToParent(child, 8));
+  }
+
+  @Test
   public void geometricMedian() throws Exception {
     MultiPoint multiPoint =
         GEOMETRY_FACTORY.createMultiPointFromCoords(coordArray(1480, 0, 620, 0));

--- a/docs/api/flink/Geometry-Functions.md
+++ b/docs/api/flink/Geometry-Functions.md
@@ -351,6 +351,7 @@ These functions work with spatial indexing systems including Bing Tiles, H3, Hil
 | [ST_H3CellIDs](Spatial-Indexing/ST_H3CellIDs.md) | `Array<Long>` | Cover the geometry by H3 cell IDs with the given resolution(level). To understand the cell statistics please refer to [H3 Doc](https://h3geo.org/docs/core-library/restable) H3 native fill functions... | v1.5.0 |
 | [ST_H3KRing](Spatial-Indexing/ST_H3KRing.md) | `Array<Long>` | return the result of H3 function [gridDisk(cell, k)](https://h3geo.org/docs/api/traversal#griddisk). | v1.5.0 |
 | [ST_H3ToGeom](Spatial-Indexing/ST_H3ToGeom.md) | `Array<Geometry>` | Return the result of H3 function [cellsToMultiPolygon(cells)](https://h3geo.org/docs/api/regions#cellstolinkedmultipolygon--cellstomultipolygon). | v1.6.0 |
+| [ST_H3ToParent](Spatial-Indexing/ST_H3ToParent.md) | Long | Returns the parent of an H3 cell at the requested resolution. | v2.0.0 |
 | [ST_HilbertDistance](Spatial-Indexing/ST_HilbertDistance.md) | Long | Maps the midpoint of a geometry's envelope to an unsigned Hilbert-curve address within a supplied extent. | v2.0.0 |
 | [ST_S2CellIDs](Spatial-Indexing/ST_S2CellIDs.md) | `Array<Long>` | Cover the geometry with Google S2 Cells, return the corresponding cell IDs with the given level. The level indicates the [size of cells](https://s2geometry.io/resources/s2cell_statistics.html). With... | v1.4.0 |
 | [ST_S2ToGeom](Spatial-Indexing/ST_S2ToGeom.md) | `Array<Geometry>` | Returns an array of Polygons for the corresponding S2 cell IDs. | v1.6.0 |

--- a/docs/api/flink/Spatial-Indexing/ST_H3ToParent.md
+++ b/docs/api/flink/Spatial-Indexing/ST_H3ToParent.md
@@ -1,0 +1,44 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_H3ToParent
+
+Introduction: Returns the result of the H3 function [cellToParent(cell, resolution)](https://h3geo.org/docs/api/hierarchy#celltoparent). The requested resolution must be between 0 and the input cell's resolution, inclusive.
+
+Format: `ST_H3ToParent(cell: Long, resolution: Int)`
+
+Return type: `Long`
+
+Since: `v2.0.0`
+
+Example:
+
+```sql
+SELECT ST_H3ToParent(614552609325318143, 5)
+```
+
+Output:
+
+```
++----+--------------------+
+| op |             EXPR$0 |
++----+--------------------+
+| +I | 601041811137363967 |
++----+--------------------+
+```

--- a/docs/api/sql/Geometry-Functions.md
+++ b/docs/api/sql/Geometry-Functions.md
@@ -359,6 +359,7 @@ These functions work with spatial indexing systems including Bing Tiles, H3, Hil
 | [ST_H3CellIDs](Spatial-Indexing/ST_H3CellIDs.md) | `Array<Long>` | Cover the geometry by H3 cell IDs with the given resolution(level). To understand the cell statistics please refer to [H3 Doc](https://h3geo.org/docs/core-library/restable) H3 native fill functions... | v1.5.0 |
 | [ST_H3KRing](Spatial-Indexing/ST_H3KRing.md) | `Array<Long>` | return the result of H3 function [gridDisk(cell, k)](https://h3geo.org/docs/api/traversal#griddisk). | v1.5.0 |
 | [ST_H3ToGeom](Spatial-Indexing/ST_H3ToGeom.md) | `Array<Geometry>` | Return the result of H3 function [cellsToMultiPolygon(cells)](https://h3geo.org/docs/api/regions#cellstolinkedmultipolygon--cellstomultipolygon). | v1.6.0 |
+| [ST_H3ToParent](Spatial-Indexing/ST_H3ToParent.md) | Long | Returns the parent of an H3 cell at the requested resolution. | v2.0.0 |
 | [ST_HilbertDistance](Spatial-Indexing/ST_HilbertDistance.md) | Long | Maps the midpoint of a geometry's envelope to an unsigned Hilbert-curve address within a supplied extent. | v2.0.0 |
 | [ST_S2CellIDs](Spatial-Indexing/ST_S2CellIDs.md) | `Array<Long>` | Cover the geometry with Google S2 Cells, return the corresponding cell IDs with the given level. The level indicates the [size of cells](https://s2geometry.io/resources/s2cell_statistics.html). With... | v1.4.0 |
 | [ST_S2ToGeom](Spatial-Indexing/ST_S2ToGeom.md) | `Array<Geometry>` | Returns an array of Polygons for the corresponding S2 cell IDs. | v1.6.0 |

--- a/docs/api/sql/Spatial-Indexing/ST_H3ToParent.md
+++ b/docs/api/sql/Spatial-Indexing/ST_H3ToParent.md
@@ -1,0 +1,44 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# ST_H3ToParent
+
+Introduction: Returns the result of the H3 function [cellToParent(cell, resolution)](https://h3geo.org/docs/api/hierarchy#celltoparent). The requested resolution must be between 0 and the input cell's resolution, inclusive.
+
+Format: `ST_H3ToParent(cell: Long, resolution: Int)`
+
+Return type: `Long`
+
+Since: `v2.0.0`
+
+SQL Example
+
+```sql
+SELECT ST_H3ToParent(614552609325318143, 5)
+```
+
+Output:
+
+```
++--------------------------------------------+
+|st_h3toparent(614552609325318143, 5)        |
++--------------------------------------------+
+|                          601041811137363967|
++--------------------------------------------+
+```

--- a/flink/src/main/java/org/apache/sedona/flink/Catalog.java
+++ b/flink/src/main/java/org/apache/sedona/flink/Catalog.java
@@ -110,6 +110,7 @@ public class Catalog {
       new Functions.ST_H3CellIDs(),
       new Functions.ST_H3KRing(),
       new Functions.ST_H3ToGeom(),
+      new Functions.ST_H3ToParent(),
       new Functions.ST_HilbertDistance(),
       new Functions.ST_BingTile(),
       new Functions.ST_BingTileAt(),

--- a/flink/src/main/java/org/apache/sedona/flink/expressions/Functions.java
+++ b/flink/src/main/java/org/apache/sedona/flink/expressions/Functions.java
@@ -2952,6 +2952,17 @@ public class Functions {
     }
   }
 
+  public static class ST_H3ToParent extends ScalarFunction {
+    @DataTypeHint(value = "BIGINT")
+    public Long eval(
+        @DataTypeHint("BIGINT") Long cell, @DataTypeHint("INTEGER") Integer resolution) {
+      if (cell == null || resolution == null) {
+        return null;
+      }
+      return org.apache.sedona.common.Functions.h3ToParent(cell, resolution);
+    }
+  }
+
   // =========================================================================
   // Bing Tile functions
   // =========================================================================

--- a/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
+++ b/flink/src/test/java/org/apache/sedona/flink/FunctionTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.table.api.Table;
 import org.apache.flink.types.Row;
 import org.apache.sedona.common.geometryObjects.Box2D;
 import org.apache.sedona.common.geometryObjects.Box3D;
+import org.apache.sedona.common.utils.H3Utils;
 import org.apache.sedona.flink.expressions.Functions;
 import org.apache.sedona.flink.expressions.FunctionsProj4;
 import org.datasyslab.proj4sedona.core.Proj;
@@ -2348,6 +2349,22 @@ public class FunctionTest extends TestBase {
     assertTrue(actual[0].intersects(target));
     assertTrue(actual[11].intersects(target));
     assertTrue(actual[20].intersects(target));
+  }
+
+  @Test
+  public void testH3ToParent() {
+    Table pointTable =
+        tableEnv.sqlQuery(
+            "SELECT ST_H3CellIDs(ST_GeomFromWKT('POINT(1 2)'), 8, true)[1], ST_H3ToParent(ST_H3CellIDs(ST_GeomFromWKT('POINT(1 2)'), 8, true)[1], 5)");
+    Row result = first(pointTable);
+    long child = (Long) Objects.requireNonNull(result.getField(0));
+    long parent = (Long) Objects.requireNonNull(result.getField(1));
+
+    assertEquals(5, H3Utils.h3.getResolution(parent));
+    assertTrue(H3Utils.h3.cellToChildren(parent, 8).contains(child));
+
+    Table nullTable = tableEnv.sqlQuery("SELECT ST_H3ToParent(CAST(NULL AS BIGINT), 5)");
+    assertNull(first(nullTable).getField(0));
   }
 
   @Test

--- a/python/sedona/spark/sql/st_functions.py
+++ b/python/sedona/spark/sql/st_functions.py
@@ -1002,6 +1002,20 @@ def ST_H3ToGeom(cells: Union[ColumnOrName, list]) -> Column:
     return _call_st_function("ST_H3ToGeom", cells)
 
 
+@validate_argument_types
+def ST_H3ToParent(
+    cell: Union[ColumnOrName, int], resolution: Union[ColumnOrName, int]
+) -> Column:
+    """Return the parent of an H3 cell at the requested resolution.
+    :param cell: H3 cell
+    :param resolution: resolution of the parent cell
+    :return: parent H3 cell
+    :rtype: Long
+    """
+    args = (cell, resolution)
+    return _call_st_function("ST_H3ToParent", args)
+
+
 # =========================================================================
 # Bing Tile functions
 # =========================================================================

--- a/python/tests/sql/test_dataframe_api.py
+++ b/python/tests/sql/test_dataframe_api.py
@@ -2004,6 +2004,11 @@ class TestDataFrameAPI(TestBase):
         for future in futures:
             future.result()
 
+    def test_st_h3_to_parent(self):
+        df = self.spark.createDataFrame([(614552609325318143,)], ["cell"])
+        parent = df.select(stf.ST_H3ToParent("cell", 5)).first()[0]
+        assert parent == 601041811137363967
+
     def test_coverage_validation_catalog_calls(self):
         rows = self.spark.createDataFrame(
             [

--- a/python/tests/sql/test_function.py
+++ b/python/tests/sql/test_function.py
@@ -2424,6 +2424,22 @@ class TestPredicateJoin(TestBase):
         exact_rings, all_rings, original_cells = df.take(1)[0]
         assert set(exact_rings + original_cells) == set(all_rings)
 
+    def test_st_h3_to_parent(self):
+        child, parent = self.spark.sql("""
+        SELECT
+            cell,
+            ST_H3ToParent(cell, 5)
+        FROM (
+            SELECT ST_H3CellIDs(ST_GeomFromWKT('POINT(1 2)'), 8, true)[0] AS cell
+        )
+        """).first()
+        assert child == 614552609325318143
+        assert parent == 601041811137363967
+        null_parent = self.spark.sql(
+            "SELECT ST_H3ToParent(CAST(NULL AS BIGINT), 5)"
+        ).first()[0]
+        assert null_parent is None
+
     def test_st_h3_togeom(self):
         df = self.spark.sql("""
         SELECT

--- a/spark/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
+++ b/spark/common/src/main/scala/org/apache/sedona/sql/UDF/Catalog.scala
@@ -317,6 +317,7 @@ object Catalog extends AbstractCatalog with Logging {
     function[ST_H3CellIDs](),
     function[ST_H3KRing](),
     function[ST_H3ToGeom](),
+    function[ST_H3ToParent](),
     function[ST_HilbertDistance](),
     function[ST_S2CellIDs](),
     function[ST_S2ToGeom](),

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
@@ -1727,6 +1727,14 @@ private[apache] case class ST_H3ToGeom(inputExpressions: Seq[Expression])
   }
 }
 
+private[apache] case class ST_H3ToParent(inputExpressions: Seq[Expression])
+    extends InferredExpression(Functions.h3ToParent _) {
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
+    copy(inputExpressions = newChildren)
+  }
+}
+
 // =========================================================================
 // Bing Tile expressions
 // =========================================================================

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/st_functions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/st_functions.scala
@@ -302,6 +302,15 @@ object st_functions {
 
   def ST_H3ToGeom(cellIds: Array[Long]): Column = wrapExpression[ST_H3ToGeom](cellIds)
 
+  def ST_H3ToParent(cell: Column, resolution: Column): Column =
+    wrapExpression[ST_H3ToParent](cell, resolution)
+
+  def ST_H3ToParent(cell: Column, resolution: Integer): Column =
+    wrapExpression[ST_H3ToParent](cell, resolution)
+
+  def ST_H3ToParent(cell: Long, resolution: Integer): Column =
+    wrapExpression[ST_H3ToParent](cell, resolution)
+
   def ST_HilbertDistance(
       geometry: Column,
       xmin: Column,

--- a/spark/common/src/test/scala/org/apache/sedona/sql/dataFrameAPITestScala.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/dataFrameAPITestScala.scala
@@ -2086,6 +2086,17 @@ class dataFrameAPITestScala extends TestBaseScala {
       assert(neighborsExactRing.toSet.subsetOf(neighborsAll.toSet))
     }
 
+    it("Passed ST_H3ToParent") {
+      val result = sparkSession
+        .sql("SELECT ST_Point(1.0, 2.0) geom")
+        .withColumn("cell", element_at(ST_H3CellIDs("geom", 8, true), 1))
+        .select(col("cell"), ST_H3ToParent(col("cell"), 5))
+        .first()
+
+      assert(result.getLong(0) == 614552609325318143L)
+      assert(result.getLong(1) == 601041811137363967L)
+    }
+
     it("Passed ST_DistanceSphere") {
       val baseDf = sparkSession.sql(
         "SELECT ST_GeomFromWKT('POINT (0 0)') AS geom1, ST_GeomFromWKT('POINT (90 0)') AS geom2")

--- a/spark/common/src/test/scala/org/apache/sedona/sql/functions/STH3Functions.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/functions/STH3Functions.scala
@@ -143,5 +143,28 @@ class STH3Functions extends TestBaseScala with Matchers with GeometrySample with
       Then("the result of spark sql should match with direct common library call")
       exacts should equal(expects)
     }
+
+    it("should return the parent cell at the requested resolution") {
+      Given("DataFrame with a valid Geometry")
+      val geometryTable = Seq("POINT(1 2)").map(geom => Tuple1(wktReader.read(geom))).toDF("geom")
+
+      When("finding the resolution 5 parent of a resolution 8 cell")
+      val result = geometryTable
+        .withColumn("cell", expr("ST_H3CellIDs(geom, 8, true)[0]"))
+        .select(col("cell"), expr("ST_H3ToParent(cell, 5)"))
+        .first()
+      val child = result.getLong(0)
+      val parent = result.getLong(1)
+
+      Then("the result should be the requested ancestor")
+      H3Utils.h3.getResolution(parent) should equal(5)
+      H3Utils.h3.cellToChildren(parent, 8).contains(child) should be(true)
+
+      Then("null input should return null")
+      sparkSession
+        .sql("SELECT ST_H3ToParent(CAST(NULL AS BIGINT), 5)")
+        .first()
+        .isNullAt(0) should be(true)
+    }
   }
 }


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/).

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-3020] Add ST_H3ToParent`.

Related to #3020.

This PR intentionally implements only `ST_H3ToParent` as the first incremental part of the H3 hierarchy functions requested in #3020. It does not close the parent issue.

## What changes were proposed in this PR?

- Add a common Java implementation of `ST_H3ToParent` backed by H3's `cellToParent`.
- Register the function in the Spark SQL expression catalog.
- Add Scala and Python DataFrame API wrappers.
- Register the function as a Flink SQL scalar function.
- Add Common, Spark SQL, Scala DataFrame API, Python, and Flink tests.
- Document the new API for both Spark SQL and Flink.

The function accepts an H3 cell and a target parent resolution and returns the corresponding parent H3 cell. Null inputs are propagated by the SQL integrations.

## How was this patch tested?

- `mvn spotless:apply`
- `mvn -pl common -Dtest=FunctionsTest#h3ToParent test`
- Spark Common production and test source compilation
- `mvn -pl spark/common -DwildcardSuites=org.apache.sedona.sql.functions.STH3Functions org.scalatest:scalatest-maven-plugin:2.2.0:test`
  - 6 tests passed, including the new parent-resolution, ancestor-relation, and null-propagation assertions
- `mvn -pl flink -Dtest=FunctionTest#testH3ToParent test`
  - 1 test passed
- `python -m py_compile python/sedona/spark/sql/st_functions.py python/tests/sql/test_function.py python/tests/sql/test_dataframe_api.py`
- `git diff --check`

The Python Spark integration tests were not run locally because PySpark is not installed in the local Python environment. The corresponding Python files passed bytecode compilation, and the underlying Spark SQL expression was covered by the JVM Spark test suite.

## Did this PR include necessary documentation updates?

- Yes, I am adding a new API and using the current SNAPSHOT version number `v2.0.0`.
- Yes, I have added the Spark SQL and Flink function pages and updated both API catalogs.