### PR TITLE
[GH-3306] GeoPandas: make fillna alignment lazy

### DIFF
--- a/docs/setup/release-notes.md
+++ b/docs/setup/release-notes.md
@@ -44,7 +44,10 @@
 * **GeoPandas `fillna`**: Index validation for an independent GeoSeries replacement
   is now deferred until Spark evaluates the result. Invalid duplicate indexes raise
   a Spark error instead of an immediate Python `ValueError`, including when using
-  `inplace=True`.
+  `inplace=True`. On Spark 3.5.0--3.5.3 with adaptive query execution enabled,
+  evaluating the same failed result again can hang because of
+  [SPARK-49979](https://issues.apache.org/jira/browse/SPARK-49979). This includes
+  failed `inplace=True` results. Spark 3.5.4 and newer fix this upstream issue.
 * **Mixed coordinate layouts in polygons and multi-geometries**: Serializing a `Polygon`,
   `MultiPoint`, `MultiLineString`, or `MultiPolygon` whose parts mix XY, XYZ, XYM, or XYZM layouts
   now raises `IllegalArgumentException` instead of silently losing or corrupting ordinates based on

--- a/docs/setup/release-notes.md
+++ b/docs/setup/release-notes.md
@@ -41,6 +41,10 @@
   former positional `GeoDataFrame.set_crs(crs, inplace, allow_override)` signature remain
   temporarily supported with a `FutureWarning`. When CRS metadata is unavailable, validation can
   require a distributed lookup of the first non-null geometry's SRID.
+* **GeoPandas `fillna`**: Index validation for an independent GeoSeries replacement
+  is now deferred until Spark evaluates the result. Invalid duplicate indexes raise
+  a Spark error instead of an immediate Python `ValueError`, including when using
+  `inplace=True`.
 * **Mixed coordinate layouts in polygons and multi-geometries**: Serializing a `Polygon`,
   `MultiPoint`, `MultiLineString`, or `MultiPolygon` whose parts mix XY, XYZ, XYM, or XYZM layouts
   now raises `IllegalArgumentException` instead of silently losing or corrupting ordinates based on
@@ -66,6 +70,7 @@
 * [<a href='https://github.com/apache/sedona/issues/3269'>GH-3269</a>] - Warn when `geom_equals` or `geom_equals_exact` compares geometry operands with mismatched CRSs
 * [<a href='https://github.com/apache/sedona/issues/3271'>GH-3271</a>] - Preserve per-column CRS state in distributed GeoPandas constructors and select `geometry` or the sole geometry column as active on file reads
 * [<a href='https://github.com/apache/sedona/issues/3293'>GH-3293</a>] - Prevent `GeoDataFrame` construction from mutating caller-owned GeoPandas geometry columns
+* [<a href='https://github.com/apache/sedona/issues/3306'>GH-3306</a>] - Defer GeoSeries fillna index validation and reuse its distributed alignment
 * [<a href='https://github.com/apache/sedona/issues/3307'>GH-3307</a>] - Preserve left-index and null-value semantics when `GeoSeries.fillna` uses another GeoSeries
 
 ## Sedona 1.9.1

--- a/python/sedona/spark/geopandas/geoseries.py
+++ b/python/sedona/spark/geopandas/geoseries.py
@@ -4855,30 +4855,6 @@ class GeoSeries(GeoFrame, pspd.Series):
         )
 
         same_index_structure = len(left_indexes) == len(right_indexes)
-        if not same_index_structure:
-            status = right_frame.agg(
-                F.count(F.col(right_present)).alias("right_count"),
-                F.countDistinct(
-                    F.struct(*[F.col(column) for column in right_indexes])
-                ).alias("right_unique_count"),
-            ).first()
-            if status["right_count"] != status["right_unique_count"]:
-                if len(right_indexes) > 1:
-                    raise ValueError("cannot handle a non-unique multi-index!")
-                raise ValueError("cannot reindex on an axis with duplicate labels")
-
-            # A flat Index and a MultiIndex have no complete keys in common.
-            aligned_frame = left_frame.select(
-                F.col("L"),
-                stc.ST_GeomFromWKB(F.lit(None).cast("binary")).alias("R"),
-                *[F.col(column) for column in left_indexes],
-                F.col(left_order),
-            )
-            aligned_frame = aligned_frame.withColumnRenamed(
-                left_order, NATURAL_ORDER_COLUMN_NAME
-            )
-            return aligned_frame, left_indexes
-
         positioned_left = _attach_ordered_sequence_column(
             left_frame, F.col(left_order), position
         )
@@ -4907,7 +4883,14 @@ class GeoSeries(GeoFrame, pspd.Series):
                 right_type,
                 positional=True,
             )
-        status = positional_join.agg(
+        # Both validation and filling consume this alignment. Hash the complete
+        # row so column pruning cannot give the consumers different exchanges;
+        # With spark.sql.exchange.reuse enabled (the default), Spark shares this
+        # shuffle within the query without a user-managed cache.
+        row = "__fillna_row__"
+        shared = positional_join.select(F.struct("*").alias(row)).repartition(row)
+        aligned = shared.select(f"{row}.*")
+        status = aligned.agg(
             F.count(F.col(left_present)).alias("left_count"),
             F.count(F.col(right_present)).alias("right_count"),
             F.countDistinct(
@@ -4917,28 +4900,57 @@ class GeoSeries(GeoFrame, pspd.Series):
                 )
             ).alias("right_unique_count"),
             F.max(index_mismatch.cast("int")).alias("index_mismatch"),
-        ).first()
-        axes_equal = (
-            index_dtypes_can_equal
-            and status["left_count"] == status["right_count"]
-            and not bool(status["index_mismatch"] or False)
+        )
+        axes_equal = "__fillna_axes_equal__"
+        invalid = "__fillna_invalid_index__"
+        status = status.withColumn(
+            axes_equal,
+            F.lit(same_index_structure and index_dtypes_can_equal)
+            & (F.col("left_count") == F.col("right_count"))
+            & (F.coalesce(F.col("index_mismatch"), F.lit(0)) == 0),
+        ).select(
+            F.col(axes_equal),
+            (
+                ~F.col(axes_equal)
+                & (F.col("right_count") != F.col("right_unique_count"))
+            ).alias(invalid),
+        )
+        message = (
+            "cannot handle a non-unique multi-index!"
+            if len(right_indexes) > 1
+            else "cannot reindex on an axis with duplicate labels"
+        )
+        left = aligned.crossJoin(F.broadcast(status)).where(
+            # Keep validation in the row filter, including right-only rows, so
+            # it is not skipped for non-null geometries or an empty left axis.
+            F.when(F.col(invalid), F.raise_error(message).cast("boolean")).otherwise(
+                F.col(left_present).isNotNull()
+            )
         )
 
-        if not axes_equal and status["right_count"] != status["right_unique_count"]:
-            if len(right_indexes) > 1:
-                raise ValueError("cannot handle a non-unique multi-index!")
-            raise ValueError("cannot reindex on an axis with duplicate labels")
-
-        if axes_equal:
-            aligned_frame = positional_join.select(
+        if not same_index_structure:
+            # A flat Index and a MultiIndex have no complete keys in common.
+            aligned_frame = left.select(
                 F.col("L"),
-                F.col("R"),
+                stc.ST_GeomFromWKB(F.lit(None).cast("binary")).alias("R"),
                 *[F.col(column) for column in left_indexes],
                 F.col(left_order),
             )
         else:
-            left_alias = left_frame.alias("left")
-            right_alias = right_frame.alias("right")
+            # Exact axes use the positional value already in `left`. Only feed
+            # the label join when reindexing is needed, avoiding duplicate-label
+            # expansion on the exact-axis path.
+            right = aligned.crossJoin(F.broadcast(status)).where(
+                F.when(F.col(axes_equal) | F.col(invalid), F.lit(False)).otherwise(
+                    F.col(right_present).isNotNull()
+                )
+            )
+            left_alias = left.select(
+                "L", "R", *left_indexes, left_order, axes_equal
+            ).alias("left")
+            right_alias = right.select(
+                *[F.col(column).alias(column) for column in ["R", *right_indexes]]
+            ).alias("right")
             join_condition = _fillna_index_columns_equal(
                 left_alias[left_indexes[0]],
                 right_alias[right_indexes[0]],
@@ -4965,7 +4977,9 @@ class GeoSeries(GeoFrame, pspd.Series):
                 how="left",
             ).select(
                 left_alias["L"].alias("L"),
-                right_alias["R"].alias("R"),
+                F.when(left_alias[axes_equal], left_alias["R"])
+                .otherwise(right_alias["R"])
+                .alias("R"),
                 *[left_alias[column].alias(column) for column in left_indexes],
                 left_alias[left_order].alias(left_order),
             )
@@ -5052,9 +5066,11 @@ class GeoSeries(GeoFrame, pspd.Series):
 
         Notes
         -----
-        Filling from an independent ``GeoSeries`` validates its distributed index
-        before returning. Filling from another column of the same ``GeoDataFrame``
-        remains lazy.
+        Index alignment with another ``GeoSeries`` is lazy. Invalid duplicate
+        replacement indexes raise a Spark error when the result is evaluated,
+        rather than a Python ``ValueError`` when calling ``fillna``. This also
+        applies to ``inplace=True``. A query that skips evaluating the result may
+        skip this validation.
 
         Using ``limit`` requires distributed global ordering and can be expensive
         for large GeoSeries.

--- a/python/sedona/spark/geopandas/geoseries.py
+++ b/python/sedona/spark/geopandas/geoseries.py
@@ -4915,12 +4915,16 @@ class GeoSeries(GeoFrame, pspd.Series):
                 & (F.col("right_count") != F.col("right_unique_count"))
             ).alias(invalid),
         )
-        message = (
+        # Join this single-row summary without broadcasting it: with AQE off,
+        # the broadcast timeout would also cover all upstream alignment work.
+        # The non-broadcast join buffers only its single right-hand row.
+        status = status.hint("SHUFFLE_REPLICATE_NL")
+        message = "GeoSeries.fillna: " + (
             "cannot handle a non-unique multi-index!"
             if len(right_indexes) > 1
             else "cannot reindex on an axis with duplicate labels"
         )
-        left = aligned.crossJoin(F.broadcast(status)).where(
+        left = aligned.crossJoin(status).where(
             # Keep validation in the row filter, including right-only rows, so
             # it is not skipped for non-null geometries or an empty left axis.
             F.when(F.col(invalid), F.raise_error(message).cast("boolean")).otherwise(
@@ -4940,7 +4944,7 @@ class GeoSeries(GeoFrame, pspd.Series):
             # Exact axes use the positional value already in `left`. Only feed
             # the label join when reindexing is needed, avoiding duplicate-label
             # expansion on the exact-axis path.
-            right = aligned.crossJoin(F.broadcast(status)).where(
+            right = aligned.crossJoin(status).where(
                 F.when(F.col(axes_equal) | F.col(invalid), F.lit(False)).otherwise(
                     F.col(right_present).isNotNull()
                 )
@@ -5071,6 +5075,16 @@ class GeoSeries(GeoFrame, pspd.Series):
         rather than a Python ``ValueError`` when calling ``fillna``. This also
         applies to ``inplace=True``. A query that skips evaluating the result may
         skip this validation.
+
+        On Spark 3.5.0--3.5.3, evaluating the same failed result again can hang
+        with adaptive query execution enabled (SPARK-49979). This also affects
+        failed ``inplace=True`` results. Use Spark 3.5.4 or newer to avoid this
+        upstream issue.
+
+        Sharing the alignment relies on ``spark.sql.exchange.reuse=true`` (the
+        default). Disabling it can execute the alignment four times instead of
+        once. Validation does not force a broadcast; normal Spark broadcast
+        settings still apply to the separate label join.
 
         Using ``limit`` requires distributed global ordering and can be expensive
         for large GeoSeries.

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -1145,10 +1145,11 @@ class TestGeoSeries(TestGeopandasBase):
             index=right_index,
         )
 
+        result = source.fillna(replacement)
         with pytest.raises(
-            ValueError, match="cannot reindex on an axis with duplicate labels"
+            Exception, match="cannot reindex on an axis with duplicate labels"
         ):
-            source.fillna(replacement)
+            result.to_geopandas()
 
     def test_fillna_series_replacement_does_not_coerce_decimal_to_float_index(self):
         source = GeoSeries([None], index=pd.Index([Decimal("0.1")], dtype=object))
@@ -1291,8 +1292,9 @@ class TestGeoSeries(TestGeopandasBase):
             index=replacement_index,
         )
 
-        with pytest.raises(ValueError, match=message):
-            source.fillna(replacement)
+        result = source.fillna(replacement)
+        with pytest.raises(Exception, match=message):
+            result.to_geopandas()
 
     @pytest.mark.parametrize("left_is_multiindex", [False, True])
     def test_fillna_series_replacement_requires_full_index_shape(
@@ -1336,8 +1338,9 @@ class TestGeoSeries(TestGeopandasBase):
         source = GeoSeries([None, None], index=left_index)
         replacement = GeoSeries([Point(1, 1), Point(2, 2)], index=right_index)
 
-        with pytest.raises(ValueError, match=message):
-            source.fillna(replacement)
+        result = source.fillna(replacement)
+        with pytest.raises(Exception, match=message):
+            result.to_geopandas()
 
     def test_fillna_series_replacement_uses_full_multiindex_in_left_order(self):
         from geopandas.testing import assert_geoseries_equal
@@ -1625,8 +1628,9 @@ class TestGeoSeries(TestGeopandasBase):
         source = GeoSeries([None, None], index=left_index)
         fill_values = GeoSeries([Point(1, 1), Point(2, 2)], index=right_index)
 
-        with pytest.raises(ValueError, match=message):
-            source.fillna(fill_values, limit=1)
+        result = source.fillna(fill_values, limit=1)
+        with pytest.raises(Exception, match=message):
+            result.to_geopandas()
 
     def test_fillna_limit_broadcasts_unique_value_to_duplicate_left_index(self):
         from geopandas.testing import assert_geoseries_equal
@@ -1638,6 +1642,65 @@ class TestGeoSeries(TestGeopandasBase):
         expected = gpd.GeoSeries([Point(1, 1), None, None], index=[1, 1, 2])
 
         assert_geoseries_equal(result.to_geopandas(), expected, check_index_type=False)
+
+    @pytest.mark.parametrize("limit", [None, 1])
+    @pytest.mark.parametrize("duplicate", [False, True])
+    @pytest.mark.parametrize("different_index_shape", [False, True])
+    def test_fillna_independent_series_is_lazy(
+        self, monkeypatch, limit, duplicate, different_index_shape
+    ):
+        source = GeoSeries([None, None], index=[1, 2])
+        dataframe_type = type(source._internal.spark_frame)
+        right_index = (
+            pd.MultiIndex.from_tuples([("a", 1), ("a", 1 if duplicate else 2)])
+            if different_index_shape
+            else pd.Index([1, 1 if duplicate else 2])
+        )
+        replacement = GeoSeries([Point(1, 1), Point(2, 2)], index=right_index)
+
+        def unexpected_action(*args, **kwargs):
+            raise AssertionError("independent fillna triggered a Spark action")
+
+        tracker = self.spark.sparkContext.statusTracker()
+        jobs_before = set(tracker.getJobIdsForGroup(None))
+        with monkeypatch.context() as actions:
+            for operation in ["count", "collect", "toPandas", "first", "head", "take"]:
+                actions.setattr(dataframe_type, operation, unexpected_action)
+            result = source.fillna(replacement, limit=limit)
+
+        assert isinstance(result, GeoSeries)
+        assert set(tracker.getJobIdsForGroup(None)) <= jobs_before
+
+    @pytest.mark.parametrize("limit", [None, 1])
+    @pytest.mark.parametrize("left_values", [[], [Point(0, 0)], [None]])
+    @pytest.mark.parametrize("projection", ["geometry", "index", "count"])
+    def test_fillna_duplicate_validation_is_not_pruned(
+        self, limit, left_values, projection
+    ):
+        source = GeoSeries(left_values, index=pd.Index(range(len(left_values))))
+        replacement = GeoSeries([Point(1, 1), None], index=[9, 9])
+
+        result = source.fillna(replacement, limit=limit)
+        frame = result._internal.spark_frame
+        with pytest.raises(
+            Exception, match="cannot reindex on an axis with duplicate labels"
+        ):
+            if projection == "geometry":
+                result.to_geopandas()
+            elif projection == "index":
+                frame.select(*result._internal.index_spark_columns).collect()
+            else:
+                frame.count()
+
+    def test_fillna_inplace_defers_duplicate_validation(self):
+        source = GeoSeries([None], index=[0])
+        replacement = GeoSeries([Point(1, 1), Point(2, 2)], index=[1, 1])
+
+        assert source.fillna(replacement, inplace=True) is None
+        with pytest.raises(
+            Exception, match="cannot reindex on an axis with duplicate labels"
+        ):
+            source.to_geopandas()
 
     def test_fillna_limit_same_anchor_series_is_lazy_and_positional(self, monkeypatch):
         from geopandas.testing import assert_geoseries_equal
@@ -1718,10 +1781,22 @@ class TestGeoSeries(TestGeopandasBase):
 
         assert_geoseries_equal(result.to_geopandas(), expected, check_index_type=False)
 
+    @pytest.mark.parametrize("adaptive", [False, True])
     @pytest.mark.parametrize(
-        "replacement_kind", ["scalar", "same_anchor", "independent"]
+        "replacement_kind",
+        ["scalar", "same_anchor", "independent", "independent_reindexed"],
     )
-    def test_fillna_limit_does_not_duplicate_input_plan(self, replacement_kind):
+    def test_fillna_limit_does_not_duplicate_input_plan(
+        self, replacement_kind, adaptive
+    ):
+        original_adaptive = self.spark.conf.get("spark.sql.adaptive.enabled")
+        try:
+            self.spark.conf.set("spark.sql.adaptive.enabled", str(adaptive).lower())
+            self._check_fillna_limit_input_plan(replacement_kind)
+        finally:
+            self.spark.conf.set("spark.sql.adaptive.enabled", original_adaptive)
+
+    def _check_fillna_limit_input_plan(self, replacement_kind):
         from geopandas.testing import assert_geoseries_equal
 
         row_id = F.col("id")
@@ -1747,8 +1822,12 @@ class TestGeoSeries(TestGeopandasBase):
             if replacement_kind == "same_anchor":
                 replacement = frame["replacement"]
             else:
+                right_index = row_id
+                if replacement_kind == "independent_reindexed":
+                    right_index = (23 - row_id).alias("id")
+                    expected_replacement.index = expected_replacement.index[::-1]
                 replacement_rows = self.spark.range(24, numPartitions=3).select(
-                    row_id, replacement_column.alias("replacement")
+                    right_index, replacement_column.alias("replacement")
                 )
                 replacement = GeoSeries(
                     replacement_rows.pandas_api(index_col="id")["replacement"]
@@ -1757,11 +1836,29 @@ class TestGeoSeries(TestGeopandasBase):
         result = frame.geometry.fillna(replacement, limit=5)
         query = result._internal.spark_frame._jdf.queryExecution()
         plan = query.optimizedPlan().toString()
-        expected_inputs = 2 if replacement_kind == "independent" else 1
-
-        assert plan.count("Range (") == expected_inputs
         assert "Union" not in plan
-        assert "SinglePartition" not in query.executedPlan().toString()
+        if replacement_kind.startswith("independent"):
+            # Validation and filling share an exchange, which is only visible
+            # in the executed plan, not in the logical tree's repeated inputs.
+            result._internal.spark_frame.collect()
+            executed = query.executedPlan()
+            if executed.nodeName() == "AdaptiveSparkPlan":
+                executed = executed.executedPlan()
+            physical = executed.toString()
+            assert physical.count("Range (") == 2
+            assert physical.count("FullOuter") == 1
+            assert "ReusedExchange" in physical
+            assert "Union" not in physical
+            # Only the bounded partial index statistics go to one partition;
+            # the geometry rows and global rank remain distributed.
+            lines = physical.splitlines()
+            for line_number, line in enumerate(lines):
+                if "SinglePartition" in line:
+                    assert "HashAggregate(keys=[]" in lines[line_number + 1]
+                    assert "partial_" in lines[line_number + 1]
+        else:
+            assert plan.count("Range (") == 1
+            assert "SinglePartition" not in query.executedPlan().toString()
         assert_geoseries_equal(
             result.to_geopandas(),
             expected.fillna(expected_replacement, limit=5),

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -1662,6 +1662,8 @@ class TestGeoSeries(TestGeopandasBase):
             raise AssertionError("independent fillna triggered a Spark action")
 
         tracker = self.spark.sparkContext.statusTracker()
+        listener_bus = self.spark.sparkContext._jsc.sc().listenerBus()
+        listener_bus.waitUntilEmpty()
         jobs_before = set(tracker.getJobIdsForGroup(None))
         with monkeypatch.context() as actions:
             for operation in ["count", "collect", "toPandas", "first", "head", "take"]:
@@ -1669,6 +1671,7 @@ class TestGeoSeries(TestGeopandasBase):
             result = source.fillna(replacement, limit=limit)
 
         assert isinstance(result, GeoSeries)
+        listener_bus.waitUntilEmpty()
         assert set(tracker.getJobIdsForGroup(None)) <= jobs_before
 
     @pytest.mark.parametrize("limit", [None, 1])
@@ -1698,7 +1701,8 @@ class TestGeoSeries(TestGeopandasBase):
 
         assert source.fillna(replacement, inplace=True) is None
         with pytest.raises(
-            Exception, match="cannot reindex on an axis with duplicate labels"
+            Exception,
+            match=r"GeoSeries\.fillna: cannot reindex on an axis with duplicate labels",
         ):
             source.to_geopandas()
 
@@ -1790,11 +1794,26 @@ class TestGeoSeries(TestGeopandasBase):
         self, replacement_kind, adaptive
     ):
         original_adaptive = self.spark.conf.get("spark.sql.adaptive.enabled")
+        original_broadcast = self.spark.conf.get("spark.sql.autoBroadcastJoinThreshold")
+        original_shuffle_partitions = self.spark.conf.get(
+            "spark.sql.shuffle.partitions"
+        )
         try:
             self.spark.conf.set("spark.sql.adaptive.enabled", str(adaptive).lower())
+            # Allow automatic broadcasting of the tiny status row, but not the
+            # 24-row label table. This catches both an explicit status broadcast
+            # and accidentally dropping the non-broadcast status hint.
+            self.spark.conf.set("spark.sql.autoBroadcastJoinThreshold", "64")
+            self.spark.conf.set("spark.sql.shuffle.partitions", "4")
             self._check_fillna_limit_input_plan(replacement_kind)
         finally:
             self.spark.conf.set("spark.sql.adaptive.enabled", original_adaptive)
+            self.spark.conf.set(
+                "spark.sql.autoBroadcastJoinThreshold", original_broadcast
+            )
+            self.spark.conf.set(
+                "spark.sql.shuffle.partitions", original_shuffle_partitions
+            )
 
     def _check_fillna_limit_input_plan(self, replacement_kind):
         from geopandas.testing import assert_geoseries_equal
@@ -1849,11 +1868,13 @@ class TestGeoSeries(TestGeopandasBase):
             assert physical.count("FullOuter") == 1
             assert "ReusedExchange" in physical
             assert "Union" not in physical
+            assert "BroadcastExchange" not in physical
+            assert "CartesianProduct" in physical
             # Only the bounded partial index statistics go to one partition;
             # the geometry rows and global rank remain distributed.
             lines = physical.splitlines()
             for line_number, line in enumerate(lines):
-                if "SinglePartition" in line:
+                if "SinglePartition" in line and "ReusedExchange" not in line:
                     assert "HashAggregate(keys=[]" in lines[line_number + 1]
                     assert "partial_" in lines[line_number + 1]
         else:


### PR DESCRIPTION
## Did you read the Contributor Guide?

Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/).

## Is this PR related to a ticket?

Yes, the PR name follows the `[GH-XXX] my subject` format. Closes #3306.

## What changes were proposed in this PR?

Make index alignment lazy when `GeoSeries.fillna` receives an independent GeoSeries replacement, with or without `limit`.

- Replace the eager validation action with a distributed aggregate and a deferred error check.
- Share the positional alignment through a full-row shuffle. Hashing the complete row prevents column pruning from producing different exchanges for validation and filling.
- Preserve positional matching for exact duplicate axes, label matching for unique replacement indexes, and the left index, order, name, and CRS. Scalar and same-frame paths remain unchanged.

Invalid duplicate replacement indexes now raise a Spark error when the result is evaluated, instead of an immediate Python `ValueError`. This also applies to `inplace=True`. A query that skips evaluating the result may skip validation.

The plan uses Spark's default `spark.sql.exchange.reuse=true` setting. Disabling exchange reuse preserves correctness but can repeat alignment work. There is no user-managed cache or new public API.

## How was this patch tested?

Local validation:

- `python -m pytest -q tests/geopandas/test_geoseries.py -k fillna`: **101 passed on Spark 3.5.4 and 101 passed on Spark 4.1.1**.
- Regression tests check that construction starts no Spark jobs, deferred errors survive empty inputs, non-null geometries, index-only projections and counts, and `inplace=True` defers the error.
- Physical-plan tests cover adaptive execution enabled and disabled. Independent replacements use one positional alignment and reused exchanges, without a union or a single-partition window over the geometry rows.
- Repository hooks passed for all three changed files.

An instrumented probe with 120 rows per input also checked equal unique axes, equal duplicate axes, and label reindexing on both Spark versions, with and without `limit`. Construction processed no source rows. Total source-row visits per input fell from 480 to 240 for equal axes and from 360 to 240 for label reindexing. The remaining two traversals are range-sort sampling and shuffle execution; these counts are not an elapsed-time benchmark.

Spark 4.0 was not run locally. Hosted CI results are separate from these local checks.

## Did this PR include necessary documentation updates?

Yes, I have updated the `fillna` docstring and release notes, including the deferred-error behavior.
