### PR TITLE
[GH-3255] Clip line segments to the raster in pixel space

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/raster/Rasterization.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/Rasterization.java
@@ -153,7 +153,7 @@ public class Rasterization {
       case "LineString":
       case "MultiLineString":
       case "LinearRing":
-        rasterizeLineString(geom, params, value, geomExtent);
+        rasterizeLineString(geom, params, value);
         break;
       default:
         rasterizePolygon(geom, params, geomExtent, value, allTouched);
@@ -216,32 +216,50 @@ public class Rasterization {
     }
   }
 
-  private static void rasterizeLineString(
-      Geometry geom, RasterizationParams params, double value, ReferencedEnvelope geomExtent) {
+  private static void rasterizeLineString(Geometry geom, RasterizationParams params, double value) {
+    int width = params.writableRaster.getWidth();
+    int height = params.writableRaster.getHeight();
+    double[] clipped = new double[4];
+
     for (int i = 0; i < geom.getNumGeometries(); i++) {
       LineString line = (LineString) geom.getGeometryN(i);
       Coordinate[] coords = line.getCoordinates();
 
       for (int j = 0; j < coords.length - 1; j++) {
-        // Extract start and end points for the segment
-        LineSegment clippedSegment =
-            clipSegmentToRasterBounds(coords[j], coords[j + 1], geomExtent);
+        // Clip in pixel space, where the window edges are the integers 0, width and height. In
+        // world space the edges are grid lines that only round-trip approximately, and an
+        // interpolated endpoint landing a rounding step off a grid line selects the wrong cell.
+        double x0 = (coords[j].x - params.upperLeftX) / params.scaleX;
+        double y0 = (coords[j].y - params.upperLeftY) / params.scaleY;
+        double x1 = (coords[j + 1].x - params.upperLeftX) / params.scaleX;
+        double y1 = (coords[j + 1].y - params.upperLeftY) / params.scaleY;
 
-        Coordinate start;
-        Coordinate end;
-        if (clippedSegment != null) {
-          start = new Coordinate(clippedSegment.p0.x, clippedSegment.p0.y);
-          end = new Coordinate(clippedSegment.p1.x, clippedSegment.p1.y);
-        } else {
-          continue; // Skip case where segment is completely outside geomExtent
+        if (x0 == x1 && y0 == y1) {
+          // A segment that was degenerate to begin with still marks the cell holding it. This is
+          // distinct from a nondegenerate segment that clipping collapses to a tangent point,
+          // which the clipper rejects below.
+          if (x0 >= 0 && x0 <= width && y0 >= 0 && y0 <= height) {
+            traverseSegment(params, x0, y0, x1, y1, value);
+          }
+          continue;
         }
 
-        double x0 = (start.x - params.upperLeftX) / params.scaleX;
-        double y0 = (start.y - params.upperLeftY) / params.scaleY;
-        double x1 = (end.x - params.upperLeftX) / params.scaleX;
-        double y1 = (end.y - params.upperLeftY) / params.scaleY;
+        // Order the endpoints before clipping, so the cells burned cannot depend on which vertex
+        // the line visits first. The two directions reach a clip edge at complementary parameters
+        // that are equal in exact arithmetic but round apart as doubles, and interpolating with
+        // them lands a coordinate on either side of an exact grid corner.
+        if (x1 < x0 || (x1 == x0 && y1 < y0)) {
+          double swap = x0;
+          x0 = x1;
+          x1 = swap;
+          swap = y0;
+          y0 = y1;
+          y1 = swap;
+        }
 
-        traverseSegment(params, x0, y0, x1, y1, value);
+        if (clipSegmentToRaster(x0, y0, x1, y1, width, height, clipped)) {
+          traverseSegment(params, clipped[0], clipped[1], clipped[2], clipped[3], value);
+        }
       }
     }
   }
@@ -335,77 +353,161 @@ public class Rasterization {
     }
   }
 
-  private static LineSegment clipSegmentToRasterBounds(
-      Coordinate p1, Coordinate p2, ReferencedEnvelope geomExtent) {
-    double minX = geomExtent.getMinX();
-    double maxX = geomExtent.getMaxX();
-    double minY = geomExtent.getMinY();
-    double maxY = geomExtent.getMaxY();
+  private static final int AXIS_NONE = -1;
+  private static final int AXIS_X = 0;
+  private static final int AXIS_Y = 1;
 
-    double x1 = p1.x, y1 = p1.y;
-    double x2 = p2.x, y2 = p2.y;
+  /**
+   * Clips a nondegenerate pixel-space segment to the raster window [0, width] x [0, height] and
+   * writes the result into {@code out} as {x0, y0, x1, y1}.
+   *
+   * <p>Returns false only when the segment and the window share no positive-length piece, which
+   * covers a disjoint segment, one running parallel to and outside an edge, and one that meets the
+   * window at a single point such as a corner. A segment that crosses the window is kept whether or
+   * not either original endpoint is inside it.
+   *
+   * <p>Both ends come from the same pair of edge crossings, so reversing the input reverses the
+   * clipped segment and nothing else.
+   */
+  private static boolean clipSegmentToRaster(
+      double x0, double y0, double x1, double y1, int width, int height, double[] out) {
 
-    boolean p1Inside = isInsideBounds(x1, y1, minX, maxX, minY, maxY);
-    boolean p2Inside = isInsideBounds(x2, y2, minX, maxX, minY, maxY);
+    // The parameters at which the segment enters and leaves the window, and which edge produced
+    // each. The clipped coordinate on that edge is the edge value exactly; only the other
+    // coordinate is interpolated, and only it can round onto a grid line.
+    double tEnter = 0.0;
+    double tExit = 1.0;
+    int enterAxis = AXIS_NONE;
+    int exitAxis = AXIS_NONE;
+    double enterEdge = 0.0;
+    double exitEdge = 0.0;
 
-    if (p1Inside && p2Inside) {
-      // Both points inside: no clipping needed
-      return new LineSegment(p1, p2);
-    }
+    for (int axis = AXIS_X; axis <= AXIS_Y; axis++) {
+      double from = axis == AXIS_X ? x0 : y0;
+      double to = axis == AXIS_X ? x1 : y1;
+      double far = axis == AXIS_X ? width : height;
 
-    if (!p1Inside && !p2Inside) {
-      // Both points outside: no clipping needed
-      return null;
-    }
-
-    double dx = x2 - x1;
-    double dy = y2 - y1;
-
-    // Clip using parametric line equation
-    double[] tValues = {0, 1}; // Stores valid segment proportions
-
-    // Clip against minX and maxX
-    if (dx != 0) {
-      double tMin = (minX - x1) / dx;
-      double tMax = (maxX - x1) / dx;
-      if (dx < 0) {
-        double temp = tMin;
-        tMin = tMax;
-        tMax = temp;
+      if (from == to) {
+        // Parallel to this axis' edges: either wholly within the band or wholly outside it.
+        if (from < 0.0 || from > far) {
+          return false;
+        }
+        continue;
       }
-      tValues[0] = Math.max(tValues[0], tMin);
-      tValues[1] = Math.min(tValues[1], tMax);
-    }
 
-    // Clip against minY and maxY
-    if (dy != 0) {
-      double tMin = (minY - y1) / dy;
-      double tMax = (maxY - y1) / dy;
-      if (dy < 0) {
-        double temp = tMin;
-        tMin = tMax;
-        tMax = temp;
+      // (edge - from) / (to - from), with the difference halved when it would otherwise overflow
+      // to infinity for two large opposite-sign endpoints. Halving is exact for normal doubles, so
+      // the parameters are the same ones the direct form would produce.
+      double delta = to - from;
+      double tAtZero;
+      double tAtFar;
+      if (Double.isInfinite(delta)) {
+        double halfDelta = to * 0.5 - from * 0.5;
+        tAtZero = -(from * 0.5) / halfDelta;
+        tAtFar = (far * 0.5 - from * 0.5) / halfDelta;
+      } else {
+        tAtZero = -from / delta;
+        tAtFar = (far - from) / delta;
       }
-      tValues[0] = Math.max(tValues[0], tMin);
-      tValues[1] = Math.min(tValues[1], tMax);
+
+      boolean increasing = to > from;
+      double tNear = increasing ? tAtZero : tAtFar;
+      double tFarther = increasing ? tAtFar : tAtZero;
+      double edgeNear = increasing ? 0.0 : far;
+      double edgeFarther = increasing ? far : 0.0;
+
+      if (tNear > tEnter) {
+        tEnter = tNear;
+        enterAxis = axis;
+        enterEdge = edgeNear;
+      }
+      if (tFarther < tExit) {
+        tExit = tFarther;
+        exitAxis = axis;
+        exitEdge = edgeFarther;
+      }
     }
 
-    // If tValues are invalid (segment is outside), return null
-    if (tValues[0] > tValues[1]) {
-      return null; // No valid clipped segment
+    // Negated so a NaN parameter lands here rather than propagating into the traversal.
+    if (!(tEnter <= tExit)) {
+      return false;
     }
 
-    // Compute new clipped endpoints
-    Coordinate newP1 = new Coordinate(x1 + tValues[0] * dx, y1 + tValues[0] * dy);
-    Coordinate newP2 = new Coordinate(x1 + tValues[1] * dx, y1 + tValues[1] * dy);
+    writeClippedEndpoint(out, 0, enterAxis, enterEdge, tEnter, x0, y0, x1, y1);
+    writeClippedEndpoint(out, 2, exitAxis, exitEdge, tExit, x0, y0, x1, y1);
 
-    return new LineSegment(newP1, newP2);
+    // Whether the piece inside the window has length is read from the clipped endpoints rather
+    // than from the parameters. The parameters answer it for a single-point touch such as a
+    // corner, but they collapse together for a crossing whose endpoints are far enough apart that
+    // the whole window falls inside one rounding step of the segment.
+    return out[0] != out[2] || out[1] != out[3];
   }
 
-  // Helper function to check if a point is inside the bounding box
-  private static boolean isInsideBounds(
-      double x, double y, double minX, double maxX, double minY, double maxY) {
-    return x >= minX && x <= maxX && y >= minY && y <= maxY;
+  private static void writeClippedEndpoint(
+      double[] out,
+      int offset,
+      int axis,
+      double edge,
+      double t,
+      double x0,
+      double y0,
+      double x1,
+      double y1) {
+    if (axis == AXIS_NONE) {
+      out[offset] = t == 0.0 ? x0 : x1;
+      out[offset + 1] = t == 0.0 ? y0 : y1;
+    } else if (axis == AXIS_X) {
+      out[offset] = edge;
+      out[offset + 1] = preserveGridLineSide(interpolate(y0, y1, t), x0, y0, x1, y1, edge, true);
+    } else {
+      out[offset + 1] = edge;
+      out[offset] = preserveGridLineSide(interpolate(x0, x1, t), x0, y0, x1, y1, edge, false);
+    }
+  }
+
+  /**
+   * Interpolates in the form that stays between the endpoints, so a segment spanning the full
+   * double range does not overflow on the way. It also reproduces the endpoints exactly at t = 0
+   * and t = 1.
+   */
+  private static double interpolate(double from, double to, double t) {
+    return (1.0 - t) * from + t * to;
+  }
+
+  /**
+   * Restores which side of a pixel grid line an interpolated clip coordinate lies on.
+   *
+   * <p>The coordinate is rounded to a double, so a true value within half a rounding step of a grid
+   * line lands exactly on it. {@link #interiorCell} then reads the segment as starting on the line
+   * and selects the neighbouring cell. The robust orientation predicate resolves the true side
+   * exactly, and one representable step off the line records it. Only a coordinate that landed on a
+   * grid line consults the predicate, so ordinary finite segments stay in plain doubles.
+   */
+  private static double preserveGridLineSide(
+      double interpolated,
+      double x0,
+      double y0,
+      double x1,
+      double y1,
+      double edge,
+      boolean edgeIsX) {
+    if (!Double.isFinite(interpolated) || interpolated != Math.floor(interpolated)) {
+      return interpolated;
+    }
+    double qx = edgeIsX ? edge : interpolated;
+    double qy = edgeIsX ? interpolated : edge;
+    int orientation = CGAlgorithmsDD.orientationIndex(x0, y0, x1, y1, qx, qy);
+    if (orientation == 0) {
+      // The segment runs exactly through the lattice point, so the coordinate belongs on the line.
+      return interpolated;
+    }
+    // Solving the clip for the interpolated coordinate leaves the cross product the predicate
+    // returns, divided by the delta along the clipped axis.
+    int side =
+        edgeIsX
+            ? -orientation * Integer.signum(Double.compare(x1, x0))
+            : orientation * Integer.signum(Double.compare(y1, y0));
+    return side > 0 ? Math.nextUp(interpolated) : Math.nextDown(interpolated);
   }
 
   static ReferencedEnvelope rasterizeGeomExtent(
@@ -695,7 +797,7 @@ public class Rasterization {
       int numPoints = coords.length;
 
       if (allTouched) {
-        rasterizeLineString(ring, params, value, geomExtent);
+        rasterizeLineString(ring, params, value);
       }
 
       for (int i = 0; i < numPoints - 1; i++) {

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterizationTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterizationTest.java
@@ -26,6 +26,7 @@ import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.junit.Assert;
 import org.junit.Test;
+import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
@@ -506,6 +507,174 @@ public class RasterizationTest extends RasterTestBase {
       0, 0, 0, 0, 0, 0,
     };
     Assert.assertArrayEquals(expected, band, 0d);
+  }
+
+  @Test
+  public void testLineCrossingRasterWithBothEndpointsOutside()
+      throws ParseException, FactoryException {
+    // A segment that crosses the raster must be rasterized even though neither endpoint is inside
+    // it. Clipping used to treat "both endpoints outside" as "no intersection" and drop it.
+    GridCoverage2D raster = unitGrid6x6();
+
+    double[] row3 = new double[36];
+    java.util.Arrays.fill(row3, 18, 24, 1d);
+    assertLineBurns(raster, "LINESTRING (-1 2.5, 7 2.5)", row3);
+    assertLineBurns(raster, "LINESTRING (7 2.5, -1 2.5)", row3);
+
+    double[] column2 = new double[36];
+    for (int row = 0; row < 6; row++) {
+      column2[row * 6 + 2] = 1d;
+    }
+    assertLineBurns(raster, "LINESTRING (2.5 -1, 2.5 7)", column2);
+    assertLineBurns(raster, "LINESTRING (2.5 7, 2.5 -1)", column2);
+
+    double[] antiDiagonal = new double[36];
+    for (int row = 0; row < 6; row++) {
+      antiDiagonal[row * 6 + (5 - row)] = 1d;
+    }
+    assertLineBurns(raster, "LINESTRING (-1 -1, 7 7)", antiDiagonal);
+    assertLineBurns(raster, "LINESTRING (7 7, -1 -1)", antiDiagonal);
+  }
+
+  @Test
+  public void testClippedEndpointKeepsGridLineSide() throws ParseException, FactoryException {
+    // Inside the raster this line is strictly above y = 3, so it belongs to row 2. Interpolating
+    // the clipped endpoint at x = 0 rounds it onto y = 3 exactly, which used to move the burn to
+    // row 3.
+    GridCoverage2D raster = unitGrid6x6();
+    double[] expected = new double[36];
+    expected[2 * 6] = 1d;
+    assertLineBurns(raster, "LINESTRING (-1 3.0000000000000004, 1 3.0)", expected);
+    assertLineBurns(raster, "LINESTRING (1 3.0, -1 3.0000000000000004)", expected);
+
+    // The mirrored case below the grid line stays in row 3.
+    double[] below = new double[36];
+    below[3 * 6] = 1d;
+    assertLineBurns(raster, "LINESTRING (-1 2.9999999999999996, 1 3.0)", below);
+    assertLineBurns(raster, "LINESTRING (1 3.0, -1 2.9999999999999996)", below);
+
+    // The same rounding on the other axis: strictly left of x = 3 inside the raster, so column 2.
+    double[] leftOfColumn3 = new double[36];
+    leftOfColumn3[5 * 6 + 2] = 1d;
+    assertLineBurns(raster, "LINESTRING (2.9999999999999996 -1, 3.0 1)", leftOfColumn3);
+    assertLineBurns(raster, "LINESTRING (3.0 1, 2.9999999999999996 -1)", leftOfColumn3);
+  }
+
+  @Test
+  public void testLineTouchingRasterAtASinglePointBurnsNothing()
+      throws ParseException, FactoryException {
+    // The segment meets the window only at the corner (6, 6) in world space, which is a single
+    // point and therefore has no length inside the raster.
+    GridCoverage2D raster = unitGrid6x6();
+    assertLineBurns(raster, "LINESTRING (5 7, 7 5)", new double[36]);
+    assertLineBurns(raster, "LINESTRING (7 5, 5 7)", new double[36]);
+  }
+
+  @Test
+  public void testLineWithExtremeCoordinatesCrossesTheRaster()
+      throws ParseException, FactoryException {
+    // Endpoints far enough apart that their difference overflows to infinity. The clip must still
+    // produce the crossing rather than a NaN-driven omission or a partial streak.
+    GridCoverage2D raster = unitGrid6x6();
+
+    double[] row3 = new double[36];
+    java.util.Arrays.fill(row3, 18, 24, 1d);
+    assertLineBurns(raster, "LINESTRING (-1E308 2.5, 1E308 2.5)", row3);
+    assertLineBurns(raster, "LINESTRING (1E308 2.5, -1E308 2.5)", row3);
+
+    double[] column2 = new double[36];
+    for (int row = 0; row < 6; row++) {
+      column2[row * 6 + 2] = 1d;
+    }
+    assertLineBurns(raster, "LINESTRING (2.5 -1E308, 2.5 1E308)", column2);
+    assertLineBurns(raster, "LINESTRING (2.5 1E308, 2.5 -1E308)", column2);
+  }
+
+  @Test
+  public void testDegenerateLineStringBurnsItsOwnCell() throws ParseException, FactoryException {
+    // A LineString that was degenerate to begin with still marks the cell holding it, unlike a
+    // nondegenerate segment that clipping collapses to a single point.
+    GridCoverage2D raster = unitGrid6x6();
+    double[] expected = new double[36];
+    expected[3 * 6 + 2] = 1d;
+    assertLineBurns(raster, "LINESTRING (2.5 2.5, 2.5 2.5)", expected);
+  }
+
+  @Test
+  public void testLineClipAgreesWithExactRationalOracle() throws ParseException, FactoryException {
+    // Cross-check the clipper against an independent exact-rational clip of the same segment
+    // against the same window. The oracle runs entirely in BigInteger rationals, so a segment that
+    // grazes a grid line is resolved rather than dropped.
+    GridCoverage2D raster = unitGrid6x6();
+    String[] segments = {
+      "LINESTRING (-1 2.5, 7 2.5)",
+      "LINESTRING (-1 -1, 7 7)",
+      "LINESTRING (-4 3, 9 3)",
+      "LINESTRING (3 -4, 3 9)",
+      "LINESTRING (-1 3.0000000000000004, 1 3.0)",
+      "LINESTRING (-2 0.5, 8 5.5)",
+      "LINESTRING (0.5 -2, 5.5 8)",
+      "LINESTRING (-3 7, 7 -3)",
+      "LINESTRING (1.25 5.75, 3.75 0.25)",
+      "LINESTRING (1.5 1.5, 4.5 4.5)",
+      "LINESTRING (0 0, 6 6)",
+      "LINESTRING (0 6, 6 0)",
+      "LINESTRING (-1 6, 1 4)",
+      "LINESTRING (2.5 2.5, 3.5 2.5)",
+      "LINESTRING (-0.5 0.25, 6.5 0.25)",
+    };
+
+    for (String wkt : segments) {
+      Geometry forward = Constructors.geomFromWKT(wkt, 0);
+      double[] band =
+          MapAlgebra.bandAsArray(
+              RasterConstructors.asRaster(forward, raster, "d", false, 1d, 0d, false), 1);
+      double[] reverseBand =
+          MapAlgebra.bandAsArray(
+              RasterConstructors.asRaster(forward.reverse(), raster, "d", false, 1d, 0d, false), 1);
+      Assert.assertArrayEquals(wkt + " must not depend on vertex order", band, reverseBand, 0d);
+
+      Coordinate[] coords = forward.getCoordinates();
+      // unitGrid6x6 puts the origin at (0, 6) with unit pixels and scaleY = -1.
+      SegmentClipOracle.Clip clip =
+          SegmentClipOracle.clip(coords[0].x, 6 - coords[0].y, coords[1].x, 6 - coords[1].y, 6, 6);
+
+      if (clip == null) {
+        Assert.assertArrayEquals(
+            wkt + " has no length inside the raster", new double[36], band, 0d);
+        continue;
+      }
+      assertBurned(wkt + " start", band, clip.x0, clip.x1, clip.y0, clip.y1);
+      assertBurned(wkt + " end", band, clip.x1, clip.x0, clip.y1, clip.y0);
+    }
+  }
+
+  private static void assertBurned(
+      String message,
+      double[] band,
+      SegmentClipOracle.Rational x,
+      SegmentClipOracle.Rational otherX,
+      SegmentClipOracle.Rational y,
+      SegmentClipOracle.Rational otherY) {
+    int column = SegmentClipOracle.cellOf(x, otherX);
+    int row = SegmentClipOracle.cellOf(y, otherY);
+    if (column < 0 || column >= 6 || row < 0 || row >= 6) {
+      return;
+    }
+    Assert.assertEquals(
+        message + " expected cell (row " + row + ", column " + column + ") to be burned",
+        1d,
+        band[row * 6 + column],
+        0d);
+  }
+
+  private void assertLineBurns(GridCoverage2D raster, String wkt, double[] expected)
+      throws ParseException, FactoryException {
+    Geometry geom = Constructors.geomFromWKT(wkt, 0);
+    double[] band =
+        MapAlgebra.bandAsArray(
+            RasterConstructors.asRaster(geom, raster, "d", false, 1d, 0d, false), 1);
+    Assert.assertArrayEquals(wkt, expected, band, 0d);
   }
 
   private GridCoverage2D unitGrid6x6() throws FactoryException {

--- a/common/src/test/java/org/apache/sedona/common/raster/SegmentClipOracle.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/SegmentClipOracle.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.common.raster;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+/**
+ * Exact-rational reference for clipping a pixel-space segment to the window [0, width] x [0,
+ * height], used by the rasterization tests to check the production clipper without sharing any of
+ * its arithmetic.
+ *
+ * <p>Every double is an exact rational, so the whole clip runs without rounding and a segment that
+ * grazes a grid line is resolved rather than discarded. Deliberately unoptimized: correctness here
+ * matters, speed does not.
+ */
+final class SegmentClipOracle {
+
+  private SegmentClipOracle() {}
+
+  /** A rational number kept with a positive denominator. */
+  static final class Rational implements Comparable<Rational> {
+    final BigInteger num;
+    final BigInteger den;
+
+    private Rational(BigInteger num, BigInteger den) {
+      if (den.signum() < 0) {
+        num = num.negate();
+        den = den.negate();
+      }
+      BigInteger g = num.gcd(den);
+      if (g.signum() != 0 && !g.equals(BigInteger.ONE)) {
+        num = num.divide(g);
+        den = den.divide(g);
+      }
+      this.num = num;
+      this.den = den;
+    }
+
+    static Rational of(long value) {
+      return new Rational(BigInteger.valueOf(value), BigInteger.ONE);
+    }
+
+    /** Exact, because {@code new BigDecimal(double)} is the double's exact value. */
+    static Rational of(double value) {
+      if (!Double.isFinite(value)) {
+        throw new IllegalArgumentException("Not a finite double: " + value);
+      }
+      BigDecimal exact = new BigDecimal(value);
+      BigInteger unscaled = exact.unscaledValue();
+      int scale = exact.scale();
+      if (scale >= 0) {
+        return new Rational(unscaled, BigInteger.TEN.pow(scale));
+      }
+      return new Rational(unscaled.multiply(BigInteger.TEN.pow(-scale)), BigInteger.ONE);
+    }
+
+    Rational add(Rational o) {
+      return new Rational(num.multiply(o.den).add(o.num.multiply(den)), den.multiply(o.den));
+    }
+
+    Rational subtract(Rational o) {
+      return new Rational(num.multiply(o.den).subtract(o.num.multiply(den)), den.multiply(o.den));
+    }
+
+    Rational multiply(Rational o) {
+      return new Rational(num.multiply(o.num), den.multiply(o.den));
+    }
+
+    Rational divide(Rational o) {
+      if (o.num.signum() == 0) {
+        throw new ArithmeticException("Division by zero");
+      }
+      return new Rational(num.multiply(o.den), den.multiply(o.num));
+    }
+
+    int signum() {
+      return num.signum();
+    }
+
+    boolean isInteger() {
+      return den.equals(BigInteger.ONE);
+    }
+
+    /** Largest integer not greater than this value. */
+    BigInteger floor() {
+      BigInteger[] qr = num.divideAndRemainder(den);
+      if (qr[1].signum() < 0) {
+        return qr[0].subtract(BigInteger.ONE);
+      }
+      return qr[0];
+    }
+
+    @Override
+    public int compareTo(Rational o) {
+      return num.multiply(o.den).compareTo(o.num.multiply(den));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      return o instanceof Rational && compareTo((Rational) o) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+      return num.hashCode() * 31 + den.hashCode();
+    }
+
+    @Override
+    public String toString() {
+      return isInteger() ? num.toString() : num + "/" + den;
+    }
+  }
+
+  /** The exact clipped segment, or {@code null} when the intersection has no length. */
+  static final class Clip {
+    final Rational x0;
+    final Rational y0;
+    final Rational x1;
+    final Rational y1;
+
+    Clip(Rational x0, Rational y0, Rational x1, Rational y1) {
+      this.x0 = x0;
+      this.y0 = y0;
+      this.x1 = x1;
+      this.y1 = y1;
+    }
+  }
+
+  /**
+   * Clips the segment to [0, width] x [0, height] exactly.
+   *
+   * @return the clipped segment, or null when the segment and the window share no positive-length
+   *     piece. A single-point touch, such as a corner, counts as no length.
+   */
+  static Clip clip(double px0, double py0, double px1, double py1, int width, int height) {
+    Rational x0 = Rational.of(px0);
+    Rational y0 = Rational.of(py0);
+    Rational x1 = Rational.of(px1);
+    Rational y1 = Rational.of(py1);
+
+    Rational tEnter = Rational.of(0);
+    Rational tExit = Rational.of(1);
+
+    Rational[][] axes = {{x0, x1, Rational.of(width)}, {y0, y1, Rational.of(height)}};
+    for (Rational[] axis : axes) {
+      Rational from = axis[0];
+      Rational to = axis[1];
+      Rational far = axis[2];
+      Rational delta = to.subtract(from);
+      if (delta.signum() == 0) {
+        if (from.signum() < 0 || from.compareTo(far) > 0) {
+          return null;
+        }
+        continue;
+      }
+      Rational tAtZero = Rational.of(0).subtract(from).divide(delta);
+      Rational tAtFar = far.subtract(from).divide(delta);
+      Rational tNear = delta.signum() > 0 ? tAtZero : tAtFar;
+      Rational tFarther = delta.signum() > 0 ? tAtFar : tAtZero;
+      if (tNear.compareTo(tEnter) > 0) {
+        tEnter = tNear;
+      }
+      if (tFarther.compareTo(tExit) < 0) {
+        tExit = tFarther;
+      }
+    }
+
+    if (tEnter.compareTo(tExit) >= 0) {
+      return null;
+    }
+    return new Clip(
+        lerp(x0, x1, tEnter), lerp(y0, y1, tEnter), lerp(x0, x1, tExit), lerp(y0, y1, tExit));
+  }
+
+  private static Rational lerp(Rational from, Rational to, Rational t) {
+    return from.add(to.subtract(from).multiply(t));
+  }
+
+  /**
+   * Zero-based cell holding an endpoint of the clipped segment, where cell i covers [i, i + 1). An
+   * endpoint exactly on a grid line belongs to the cell holding the segment's interior, matching
+   * how the traversal selects its first and last cell.
+   */
+  static int cellOf(Rational coordinate, Rational otherEnd) {
+    BigInteger floor = coordinate.floor();
+    boolean interiorIsBelow = otherEnd.compareTo(coordinate) < 0;
+    if (interiorIsBelow && coordinate.isInteger()) {
+      floor = floor.subtract(BigInteger.ONE);
+    }
+    return floor.intValueExact();
+  }
+}


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #3255

## What changes were proposed in this PR?

`Rasterization.clipSegmentToRasterBounds` is replaced by a clip that runs in pixel space. Both reproducers from the issue now produce the expected band, and the four other numerical points in the acceptance criteria are covered.

### Both endpoints outside

The old clipper returned `null` as soon as neither endpoint was inside the extent, which dropped every segment that crosses the raster from one side to the other. On the issue's 6x6 unit raster, `LINESTRING (-1 2.5, 7 2.5)` left the band empty; it now burns all six cells of row 3. The parametric clip below that early return was already able to handle the case, it was simply never reached.

### Grid-line sidedness

Clipping moved to pixel space, where the window edges are the integers `0`, `width` and `height`. In world space the edges are grid lines that only round-trip approximately through `(coordinate - upperLeft) / scale`, so a clipped endpoint can land a rounding step off the line it belongs to.

The coordinate pinned to a window edge is now exact by construction, and only the interpolated one can round onto a grid line. When it does, its true side is resolved with `CGAlgorithmsDD.orientationIndex` against the lattice point and the coordinate steps one ulp off the line. Solving the clip for the interpolated coordinate leaves exactly the cross product that predicate returns, divided by the delta along the clipped axis, so the sign follows directly.

`LINESTRING (-1 3.0000000000000004, 1 3.0)` is strictly above `y = 3` inside the raster except at its final endpoint. Its clipped endpoint rounded onto `y = 3` and burned row 3; it now burns row 2. The mirrored case below the line still burns row 3, and the same rounding on the x axis is covered too.

### Direction independence

Segment endpoints are ordered before clipping. The two directions reach a clip edge at complementary parameters that are equal in exact arithmetic but round apart as doubles, and interpolating with them puts a coordinate on either side of an exact grid corner. My own oracle test caught this on `LINESTRING (-2 0.5, 8 5.5)`, which passes exactly through the pixel lattice point (5, 2).

### Overflow and collapsed parameters

A difference that would overflow to infinity for two large opposite-sign endpoints is taken on halved coordinates, which is exact for normal doubles, so the parameters are the ones the direct form would have produced. That path is entered only when the direct difference is infinite.

Whether the clipped piece has length is read from the clipped endpoints rather than from the parameters. The parameters answer it correctly for a single-point touch such as a corner, but they collapse together for a genuine crossing whose endpoints are far enough apart that the whole window falls inside one rounding step. `LINESTRING (-1E308 2.5, 1E308 2.5)` burns row 3 rather than nothing, in both directions and on both axes.

### Degenerate versus collapsed

A segment that was degenerate to begin with still marks the cell holding it. A nondegenerate segment that clipping collapses to a tangent point burns nothing: `LINESTRING (5 7, 7 5)` meets the raster only at the corner (6, 6).

### Allocation

The ordinary finite path is plain doubles with no per-segment allocation. The single scratch array for clipped endpoints is allocated once per geometry, not per segment. `CGAlgorithmsDD.orientationIndex` is reached only by an interpolated coordinate that landed exactly on a grid line, and it is already the predicate the traversal uses.

## How was this patch tested?

Six new tests in `RasterizationTest`:

- `testLineCrossingRasterWithBothEndpointsOutside` covers the issue's first reproducer plus vertical and diagonal crossings, each in both vertex orders.
- `testClippedEndpointKeepsGridLineSide` covers the second reproducer, its mirror below the grid line, and the same rounding on the x axis.
- `testLineTouchingRasterAtASinglePointBurnsNothing` covers the corner tangency.
- `testLineWithExtremeCoordinatesCrossesTheRaster` covers horizontal and vertical `+/-1e308` crossings.
- `testDegenerateLineStringBurnsItsOwnCell` covers the degenerate input.
- `testLineClipAgreesWithExactRationalOracle` cross-checks fifteen segments against `SegmentClipOracle`, a new test-only exact-rational clip of the same segment against the same window. It runs entirely in `BigInteger` rationals with no rounding anywhere, so a segment grazing a grid line is resolved rather than excluded, and it shares no arithmetic with the production clipper. For each segment it asserts that the band is empty exactly when the exact intersection has no length, that the cells holding the exact clipped endpoints are burned, and that reversing the vertices produces an identical band.

That oracle test is what caught the direction dependence and the collapsed-parameter omission described above, both of which were in my first draft of the clipper.

`mvn -pl common test` on Windows with JDK 17: 1350 tests, the same 13 failures as on unmodified `master` (`RasterBandEditorsTest.testClip`, 5 `RasterEditorsTest.testResample*`, 7 `RasterOutputTest.testAsMatrix*`). They fail identically before and after, so they are pre-existing on this platform and unrelated. Everything else passes, including the GH-3118 coastline fixtures with their pinned 1738/1842 counts and the GH-3120 and GH-3251 endpoint-cell tests.

I could not run `spark/common` locally: it fails to compile on the generated OSM PBF protobuf sources (`package proto4 does not exist`) before reaching any raster code. Leaving those suites to CI.

One note on scope. The clip window is now the raster's own pixel bounds rather than the snapped `geomExtent`. The two give the same burned cells, because a segment lies inside its geometry's snapped extent and `burnCell` already discards anything outside the raster, and the traversal step bound `width + height + 2` assumed the raster bounds anyway. It also means the window edges are exact integers, which is what makes the sidedness argument hold. `rasterizeLineString` no longer takes `geomExtent`.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6hpqAnXfeaWRLkL1VQDMd
