### PR TITLE
[GH-3320] Error on unknown resample algorithm names

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/raster/RasterEditors.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterEditors.java
@@ -345,6 +345,10 @@ public class RasterEditors {
       boolean useScale,
       String algorithm)
       throws TransformException {
+    // Validated before the no-op early return below, so an unknown algorithm
+    // name errors even when the requested grid matches the source's.
+    Interpolation resamplingAlgorithm = createInterpolationAlgorithm(algorithm);
+
     /*
      * Old Parameters
      */
@@ -461,7 +465,6 @@ public class RasterEditors {
             transform,
             crs,
             null);
-    Interpolation resamplingAlgorithm = createInterpolationAlgorithm(algorithm);
     GridCoverage2D newRaster;
     GridCoverage2D noDataValueMask;
     GridCoverage2D resampledNoDataValueMask;

--- a/common/src/main/java/org/apache/sedona/common/raster/RasterEditors.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterEditors.java
@@ -710,17 +710,20 @@ public class RasterEditors {
   }
 
   private static Interpolation createInterpolationAlgorithm(String algorithm) {
-    Interpolation interp = Interpolation.getInstance(Interpolation.INTERP_NEAREST);
-    if (!Objects.isNull(algorithm) && !algorithm.isEmpty()) {
-      if (algorithm.equalsIgnoreCase("nearestneighbor")) {
-        interp = Interpolation.getInstance(Interpolation.INTERP_NEAREST);
-      } else if (algorithm.equalsIgnoreCase("bilinear")) {
-        interp = Interpolation.getInstance(Interpolation.INTERP_BILINEAR);
-      } else if (algorithm.equalsIgnoreCase("bicubic")) {
-        interp = Interpolation.getInstance(Interpolation.INTERP_BICUBIC);
-      }
+    if (Objects.isNull(algorithm) || algorithm.isEmpty()) {
+      return Interpolation.getInstance(Interpolation.INTERP_NEAREST);
     }
-    return interp;
+    if (algorithm.equalsIgnoreCase("nearestneighbor")) {
+      return Interpolation.getInstance(Interpolation.INTERP_NEAREST);
+    } else if (algorithm.equalsIgnoreCase("bilinear")) {
+      return Interpolation.getInstance(Interpolation.INTERP_BILINEAR);
+    } else if (algorithm.equalsIgnoreCase("bicubic")) {
+      return Interpolation.getInstance(Interpolation.INTERP_BICUBIC);
+    }
+    throw new IllegalArgumentException(
+        "Invalid 'algorithm': '"
+            + algorithm
+            + "'. Expected one of: NearestNeighbor, Bilinear, Bicubic.");
   }
 
   private static double castRasterDataType(double value, int dataType) {

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterEditorsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterEditorsTest.java
@@ -3936,6 +3936,25 @@ public class RasterEditorsTest extends RasterTestBase {
   }
 
   @Test
+  public void testResampleUnknownAlgorithm() throws FactoryException {
+    GridCoverage2D raster = RasterConstructors.makeEmptyRaster(1, "d", 4, 3, 0, 0, 2, -2, 0, 0, 0);
+    assertThrows(
+        "Invalid 'algorithm': 'sinc'. Expected one of: NearestNeighbor, Bilinear, Bicubic.",
+        IllegalArgumentException.class,
+        () -> RasterEditors.resample(raster, 6, 5, 1, -1, false, "sinc"));
+  }
+
+  @Test
+  public void testReprojectMatchUnknownAlgorithm() throws FactoryException {
+    GridCoverage2D raster = RasterConstructors.makeEmptyRaster(1, "d", 4, 3, 0, 0, 2, -2, 0, 0, 0);
+    GridCoverage2D alignTo = RasterConstructors.makeEmptyRaster(1, "d", 6, 5, 0, 0, 1, -1, 0, 0, 0);
+    assertThrows(
+        "Invalid 'algorithm': 'sinc'. Expected one of: NearestNeighbor, Bilinear, Bicubic.",
+        IllegalArgumentException.class,
+        () -> RasterEditors.reprojectMatch(raster, alignTo, "sinc"));
+  }
+
+  @Test
   public void testNormalizeAll() throws FactoryException {
     GridCoverage2D raster1 = RasterConstructors.makeEmptyRaster(2, 4, 4, 0, 0, 1);
     GridCoverage2D raster2 = RasterConstructors.makeEmptyRaster(2, 4, 4, 0, 0, 1);

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterEditorsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterEditorsTest.java
@@ -3942,6 +3942,19 @@ public class RasterEditorsTest extends RasterTestBase {
         "Invalid 'algorithm': 'sinc'. Expected one of: NearestNeighbor, Bilinear, Bicubic.",
         IllegalArgumentException.class,
         () -> RasterEditors.resample(raster, 6, 5, 1, -1, false, "sinc"));
+
+    // The no-op early return must not bypass validation: the requested grid
+    // matches the source exactly here, and via the matching reference raster.
+    assertThrows(
+        "Invalid 'algorithm': 'sinc'. Expected one of: NearestNeighbor, Bilinear, Bicubic.",
+        IllegalArgumentException.class,
+        () -> RasterEditors.resample(raster, 4, 3, 0, 0, false, "sinc"));
+    GridCoverage2D sameGrid =
+        RasterConstructors.makeEmptyRaster(1, "d", 4, 3, 0, 0, 2, -2, 0, 0, 0);
+    assertThrows(
+        "Invalid 'algorithm': 'sinc'. Expected one of: NearestNeighbor, Bilinear, Bicubic.",
+        IllegalArgumentException.class,
+        () -> RasterEditors.resample(raster, sameGrid, false, "sinc"));
   }
 
   @Test

--- a/docs/api/sql/Raster-Operators/RS_Resample.md
+++ b/docs/api/sql/Raster-Operators/RS_Resample.md
@@ -31,7 +31,7 @@ The `useScale` parameter controls whether to use width-height or scaleX-scaleY. 
 
 Currently, RS_Resample does not support skewed rasters, and hence even if a skewed reference raster is provided, its skew values are ignored. If the input raster is skewed, the output raster geometry and interpolation may be incorrect.
 
-The default algorithm used for resampling is `NearestNeighbor`, and hence if a null, empty or invalid value of algorithm is provided, RS_Resample defaults to using `NearestNeighbor`. However, the algorithm parameter is non-optional.
+The default algorithm used for resampling is `NearestNeighbor`: if a null or empty algorithm is provided, RS_Resample defaults to using `NearestNeighbor`. An unknown algorithm name raises an `IllegalArgumentException`. The algorithm parameter is non-optional.
 
 Following are valid values for the algorithm parameter (Case-insensitive):
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #3320

## What changes were proposed in this PR?

`RS_Resample` and `RS_ReprojectMatch` silently fell back to NearestNeighbor for any algorithm name other than `nearestneighbor`/`bilinear`/`bicubic` — a typo like `'biliner'` or another engine's vocabulary like `'CubicSpline'` quietly returned wrong-interpolation results. `RasterEditors.createInterpolationAlgorithm` now throws `IllegalArgumentException` naming the accepted values. A null or empty algorithm keeps its documented default of NearestNeighbor, and the accepted spellings are unchanged.

Surfaced by the SedonaDB↔Sedona Spark parity suite (apache/sedona-db `integration/spark-parity`), where SedonaDB rejects unknown names and the silent fallback shows up as a cataloged divergence.

## How was this patch tested?

Two new unit tests (`testResampleUnknownAlgorithm`, `testReprojectMatchUnknownAlgorithm`) assert the error through both public entry points; the full `RasterEditorsTest` class passes locally (29 tests, JDK 17), and `mvn spotless:apply` is clean.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation. (The docs do not describe the silent fallback; the accepted algorithm names are unchanged.)
