### PR TITLE
[GH-3324] Keep other bands' no-data value when clearing one band

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/raster/RasterBandEditors.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterBandEditors.java
@@ -18,11 +18,13 @@
  */
 package org.apache.sedona.common.raster;
 
+import it.geosolutions.jaiext.range.NoDataContainer;
 import java.awt.geom.Point2D;
 import java.awt.image.Raster;
 import java.awt.image.RenderedImage;
 import java.awt.image.WritableRaster;
 import java.util.Collections;
+import java.util.Map;
 import javax.media.jai.RasterFactory;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -53,14 +55,22 @@ public class RasterBandEditors {
 
     // Remove no-Data if it is null
     if (noDataValue == null) {
-      if (RasterBandAccessors.getBandNoDataValue(raster) == null) {
+      if (rasterNoData == null) {
         return raster;
       }
       GridSampleDimension[] sampleDimensions = raster.getSampleDimensions();
       sampleDimensions[bandIndex - 1] =
           RasterUtils.removeNoDataValue(sampleDimensions[bandIndex - 1]);
-      return RasterUtils.clone(
-          raster.getRenderedImage(), null, sampleDimensions, raster, null, true);
+      // The GC_NODATA sentinel also rides on the rendered image itself as an image
+      // property and survives serialization there, so cloning the image would let
+      // readers and writers resurrect the cleared value. Copy the pixels into a
+      // property-free image and drop the sentinel from the coverage properties too.
+      Map propertyMap = raster.getProperties();
+      if (propertyMap != null) {
+        propertyMap.remove(NoDataContainer.GC_NODATA);
+      }
+      WritableRaster pixels = raster.getRenderedImage().copyData(null);
+      return RasterUtils.clone(pixels, null, sampleDimensions, raster, null, true, propertyMap);
     }
 
     if (rasterNoData != null && rasterNoData.equals(noDataValue)) {

--- a/common/src/main/java/org/apache/sedona/common/raster/RasterBandEditors.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterBandEditors.java
@@ -24,10 +24,12 @@ import java.awt.image.Raster;
 import java.awt.image.RenderedImage;
 import java.awt.image.WritableRaster;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import javax.media.jai.RasterFactory;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.sedona.common.utils.PropertyMaskedRenderedImage;
 import org.apache.sedona.common.utils.RasterUtils;
 import org.geotools.api.parameter.ParameterValueGroup;
 import org.geotools.api.referencing.FactoryException;
@@ -61,16 +63,19 @@ public class RasterBandEditors {
       GridSampleDimension[] sampleDimensions = raster.getSampleDimensions();
       sampleDimensions[bandIndex - 1] =
           RasterUtils.removeNoDataValue(sampleDimensions[bandIndex - 1]);
-      // The GC_NODATA sentinel also rides on the rendered image itself as an image
-      // property and survives serialization there, so cloning the image would let
-      // readers and writers resurrect the cleared value. Copy the pixels into a
-      // property-free image and drop the sentinel from the coverage properties too.
-      Map propertyMap = raster.getProperties();
-      if (propertyMap != null) {
-        propertyMap.remove(NoDataContainer.GC_NODATA);
-      }
-      WritableRaster pixels = raster.getRenderedImage().copyData(null);
-      return RasterUtils.clone(pixels, null, sampleDimensions, raster, null, true, propertyMap);
+      // The GC_NODATA sentinel is carried both by the coverage properties and by the
+      // rendered image, and GridCoverage2D.getProperty falls through to the image, so it
+      // has to be dropped from both or GeoTools operations keep treating the cleared
+      // value as no-data. Masking wraps the image lazily: no pixels are copied, so a
+      // streamed raster stays undecoded and a non-zero image origin is preserved.
+      RenderedImage image =
+          PropertyMaskedRenderedImage.mask(raster.getRenderedImage(), NoDataContainer.GC_NODATA);
+      Map<?, ?> properties = raster.getProperties();
+      Map<Object, Object> retainedProperties =
+          properties == null ? new HashMap<>() : new HashMap<>(properties);
+      retainedProperties.remove(NoDataContainer.GC_NODATA);
+      return RasterUtils.clone(
+          image, null, sampleDimensions, raster, null, true, retainedProperties);
     }
 
     if (rasterNoData != null && rasterNoData.equals(noDataValue)) {

--- a/common/src/main/java/org/apache/sedona/common/raster/RasterBandEditors.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterBandEditors.java
@@ -63,11 +63,20 @@ public class RasterBandEditors {
       GridSampleDimension[] sampleDimensions = raster.getSampleDimensions();
       sampleDimensions[bandIndex - 1] =
           RasterUtils.removeNoDataValue(sampleDimensions[bandIndex - 1]);
-      // The GC_NODATA sentinel is carried both by the coverage properties and by the
-      // rendered image, and GridCoverage2D.getProperty falls through to the image, so it
-      // has to be dropped from both or GeoTools operations keep treating the cleared
-      // value as no-data. Masking wraps the image lazily: no pixels are copied, so a
-      // streamed raster stays undecoded and a non-zero image origin is preserved.
+      // No-data values are per band on the sample dimensions, but GC_NODATA is a single
+      // sentinel for the whole coverage, carried both by the coverage properties and by the
+      // rendered image. Bands that were not cleared still declare their no-data value, and
+      // GeoTools operations that read the sentinel rather than the sample dimensions --
+      // Jiffle map algebra among them -- would stop honouring those bands if it were
+      // dropped here. So keep it until no band declares a no-data value at all.
+      if (hasNoDataValue(sampleDimensions)) {
+        return RasterUtils.clone(
+            raster.getRenderedImage(), null, sampleDimensions, raster, null, true);
+      }
+      // GridCoverage2D.getProperty falls through to the image, so the sentinel has to be
+      // dropped from both or GeoTools keeps treating the cleared value as no-data. Masking
+      // wraps the image lazily: no pixels are copied, so a streamed raster stays undecoded
+      // and a non-zero image origin is preserved.
       RenderedImage image =
           PropertyMaskedRenderedImage.mask(raster.getRenderedImage(), NoDataContainer.GC_NODATA);
       Map<?, ?> properties = raster.getProperties();
@@ -110,6 +119,19 @@ public class RasterBandEditors {
     }
 
     return RasterUtils.clone(raster.getRenderedImage(), null, bands, raster, null, true);
+  }
+
+  /**
+   * @param sampleDimensions Bands to inspect
+   * @return true when at least one band declares a no-data value
+   */
+  private static boolean hasNoDataValue(GridSampleDimension[] sampleDimensions) {
+    for (GridSampleDimension sampleDimension : sampleDimensions) {
+      if (!Double.isNaN(RasterUtils.getNoDataValue(sampleDimension))) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/common/src/main/java/org/apache/sedona/common/raster/RasterOutputs.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterOutputs.java
@@ -47,6 +47,7 @@ import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.coverage.grid.io.AbstractGridFormat;
 import org.geotools.gce.arcgrid.ArcGridWriteParams;
 import org.geotools.gce.arcgrid.ArcGridWriter;
+import org.geotools.gce.geotiff.GeoTiffFormat;
 import org.geotools.gce.geotiff.GeoTiffWriteParams;
 import org.geotools.gce.geotiff.GeoTiffWriter;
 import org.geotools.referencing.operation.transform.AffineTransform2D;
@@ -62,6 +63,19 @@ public class RasterOutputs {
       throw new RuntimeException(e);
     }
     ParameterValueGroup defaultParams = writer.getFormat().getWriteParameters();
+    // Without this, GeoTiffWriter writes a default GDAL_NODATA of 0 for coverages that
+    // have no no-data value, so a cleared (or never set) no-data value comes back as 0
+    // when the written bytes are read again.
+    boolean hasNoDataValue = false;
+    for (int band = 1; band <= raster.getNumSampleDimensions(); band++) {
+      if (RasterBandAccessors.getBandNoDataValue(raster, band) != null) {
+        hasNoDataValue = true;
+        break;
+      }
+    }
+    defaultParams
+        .parameter(GeoTiffFormat.WRITE_NODATA.getName().toString())
+        .setValue(hasNoDataValue);
     if (compressionType != null && compressionQuality >= 0 && compressionQuality <= 1) {
       GeoTiffWriteParams params = new GeoTiffWriteParams();
       params.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);

--- a/common/src/main/java/org/apache/sedona/common/raster/RasterOutputs.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterOutputs.java
@@ -63,9 +63,10 @@ public class RasterOutputs {
       throw new RuntimeException(e);
     }
     ParameterValueGroup defaultParams = writer.getFormat().getWriteParameters();
-    // Without this, GeoTiffWriter writes a default GDAL_NODATA of 0 for coverages that
-    // have no no-data value, so a cleared (or never set) no-data value comes back as 0
-    // when the written bytes are read again.
+    // GeoTiffWriter writes a default GDAL_NODATA of 0 for coverages that have no no-data
+    // value, so a cleared (or never set) no-data value would come back as 0 when the
+    // written bytes are read again. Only opt out in that case: forcing the flag on when a
+    // no-data value is present would override an explicit -Dgeotiff.writenodata=false.
     boolean hasNoDataValue = false;
     for (int band = 1; band <= raster.getNumSampleDimensions(); band++) {
       if (RasterBandAccessors.getBandNoDataValue(raster, band) != null) {
@@ -73,9 +74,9 @@ public class RasterOutputs {
         break;
       }
     }
-    defaultParams
-        .parameter(GeoTiffFormat.WRITE_NODATA.getName().toString())
-        .setValue(hasNoDataValue);
+    if (!hasNoDataValue) {
+      defaultParams.parameter(GeoTiffFormat.WRITE_NODATA.getName().toString()).setValue(false);
+    }
     if (compressionType != null && compressionQuality >= 0 && compressionQuality <= 1) {
       GeoTiffWriteParams params = new GeoTiffWriteParams();
       params.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);

--- a/common/src/main/java/org/apache/sedona/common/raster/RasterOutputs.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterOutputs.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
 import java.util.Base64;
+import java.util.Objects;
 import javax.imageio.ImageIO;
 import javax.imageio.ImageWriteParam;
 import javax.media.jai.InterpolationNearest;
@@ -63,18 +64,28 @@ public class RasterOutputs {
       throw new RuntimeException(e);
     }
     ParameterValueGroup defaultParams = writer.getFormat().getWriteParameters();
+    // GDAL_NODATA is a single value for the whole file, so a raster whose bands disagree about
+    // their no-data value cannot be written faithfully: every band reads back with whichever
+    // value was written. Reject that instead of changing it silently.
+    Double firstNoDataValue = RasterBandAccessors.getBandNoDataValue(raster, 1);
+    for (int band = 2; band <= raster.getNumSampleDimensions(); band++) {
+      if (!Objects.equals(firstNoDataValue, RasterBandAccessors.getBandNoDataValue(raster, band))) {
+        throw new IllegalArgumentException(
+            "Cannot write a GeoTIFF for a raster whose bands have different no-data values, "
+                + "because GeoTIFF stores one no-data value for the whole file. Band 1 has "
+                + firstNoDataValue
+                + " and band "
+                + band
+                + " has "
+                + RasterBandAccessors.getBandNoDataValue(raster, band)
+                + ". Set the same no-data value on every band, or clear it on every band.");
+      }
+    }
     // GeoTiffWriter writes a default GDAL_NODATA of 0 for coverages that have no no-data
     // value, so a cleared (or never set) no-data value would come back as 0 when the
     // written bytes are read again. Only opt out in that case: forcing the flag on when a
     // no-data value is present would override an explicit -Dgeotiff.writenodata=false.
-    boolean hasNoDataValue = false;
-    for (int band = 1; band <= raster.getNumSampleDimensions(); band++) {
-      if (RasterBandAccessors.getBandNoDataValue(raster, band) != null) {
-        hasNoDataValue = true;
-        break;
-      }
-    }
-    if (!hasNoDataValue) {
+    if (firstNoDataValue == null) {
       defaultParams.parameter(GeoTiffFormat.WRITE_NODATA.getName().toString()).setValue(false);
     }
     if (compressionType != null && compressionQuality >= 0 && compressionQuality <= 1) {

--- a/common/src/main/java/org/apache/sedona/common/utils/PropertyMaskedRenderedImage.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/PropertyMaskedRenderedImage.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.common.utils;
+
+import java.awt.Image;
+import java.awt.Rectangle;
+import java.awt.image.ColorModel;
+import java.awt.image.Raster;
+import java.awt.image.RenderedImage;
+import java.awt.image.SampleModel;
+import java.awt.image.WritableRaster;
+import java.util.Arrays;
+import java.util.Vector;
+
+/**
+ * A {@link RenderedImage} that delegates everything to a source image but hides a single property.
+ *
+ * <p>Image properties cannot be removed in place: {@link javax.media.jai.RenderedImageAdapter}
+ * declares {@code getProperty} final and answers from the source, so {@code removeProperty} cannot
+ * mask an inherited value. Wrapping is also the only way to drop a property without touching pixels
+ * — copying the raster would materialize a lazily decoded image and lose a non-zero image origin.
+ */
+public class PropertyMaskedRenderedImage implements RenderedImage {
+  private final RenderedImage source;
+  private final String maskedProperty;
+
+  private PropertyMaskedRenderedImage(RenderedImage source, String maskedProperty) {
+    this.source = source;
+    this.maskedProperty = maskedProperty;
+  }
+
+  /**
+   * Wrap {@code source} so that {@code propertyName} reads back as {@link Image#UndefinedProperty}.
+   * Returns the source unchanged when it does not carry the property.
+   */
+  public static RenderedImage mask(RenderedImage source, String propertyName) {
+    if (source.getProperty(propertyName) == Image.UndefinedProperty) {
+      return source;
+    }
+    return new PropertyMaskedRenderedImage(source, propertyName);
+  }
+
+  @Override
+  public Object getProperty(String name) {
+    if (maskedProperty.equalsIgnoreCase(name)) {
+      return Image.UndefinedProperty;
+    }
+    return source.getProperty(name);
+  }
+
+  @Override
+  public String[] getPropertyNames() {
+    String[] names = source.getPropertyNames();
+    if (names == null) {
+      return null;
+    }
+    String[] retained =
+        Arrays.stream(names)
+            .filter(name -> !maskedProperty.equalsIgnoreCase(name))
+            .toArray(String[]::new);
+    // RenderedImage uses null, not an empty array, to mean "no properties".
+    return retained.length == 0 ? null : retained;
+  }
+
+  @Override
+  public Vector<RenderedImage> getSources() {
+    return source.getSources();
+  }
+
+  @Override
+  public ColorModel getColorModel() {
+    return source.getColorModel();
+  }
+
+  @Override
+  public SampleModel getSampleModel() {
+    return source.getSampleModel();
+  }
+
+  @Override
+  public int getWidth() {
+    return source.getWidth();
+  }
+
+  @Override
+  public int getHeight() {
+    return source.getHeight();
+  }
+
+  @Override
+  public int getMinX() {
+    return source.getMinX();
+  }
+
+  @Override
+  public int getMinY() {
+    return source.getMinY();
+  }
+
+  @Override
+  public int getNumXTiles() {
+    return source.getNumXTiles();
+  }
+
+  @Override
+  public int getNumYTiles() {
+    return source.getNumYTiles();
+  }
+
+  @Override
+  public int getMinTileX() {
+    return source.getMinTileX();
+  }
+
+  @Override
+  public int getMinTileY() {
+    return source.getMinTileY();
+  }
+
+  @Override
+  public int getTileWidth() {
+    return source.getTileWidth();
+  }
+
+  @Override
+  public int getTileHeight() {
+    return source.getTileHeight();
+  }
+
+  @Override
+  public int getTileGridXOffset() {
+    return source.getTileGridXOffset();
+  }
+
+  @Override
+  public int getTileGridYOffset() {
+    return source.getTileGridYOffset();
+  }
+
+  @Override
+  public Raster getTile(int tileX, int tileY) {
+    return source.getTile(tileX, tileY);
+  }
+
+  @Override
+  public Raster getData() {
+    return source.getData();
+  }
+
+  @Override
+  public Raster getData(Rectangle rect) {
+    return source.getData(rect);
+  }
+
+  @Override
+  public WritableRaster copyData(WritableRaster raster) {
+    return source.copyData(raster);
+  }
+}

--- a/common/src/main/java/org/apache/sedona/common/utils/RasterUtils.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/RasterUtils.java
@@ -109,6 +109,24 @@ public class RasterUtils {
     if (keepMetadata) {
       propertyMap = referenceRaster.getProperties();
     }
+    return clone(
+        raster, gridGeometry2D, bands, referenceRaster, noDataValue, keepMetadata, propertyMap);
+  }
+
+  /**
+   * Variant of {@link #clone(WritableRaster, GridGeometry2D, GridSampleDimension[], GridCoverage2D,
+   * Double, boolean)} taking the coverage property map explicitly instead of copying it from the
+   * reference raster, so callers can filter properties (e.g. drop the GC_NODATA no-data sentinel)
+   * while keeping the rest of the metadata.
+   */
+  public static GridCoverage2D clone(
+      WritableRaster raster,
+      GridGeometry2D gridGeometry2D,
+      GridSampleDimension[] bands,
+      GridCoverage2D referenceRaster,
+      Double noDataValue,
+      boolean keepMetadata,
+      Map propertyMap) {
     ColorModel originalColorModel = referenceRaster.getRenderedImage().getColorModel();
     if (Objects.isNull(gridGeometry2D)) {
       gridGeometry2D = referenceRaster.getGridGeometry();

--- a/common/src/main/java/org/apache/sedona/common/utils/RasterUtils.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/RasterUtils.java
@@ -109,24 +109,6 @@ public class RasterUtils {
     if (keepMetadata) {
       propertyMap = referenceRaster.getProperties();
     }
-    return clone(
-        raster, gridGeometry2D, bands, referenceRaster, noDataValue, keepMetadata, propertyMap);
-  }
-
-  /**
-   * Variant of {@link #clone(WritableRaster, GridGeometry2D, GridSampleDimension[], GridCoverage2D,
-   * Double, boolean)} taking the coverage property map explicitly instead of copying it from the
-   * reference raster, so callers can filter properties (e.g. drop the GC_NODATA no-data sentinel)
-   * while keeping the rest of the metadata.
-   */
-  public static GridCoverage2D clone(
-      WritableRaster raster,
-      GridGeometry2D gridGeometry2D,
-      GridSampleDimension[] bands,
-      GridCoverage2D referenceRaster,
-      Double noDataValue,
-      boolean keepMetadata,
-      Map propertyMap) {
     ColorModel originalColorModel = referenceRaster.getRenderedImage().getColorModel();
     if (Objects.isNull(gridGeometry2D)) {
       gridGeometry2D = referenceRaster.getGridGeometry();
@@ -202,6 +184,26 @@ public class RasterUtils {
       GridCoverage2D referenceRaster,
       Double noDataValue,
       boolean keepMetadata) {
+    Map propertyMap = keepMetadata ? referenceRaster.getProperties() : null;
+    return clone(
+        image, gridGeometry2D, bands, referenceRaster, noDataValue, keepMetadata, propertyMap);
+  }
+
+  /**
+   * Variant of {@link #clone(RenderedImage, GridGeometry2D, GridSampleDimension[], GridCoverage2D,
+   * Double, boolean)} taking the coverage property map explicitly instead of copying it from the
+   * reference raster, so callers can filter properties (e.g. drop the GC_NODATA no-data sentinel,
+   * which {@link GridCoverage2D#getProperty} would otherwise keep reporting) while retaining the
+   * rest of the metadata.
+   */
+  public static GridCoverage2D clone(
+      RenderedImage image,
+      GridGeometry2D gridGeometry2D,
+      GridSampleDimension[] bands,
+      GridCoverage2D referenceRaster,
+      Double noDataValue,
+      boolean keepMetadata,
+      Map propertyMap) {
     int numBand = image.getSampleModel().getNumBands();
     if (Objects.isNull(gridGeometry2D)) {
       gridGeometry2D = referenceRaster.getGridGeometry();
@@ -219,10 +221,6 @@ public class RasterUtils {
     }
     GridCoverage2D[] referenceRasterSources =
         keepMetadata ? referenceRaster.getSources().toArray(new GridCoverage2D[0]) : null;
-    Map propertyMap = null;
-    if (keepMetadata) {
-      propertyMap = referenceRaster.getProperties();
-    }
     CharSequence rasterName = keepMetadata ? referenceRaster.getName() : "genericCoverage";
     return gridCoverageFactory.create(
         rasterName, image, gridGeometry2D, bands, referenceRasterSources, propertyMap);

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterBandEditorsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterBandEditorsTest.java
@@ -22,6 +22,7 @@ import static org.apache.sedona.common.raster.RasterBandEditors.rasterUnion;
 import static org.apache.sedona.common.utils.RasterUtils.flipVerticallyPixelSpace;
 import static org.junit.Assert.*;
 
+import it.geosolutions.jaiext.range.NoDataContainer;
 import java.io.IOException;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
@@ -66,6 +67,41 @@ public class RasterBandEditorsTest extends RasterTestBase {
     String actual = Arrays.toString(grid.getSampleDimensions());
     String expected = "[RenderedSampleDimension[\"PALETTE_INDEX\"]]";
     assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testSetBandNoDataValueWithNullOnSecondBand() throws FactoryException {
+    // The clear must consult the target band's no-data value, not band 1's:
+    // band 1 has none here, which used to short-circuit the removal on band 2.
+    GridCoverage2D raster = RasterConstructors.makeEmptyRaster(2, 20, 20, 0, 0, 8, 8, 0.1, 0.1, 0);
+    GridCoverage2D grid = RasterBandEditors.setBandNoDataValue(raster, 2, 444d);
+    grid = RasterBandEditors.setBandNoDataValue(grid, 2, null);
+    assertNull(RasterBandAccessors.getBandNoDataValue(grid, 2));
+    assertNull(RasterBandAccessors.getBandNoDataValue(grid, 1));
+  }
+
+  @Test
+  public void testSetBandNoDataValueWithNullClearsNoDataProperty()
+      throws IOException, ClassNotFoundException {
+    GridCoverage2D raster =
+        rasterFromGeoTiff(resourceFolder + "raster/raster_with_no_data/test5.tiff");
+    GridCoverage2D grid = RasterBandEditors.setBandNoDataValue(raster, 1, null);
+
+    // The GC_NODATA sentinel must be gone from both the coverage properties and the
+    // rendered image, or serialization and GeoTIFF writers resurrect the cleared value.
+    Map properties = grid.getProperties();
+    assertTrue(properties == null || !properties.containsKey(NoDataContainer.GC_NODATA));
+    assertSame(
+        java.awt.Image.UndefinedProperty,
+        grid.getRenderedImage().getProperty(NoDataContainer.GC_NODATA));
+    assert (Arrays.equals(MapAlgebra.bandAsArray(raster, 1), MapAlgebra.bandAsArray(grid, 1)));
+
+    GridCoverage2D roundTripped = Serde.deserialize(Serde.serialize(grid));
+    assertNull(RasterBandAccessors.getBandNoDataValue(roundTripped, 1));
+    Map roundTrippedProperties = roundTripped.getProperties();
+    assertTrue(
+        roundTrippedProperties == null
+            || !roundTrippedProperties.containsKey(NoDataContainer.GC_NODATA));
   }
 
   @Test

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterBandEditorsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterBandEditorsTest.java
@@ -23,6 +23,7 @@ import static org.apache.sedona.common.utils.RasterUtils.flipVerticallyPixelSpac
 import static org.junit.Assert.*;
 
 import it.geosolutions.jaiext.range.NoDataContainer;
+import java.awt.image.RenderedImage;
 import java.io.IOException;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
@@ -31,12 +32,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import javax.media.jai.operator.TranslateDescriptor;
 import org.apache.sedona.common.Constructors;
 import org.apache.sedona.common.FunctionsGeoTools;
 import org.apache.sedona.common.raster.serde.Serde;
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.operation.TransformException;
+import org.geotools.coverage.CoverageFactoryFinder;
 import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.coverage.grid.GridEnvelope2D;
+import org.geotools.coverage.grid.GridGeometry2D;
+import org.geotools.coverage.util.CoverageUtilities;
 import org.junit.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.io.ParseException;
@@ -88,20 +94,54 @@ public class RasterBandEditorsTest extends RasterTestBase {
     GridCoverage2D grid = RasterBandEditors.setBandNoDataValue(raster, 1, null);
 
     // The GC_NODATA sentinel must be gone from both the coverage properties and the
-    // rendered image, or serialization and GeoTIFF writers resurrect the cleared value.
-    Map properties = grid.getProperties();
-    assertTrue(properties == null || !properties.containsKey(NoDataContainer.GC_NODATA));
+    // rendered image: GridCoverage2D.getProperty falls through to the image, so GeoTools
+    // operations would otherwise keep treating the cleared value as no-data.
+    assertNull(CoverageUtilities.getNoDataProperty(grid));
     assertSame(
         java.awt.Image.UndefinedProperty,
         grid.getRenderedImage().getProperty(NoDataContainer.GC_NODATA));
     assert (Arrays.equals(MapAlgebra.bandAsArray(raster, 1), MapAlgebra.bandAsArray(grid, 1)));
 
+    // Clearing must not mutate the input raster's own metadata.
+    assertNotNull(CoverageUtilities.getNoDataProperty(raster));
+    assertEquals(0.0, RasterBandAccessors.getBandNoDataValue(raster, 1), 0.0001d);
+
     GridCoverage2D roundTripped = Serde.deserialize(Serde.serialize(grid));
     assertNull(RasterBandAccessors.getBandNoDataValue(roundTripped, 1));
-    Map roundTrippedProperties = roundTripped.getProperties();
-    assertTrue(
-        roundTrippedProperties == null
-            || !roundTrippedProperties.containsKey(NoDataContainer.GC_NODATA));
+    assertNull(CoverageUtilities.getNoDataProperty(roundTripped));
+  }
+
+  @Test
+  public void testSetBandNoDataValueWithNullOnTranslatedRaster() throws IOException {
+    // A coverage whose image origin is not (0, 0): clearing must stay on a RenderedImage
+    // path. Copying the pixels instead would both materialize a lazily decoded image and
+    // fail, since BufferedImage rejects a raster with a non-zero minX/minY.
+    GridCoverage2D raster =
+        rasterFromGeoTiff(resourceFolder + "raster/raster_with_no_data/test5.tiff");
+    RenderedImage translatedImage =
+        TranslateDescriptor.create(raster.getRenderedImage(), 5f, 7f, null, null);
+    GridCoverage2D translated =
+        CoverageFactoryFinder.getGridCoverageFactory(null)
+            .create(
+                "translated",
+                translatedImage,
+                new GridGeometry2D(
+                    new GridEnvelope2D(
+                        translatedImage.getMinX(),
+                        translatedImage.getMinY(),
+                        translatedImage.getWidth(),
+                        translatedImage.getHeight()),
+                    raster.getGridGeometry().getGridToCRS(),
+                    raster.getCoordinateReferenceSystem()),
+                raster.getSampleDimensions(),
+                null,
+                null);
+
+    GridCoverage2D grid = RasterBandEditors.setBandNoDataValue(translated, 1, null);
+    assertNull(RasterBandAccessors.getBandNoDataValue(grid, 1));
+    assertNull(CoverageUtilities.getNoDataProperty(grid));
+    assertEquals(5, grid.getRenderedImage().getMinX());
+    assertEquals(7, grid.getRenderedImage().getMinY());
   }
 
   @Test

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterBandEditorsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterBandEditorsTest.java
@@ -144,6 +144,76 @@ public class RasterBandEditorsTest extends RasterTestBase {
     assertEquals(7, grid.getRenderedImage().getMinY());
   }
 
+  /**
+   * A two-band raster whose bands both use no-data 0, round-tripped through GeoTIFF so that the
+   * coverage carries the image-level GC_NODATA sentinel a real GeoTIFF has.
+   */
+  private GridCoverage2D twoBandRasterWithNoDataZero() throws FactoryException, IOException {
+    GridCoverage2D raster = RasterConstructors.makeEmptyRaster(2, 20, 20, 0, 0, 1, -1, 0, 0, 4326);
+    raster = RasterBandEditors.setBandNoDataValue(raster, 1, 0.0);
+    raster = RasterBandEditors.setBandNoDataValue(raster, 2, 0.0);
+    return RasterConstructors.fromGeoTiff(RasterOutputs.asGeoTiff(raster));
+  }
+
+  /** Runs {@code rast[0] + 1} over band 1 and returns the top-left pixel. */
+  private static double band1PlusOne(GridCoverage2D raster) {
+    GridCoverage2D result = MapAlgebra.mapAlgebra(raster, "d", "out = rast[0] + 1;");
+    return result.getRenderedImage().getData().getSampleDouble(0, 0, 0);
+  }
+
+  @Test
+  public void testSetBandNoDataValueWithNullKeepsNoDataOnOtherBands()
+      throws FactoryException, IOException {
+    GridCoverage2D raster = twoBandRasterWithNoDataZero();
+    assertEquals(0.0, RasterBandAccessors.getBandNoDataValue(raster, 1), 0.0001d);
+    assertEquals(0.0, RasterBandAccessors.getBandNoDataValue(raster, 2), 0.0001d);
+    assertTrue(Double.isNaN(band1PlusOne(raster)));
+
+    // Clearing band 2 must leave band 1 alone. GC_NODATA is one sentinel for the whole
+    // coverage, so dropping it here would also stop map algebra from treating band 1's
+    // zeros as no-data.
+    GridCoverage2D clearedSecond = RasterBandEditors.setBandNoDataValue(raster, 2, null);
+    assertNull(RasterBandAccessors.getBandNoDataValue(clearedSecond, 2));
+    assertEquals(0.0, RasterBandAccessors.getBandNoDataValue(clearedSecond, 1), 0.0001d);
+    assertNotNull(CoverageUtilities.getNoDataProperty(clearedSecond));
+    assertNotSame(
+        java.awt.Image.UndefinedProperty,
+        clearedSecond.getRenderedImage().getProperty(NoDataContainer.GC_NODATA));
+    assertTrue(Double.isNaN(band1PlusOne(clearedSecond)));
+
+    // The same holds the other way round: clearing band 1 leaves band 2's no-data value.
+    GridCoverage2D clearedFirst = RasterBandEditors.setBandNoDataValue(raster, 1, null);
+    assertNull(RasterBandAccessors.getBandNoDataValue(clearedFirst, 1));
+    assertEquals(0.0, RasterBandAccessors.getBandNoDataValue(clearedFirst, 2), 0.0001d);
+    assertNotNull(CoverageUtilities.getNoDataProperty(clearedFirst));
+
+    // Clearing must not mutate the input raster.
+    assertEquals(0.0, RasterBandAccessors.getBandNoDataValue(raster, 2), 0.0001d);
+  }
+
+  @Test
+  public void testSetBandNoDataValueWithNullOnEveryBandClearsNoDataProperty()
+      throws FactoryException, IOException {
+    GridCoverage2D raster = twoBandRasterWithNoDataZero();
+
+    GridCoverage2D cleared = RasterBandEditors.setBandNoDataValue(raster, 2, null);
+    cleared = RasterBandEditors.setBandNoDataValue(cleared, 1, null);
+
+    // Once no band declares a no-data value the sentinel goes, and map algebra reads the
+    // zeros as ordinary data.
+    assertNull(RasterBandAccessors.getBandNoDataValue(cleared, 1));
+    assertNull(RasterBandAccessors.getBandNoDataValue(cleared, 2));
+    assertNull(CoverageUtilities.getNoDataProperty(cleared));
+    assertSame(
+        java.awt.Image.UndefinedProperty,
+        cleared.getRenderedImage().getProperty(NoDataContainer.GC_NODATA));
+    assertEquals(1.0, band1PlusOne(cleared), 0.0001d);
+
+    GridCoverage2D roundTripped = RasterConstructors.fromGeoTiff(RasterOutputs.asGeoTiff(cleared));
+    assertNull(RasterBandAccessors.getBandNoDataValue(roundTripped, 1));
+    assertNull(RasterBandAccessors.getBandNoDataValue(roundTripped, 2));
+  }
+
   @Test
   public void testGetSummaryStats() throws IOException {
     GridCoverage2D raster =

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterOutputTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterOutputTest.java
@@ -91,6 +91,36 @@ public class RasterOutputTest extends RasterTestBase {
   }
 
   @Test
+  public void testAsGeoTiffRejectsBandsWithDifferentNoDataValues()
+      throws FactoryException, IOException {
+    GridCoverage2D raster = RasterConstructors.makeEmptyRaster(2, 20, 20, 0, 0, 1, -1, 0, 0, 4326);
+
+    // Only one band has a no-data value. GeoTIFF stores one value for the whole file, so
+    // band 2 would silently read back with band 1's value.
+    GridCoverage2D oneBandSet = RasterBandEditors.setBandNoDataValue(raster, 1, 0.0);
+    IllegalArgumentException oneSet =
+        assertThrows(IllegalArgumentException.class, () -> RasterOutputs.asGeoTiff(oneBandSet));
+    assertTrue(oneSet.getMessage().contains("different no-data values"));
+
+    // Both bands have a no-data value, but they disagree.
+    GridCoverage2D bothSet = RasterBandEditors.setBandNoDataValue(oneBandSet, 2, 5.0);
+    IllegalArgumentException differing =
+        assertThrows(IllegalArgumentException.class, () -> RasterOutputs.asGeoTiff(bothSet));
+    assertTrue(differing.getMessage().contains("different no-data values"));
+
+    // Agreeing bands, and bands with no no-data value at all, both write fine.
+    GridCoverage2D agreeing = RasterBandEditors.setBandNoDataValue(oneBandSet, 2, 0.0);
+    assertEquals(
+        0.0,
+        RasterBandAccessors.getBandNoDataValue(
+            RasterConstructors.fromGeoTiff(RasterOutputs.asGeoTiff(agreeing)), 2),
+        0.0001d);
+    assertNull(
+        RasterBandAccessors.getBandNoDataValue(
+            RasterConstructors.fromGeoTiff(RasterOutputs.asGeoTiff(raster)), 1));
+  }
+
+  @Test
   public void testWriteToDiskFile() throws IOException {
     new File(System.getProperty("user.dir") + "/target/estToGeoTiffFunction/").mkdirs();
     GridCoverage2D rasterOg = rasterFromGeoTiff(resourceFolder + "raster/test1.tiff");

--- a/docs/api/sql/Raster-Operators/RS_SetBandNoDataValue.md
+++ b/docs/api/sql/Raster-Operators/RS_SetBandNoDataValue.md
@@ -30,6 +30,8 @@ Since `v1.5.1`, this function supports the ability to replace the current no-dat
 
     To use this for no-data replacement, the input raster must first set its no-data value, which can then be selectively replaced via this function.
 
+    `noDataValue` must be non-null when using the `replace` variant; to remove a no data value, use the 2 or 3 argument form.
+
 Format:
 
 ```

--- a/docs/api/sql/Raster-Operators/RS_SetBandNoDataValue.md
+++ b/docs/api/sql/Raster-Operators/RS_SetBandNoDataValue.md
@@ -21,6 +21,8 @@
 
 Introduction: This sets the no data value for a specified band in the raster. If the band index is not provided, band 1 is assumed by default. Passing a `null` value for `noDataValue` will remove the no data value and that will ensure all pixels are included in functions rather than excluded as no data.
 
+No-data values are tracked per band, so clearing one band leaves the other bands' no-data values in place and functions that read them keep excluding those pixels.
+
 Since `v1.5.1`, this function supports the ability to replace the current no-data value with the new `noDataValue`.
 
 !!!Note

--- a/docs/api/sql/Raster-Operators/RS_SetBandNoDataValue.md
+++ b/docs/api/sql/Raster-Operators/RS_SetBandNoDataValue.md
@@ -23,6 +23,9 @@ Introduction: This sets the no data value for a specified band in the raster. If
 
 No-data values are tracked per band, so clearing one band leaves the other bands' no-data values in place and functions that read them keep excluding those pixels.
 
+!!!Note
+    A raster whose bands disagree about their no-data value cannot be written to GeoTiff, which stores a single no-data value per file. [RS_AsGeoTiff](../Raster-Output/RS_AsGeoTiff.md) rejects such a raster rather than writing one band's value for all of them.
+
 Since `v1.5.1`, this function supports the ability to replace the current no-data value with the new `noDataValue`.
 
 !!!Note

--- a/docs/api/sql/Raster-Output/RS_AsGeoTiff.md
+++ b/docs/api/sql/Raster-Output/RS_AsGeoTiff.md
@@ -25,6 +25,9 @@ Possible values for `compressionType`: `None`, `PackBits`, `Deflate`, `Huffman`,
 
 Possible values for `imageQuality`: any decimal number between 0 and 1. 0 means the lowest quality and 1 means the highest quality.
 
+!!!Note
+    GeoTiff stores one no-data value for the whole file, so every band of the input raster must agree on its no-data value. An `IllegalArgumentException` is thrown when the bands differ, including when only some of them have a no-data value. Use [RS_SetBandNoDataValue](../Raster-Operators/RS_SetBandNoDataValue.md) to give every band the same no-data value, or to clear it on every band, before writing.
+
 Format:
 
 `RS_AsGeoTiff(raster: Raster)`

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/InferredExpression.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/InferredExpression.scala
@@ -468,4 +468,45 @@ object InferrableFunction {
       })
   }
 
+  /**
+   * A variant of ternary inferred expression which allows the third argument to be null. This is
+   * not an overload of [[allowRightNull]] since overloading it breaks eta-expansion of the
+   * overloaded methods passed to it at existing call sites.
+   * @param f
+   *   Function to be wrapped as a catalyst expression.
+   * @param typeTag
+   *   Type tag of the function.
+   * @tparam R
+   *   Return type of the function.
+   * @tparam A1
+   *   Type of the first argument.
+   * @tparam A2
+   *   Type of the second argument.
+   * @tparam A3
+   *   Type of the third argument.
+   * @return
+   *   InferrableFunction.
+   */
+  def allowRightNull3[R, A1, A2, A3](f: (A1, A2, A3) => R)(implicit
+      typeTag: TypeTag[(A1, A2, A3) => R]): InferrableFunction = {
+    apply(
+      typeTag,
+      extractors => {
+        val func = f.asInstanceOf[(Any, Any, Any) => Any]
+        val extractor1 = extractors(0)
+        val extractor2 = extractors(1)
+        val extractor3 = extractors(2)
+        input => {
+          val arg1 = extractor1(input)
+          val arg2 = extractor2(input)
+          val arg3 = extractor3(input)
+          if (arg1 != null && arg2 != null) {
+            func(arg1, arg2, arg3)
+          } else {
+            null
+          }
+        }
+      })
+  }
+
 }

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterBandEditors.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterBandEditors.scala
@@ -22,13 +22,15 @@ import org.apache.sedona.common.raster.RasterBandEditors
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.sedona_sql.expressions.InferrableFunctionConverter._
 import org.apache.spark.sql.sedona_sql.expressions.InferrableRasterTypes._
-import org.apache.spark.sql.sedona_sql.expressions.InferredExpression
+import org.apache.spark.sql.sedona_sql.expressions.{InferrableFunction, InferredExpression}
 
 private[apache] case class RS_SetBandNoDataValue(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction4(RasterBandEditors.setBandNoDataValue),
-      inferrableFunction3(RasterBandEditors.setBandNoDataValue),
-      inferrableFunction2(RasterBandEditors.setBandNoDataValue)) {
+      // A null noDataValue removes the band's no-data value, so let it through instead of
+      // null-propagating the whole expression.
+      InferrableFunction.allowRightNull3(RasterBandEditors.setBandNoDataValue),
+      InferrableFunction.allowRightNull(RasterBandEditors.setBandNoDataValue)) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }

--- a/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
@@ -895,6 +895,38 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
       assertNull(sparkSession.sql("SELECT RS_SetBandNoDataValue(null, -999)").first().get(0))
     }
 
+    it("Passed RS_SetBandNoDataValue clearing a band other than band 1") {
+      // The clear consults the target band's no-data value; band 1 having none
+      // must not short-circuit the removal on band 2.
+      var df = sparkSession.sql(
+        "SELECT RS_MakeEmptyRaster(2, 20, 20, 0, 0, 8, 8, 0.1, 0.1, 0) AS raster")
+      df = df.selectExpr("RS_SetBandNoDataValue(raster, 2, 444) AS raster")
+      assertEquals(
+        444.0,
+        df.selectExpr("RS_BandNoDataValue(raster, 2)").first().getDouble(0),
+        0.001d)
+      val cleared = df.selectExpr("RS_SetBandNoDataValue(raster, 2, null) AS raster")
+      assertNotNull(cleared.first().get(0))
+      assertNull(cleared.selectExpr("RS_BandNoDataValue(raster, 2)").first().get(0))
+      assertNull(cleared.selectExpr("RS_BandNoDataValue(raster, 1)").first().get(0))
+    }
+
+    it("Passed RS_SetBandNoDataValue null clear survives a GeoTiff round trip") {
+      // The image-level GC_NODATA property must be cleared along with the band
+      // metadata, or writing and re-reading the raster resurrects the old value.
+      val df = sparkSession.read
+        .format("binaryFile")
+        .load(resourceFolder + "raster/raster_with_no_data/test5.tiff")
+      val cleared =
+        df.selectExpr("RS_SetBandNoDataValue(RS_FromGeoTiff(content), null) AS raster")
+      val actual = cleared
+        .selectExpr("RS_AsGeoTiff(raster) AS bytes")
+        .selectExpr("RS_BandNoDataValue(RS_FromGeoTiff(bytes))")
+        .first()
+        .get(0)
+      assertNull(actual)
+    }
+
     it("Passed RS_SetBandNoDataValue with empty raster") {
       val df =
         sparkSession.sql("Select RS_MakeEmptyRaster(1, 20, 20, 2, 22, 2, 3, 1, 1, 0) as raster")

--- a/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/rasteralgebraTest.scala
@@ -879,9 +879,20 @@ class rasteralgebraTest extends TestBaseScala with BeforeAndAfter with GivenWhen
       val expected = -999
       assertEquals(expected, actual, 0.001d)
 
-      val actualNull =
-        df.selectExpr("RS_BandNoDataValue(RS_SetBandNoDataValue(raster, 1, null))").first().get(0)
-      assertNull(actualNull)
+      // Passing a null noDataValue removes the no-data value instead of returning a null raster
+      val cleared = df
+        .selectExpr(
+          "RS_SetBandNoDataValue(RS_SetBandNoDataValue(raster, 1, -999), 1, null) as raster")
+      assertNotNull(cleared.first().get(0))
+      assertNull(cleared.selectExpr("RS_BandNoDataValue(raster)").first().get(0))
+
+      val clearedNoBandIndex = df
+        .selectExpr("RS_SetBandNoDataValue(RS_SetBandNoDataValue(raster, -999), null) as raster")
+      assertNotNull(clearedNoBandIndex.first().get(0))
+      assertNull(clearedNoBandIndex.selectExpr("RS_BandNoDataValue(raster)").first().get(0))
+
+      // A null raster still yields a null result
+      assertNull(sparkSession.sql("SELECT RS_SetBandNoDataValue(null, -999)").first().get(0))
     }
 
     it("Passed RS_SetBandNoDataValue with empty raster") {


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #3324

> **Stacked on #3312.** #3324 is a follow-up to that PR and only reproduces with it applied, so this branch starts from `2b06236` (its current head) and adds two commits on top. The first three commits in the diff belong to #3312. Please merge #3312 first and I will rebase this onto `master`, or fold this into #3312 if that is easier to review.

## What changes were proposed in this PR?

Two independent commits, so the second can be dropped without losing the first.

### 1. Keep other bands' no-data value when clearing one band (`309b16a`)

No-data values are tracked per band on the sample dimensions. `GC_NODATA` is a single sentinel for the whole coverage, carried both by the coverage properties and by the rendered image. The clear path dropped that sentinel unconditionally, so clearing one band also stopped GeoTools operations that read the sentinel from honouring the bands that still declared a no-data value. Jiffle reads it, which is how clearing band 2 changed band 1's `out = rast[0] + 1;` from `NaN` to `1.0`.

The fix drops the sentinel only once no band declares a no-data value at all. Reproduced before the change and verified after, on the exact steps in the issue:

- Loaded from GeoTIFF: band 1 `0.0`, band 2 `0.0`, `rast[0] + 1` gives `NaN`.
- After clearing band 2, before this PR: band 1 `0.0`, band 2 `null`, `rast[0] + 1` gives `1.0`. This is the bug.
- After clearing band 2, with this PR: band 1 `0.0`, band 2 `null`, `rast[0] + 1` gives `NaN`.
- After clearing band 1 as well: band 1 `null`, band 2 `null`, `rast[0] + 1` gives `1.0`.

### 2. Reject mixed per-band no-data values when writing GeoTiff (`9e5525c`)

This is the second half of the issue: a `(0, null)` raster came back from a GeoTIFF round trip as `(0, 0)`. GDAL_NODATA is one value for the whole file, so that state cannot be written faithfully. `RS_AsGeoTiff` now throws `IllegalArgumentException` on it, rather than resurrecting a no-data value on a band that had it cleared.

**This commit needs a maintainer decision, because its blast radius is wider than the clear path.** `RasterUtils.copyRasterAndAppendBand` sets the appended band's no-data value and leaves the existing bands' sample dimensions alone, so `RS_AddBand` and `RS_Union` routinely produce rasters whose bands disagree. Writing one of those to GeoTIFF silently rewrites the other bands' no-data today; with this commit it fails loudly. That follows the issue's preference for rejecting unsupported mixed states, but if it reads as too strong for `RS_AsGeoTiff`, dropping `9e5525c` leaves commit 1 intact and I will open a separate issue for the writer.

## How was this patch tested?

New tests in `common`:

- `RasterBandEditorsTest.testSetBandNoDataValueWithNullKeepsNoDataOnOtherBands` covers the issue's reproducer. It checks both bands and map algebra after clearing either one, before serialization, and that the input raster is not mutated.
- `RasterBandEditorsTest.testSetBandNoDataValueWithNullOnEveryBandClearsNoDataProperty` covers the case where every band is cleared: the sentinel is dropped from the coverage and the image, map algebra reads the zeros as ordinary data, and the state survives a GeoTIFF round trip.
- `RasterOutputTest.testAsGeoTiffRejectsBandsWithDifferentNoDataValues` covers "only one band set" and "both set but different". Rasters whose bands agree, and rasters with no no-data value at all, still round-trip.

`mvn -pl common test` was run before and after the change on Windows with JDK 17. The same 13 tests fail both times: `RasterBandEditorsTest.testClip`, 5 `RasterEditorsTest.testResample*`, and 7 `RasterOutputTest.testAsMatrix*`. They fail identically on unmodified `2b06236`, so they are pre-existing on this platform and unrelated to this change. Everything else passes, including the three new tests.

I could not run `spark/common` locally. It fails to compile on the generated OSM PBF protobuf sources (`package proto4 does not exist`) before reaching any raster code, so those suites are left to CI.

One note for whoever reviews the tests. `MapAlgebra` caches a compiled Jiffle runtime per script text in a `ThreadLocal`, so I checked whether a cached runtime could mask this regression by carrying a previous raster's no-data handling into a later call with the same script. It does not: `setSourceImage` re-reads the property. The tests therefore use a plain shared script.

## Did this PR include necessary documentation updates?

- Yes, I have updated the documentation. `RS_SetBandNoDataValue` now states that no-data is tracked per band, and `RS_AsGeoTiff` documents the single-value-per-file constraint and the new rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6hpqAnXfeaWRLkL1VQDMd
