### PR TITLE
[GH-3307] GeoPandas: preserve GeoSeries fillna alignment

### DIFF
--- a/docs/setup/release-notes.md
+++ b/docs/setup/release-notes.md
@@ -65,6 +65,7 @@
 * [<a href='https://github.com/apache/sedona/issues/3269'>GH-3269</a>] - Warn when `geom_equals` or `geom_equals_exact` compares geometry operands with mismatched CRSs
 * [<a href='https://github.com/apache/sedona/issues/3271'>GH-3271</a>] - Preserve per-column CRS state in distributed GeoPandas constructors and select `geometry` or the sole geometry column as active on file reads
 * [<a href='https://github.com/apache/sedona/issues/3293'>GH-3293</a>] - Prevent `GeoDataFrame` construction from mutating caller-owned GeoPandas geometry columns
+* [<a href='https://github.com/apache/sedona/issues/3307'>GH-3307</a>] - Preserve left-index and null-value semantics when `GeoSeries.fillna` uses another GeoSeries
 
 ## Sedona 1.9.1
 

--- a/python/sedona/spark/geopandas/geoseries.py
+++ b/python/sedona/spark/geopandas/geoseries.py
@@ -37,13 +37,18 @@ from pyspark.pandas.utils import same_anchor, scol_for, verify_temp_column_name
 from pyspark.sql.types import (
     ArrayType,
     BooleanType,
+    DataType,
+    DateType,
+    DecimalType,
     DoubleType,
     FloatType,
     IntegralType,
     LongType,
+    NumericType,
     NullType,
     StructField,
     StructType,
+    TimestampType,
 )
 from sedona.spark.sql.types import GeometryType
 
@@ -230,6 +235,67 @@ def _attach_ordered_sequence_column(
         sdf.orderBy(order_column),
         sequence_column,
     )
+
+
+def _fillna_index_columns_equal(
+    left: PySparkColumn,
+    right: PySparkColumn,
+    left_type: DataType,
+    right_type: DataType,
+    positional: bool,
+) -> PySparkColumn:
+    """Compare index keys without Spark's unrelated-type coercions."""
+    floating_types = (FloatType, DoubleType)
+    decimal_floating = (
+        isinstance(left_type, DecimalType) and isinstance(right_type, floating_types)
+    ) or (isinstance(left_type, floating_types) and isinstance(right_type, DecimalType))
+    both_numeric = (
+        isinstance(left_type, NumericType)
+        and isinstance(right_type, NumericType)
+        and not decimal_floating
+    )
+    temporal_types = (DateType, TimestampType)
+    both_temporal = isinstance(left_type, temporal_types) and isinstance(
+        right_type, temporal_types
+    )
+    boolean_numeric = (
+        isinstance(left_type, BooleanType) and isinstance(right_type, NumericType)
+    ) or (isinstance(left_type, NumericType) and isinstance(right_type, BooleanType))
+    # Spark's Decimal/float coercion can equate values that pandas keeps
+    # distinct, such as Decimal("0.1") and binary 0.1. Exact cross-type
+    # comparison is not available as a simple Catalyst expression, so keep
+    # those key families distinct.
+    #
+    # pandas treats boolean/numeric axes as equal positionally, but does not
+    # label-reindex between those types when their order differs.
+    if (
+        left_type == right_type
+        or both_numeric
+        or both_temporal
+        or (positional and boolean_numeric)
+    ):
+        return left.eqNullSafe(right)
+    return left.isNull() & right.isNull()
+
+
+def _fillna_index_dtypes_can_equal(
+    left_dtype: Any,
+    right_dtype: Any,
+    left_type: DataType,
+    right_type: DataType,
+) -> bool:
+    """Whether pandas can consider two index dtypes positionally equal."""
+    if left_dtype == right_dtype:
+        return True
+
+    temporal_types = (DateType, TimestampType)
+    if isinstance(left_type, temporal_types) and isinstance(right_type, temporal_types):
+        return True
+
+    # NumPy-backed indexes use value equality across dtypes, including object-
+    # backed values such as Decimal. Pandas extension dtypes only compare equal
+    # when the dtypes themselves match, which the first branch handles.
+    return isinstance(left_dtype, np.dtype) and isinstance(right_dtype, np.dtype)
 
 
 def _dwithin_expression(
@@ -4706,6 +4772,205 @@ class GeoSeries(GeoFrame, pspd.Series):
         """Alias for `notna` method. See `notna` for more detail."""
         return self.notna()
 
+    def _align_fillna_series(self, replacement: "GeoSeries"):
+        """Align a replacement GeoSeries to the exact left axis."""
+        position = "__fillna_position__"
+        left_order = "__fillna_left_order__"
+        right_order = "__fillna_right_order__"
+        left_present = "__fillna_left_present__"
+        right_present = "__fillna_right_present__"
+        left_indexes = [
+            f"__fillna_left_index_{level}__"
+            for level in range(len(self._internal.index_spark_columns))
+        ]
+        right_indexes = [
+            f"__fillna_right_index_{level}__"
+            for level in range(len(replacement._internal.index_spark_columns))
+        ]
+
+        left_source = self._internal.spark_frame
+        if same_anchor(self, replacement):
+            aligned_frame = left_source.select(
+                self.spark.column.alias("L"),
+                replacement.spark.column.alias("R"),
+                *[
+                    column.alias(alias)
+                    for column, alias in zip(
+                        self._internal.index_spark_columns, left_indexes
+                    )
+                ],
+                scol_for(left_source, NATURAL_ORDER_COLUMN_NAME).alias(left_order),
+            )
+            aligned_frame = aligned_frame.withColumnRenamed(
+                left_order, NATURAL_ORDER_COLUMN_NAME
+            ).orderBy(NATURAL_ORDER_COLUMN_NAME)
+            return aligned_frame, left_indexes
+
+        left_frame = left_source.select(
+            self.spark.column.alias("L"),
+            *[
+                column.alias(alias)
+                for column, alias in zip(
+                    self._internal.index_spark_columns, left_indexes
+                )
+            ],
+            scol_for(left_source, NATURAL_ORDER_COLUMN_NAME).alias(left_order),
+            F.lit(True).alias(left_present),
+        )
+        right_source = replacement._internal.spark_frame
+        right_frame = right_source.select(
+            replacement.spark.column.alias("R"),
+            *[
+                column.alias(alias)
+                for column, alias in zip(
+                    replacement._internal.index_spark_columns, right_indexes
+                )
+            ],
+            scol_for(right_source, NATURAL_ORDER_COLUMN_NAME).alias(right_order),
+            F.lit(True).alias(right_present),
+        )
+        left_index_types = [
+            left_frame.schema[column].dataType for column in left_indexes
+        ]
+        right_index_types = [
+            right_frame.schema[column].dataType for column in right_indexes
+        ]
+        index_dtypes_can_equal = all(
+            _fillna_index_dtypes_can_equal(
+                left_field.dtype,
+                right_field.dtype,
+                left_type,
+                right_type,
+            )
+            for left_field, right_field, left_type, right_type in zip(
+                self._internal.index_fields,
+                replacement._internal.index_fields,
+                left_index_types,
+                right_index_types,
+            )
+        )
+
+        same_index_structure = len(left_indexes) == len(right_indexes)
+        if not same_index_structure:
+            status = right_frame.agg(
+                F.count(F.col(right_present)).alias("right_count"),
+                F.countDistinct(
+                    F.struct(*[F.col(column) for column in right_indexes])
+                ).alias("right_unique_count"),
+            ).first()
+            if status["right_count"] != status["right_unique_count"]:
+                if len(right_indexes) > 1:
+                    raise ValueError("cannot handle a non-unique multi-index!")
+                raise ValueError("cannot reindex on an axis with duplicate labels")
+
+            # A flat Index and a MultiIndex have no complete keys in common.
+            aligned_frame = left_frame.select(
+                F.col("L"),
+                stc.ST_GeomFromWKB(F.lit(None).cast("binary")).alias("R"),
+                *[F.col(column) for column in left_indexes],
+                F.col(left_order),
+            )
+            aligned_frame = aligned_frame.withColumnRenamed(
+                left_order, NATURAL_ORDER_COLUMN_NAME
+            ).orderBy(NATURAL_ORDER_COLUMN_NAME)
+            return aligned_frame, left_indexes
+
+        positioned_left = _attach_ordered_sequence_column(
+            left_frame, F.col(left_order), position
+        )
+        positioned_right = _attach_ordered_sequence_column(
+            right_frame, F.col(right_order), position
+        )
+        positional_join = positioned_left.join(
+            positioned_right,
+            on=position,
+            how="outer",
+        )
+
+        # Exact axes, including duplicate labels, pair positionally. Otherwise,
+        # GeoPandas reindexes a unique replacement onto the complete left key.
+        index_mismatch = F.col(left_present).isNull() | F.col(right_present).isNull()
+        for left_index, right_index, left_type, right_type in zip(
+            left_indexes,
+            right_indexes,
+            left_index_types,
+            right_index_types,
+        ):
+            index_mismatch = index_mismatch | ~_fillna_index_columns_equal(
+                F.col(left_index),
+                F.col(right_index),
+                left_type,
+                right_type,
+                positional=True,
+            )
+        status = positional_join.agg(
+            F.count(F.col(left_present)).alias("left_count"),
+            F.count(F.col(right_present)).alias("right_count"),
+            F.countDistinct(
+                F.when(
+                    F.col(right_present).isNotNull(),
+                    F.struct(*[F.col(column) for column in right_indexes]),
+                )
+            ).alias("right_unique_count"),
+            F.max(index_mismatch.cast("int")).alias("index_mismatch"),
+        ).first()
+        axes_equal = (
+            index_dtypes_can_equal
+            and status["left_count"] == status["right_count"]
+            and not bool(status["index_mismatch"] or False)
+        )
+
+        if not axes_equal and status["right_count"] != status["right_unique_count"]:
+            if len(right_indexes) > 1:
+                raise ValueError("cannot handle a non-unique multi-index!")
+            raise ValueError("cannot reindex on an axis with duplicate labels")
+
+        if axes_equal:
+            aligned_frame = positional_join.select(
+                F.col("L"),
+                F.col("R"),
+                *[F.col(column) for column in left_indexes],
+                F.col(left_order),
+            )
+        else:
+            left_alias = left_frame.alias("left")
+            right_alias = right_frame.alias("right")
+            join_condition = _fillna_index_columns_equal(
+                left_alias[left_indexes[0]],
+                right_alias[right_indexes[0]],
+                left_index_types[0],
+                right_index_types[0],
+                positional=False,
+            )
+            for left_index, right_index, left_type, right_type in zip(
+                left_indexes[1:],
+                right_indexes[1:],
+                left_index_types[1:],
+                right_index_types[1:],
+            ):
+                join_condition = join_condition & _fillna_index_columns_equal(
+                    left_alias[left_index],
+                    right_alias[right_index],
+                    left_type,
+                    right_type,
+                    positional=False,
+                )
+            aligned_frame = left_alias.join(
+                right_alias,
+                on=join_condition,
+                how="left",
+            ).select(
+                left_alias["L"].alias("L"),
+                right_alias["R"].alias("R"),
+                *[left_alias[column].alias(column) for column in left_indexes],
+                left_alias[left_order].alias(left_order),
+            )
+
+        aligned_frame = aligned_frame.withColumnRenamed(
+            left_order, NATURAL_ORDER_COLUMN_NAME
+        ).orderBy(NATURAL_ORDER_COLUMN_NAME)
+        return aligned_frame, left_indexes
+
     # GeoSeries-only (not in GeoDataFrame)
     def fillna(
         self, value=None, inplace: bool = False, limit=None, **kwargs
@@ -4729,6 +4994,12 @@ class GeoSeries(GeoFrame, pspd.Series):
         Returns
         -------
         GeoSeries
+
+        Notes
+        -----
+        Filling from an independent ``GeoSeries`` validates its distributed index
+        before returning. Filling from another column of the same ``GeoDataFrame``
+        remains lazy.
 
         Examples
         --------
@@ -4794,7 +5065,37 @@ class GeoSeries(GeoFrame, pspd.Series):
 
         align = True
 
-        if pd.isna(value) == True or isinstance(value, BaseGeometry):
+        if isinstance(value, (GeoSeries, gpd.GeoSeries)):
+
+            if isinstance(value, gpd.GeoSeries):
+                value_crs = value.crs
+                value = GeoSeries(
+                    pd.Series(
+                        value.to_numpy(dtype=object, copy=False),
+                        index=value.index,
+                        name=value.name,
+                        dtype=object,
+                    ),
+                    crs=value_crs,
+                )
+
+            aligned_frame, left_indexes = self._align_fillna_series(value)
+            left_crs = self.crs
+            left_srid = (left_crs.to_epsg() or 0) if left_crs is not None else 0
+            result = self._result_preserving_index(
+                F.coalesce(
+                    F.col("L"),
+                    stf.ST_SetSRID(F.col("R"), left_srid),
+                ),
+                aligned_frame,
+                [scol_for(aligned_frame, name) for name in left_indexes],
+                self._internal.index_fields,
+                self._internal.index_names,
+                returns_geom=True,
+                keep_name=True,
+            )
+
+        elif pd.isna(value) == True or isinstance(value, BaseGeometry):
             if (
                 value is not None and pd.isna(value) == True
             ):  # ie. value is np.nan or pd.NA:
@@ -4808,27 +5109,19 @@ class GeoSeries(GeoFrame, pspd.Series):
             other, extended = self._make_series_of_val(value)
             align = False if extended else align
 
-        elif isinstance(value, (GeoSeries, gpd.GeoSeries)):
-
-            if not isinstance(value, GeoSeries):
-                value = GeoSeries(value)
-
-            # Replace all None's with empty geometries (this is a recursive call)
-            other = value.fillna(None)
+            # Coalesce: If the value in L is null, use the corresponding value in R for that row
+            spark_expr = F.coalesce(F.col("L"), F.col("R"))
+            result = self._row_wise_operation(
+                spark_expr,
+                other,
+                align=align,
+                returns_geom=True,
+                default_val=None,
+                keep_name=True,
+            )
 
         else:
             raise ValueError(f"Invalid value type: {type(value)}")
-
-        # Coalesce: If the value in L is null, use the corresponding value in R for that row
-        spark_expr = F.coalesce(F.col("L"), F.col("R"))
-        result = self._row_wise_operation(
-            spark_expr,
-            other,
-            align=align,
-            returns_geom=True,
-            default_val=None,
-            keep_name=True,
-        )
 
         if inplace:
             self._update_inplace(result)

--- a/python/sedona/spark/geopandas/geoseries.py
+++ b/python/sedona/spark/geopandas/geoseries.py
@@ -275,7 +275,11 @@ def _fillna_index_columns_equal(
         or (positional and boolean_numeric)
     ):
         return left.eqNullSafe(right)
-    return left.isNull() & right.isNull()
+    # Missing labels can make otherwise incompatible axes positionally equal,
+    # but pandas does not label-reindex between those index families.
+    if positional:
+        return left.isNull() & right.isNull()
+    return F.lit(False)
 
 
 def _fillna_index_dtypes_can_equal(

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from datetime import date
 from decimal import Decimal
 import typing
 import warnings
@@ -74,6 +75,35 @@ requires_shapely_m_support = pytest.mark.skipif(
         f"{getattr(shapely, 'geos_version_string', 'unknown')}"
     ),
 )
+
+
+class TestGeoSeriesFillnaCompatibility(TestGeopandasBase):
+    def test_fillna_accepts_local_geoseries_replacement(self):
+        from geopandas.testing import assert_geoseries_equal
+
+        _ = self.spark
+        left_index = pd.Index([3, 2, 1, 0], name="feature_id")
+        source = GeoSeries(
+            [Point(7, 7), None, None, None],
+            index=left_index,
+            name="geometry",
+            crs="EPSG:4326",
+        )
+        replacement = gpd.GeoSeries(
+            [Point(3, 3), None, Point(4, 4), Point(99, 99)],
+            index=pd.Index([1, 2, 3, 99], name="other_id"),
+            crs="EPSG:3857",
+        )
+        expected = gpd.GeoSeries(
+            [Point(7, 7), None, Point(3, 3), None],
+            index=left_index,
+            name="geometry",
+            crs="EPSG:4326",
+        )
+
+        result = source.fillna(replacement)
+
+        assert_geoseries_equal(result.to_geopandas(), expected, check_index_type=False)
 
 
 @pytest.mark.skipif(
@@ -969,6 +999,346 @@ class TestGeoSeries(TestGeopandasBase):
         result.fillna(None, inplace=True)
         expected = gpd.GeoSeries([Point(0, 0), GeometryCollection()], name="geometry")
         self.check_sgpd_equals_gpd(result, expected)
+
+    def test_fillna_series_replacement_preserves_nulls(self):
+        from geopandas.testing import assert_geoseries_equal
+
+        index = pd.Index(["a", "b"], name="feature_id")
+        source = GeoSeries(
+            [None, None],
+            index=index,
+            name="geometry",
+            crs="EPSG:4326",
+        )
+        replacement = gpd.GeoSeries(
+            [Point(1, 1), None],
+            index=index,
+            crs="EPSG:3857",
+        )
+        replacement = GeoSeries(replacement)
+        expected = gpd.GeoSeries(
+            [Point(1, 1), None],
+            index=index,
+            name="geometry",
+            crs="EPSG:4326",
+        )
+
+        result = source.fillna(replacement)
+
+        assert_geoseries_equal(result.to_geopandas(), expected, check_index_type=False)
+
+    def test_fillna_series_replacement_preserves_left_axis(self):
+        from geopandas.testing import assert_geoseries_equal
+
+        left_index = pd.Index([3, 2, 1, 0], name="feature_id")
+        source = GeoSeries(
+            [Point(7, 7), None, None, None],
+            index=left_index,
+            name="geometry",
+            crs="EPSG:4326",
+        )
+        replacement = gpd.GeoSeries(
+            [Point(3, 3), None, Point(4, 4), Point(99, 99)],
+            index=pd.Index([1, 2, 3, 99], name="other_id"),
+            crs="EPSG:3857",
+        )
+        replacement = GeoSeries(replacement)
+        expected = gpd.GeoSeries(
+            [Point(7, 7), None, Point(3, 3), None],
+            index=left_index,
+            name="geometry",
+            crs="EPSG:4326",
+        )
+
+        result = source.fillna(replacement)
+
+        assert_geoseries_equal(result.to_geopandas(), expected, check_index_type=False)
+
+    def test_fillna_series_replacement_uses_left_crs_for_embedded_srid(self):
+        source = GeoSeries([None], crs="EPSG:4326")
+        replacement = GeoSeries([Point(1, 1)], crs="EPSG:3857")
+
+        result = source.fillna(replacement)
+        embedded_srid = result._internal.spark_frame.select(
+            stf.ST_SRID(result.spark.column).alias("srid")
+        ).first()["srid"]
+        expected = gpd.GeoSeries([Point(1, 1)], crs="EPSG:4326").to_crs(3857)
+
+        assert result.crs.to_epsg() == 4326
+        assert embedded_srid == 4326
+        self.check_sgpd_equals_gpd(result.to_crs(3857), expected)
+
+    @pytest.mark.parametrize(
+        ("left_index", "right_index"),
+        [
+            (
+                pd.Index(["y", "x", "x"], name="feature_id"),
+                pd.Index(["y", "x", "x"], name="feature_id"),
+            ),
+            (
+                pd.Index([0, 1, 1], name="feature_id"),
+                pd.Index([0.0, 1.0, 1.0], name="feature_id"),
+            ),
+        ],
+    )
+    def test_fillna_series_replacement_pairs_equal_duplicate_indexes_positionally(
+        self, left_index, right_index
+    ):
+        from geopandas.testing import assert_geoseries_equal
+
+        source = GeoSeries([Point(7, 7), None, None], index=left_index)
+        replacement = GeoSeries(
+            [Point(8, 8), Point(1, 1), Point(2, 2)],
+            index=right_index,
+        )
+        expected = gpd.GeoSeries(
+            [Point(7, 7), Point(1, 1), Point(2, 2)],
+            index=left_index,
+        )
+
+        result = source.fillna(replacement)
+
+        assert_geoseries_equal(result.to_geopandas(), expected, check_index_type=False)
+
+    @pytest.mark.parametrize(
+        ("left_index", "right_index"),
+        [
+            (
+                pd.Index(["a", "a"], dtype=object),
+                pd.Index(["a", "a"], dtype="string"),
+            ),
+            (
+                pd.Index([1, 1], dtype="int64"),
+                pd.Index([1, 1], dtype="Int64"),
+            ),
+            (
+                pd.Index([Decimal("0.1"), Decimal("0.1")], dtype=object),
+                pd.Index([0.1, 0.1], dtype="float64"),
+            ),
+        ],
+    )
+    def test_fillna_series_replacement_rejects_duplicate_index_dtype_mismatch(
+        self, left_index, right_index
+    ):
+        source = GeoSeries([None, None], index=left_index)
+        replacement = GeoSeries(
+            [Point(1, 1), Point(2, 2)],
+            index=right_index,
+        )
+
+        with pytest.raises(
+            ValueError, match="cannot reindex on an axis with duplicate labels"
+        ):
+            source.fillna(replacement)
+
+    def test_fillna_series_replacement_does_not_coerce_decimal_to_float_index(self):
+        source = GeoSeries([None], index=pd.Index([Decimal("0.1")], dtype=object))
+        replacement = GeoSeries([Point(1, 1)], index=pd.Index([0.1]))
+
+        result = source.fillna(replacement).to_geopandas()
+
+        assert result.iloc[0] is None
+
+    def test_fillna_series_replacement_broadcasts_unique_index_to_duplicate_left(self):
+        from geopandas.testing import assert_geoseries_equal
+
+        source = GeoSeries([None, None, None], index=pd.Index([1, 1, 2]))
+        replacement = GeoSeries(
+            [Point(1, 1), Point(2, 2)],
+            index=pd.Index([1, 2]),
+        )
+        expected = gpd.GeoSeries(
+            [Point(1, 1), Point(1, 1), Point(2, 2)],
+            index=pd.Index([1, 1, 2]),
+        )
+
+        result = source.fillna(replacement)
+
+        assert_geoseries_equal(result.to_geopandas(), expected, check_index_type=False)
+
+    @pytest.mark.parametrize(
+        ("left_index", "right_index"),
+        [
+            (pd.Index([1]), pd.Index(["1"])),
+            (pd.Index(["1"]), pd.Index([1])),
+        ],
+    )
+    def test_fillna_series_replacement_does_not_match_numeric_and_string_keys(
+        self, left_index, right_index
+    ):
+        source = GeoSeries([None], index=left_index)
+        replacement = GeoSeries([Point(1, 1)], index=right_index)
+
+        result = source.fillna(replacement).to_geopandas()
+
+        assert result.iloc[0] is None
+
+    @pytest.mark.parametrize(
+        ("left_index", "right_index"),
+        [
+            (pd.Index([2, 1]), pd.Index([1.0, 2.0])),
+            (pd.Index([True]), pd.Index([1])),
+            (
+                pd.DatetimeIndex(["2020-01-02", "2020-01-01"]),
+                pd.Index([date(2020, 1, 1), date(2020, 1, 2)]),
+            ),
+            (
+                pd.Index(["b", "a"], dtype=object),
+                pd.Index(["a", "b"], dtype="string"),
+            ),
+        ],
+    )
+    def test_fillna_series_replacement_matches_compatible_index_keys(
+        self, left_index, right_index
+    ):
+        from geopandas.testing import assert_geoseries_equal
+
+        fill_values = [
+            Point(position, position) for position in range(len(right_index))
+        ]
+        source = GeoSeries([None] * len(left_index), index=left_index)
+        replacement = GeoSeries(fill_values, index=right_index)
+        expected = gpd.GeoSeries([None] * len(left_index), index=left_index).fillna(
+            gpd.GeoSeries(fill_values, index=right_index)
+        )
+
+        result = source.fillna(replacement).to_geopandas()
+
+        assert_geoseries_equal(result, expected, check_index_type=False)
+
+    def test_fillna_series_replacement_does_not_reindex_boolean_as_numeric(self):
+        source = GeoSeries([None, None], index=pd.Index([True, False]))
+        replacement = GeoSeries([Point(0, 0), Point(1, 1)], index=pd.Index([0, 1]))
+
+        result = source.fillna(replacement).to_geopandas()
+
+        assert result.isna().all()
+
+    @pytest.mark.parametrize("multiindex", [False, True])
+    def test_fillna_series_replacement_rejects_nonidentical_duplicate_index(
+        self, multiindex
+    ):
+        if multiindex:
+            source_index = pd.MultiIndex.from_tuples([("a", 1), ("b", 2)])
+            replacement_index = pd.MultiIndex.from_tuples([("a", 1), ("a", 1)])
+            message = "cannot handle a non-unique multi-index!"
+        else:
+            source_index = pd.Index([1, 2])
+            replacement_index = pd.Index([1, 1])
+            message = "cannot reindex on an axis with duplicate labels"
+
+        source = GeoSeries([None, None], index=source_index)
+        replacement = GeoSeries(
+            [Point(1, 1), Point(2, 2)],
+            index=replacement_index,
+        )
+
+        with pytest.raises(ValueError, match=message):
+            source.fillna(replacement)
+
+    @pytest.mark.parametrize("left_is_multiindex", [False, True])
+    def test_fillna_series_replacement_requires_full_index_shape(
+        self, left_is_multiindex
+    ):
+        from geopandas.testing import assert_geoseries_equal
+
+        single_index = pd.Index(["a", "b"], name="id")
+        multi_index = pd.MultiIndex.from_tuples(
+            [("a", "x"), ("b", "y")], names=["id", "kind"]
+        )
+        left_index = multi_index if left_is_multiindex else single_index
+        right_index = single_index if left_is_multiindex else multi_index
+        source = GeoSeries([None, None], index=left_index)
+        replacement = GeoSeries([Point(1, 1), Point(2, 2)], index=right_index)
+        expected = gpd.GeoSeries([None, None], index=left_index)
+
+        result = source.fillna(replacement)
+
+        assert_geoseries_equal(result.to_geopandas(), expected, check_index_type=False)
+
+    @pytest.mark.parametrize("left_is_multiindex", [False, True])
+    def test_fillna_series_replacement_rejects_duplicate_different_index_shape(
+        self, left_is_multiindex
+    ):
+        single_index = pd.Index(["a", "a"], name="id")
+        multi_index = pd.MultiIndex.from_tuples(
+            [("a", "x"), ("a", "x")], names=["id", "kind"]
+        )
+        left_index = (
+            pd.MultiIndex.from_tuples([("a", "x"), ("b", "y")])
+            if left_is_multiindex
+            else pd.Index(["a", "b"])
+        )
+        right_index = single_index if left_is_multiindex else multi_index
+        message = (
+            "cannot reindex on an axis with duplicate labels"
+            if left_is_multiindex
+            else "cannot handle a non-unique multi-index!"
+        )
+        source = GeoSeries([None, None], index=left_index)
+        replacement = GeoSeries([Point(1, 1), Point(2, 2)], index=right_index)
+
+        with pytest.raises(ValueError, match=message):
+            source.fillna(replacement)
+
+    def test_fillna_series_replacement_uses_full_multiindex_in_left_order(self):
+        from geopandas.testing import assert_geoseries_equal
+
+        left_index = pd.MultiIndex.from_tuples(
+            [("z", 0), ("b", 0), ("a", 0)], names=["group", "row"]
+        )
+        right_index = pd.MultiIndex.from_tuples(
+            [("a", 0), ("b", 0), ("z", 0)],
+            names=["other_group", "other_row"],
+        )
+        source = GeoSeries([Point(7, 7), None, None], index=left_index)
+        replacement = GeoSeries(
+            [Point(1, 1), Point(2, 2), Point(8, 8)], index=right_index
+        )
+        expected = gpd.GeoSeries(
+            [Point(7, 7), Point(2, 2), Point(1, 1)], index=left_index
+        )
+
+        result = source.fillna(replacement)
+
+        assert_geoseries_equal(result.to_geopandas(), expected, check_index_type=False)
+
+    def test_fillna_same_anchor_series_is_lazy_and_positional(self, monkeypatch):
+        from geopandas.testing import assert_geoseries_equal
+        from pyspark.sql import DataFrame
+
+        index = pd.Index(["x", "x", "y"], name="feature_id")
+        frame = GeoDataFrame(
+            gpd.GeoDataFrame(
+                {
+                    "geometry": gpd.GeoSeries([Point(7, 7), None, None], index=index),
+                    "replacement": gpd.GeoSeries(
+                        [Point(8, 8), Point(1, 1), Point(2, 2)], index=index
+                    ),
+                },
+                geometry="geometry",
+            )
+        )
+
+        def unexpected_action(*args, **kwargs):
+            raise AssertionError("same-anchor fillna ran a Spark action")
+
+        monkeypatch.setattr(DataFrame, "first", unexpected_action)
+
+        result = frame.geometry.fillna(frame["replacement"])
+        plan = (
+            result._internal.spark_frame._jdf.queryExecution()
+            .optimizedPlan()
+            .toString()
+        )
+        expected = gpd.GeoSeries(
+            [Point(7, 7), Point(1, 1), Point(2, 2)],
+            index=index,
+            name="geometry",
+        )
+
+        assert "Join" not in plan
+        assert_geoseries_equal(result.to_geopandas(), expected, check_index_type=False)
 
     @pytest.mark.parametrize(
         "kwargs",

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -1173,6 +1173,45 @@ class TestGeoSeries(TestGeopandasBase):
 
         assert result.iloc[0] is None
 
+    def test_fillna_series_replacement_matches_null_keys_positionally(self):
+        from geopandas.testing import assert_geoseries_equal
+
+        left_index = pd.Index([None], dtype=object, name="feature_id")
+        right_index = pd.Index([np.nan], dtype="float64", name="replacement_id")
+        source = GeoSeries([None], index=left_index, name="geometry")
+        replacement = GeoSeries([Point(1, 1)], index=right_index)
+        expected = gpd.GeoSeries([None], index=left_index, name="geometry").fillna(
+            gpd.GeoSeries([Point(1, 1)], index=right_index)
+        )
+
+        assert_geoseries_equal(
+            source.fillna(replacement).to_geopandas(),
+            expected,
+            check_index_type=False,
+        )
+
+    def test_fillna_series_replacement_does_not_reindex_null_keys_across_dtypes(
+        self,
+    ):
+        from geopandas.testing import assert_geoseries_equal
+
+        left_index = pd.Index([None, "left-only"], dtype=object, name="feature_id")
+        right_index = pd.Index([1.0, np.nan], dtype="float64", name="replacement_id")
+        source_values = [None, None]
+        replacement_values = [Point(1, 1), Point(2, 2)]
+        source = GeoSeries(source_values, index=left_index, name="geometry")
+        replacement = GeoSeries(replacement_values, index=right_index)
+        expected = gpd.GeoSeries(
+            source_values, index=left_index, name="geometry"
+        ).fillna(gpd.GeoSeries(replacement_values, index=right_index))
+
+        assert expected.isna().all()
+        assert_geoseries_equal(
+            source.fillna(replacement).to_geopandas(),
+            expected,
+            check_index_type=False,
+        )
+
     @pytest.mark.parametrize(
         ("left_index", "right_index"),
         [
@@ -1317,6 +1356,22 @@ class TestGeoSeries(TestGeopandasBase):
                     ),
                 },
                 geometry="geometry",
+            )
+        )
+        reversed_sdf = frame._internal.spark_frame.orderBy(
+            F.col(NATURAL_ORDER_COLUMN_NAME).desc()
+        )
+        frame._update_internal_frame(
+            frame._internal.copy(
+                spark_frame=reversed_sdf,
+                index_spark_columns=[
+                    scol_for(reversed_sdf, name)
+                    for name in frame._internal.index_spark_column_names
+                ],
+                data_spark_columns=[
+                    scol_for(reversed_sdf, name)
+                    for name in frame._internal.data_spark_column_names
+                ],
             )
         )
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #3307

## What changes were proposed in this PR?

This PR makes unlimited `GeoSeries.fillna(value=GeoSeries)` preserve GeoPandas-compatible left-index semantics.

- Preserve the left index, row order, name, and CRS.
- Keep null replacement geometries null and omit replacement-only labels.
- Handle duplicate indexes, Index/MultiIndex differences, and compatible index key types.
- Keep same-frame replacement fills lazy and join-free.
- Normalize replacement geometry SRIDs to the left CRS.
- Add regression coverage and a release note.

## How was this patch tested?

- Focused GeoSeries fillna tests on Spark 3.5: 30 passed.
- Focused GeoSeries fillna tests on Spark 4.1: 30 passed.
- The focused GeoPandas 0.13.2 and Shapely 1.8.5 compatibility test passed.
- Black and all repository commit hooks passed.

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation.
