### PR TITLE
[GH-2392] Test single-member GeometryCollection

### DIFF
--- a/python/tests/geopandas/test_match_geopandas_series.py
+++ b/python/tests/geopandas/test_match_geopandas_series.py
@@ -137,10 +137,6 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
 
         self.geomcollection = [
             GeometryCollection(),
-            # A collection can be empty even when it contains typed empty members.
-            GeometryCollection([Point(), LineString(), Polygon()]),
-            # Collection predicates must retain collection semantics with one member.
-            GeometryCollection([LineString([(0, 0), (1, 1), (0, 0)])]),
             GeometryCollection(
                 [
                     MultiPoint([(0, 0), (1, 1)]),
@@ -155,6 +151,8 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
                     ),
                 ]
             ),
+            # Collection predicates must retain collection semantics with one member.
+            GeometryCollection([LineString([(0, 0), (1, 1), (0, 0)])]),
         ]
 
         self.geoms = [

--- a/python/tests/geopandas/test_match_geopandas_series.py
+++ b/python/tests/geopandas/test_match_geopandas_series.py
@@ -137,6 +137,10 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
 
         self.geomcollection = [
             GeometryCollection(),
+            # A collection can be empty even when it contains typed empty members.
+            GeometryCollection([Point(), LineString(), Polygon()]),
+            # Collection predicates must retain collection semantics with one member.
+            GeometryCollection([LineString([(0, 0), (1, 1), (0, 0)])]),
             GeometryCollection(
                 [
                     MultiPoint([(0, 0), (1, 1)]),


### PR DESCRIPTION
## Did you read the Contributor Guide?

The contributor rules and Python development/test instructions were reviewed while preparing this patch.

## Is this PR related to a ticket?

Yes. Partially addresses #2392.

## What changes were proposed in this PR?

Extend the shared GeoSeries parity fixtures with a missing single-member GeometryCollection containing a closed LineString. Because `self.geomcollection` is part of `self.geoms`, the case flows through the existing Sedona-versus-GeoPandas checks, including construction, serialization, predicates, measurements, transformations, and `is_closed`.

The initial revision also included a collection whose members were all typed empty geometries. The full matrix demonstrated a distinct `to_arrow` WKB dimensionality mismatch for that shape, now tracked separately in #3329; it was removed here rather than masking a real defect with an expected failure.

## How was this patch tested?

- Black 26.5.1 formatting check
- Python bytecode compilation
- `git diff --check`
- Reference GeoPandas 1.1+ / Shapely 2.1+ evaluation of the fixture, including `is_empty`, `is_valid`, `is_closed`, `has_z`, `geom_type`, `length`, `area`, and `count_geometries`
- Upstream CI on the initial revision: 2,092 tests passed and the only failure was the separately tracked all-empty-member serialization mismatch in #3329
- Focused distributed checks for the narrowed fixture: constructor plus all four `explode` variants passed (5 tests)
- Broader fail-fast run: 44 passed and 1 skipped before `test_coverage_validation` reached an internal JVM function absent from the released Sedona 1.9.0 shaded JAR used locally

## Did this PR include necessary documentation updates?

No. This only expands test coverage and does not change a public API.
