### PR TITLE
[GH-3329] Preserve WKB dimensions in Arrow export

### DIFF
--- a/python/sedona/spark/geopandas/geoseries.py
+++ b/python/sedona/spark/geopandas/geoseries.py
@@ -5744,6 +5744,18 @@ e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3
         ]
 
         """
+        if geometry_encoding == "WKB":
+            # Collect Sedona's WKB instead of round-tripping GeometryType through
+            # Python first. Some JTS/Shapely combinations otherwise infer a Z
+            # dimension for collections whose members are all typed empties.
+            wkb = self.to_wkb()._to_internal_pandas()
+            wkb = wkb.map(lambda value: bytes(value) if value is not None else None)
+            return gpd.GeoSeries.from_wkb(
+                wkb,
+                index=wkb.index,
+                crs=self.crs,
+            ).to_arrow(geometry_encoding=geometry_encoding)
+
         # Because this function returns the Arrow array in memory, we simply rely on GeoPandas's implementation.
         # This also returns a GeoPandas-specific data type, which can be converted to an actual PyArrow array,
         # so there is no direct Sedona equivalent. This way we also get all of the arguments implemented for free.

--- a/python/tests/geopandas/test_match_geopandas_series.py
+++ b/python/tests/geopandas/test_match_geopandas_series.py
@@ -137,6 +137,7 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
 
         self.geomcollection = [
             GeometryCollection(),
+            GeometryCollection([Point(), LineString(), Polygon()]),
             GeometryCollection(
                 [
                     MultiPoint([(0, 0), (1, 1)]),


### PR DESCRIPTION
## Did you read the Contributor Guide?

The applicable contributor rules and Python development instructions were checked during delegated preparation.

## Is this PR related to a ticket?

Yes. Closes #3329.

## What changes were proposed in this PR?

For WKB encoding, collect the canonical output of `GeoSeries.to_wkb()` before delegating Arrow construction to GeoPandas. This avoids a GeometryType-to-Python round trip that can infer a Z dimension for a 2D GeometryCollection whose typed members are all empty. Native GeoArrow encoding continues to use the existing path.

The shared parity fixture now includes `GeometryCollection([Point(), LineString(), Polygon()])`, reproducing the case removed from #3326 and verifying that Sedona matches GeoPandas.

## How was this patch tested?

- Python 3.9 with PySpark 3.5 and the Sedona 1.9.0 shaded JAR
- `TestMatchGeopandasSeries::test_to_arrow`
- `TestMatchGeopandasSeries::test_to_wkb`
- `TestGeoSeries::test_to_arrow`
- all configured pre-commit hooks for both changed files
- Python bytecode compilation and `git diff --check`

## Did this PR include necessary documentation updates?

No. This fixes serialization behavior without changing the public API.