### PR TITLE
[GH-3311] Make RS_SetBandNoDataValue honor NULL to remove a band's no-data value in Spark SQL

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/raster/RasterBandEditors.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterBandEditors.java
@@ -53,7 +53,9 @@ public class RasterBandEditors {
 
     // Remove no-Data if it is null
     if (noDataValue == null) {
-      if (RasterBandAccessors.getBandNoDataValue(raster) == null) {
+      // Consult the target band, not band 1: otherwise clearing band N is a no-op
+      // whenever band 1 happens to have no no-data value.
+      if (rasterNoData == null) {
         return raster;
       }
       GridSampleDimension[] sampleDimensions = raster.getSampleDimensions();

--- a/common/src/main/java/org/apache/sedona/common/raster/RasterOutputs.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterOutputs.java
@@ -47,6 +47,7 @@ import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.coverage.grid.io.AbstractGridFormat;
 import org.geotools.gce.arcgrid.ArcGridWriteParams;
 import org.geotools.gce.arcgrid.ArcGridWriter;
+import org.geotools.gce.geotiff.GeoTiffFormat;
 import org.geotools.gce.geotiff.GeoTiffWriteParams;
 import org.geotools.gce.geotiff.GeoTiffWriter;
 import org.geotools.referencing.operation.transform.AffineTransform2D;
@@ -62,6 +63,20 @@ public class RasterOutputs {
       throw new RuntimeException(e);
     }
     ParameterValueGroup defaultParams = writer.getFormat().getWriteParameters();
+    // GeoTiffWriter writes a default GDAL_NODATA of 0 for coverages that have no no-data
+    // value, so a cleared (or never set) no-data value would come back as 0 when the
+    // written bytes are read again. Only opt out in that case: forcing the flag on when a
+    // no-data value is present would override an explicit -Dgeotiff.writenodata=false.
+    boolean hasNoDataValue = false;
+    for (int band = 1; band <= raster.getNumSampleDimensions(); band++) {
+      if (RasterBandAccessors.getBandNoDataValue(raster, band) != null) {
+        hasNoDataValue = true;
+        break;
+      }
+    }
+    if (!hasNoDataValue) {
+      defaultParams.parameter(GeoTiffFormat.WRITE_NODATA.getName().toString()).setValue(false);
+    }
     if (compressionType != null && compressionQuality >= 0 && compressionQuality <= 1) {
       GeoTiffWriteParams params = new GeoTiffWriteParams();
       params.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterBandEditorsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterBandEditorsTest.java
@@ -69,6 +69,19 @@ public class RasterBandEditorsTest extends RasterTestBase {
   }
 
   @Test
+  public void testSetBandNoDataValueWithNullOnSecondBand() throws FactoryException {
+    // The clear must consult the target band's no-data value, not band 1's: band 1 has
+    // none here, which used to short-circuit the removal on band 2.
+    GridCoverage2D raster = RasterConstructors.makeEmptyRaster(2, 20, 20, 0, 0, 8, 8, 0.1, 0.1, 0);
+    GridCoverage2D grid = RasterBandEditors.setBandNoDataValue(raster, 2, 444d);
+    assertEquals(444, (double) RasterBandAccessors.getBandNoDataValue(grid, 2), 0.1d);
+
+    grid = RasterBandEditors.setBandNoDataValue(grid, 2, null);
+    assertNull(RasterBandAccessors.getBandNoDataValue(grid, 2));
+    assertNull(RasterBandAccessors.getBandNoDataValue(grid, 1));
+  }
+
+  @Test
   public void testGetSummaryStats() throws IOException {
     GridCoverage2D raster =
         rasterFromGeoTiff(resourceFolder + "raster/raster_with_no_data/test5.tiff");

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterOutputTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterOutputTest.java
@@ -30,6 +30,27 @@ import org.junit.Test;
 public class RasterOutputTest extends RasterTestBase {
 
   @Test
+  public void testAsGeoTiffDoesNotInventNoDataValue() throws FactoryException, IOException {
+    // GeoTiffWriter writes a default GDAL_NODATA of 0 unless told otherwise, which made a
+    // raster that never had a no-data value read back claiming one.
+    GridCoverage2D raster = RasterConstructors.makeEmptyRaster(1, 20, 20, 0, 0, 1, -1, 0, 0, 4326);
+    assertNull(RasterBandAccessors.getBandNoDataValue(raster, 1));
+
+    GridCoverage2D roundTripped = RasterConstructors.fromGeoTiff(RasterOutputs.asGeoTiff(raster));
+    assertNull(RasterBandAccessors.getBandNoDataValue(roundTripped, 1));
+  }
+
+  @Test
+  public void testAsGeoTiffKeepsNoDataValue() throws FactoryException, IOException {
+    // The opt-out must only apply when there is no no-data value to write.
+    GridCoverage2D raster = RasterConstructors.makeEmptyRaster(1, 20, 20, 0, 0, 1, -1, 0, 0, 4326);
+    raster = RasterBandEditors.setBandNoDataValue(raster, 1, -999d);
+
+    GridCoverage2D roundTripped = RasterConstructors.fromGeoTiff(RasterOutputs.asGeoTiff(raster));
+    assertEquals(-999d, RasterBandAccessors.getBandNoDataValue(roundTripped, 1), 0.0001d);
+  }
+
+  @Test
   public void testAsBase64() throws IOException {
     GridCoverage2D raster =
         rasterFromGeoTiff(resourceFolder + "raster/raster_with_no_data/test5.tiff");

--- a/docs/api/sql/Raster-Operators/RS_SetBandNoDataValue.md
+++ b/docs/api/sql/Raster-Operators/RS_SetBandNoDataValue.md
@@ -30,6 +30,8 @@ Since `v1.5.1`, this function supports the ability to replace the current no-dat
 
     To use this for no-data replacement, the input raster must first set its no-data value, which can then be selectively replaced via this function.
 
+    `noDataValue` must be non-null when using the `replace` variant; to remove a no data value, use the 2 or 3 argument form.
+
 Format:
 
 ```

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/InferredExpression.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/InferredExpression.scala
@@ -468,4 +468,45 @@ object InferrableFunction {
       })
   }
 
+  /**
+   * A variant of ternary inferred expression which allows the third argument to be null. This is
+   * not an overload of [[allowRightNull]] since overloading it breaks eta-expansion of the
+   * overloaded methods passed to it at existing call sites.
+   * @param f
+   *   Function to be wrapped as a catalyst expression.
+   * @param typeTag
+   *   Type tag of the function.
+   * @tparam R
+   *   Return type of the function.
+   * @tparam A1
+   *   Type of the first argument.
+   * @tparam A2
+   *   Type of the second argument.
+   * @tparam A3
+   *   Type of the third argument.
+   * @return
+   *   InferrableFunction.
+   */
+  def allowRightNull3[R, A1, A2, A3](f: (A1, A2, A3) => R)(implicit
+      typeTag: TypeTag[(A1, A2, A3) => R]): InferrableFunction = {
+    apply(
+      typeTag,
+      extractors => {
+        val func = f.asInstanceOf[(Any, Any, Any) => Any]
+        val extractor1 = extractors(0)
+        val extractor2 = extractors(1)
+        val extractor3 = extractors(2)
+        input => {
+          val arg1 = extractor1(input)
+          val arg2 = extractor2(input)
+          val arg3 = extractor3(input)
+          if (arg1 != null && arg2 != null) {
+            func(arg1, arg2, arg3)
+          } else {
+            null
+          }
+        }
+      })
+  }
+
 }

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterBandEditors.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterBandEditors.scala
@@ -22,13 +22,15 @@ import org.apache.sedona.common.raster.RasterBandEditors
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.sedona_sql.expressions.InferrableFunctionConverter._
 import org.apache.spark.sql.sedona_sql.expressions.InferrableRasterTypes._
-import org.apache.spark.sql.sedona_sql.expressions.InferredExpression
+import org.apache.spark.sql.sedona_sql.expressions.{InferrableFunction, InferredExpression}
 
 private[apache] case class RS_SetBandNoDataValue(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction4(RasterBandEditors.setBandNoDataValue),
-      inferrableFunction3(RasterBandEditors.setBandNoDataValue),
-      inferrableFunction2(RasterBandEditors.setBandNoDataValue)) {
+      // A null noDataValue removes the band's no-data value, so let it through instead of
+      // null-propagating the whole expression.
+      InferrableFunction.allowRightNull3(RasterBandEditors.setBandNoDataValue),
+      InferrableFunction.allowRightNull(RasterBandEditors.setBandNoDataValue)) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }

--- a/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
@@ -879,9 +879,20 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
       val expected = -999
       assertEquals(expected, actual, 0.001d)
 
-      val actualNull =
-        df.selectExpr("RS_BandNoDataValue(RS_SetBandNoDataValue(raster, 1, null))").first().get(0)
-      assertNull(actualNull)
+      // Passing a null noDataValue removes the no-data value instead of returning a null raster
+      val cleared = df
+        .selectExpr(
+          "RS_SetBandNoDataValue(RS_SetBandNoDataValue(raster, 1, -999), 1, null) as raster")
+      assertNotNull(cleared.first().get(0))
+      assertNull(cleared.selectExpr("RS_BandNoDataValue(raster)").first().get(0))
+
+      val clearedNoBandIndex = df
+        .selectExpr("RS_SetBandNoDataValue(RS_SetBandNoDataValue(raster, -999), null) as raster")
+      assertNotNull(clearedNoBandIndex.first().get(0))
+      assertNull(clearedNoBandIndex.selectExpr("RS_BandNoDataValue(raster)").first().get(0))
+
+      // A null raster still yields a null result
+      assertNull(sparkSession.sql("SELECT RS_SetBandNoDataValue(null, -999)").first().get(0))
     }
 
     it("Passed RS_SetBandNoDataValue with empty raster") {

--- a/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
@@ -895,6 +895,38 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
       assertNull(sparkSession.sql("SELECT RS_SetBandNoDataValue(null, -999)").first().get(0))
     }
 
+    it("Passed RS_SetBandNoDataValue clearing a band other than band 1") {
+      // The clear consults the target band's no-data value; band 1 having none
+      // must not short-circuit the removal on band 2.
+      var df = sparkSession.sql(
+        "SELECT RS_MakeEmptyRaster(2, 20, 20, 0, 0, 8, 8, 0.1, 0.1, 0) AS raster")
+      df = df.selectExpr("RS_SetBandNoDataValue(raster, 2, 444) AS raster")
+      assertEquals(
+        444.0,
+        df.selectExpr("RS_BandNoDataValue(raster, 2)").first().getDouble(0),
+        0.001d)
+      val cleared = df.selectExpr("RS_SetBandNoDataValue(raster, 2, null) AS raster")
+      assertNotNull(cleared.first().get(0))
+      assertNull(cleared.selectExpr("RS_BandNoDataValue(raster, 2)").first().get(0))
+      assertNull(cleared.selectExpr("RS_BandNoDataValue(raster, 1)").first().get(0))
+    }
+
+    it("Passed RS_SetBandNoDataValue null clear survives a GeoTiff round trip") {
+      // RS_AsGeoTiff must not write a default GDAL_NODATA of 0 for a raster that no
+      // longer has a no-data value, or reading the bytes back resurrects it.
+      val df = sparkSession.read
+        .format("binaryFile")
+        .load(resourceFolder + "raster/raster_with_no_data/test5.tiff")
+      val cleared =
+        df.selectExpr("RS_SetBandNoDataValue(RS_FromGeoTiff(content), null) AS raster")
+      val actual = cleared
+        .selectExpr("RS_AsGeoTiff(raster) AS bytes")
+        .selectExpr("RS_BandNoDataValue(RS_FromGeoTiff(bytes))")
+        .first()
+        .get(0)
+      assertNull(actual)
+    }
+
     it("Passed RS_SetBandNoDataValue with empty raster") {
       val df =
         sparkSession.sql("Select RS_MakeEmptyRaster(1, 20, 20, 2, 22, 2, 3, 1, 1, 0) as raster")


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #3311

## What changes were proposed in this PR?

Scoped down to just making a `NULL` `noDataValue` behave as documented. The `GC_NODATA` property work that grew out of the review is split into a follow-up, since it turned out to be a separate problem with its own failure modes (see the end of this description).

**Make the documented NULL behavior reachable from SQL.** The docs and the common Java implementation both say a `null` `noDataValue` removes the band's no-data value, but from Spark SQL that path was unreachable: the catalyst expression wrapped `RasterBandEditors.setBandNoDataValue` with `inferrableFunction2/3/4`, which null-propagate as soon as any argument is null, so `RS_SetBandNoDataValue(raster, 1, NULL)` returned a NULL raster instead. This matches PostGIS `ST_SetBandNoDataValue` NULL-clears semantics and the behavior SedonaDB adopted in apache/sedona-db#1158.

Added `InferrableFunction.allowRightNull3`, an arity-3 counterpart of the existing `allowRightNull` pattern (allows the third argument to be null; still null-propagates when the raster or band index is null), and wired the 2- and 3-argument overloads through it. It is a separate name rather than an overload because overloading `allowRightNull` breaks eta-expansion of the overloaded functions passed to it at existing call sites. The 4-argument `replace` overload still null-propagates, since replacing pixels with a null no-data value is meaningless; the docs now say so.

**Clear the target band, not band 1.** The null path consulted band 1's no-data value to decide whether there was anything to remove, so clearing band N was a no-op whenever band 1 had none. Latent until now because the path was unreachable from SQL and the Java tests only ever cleared band 1.

**Stop `RS_AsGeoTiff` inventing a no-data value.** `GeoTiffWriter` writes a default `GDAL_NODATA` of 0 when a coverage has no no-data value, so a raster that never had one came back from a write/read round trip reporting `0`. This is independent of NULL handling, but it is what made a *cleared* no-data value reappear on the round trip, so it is fixed here: `WRITE_NODATA` is set to false in that case only, leaving an explicit `-Dgeotiff.writenodata=false` untouched.

## How was this patch tested?

The existing `RS_SetBandNoDataValue` test could not distinguish clearing from null-propagation — `RS_BandNoDataValue` returns null for a null raster too, so it passed under both semantics. It now sets a no-data value, clears it with NULL through both the 2- and 3-argument forms, and asserts the resulting raster is non-null while `RS_BandNoDataValue` on it is null; a NULL raster input still yields NULL.

New coverage for the other two fixes: clearing band 2 of a raster whose band 1 has no no-data value (both at the Java and SQL levels), a SQL round trip asserting a cleared value does not come back through `RS_AsGeoTiff`, and two `RasterOutputTest` cases pinning that a raster without a no-data value round-trips without gaining one while a raster with one keeps it.

Each new assertion fails without its fix. Full runs: `common` 1339 passed, `rasteralgebraTest` 168 passed, `rasterIOTest` 21 passed.

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.

## Follow-up, not in this PR

`GC_NODATA` is a single coverage-wide property while no-data is declared per band, and the two are not kept in sync in either direction. This PR deliberately does not touch that:

- Setting a no-data value only writes the band's sample dimension. On a raster with an existing `GC_NODATA` the declared value is then ignored by anything reading the property — `RS_MapAlgebra` keeps using the old sentinel. On a raster without one, nothing creates it, so a freshly set no-data value has no effect on `RS_MapAlgebra` at all.
- Clearing has the mirror problem, and removing the property is not a safe fix on its own: because it is coverage-wide, dropping it while another band still declares that value changes *that* band's results (#3324).
- A GeoTIFF also cannot represent a heterogeneous per-band state — the container has one `GDAL_NODATA` slot, and GDAL itself spills a divergent per-band value into a `.aux.xml` sidecar rather than the TIFF, which `RS_AsGeoTiff` has no equivalent of since it returns bytes.

Keeping the property in step with the sample dimensions in both directions, and deciding what `RS_AsGeoTiff` should do with a heterogeneous state, belongs in a separate PR.
