### PR TITLE
[GH-3316] Seed the SpiderTests diagonal distribution check

### DIFF
--- a/spark/common/src/test/scala/org/apache/sedona/sql/SpiderTests.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/SpiderTests.scala
@@ -185,6 +185,7 @@ class SpiderTests extends TestBaseScala with BeforeAndAfterAll {
         .option("numPartitions", "4")
         .option("percentage", "0.7")
         .option("distribution", "diagonal")
+        .option("seed", "42")
         .load()
       assert(spiderDf.rdd.getNumPartitions == 4)
       val records = spiderDf.collect()
@@ -194,7 +195,11 @@ class SpiderTests extends TestBaseScala with BeforeAndAfterAll {
         val geom = row.getAs[Geometry]("geometry").getCentroid
         Math.abs(geom.getX - geom.getY) < 0.000001
       }
-      assert(numPoints >= 650 && numPoints <= 750)
+      // With seed 42, exactly 676 of the 1000 generated points lie on the diagonal,
+      // consistent with percentage=0.7. Without a fixed seed the count is binomial
+      // (drawn with the current time as the seed), so a statistically valid sample
+      // can fall outside any bounded range and fail the test spuriously.
+      assert(numPoints == 676)
     }
 
     it("generate parcel data") {


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #3316

## What changes were proposed in this PR?

Makes the `generate data with diagonal distribution` test in `SpiderTests` deterministic, as suggested in the issue.

The test asked for 1000 records with `percentage=0.7` but never set the Spider `seed` option, so `SpiderDataSource` fell back to `System.currentTimeMillis()` and the on-diagonal count was a binomial random variable. A legitimate sample could land outside the asserted `[650, 750]` window (a CI run recently produced 649), and the spurious failure also fail-fasted the JVM compatibility matrix.

This PR sets `seed=42` and asserts the exact deterministic count for that seed: 676 of the 1000 points on the diagonal, which keeps the `percentage` behavior covered (676/1000 is consistent with `percentage=0.7`) while removing the randomness. A comment in the test explains why the seed is fixed.

The expected count is fully determined by the seed regardless of Spark/Scala version: `SpiderScanBuilder` gives partition `i` the seed `seed + i`, `SpiderPartitionReader` draws from `java.util.Random(seed + i)`, and `java.util.Random` is specified platform-independently. I cross-checked the value by replicating the partition-range and generator logic (`computePartitionRanges(4, 1000)` + `GeneratorFactory.create("diagonal", ...)`) in a standalone driver against `sedona-common`, which also yields 676 for seed 42.

## How was this patch tested?

Ran the focused suite with the default profile (Spark 3.5.0, Java 11):

```
mvn -pl spark/common test -DwildcardSuites=org.apache.sedona.sql.SpiderTests -Dtest=none
```

All `SpiderTests` cases pass, including the now-deterministic diagonal test. Repeated runs produce the same result by construction since no time-based seed remains.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
