### PR TITLE
[GH-3338] Support Spark 4.x in the R interface

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -59,21 +59,26 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        spark: [3.5.0]
-        hadoop: [3]
-        scala: [2.12.15]
-        r: [oldrel, release]
-        java: [11]
         include:
-          # Spark 4 is Scala 2.13 only and needs Java 17
-          - spark: 4.0.2
-            hadoop: 3
+          - spark: 4.1.1
             scala: 2.13.16
+            java: '17'
             r: release
-            java: 17
+          - spark: 4.0.2
+            scala: 2.13.16
+            java: '17'
+            r: release
+          - spark: 3.5.0
+            scala: 2.12.15
+            java: '11'
+            r: release
+          - spark: 3.5.0
+            scala: 2.12.15
+            java: '11'
+            r: oldrel
     env:
       SPARK_VERSION: ${{ matrix.spark }}
-      HADOOP_VERSION: ${{ matrix.hadoop }}
+      HADOOP_VERSION: 3
       SCALA_VERSION: ${{ matrix.scala }}
       # Ensure the temporary auth token for this workflow, instead of the
       # bundled GitHub PAT from the `remotes` package is used for

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -63,6 +63,14 @@ jobs:
         hadoop: [3]
         scala: [2.12.15]
         r: [oldrel, release]
+        java: [11]
+        include:
+          # Spark 4 is Scala 2.13 only and needs Java 17
+          - spark: 4.0.2
+            hadoop: 3
+            scala: 2.13.16
+            r: release
+            java: 17
     env:
       SPARK_VERSION: ${{ matrix.spark }}
       HADOOP_VERSION: ${{ matrix.hadoop }}
@@ -115,7 +123,7 @@ jobs:
       - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: ${{ matrix.java }}
           cache: 'maven'
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:

--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -39,5 +39,5 @@ Suggests:
     rmarkdown
 Encoding: UTF-8
 RoxygenNote: 7.3.2
-SystemRequirements: 'Apache Spark' 3.x
+SystemRequirements: 'Apache Spark' 3.x or 4.x
 Roxygen: list(markdown = TRUE)

--- a/R/R/dependencies.R
+++ b/R/R/dependencies.R
@@ -17,9 +17,15 @@
 
 
 spark_dependencies <- function(spark_version, scala_version, ...) {
-  if (spark_version[1, 1] == "3") {
-    spark_version <- spark_version
+  spark_major <- as.character(spark_version[1, 1])
+  if (spark_major == "3") {
+    # Sedona publishes Scala 2.12 artifacts for Spark 3.x
     scala_version <- scala_version %||% "2.12"
+  } else if (spark_major == "4") {
+    # Spark 4.x and Sedona's Spark 4 artifacts are Scala 2.13 only. sparklyr
+    # still passes extensions "2.12" for every Spark >= 3.0, so do not rely on
+    # the value it hands us here.
+    scala_version <- "2.13"
   } else {
     stop("Unsupported Spark version: ", spark_version)
   }

--- a/R/R/spatial_queries.R
+++ b/R/R/spatial_queries.R
@@ -91,8 +91,10 @@ sedona_knn_query <- function(rdd,
                              index_type = c("quadtree", "rtree"),
                              result_type = c("rdd", "sdf", "raw")) {
   as.spatial_rdd <- function(sc, query_result) {
-    query_result <-
-      invoke_static(sc, "java.util.Arrays", "asList", query_result)
+    if (!inherits(query_result, "spark_jobj")) {
+      query_result <-
+        invoke_static(sc, "java.util.Arrays", "asList", query_result)
+    }
     raw_spatial_rdd <- invoke(java_context(sc), "parallelize", query_result)
     spatial_rdd <- invoke_new(
       sc,
@@ -111,7 +113,7 @@ sedona_knn_query <- function(rdd,
     switch(result_type,
       rdd = as.spatial_rdd(sc, query_result),
       sdf = as.spatial_rdd(sc, query_result) %>% sdf_register(),
-      raw = query_result
+      raw = as_r_list(query_result)
     )
   }
 
@@ -206,7 +208,7 @@ sedona_range_query <- function(rdd,
     switch(result_type,
       rdd = as.spatial_rdd(sc, result_rdd),
       sdf = as.spatial_rdd(sc, result_rdd) %>% sdf_register(),
-      raw = result_rdd %>% invoke("collect")
+      raw = result_rdd %>% invoke("collect") %>% as_r_list()
     )
   }
 
@@ -236,4 +238,17 @@ ensure_spatial_indexing <- function(rdd, index_type = c("quadtree", "rtree")) {
 
 has_raw_partition_index <- function(rdd) {
   !is.null(rdd$.state$raw_partition_index_type)
+}
+
+# `java.util.List` results that wrap a Scala `Seq` (for example the ones
+# returned by `JavaRDD.take()`, `JavaRDD.collect()` and `KNNQuery`) are
+# unwrapped into R lists by the sparklyr backend for Spark 3, but the backend
+# for Spark 4 hands them back as a single Java object. Convert on the JVM side
+# so callers see an R list of Java objects on both.
+as_r_list <- function(x) {
+  if (inherits(x, "spark_jobj")) {
+    invoke(x, "toArray")
+  } else {
+    x
+  }
 }

--- a/R/tests/testthat/test-data-interface.R
+++ b/R/tests/testthat/test-data-interface.R
@@ -167,7 +167,7 @@ test_that("sedona_read_geojson_to_typed_rdd() creates PolygonRDD correctly", {
   expect_equal(polygon_rdd$.jobj %>% invoke("approximateTotalCount"), 1001)
   expect_false(is.null(polygon_rdd$.jobj %>% invoke("boundaryEnvelope")))
   first_2 <- polygon_rdd$.jobj %>%
-    invoke("%>%", list("rawSpatialRDD"), list("take", 2L))
+    invoke("%>%", list("rawSpatialRDD"), list("take", 2L), list("toArray"))
   expected_data <- c(
     "01\t077\t011501\t5\t1500000US010770115015\t010770115015\t5\tBG\t6844991\t32636",
     "01\t045\t021102\t4\t1500000US010450211024\t010450211024\t4\tBG\t11360854\t0"
@@ -647,7 +647,7 @@ test_that("sedona_save_spatial_rdd() works as expected", {
       sdf$.jobj %>% invoke("%>%", list("rawSpatialRDD"), list("count")), 1
     )
     pts <- sdf$.jobj %>%
-      invoke("%>%", list("rawSpatialRDD"), list("takeOrdered", 1L))
+      invoke("%>%", list("rawSpatialRDD"), list("takeOrdered", 1L), list("toArray"))
     expect_equal(pts[[1]] %>% invoke("getX"), 123)
     expect_equal(pts[[1]] %>% invoke("getY"), 456)
     expect_equal(pts[[1]] %>% invoke("getUserData"), "1.0\ta point\tpoint")

--- a/R/tests/testthat/test-dependencies.R
+++ b/R/tests/testthat/test-dependencies.R
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+context("spark_dependencies")
+
+sedona_packages <- function(spark_version, scala_version = NULL) {
+  old <- Sys.getenv("SEDONA_JAR_FILES", unset = NA)
+  Sys.unsetenv("SEDONA_JAR_FILES")
+  on.exit(if (!is.na(old)) Sys.setenv(SEDONA_JAR_FILES = old))
+  apache.sedona:::spark_dependencies(numeric_version(spark_version), scala_version)$packages
+}
+
+test_that("Spark 3.x requests the Scala 2.12 artifact", {
+  expect_true("org.apache.sedona:sedona-spark-shaded-3.5_2.12:1.9.1" %in% sedona_packages("3.5", "2.12"))
+  expect_true("org.apache.sedona:sedona-spark-shaded-3.5_2.12:1.9.1" %in% sedona_packages("3.5"))
+})
+
+test_that("Spark 4.x requests the Scala 2.13 artifact even when sparklyr passes 2.12", {
+  # sparklyr hands extensions "2.12" for every Spark >= 3.0
+  expect_true("org.apache.sedona:sedona-spark-shaded-4.0_2.13:1.9.1" %in% sedona_packages("4.0", "2.12"))
+  expect_true("org.apache.sedona:sedona-spark-shaded-4.1_2.13:1.9.1" %in% sedona_packages("4.1"))
+  expect_false(any(grepl("_2.12:", sedona_packages("4.0", "2.12"))))
+})
+
+test_that("Spark 2.x is rejected", {
+  expect_error(sedona_packages("2.4"), "Unsupported Spark version")
+})
+
+test_that("SEDONA_JAR_FILES replaces the Sedona coordinate with local jars", {
+  old <- Sys.getenv("SEDONA_JAR_FILES", unset = NA)
+  Sys.setenv(SEDONA_JAR_FILES = "/tmp/a.jar:/tmp/b.jar")
+  on.exit(if (is.na(old)) Sys.unsetenv("SEDONA_JAR_FILES") else Sys.setenv(SEDONA_JAR_FILES = old))
+  deps <- apache.sedona:::spark_dependencies(numeric_version("4.0"), "2.12")
+  expect_equal(deps$jars, c("/tmp/a.jar", "/tmp/b.jar"))
+  expect_false(any(grepl("sedona-spark-shaded", deps$packages)))
+})


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #3338

## What changes were proposed in this PR?

`spark_dependencies()` in `R/R/dependencies.R` only accepted Spark major version 3 and defaulted the Scala suffix to `2.12`, so `spark_connect()` on Spark 4.x failed with `Unsupported Spark version: 4.0` before any jar or Maven coordinate was considered.

- Accept Spark 4.x and pin its Scala suffix to `2.13`. Pinning is deliberate: sparklyr 1.9.5 hands every extension `scala_version = "2.12"` for any Spark release at or above 3.0, so honouring that value would request the non-existent `sedona-spark-shaded-4.0_2.12`. Spark 4 and Sedona's Spark 4 artifacts are Scala 2.13 only. Spark 3.x keeps the previous behaviour (`2.12` unless a Scala version is passed), and Spark 2.x and earlier are still rejected.
- `R/DESCRIPTION`: `SystemRequirements` now reads Spark 3.x or 4.x.
- `R/tests/testthat/test-dependencies.R`: unit tests for the artifact selection (Spark 3.5 -> `3.5_2.12`; Spark 4.0 with `2.12` passed in -> `4.0_2.13`; Spark 4.1 -> `4.1_2.13`; Spark 2.4 rejected; `SEDONA_JAR_FILES` swaps the Sedona coordinate for local jars). They run without a Spark connection.
- `.github/workflows/r.yml`: list the matrix explicitly, one entry per Spark/Scala/Java/R combination like the Java and Python workflows, and add Spark 4.0.2 and 4.1.1 (Scala 2.13.16, Java 17) so the R test suite also runs on Spark 4.
- `R/R/spatial_queries.R`: the sparklyr backend for Spark 3 unwraps `java.util.List` results that wrap a Scala `Seq` (`JavaRDD.take()`, `collect()`, `KNNQuery`) into R lists, while the backend for Spark 4 returns them as a single Java object. `sedona_knn_query()` and `sedona_range_query()` now convert on the JVM side with `toArray`, so `result_type = "raw"` returns an R list of geometries on both backends, and the KNN result RDD is built from the Java list directly when that is what came back. Two tests that index `take()` / `takeOrdered()` results now call `toArray` like the neighbouring tests already do.

## How was this patch tested?

- The new unit tests pass locally.
- First CI run on Spark 4.0.2: the package check, the `4.0_2.13` build and the connection worked; 6 of 267 tests failed because of the Java list serialisation difference described above, which the second commit addresses.
- On EMR release `emr-spark-8.0.0` (Spark 4.0.2, Scala 2.13.16, Java 17) with sparklyr 1.9.5: the CRAN 1.9.1 package fails with `Unsupported Spark version: 4.0`. With this patch installed from source, `spark_connect(master = "yarn", spark_home = "/usr/lib/spark")` connects both with `SEDONA_JAR_FILES` pointing at `sedona-spark-shaded-4.0_2.13-1.9.1.jar` and with it unset, in which case Maven resolves `org.apache.sedona:sedona-spark-shaded-4.0_2.13:1.9.1`. `ST_Point`, `ST_Transform` and an executor-side aggregation over 100k points return correct results.
- Spark 3.5 behaviour was re-checked on EMR 7.9.0 (Spark 3.5.5) and is unchanged.
- The new CI matrix entry runs the full R test suite on Spark 4.0.2 as part of this PR.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
