### PR TITLE
[SEDONA-3306] GeoPandas: avoid eager alignment in GeoSeries.fillna wh…

### DIFF
--- a/python/sedona/spark/geopandas/geoseries.py
+++ b/python/sedona/spark/geopandas/geoseries.py
@@ -4813,6 +4813,9 @@ class GeoSeries(GeoFrame, pspd.Series):
             if not isinstance(value, GeoSeries):
                 value = GeoSeries(value)
 
+            if self.index.equals(value.index):
+                align = False
+
             # Replace all None's with empty geometries (this is a recursive call)
             other = value.fillna(None)
 


### PR DESCRIPTION
Fixes #3306

Adds index equality fast path in `GeoSeries.fillna()` in `python/sedona/spark/geopandas/geoseries.py` to set `align = False` when `self.index.equals(value.index)`, avoiding unnecessary eager alignment passes and repeated plan evaluation for same-index GeoSeries replacements.