### PR TITLE
[CI] security: pin prettier hook additional dependency to SHA

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,11 +59,11 @@ repos:
       - id: prettier
         name: run prettier
         description: format files with prettier
-        entry: prettier --write '**/*.js' '**/*.yaml' '**/*.yml'
+        entry: prettier --write
         files: \.(js|ya?ml)$
         language: node
-        additional_dependencies: ['prettier@3.8.4']
-        pass_filenames: false
+        additional_dependencies:
+          - 'prettier/prettier#8f0c95057cc91d5836409466cd9d9af3bb901e84' # 3.9.6
       - id: maven-spotless-apply
         name: maven spotless apply
         description: automatically formats Java and Scala code using mvn spotless:apply.


### PR DESCRIPTION
Supply chain security enhancement

Clean up prettier hook

## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- No:
  - this is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

As described above

https://github.com/prettier/prettier/commit/8f0c95057cc91d5836409466cd9d9af3bb901e84

## How was this patch tested?

prek run -a

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
