### PR TITLE
[GH-3330] Keep the other bands when replacing a band's no-data value

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/raster/RasterBandEditors.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/RasterBandEditors.java
@@ -83,14 +83,20 @@ public class RasterBandEditors {
       int width = RasterAccessors.getWidth(raster);
       WritableRaster wr =
           RasterFactory.createBandedRaster(dataTypeCode, width, height, numBands, null);
-      double[] bandData =
-          rasterData.getSamples(0, 0, width, height, bandIndex - 1, (double[]) null);
-      for (int i = 0; i < bandData.length; i++) {
-        if (bandData[i] == rasterNoData) {
-          bandData[i] = noDataValue;
+      // The replacement writes into a freshly allocated raster, so every band has to be carried
+      // over. Copying only the target band would leave the others reading back as the allocation
+      // default of 0 while their sample dimensions still describe the original data.
+      for (int band = 0; band < numBands; band++) {
+        double[] bandData = rasterData.getSamples(0, 0, width, height, band, (double[]) null);
+        if (band == bandIndex - 1) {
+          for (int i = 0; i < bandData.length; i++) {
+            if (bandData[i] == rasterNoData) {
+              bandData[i] = noDataValue;
+            }
+          }
         }
+        wr.setSamples(0, 0, width, height, band, bandData);
       }
-      wr.setSamples(0, 0, width, height, bandIndex - 1, bandData);
       return RasterUtils.clone(wr, null, bands, raster, null, true);
     }
 

--- a/common/src/test/java/org/apache/sedona/common/raster/RasterBandEditorsTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/RasterBandEditorsTest.java
@@ -152,6 +152,41 @@ public class RasterBandEditorsTest extends RasterTestBase {
   }
 
   @Test
+  public void testSetBandNoDataValueWithReplaceOptionKeepsOtherBands() throws FactoryException {
+    // The replacement writes into a freshly allocated raster. Copying only the target band left
+    // every other band reading back as zeros while its sample dimension still described the
+    // original data.
+    double[] band1 = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+    double[] band2 = {11, 12, 13, 14, 15, 16, 17, 18, 19};
+    double[] band3 = {21, 22, 23, 24, 25, 26, 27, 28, 29};
+    GridCoverage2D raster =
+        RasterConstructors.makeNonEmptyRaster(
+            3, "d", 3, 3, 0, 3, 1, -1, 0, 0, 0, new double[][] {band1, band2, band3});
+
+    GridCoverage2D replacedFirst =
+        RasterBandEditors.setBandNoDataValue(
+            RasterBandEditors.setBandNoDataValue(raster, 1, 5.0), 1, -999.0, true);
+    assertArrayEquals(
+        new double[] {1, 2, 3, 4, -999, 6, 7, 8, 9},
+        MapAlgebra.bandAsArray(replacedFirst, 1),
+        0.0001d);
+    assertArrayEquals(band2, MapAlgebra.bandAsArray(replacedFirst, 2), 0.0001d);
+    assertArrayEquals(band3, MapAlgebra.bandAsArray(replacedFirst, 3), 0.0001d);
+
+    // Replacing on a band other than the first leaves the first band alone too.
+    GridCoverage2D replacedSecond =
+        RasterBandEditors.setBandNoDataValue(
+            RasterBandEditors.setBandNoDataValue(raster, 2, 15.0), 2, -777.0, true);
+    assertArrayEquals(band1, MapAlgebra.bandAsArray(replacedSecond, 1), 0.0001d);
+    assertArrayEquals(
+        new double[] {11, 12, 13, 14, -777, 16, 17, 18, 19},
+        MapAlgebra.bandAsArray(replacedSecond, 2),
+        0.0001d);
+    assertArrayEquals(band3, MapAlgebra.bandAsArray(replacedSecond, 3), 0.0001d);
+    assertEquals(-777.0, RasterBandAccessors.getBandNoDataValue(replacedSecond, 2), 0.0001d);
+  }
+
+  @Test
   public void testSetBandNoDataValueWithEmptyRaster() throws FactoryException {
     GridCoverage2D emptyRaster =
         RasterConstructors.makeEmptyRaster(1, 20, 20, 0, 0, 8, 8, 0.1, 0.1, 4326);


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #3330

## What changes were proposed in this PR?

`RasterBandEditors.setBandNoDataValue(raster, bandIndex, noDataValue, replace = true)` allocates a fresh `WritableRaster` with every band and then wrote only `bandIndex - 1` into it. The remaining bands came back as the allocation default of `0`, while their sample dimensions still described the original data, so the raster looked intact in its metadata and had lost its pixels.

On a three-band raster, `setBandNoDataValue(raster, 1, -999.0, true)` returned:

- band 1 as `[1, 2, 3, 4, -999, 6, 7, 8, 9]`, correct
- band 2 as all zeros, where `[11 ... 19]` was expected
- band 3 as all zeros, where `[21 ... 29]` was expected

Replacing on a band other than the first lost band 1 the same way. The fix copies every band across and applies the replacement only to the targeted one.

This reaches SQL as `RS_SetBandNoDataValue(raster, bandIndex, noDataValue, true)` on any raster with two or more bands.

## How was this patch tested?

New test `RasterBandEditorsTest.testSetBandNoDataValueWithReplaceOptionKeepsOtherBands`, which replaces on band 1 and then on band 2 of a three-band raster and asserts the full contents of all three bands each time, plus the resulting no-data metadata. It fails on `master` with band 2 and band 3 read back as zeros.

Both existing tests for the replace option, `testSetBandNoDataValueWithReplaceOption` and `testSetBandNoDataValueWithReplaceOptionRaster`, use single-band rasters, which is why this went unnoticed. They still pass unchanged.

`mvn -pl common test` on Windows with JDK 17: the same 13 tests fail before and after the change (`RasterBandEditorsTest.testClip`, 5 `RasterEditorsTest.testResample*`, 7 `RasterOutputTest.testAsMatrix*`). They fail identically on unmodified `master`, so they are pre-existing on this platform and unrelated. Everything else passes.

I could not run `spark/common` locally: it fails to compile on the generated OSM PBF protobuf sources (`package proto4 does not exist`) before reaching any raster code. Leaving those suites to CI.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation. The behaviour now matches what `RS_SetBandNoDataValue` already documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6hpqAnXfeaWRLkL1VQDMd
