### PR TITLE
[GH-1776] Report oversized raster values with tiling guidance

### DIFF
--- a/common/src/main/java/org/apache/sedona/common/raster/serde/DataBufferSerializer.java
+++ b/common/src/main/java/org/apache/sedona/common/raster/serde/DataBufferSerializer.java
@@ -28,6 +28,7 @@ import java.awt.image.DataBufferByte;
 import java.awt.image.DataBufferInt;
 import java.awt.image.DataBufferShort;
 import java.awt.image.DataBufferUShort;
+import java.lang.reflect.Array;
 
 public class DataBufferSerializer extends Serializer<DataBuffer> {
   @Override
@@ -39,30 +40,60 @@ public class DataBufferSerializer extends Serializer<DataBuffer> {
     switch (dataType) {
       case DataBuffer.TYPE_BYTE:
         byte[][] byteDataArray = ((DataBufferByte) dataBuffer).getBankData();
+        checkBufferSize(output, byteDataArray, Byte.BYTES);
         KryoUtil.writeByteArrays(output, byteDataArray);
         break;
       case DataBuffer.TYPE_USHORT:
         short[][] uShortDataArray = ((DataBufferUShort) dataBuffer).getBankData();
+        checkBufferSize(output, uShortDataArray, Short.BYTES);
         KryoUtil.writeShortArrays(output, uShortDataArray);
         break;
       case DataBuffer.TYPE_SHORT:
         short[][] shortDataArray = ((DataBufferShort) dataBuffer).getBankData();
+        checkBufferSize(output, shortDataArray, Short.BYTES);
         KryoUtil.writeShortArrays(output, shortDataArray);
         break;
       case DataBuffer.TYPE_INT:
         int[][] intDataArray = ((DataBufferInt) dataBuffer).getBankData();
+        checkBufferSize(output, intDataArray, Integer.BYTES);
         KryoUtil.writeIntArrays(output, intDataArray);
         break;
       case DataBuffer.TYPE_FLOAT:
         float[][] floatDataArray = DataBufferUtils.getBankDataFloat(dataBuffer);
+        checkBufferSize(output, floatDataArray, Float.BYTES);
         KryoUtil.writeFloatArrays(output, floatDataArray);
         break;
       case DataBuffer.TYPE_DOUBLE:
         double[][] doubleDataArray = DataBufferUtils.getBankDataDouble(dataBuffer);
+        checkBufferSize(output, doubleDataArray, Double.BYTES);
         KryoUtil.writeDoubleArrays(output, doubleDataArray);
         break;
       default:
         throw new RuntimeException("Unknown data type: " + dataType);
+    }
+  }
+
+  private static void checkBufferSize(Output output, Object[] banks, int bytesPerElement) {
+    // Serde.serialize uses one in-memory output. Stream-backed outputs can flush their buffers.
+    if (output.getOutputStream() != null) {
+      return;
+    }
+    // Count actual backing arrays: packed pixels, padding, and shared banks make logical
+    // width/height/band counts insufficient. Existing raster metadata is already in the output.
+    long requiredBytes = (long) output.position() + Integer.BYTES;
+    for (Object bank : banks) {
+      requiredBytes += Integer.BYTES + (long) Array.getLength(bank) * bytesPerElement;
+    }
+    // Kryo 4's maximum capacity for an in-memory Output constructed with maxBufferSize = -1.
+    long maxBytes = Integer.MAX_VALUE - 8L;
+    if (requiredBytes > maxBytes) {
+      throw new IllegalArgumentException(
+          "Raster is too large to serialize as a single value: requires "
+              + requiredBytes
+              + " bytes, exceeding the "
+              + maxBytes
+              + " byte limit. Use the raster reader with retile=true and tileWidth/tileHeight, "
+              + "or RS_TileExplode, to serialize smaller tiles.");
     }
   }
 

--- a/common/src/test/java/org/apache/sedona/common/raster/serde/DataBufferSerializerTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/serde/DataBufferSerializerTest.java
@@ -60,7 +60,11 @@ public class DataBufferSerializerTest extends KryoSerializerTestBase {
                 IllegalArgumentException.class, () -> serializer.write(kryo, out, buffer));
         Assert.assertTrue(error.getMessage().contains("too large to serialize"));
         Assert.assertTrue(error.getMessage().contains("RS_TileExplode"));
-        Assert.assertTrue("No pixel bank should have been copied", out.position() < 65536);
+        // Only the data type, offsets array, and logical size should have been written.
+        Assert.assertEquals(
+            "No pixel bank should have been copied",
+            (3 + buffer.getNumBanks()) * Integer.BYTES,
+            out.position());
       }
     }
   }

--- a/common/src/test/java/org/apache/sedona/common/raster/serde/DataBufferSerializerTest.java
+++ b/common/src/test/java/org/apache/sedona/common/raster/serde/DataBufferSerializerTest.java
@@ -20,6 +20,9 @@ package org.apache.sedona.common.raster.serde;
 
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.io.UnsafeOutput;
+import java.awt.Point;
+import java.awt.image.BandedSampleModel;
 import java.awt.image.DataBuffer;
 import java.awt.image.DataBufferByte;
 import java.awt.image.DataBufferDouble;
@@ -27,11 +30,86 @@ import java.awt.image.DataBufferFloat;
 import java.awt.image.DataBufferInt;
 import java.awt.image.DataBufferShort;
 import java.awt.image.DataBufferUShort;
+import java.awt.image.Raster;
+import java.awt.image.WritableRaster;
+import java.lang.reflect.Array;
+import java.util.Arrays;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class DataBufferSerializerTest extends KryoSerializerTestBase {
   private static final DataBufferSerializer serializer = new DataBufferSerializer();
+
+  @Test
+  public void rejectOversizedBankPayloadsBeforeCopyingPixels() {
+    // The writer emits every bank in full, even when banks share the same backing array.
+    // Each buffer below needs 2 GiB on the wire but only 1-8 MiB of pixel storage in this test.
+    DataBuffer[] buffers = {
+      new DataBufferByte((byte[][]) repeatBank(new byte[1 << 20], 2048), 1),
+      new DataBufferShort((short[][]) repeatBank(new short[1 << 20], 1024), 1),
+      new DataBufferUShort((short[][]) repeatBank(new short[1 << 20], 1024), 1),
+      new DataBufferInt((int[][]) repeatBank(new int[1 << 20], 512), 1),
+      new DataBufferFloat((float[][]) repeatBank(new float[1 << 20], 512), 1),
+      new DataBufferDouble((double[][]) repeatBank(new double[1 << 20], 256), 1)
+    };
+    for (DataBuffer buffer : buffers) {
+      // Bound output allocation so the unfixed writer fails safely, without allocating GiB.
+      try (Output out = new UnsafeOutput(65536, 65536)) {
+        IllegalArgumentException error =
+            Assert.assertThrows(
+                IllegalArgumentException.class, () -> serializer.write(kryo, out, buffer));
+        Assert.assertTrue(error.getMessage().contains("too large to serialize"));
+        Assert.assertTrue(error.getMessage().contains("RS_TileExplode"));
+        Assert.assertTrue("No pixel bank should have been copied", out.position() < 65536);
+      }
+    }
+  }
+
+  @Test
+  public void includeExistingOutputAndBankHeadersInSizeLimit() {
+    float[][] banks = (float[][]) repeatBank(new float[1 << 20], 512);
+    banks[511] = new float[(1 << 20) - 2048];
+    // Pixel payload is 2 GiB - 8192 bytes. With 4096 bytes already written and
+    // 4112 bytes of DataBuffer headers, the complete value needs 2147483664 bytes.
+    DataBufferFloat buffer = new DataBufferFloat(banks, 1);
+    try (Output out = new UnsafeOutput(65536, 65536)) {
+      out.writeBytes(new byte[4096]);
+      IllegalArgumentException error =
+          Assert.assertThrows(
+              IllegalArgumentException.class, () -> serializer.write(kryo, out, buffer));
+      Assert.assertTrue(error.getMessage().contains("2147483664"));
+      Assert.assertTrue(error.getMessage().contains("RS_TileExplode"));
+    }
+  }
+
+  @Test
+  public void serializeChildRasterWithoutUnusedParentBanks() {
+    float[] bank = new float[1 << 20];
+    bank[0] = 42;
+    DataBufferFloat buffer = new DataBufferFloat((float[][]) repeatBank(bank, 512), bank.length);
+    WritableRaster parent =
+        Raster.createWritableRaster(
+            new BandedSampleModel(DataBuffer.TYPE_FLOAT, 1024, 1024, 512), buffer, new Point());
+    WritableRaster child = parent.createWritableChild(0, 0, 2, 2, 0, 0, new int[] {0});
+    AWTRasterSerializer rasterSerializer = new AWTRasterSerializer();
+    try (Output out = createOutput()) {
+      rasterSerializer.write(kryo, out, child);
+      Assert.assertTrue("Only the small child should be serialized", out.position() < 1024);
+      try (Input in = createInput(out)) {
+        Raster restored = rasterSerializer.read(kryo, in, Raster.class);
+        Assert.assertEquals(2, restored.getWidth());
+        Assert.assertEquals(2, restored.getHeight());
+        Assert.assertEquals(1, restored.getNumBands());
+        Assert.assertEquals(42, restored.getSampleFloat(0, 0, 0), 0);
+      }
+    }
+  }
+
+  private static Object[] repeatBank(Object bank, int count) {
+    Object[] banks = (Object[]) Array.newInstance(bank.getClass(), count);
+    Arrays.fill(banks, bank);
+    return banks;
+  }
 
   private static void assertEquals(DataBuffer expected, DataBuffer actual) {
     Assert.assertEquals(expected.getDataType(), actual.getDataType());

--- a/docs/api/sql/Raster-Constructors/RS_FromGeoTiff.md
+++ b/docs/api/sql/Raster-Constructors/RS_FromGeoTiff.md
@@ -27,10 +27,12 @@ Return type: `Raster`
 
 Since: `v1.4.0`
 
-SQL Example
+Python example
 
-```scala
-var df = sedona.read.format("binaryFile").load("/some/path/*.tiff")
+```python
+from pyspark.sql import functions as f
+
+df = sedona.read.format("binaryFile").load("/some/path/*.tiff")
 df = df.withColumn("raster", f.expr("RS_FromGeoTiff(content)"))
 ```
 

--- a/docs/api/sql/Raster-Constructors/RS_FromGeoTiff.md
+++ b/docs/api/sql/Raster-Constructors/RS_FromGeoTiff.md
@@ -33,3 +33,19 @@ SQL Example
 var df = sedona.read.format("binaryFile").load("/some/path/*.tiff")
 df = df.withColumn("raster", f.expr("RS_FromGeoTiff(content)"))
 ```
+
+A single serialized `Raster` value must fit in a Java byte array, which limits its size to roughly 2 GiB, including pixel data and metadata. A compressed GeoTIFF can be much smaller than its decoded raster. The number of pixels that fits depends on the band count, data types, and metadata.
+
+For large GeoTIFFs, use the [raster reader](../../../tutorial/raster.md#tile-size-overrides) with explicit tile dimensions:
+
+```python
+df = (
+    sedona.read.format("raster")
+    .option("retile", "true")
+    .option("tileWidth", "256")
+    .option("tileHeight", "256")
+    .load("/some/path/*.tiff")
+)
+```
+
+If the file bytes are already in a `binaryFile` DataFrame, nest `RS_FromGeoTiff` directly inside [RS_TileExplode](../Raster-Tiles/RS_TileExplode.md) to avoid serializing the whole raster as one value.

--- a/docs/api/sql/Raster-Tiles/RS_TileExplode.md
+++ b/docs/api/sql/Raster-Tiles/RS_TileExplode.md
@@ -47,6 +47,15 @@ The returned records have the following schema:
 - `y`: The index of the tile along Y axis (0-based).
 - `tile`: The tile.
 
+For large GeoTIFFs in a `binaryFile` DataFrame, nest `RS_FromGeoTiff` directly inside `RS_TileExplode`:
+
+```sql
+SELECT RS_TileExplode(RS_FromGeoTiff(content), 256, 256)
+FROM binary_rasters
+```
+
+Here, `binary_rasters` is a view of the `binaryFile` DataFrame. `RS_TileExplode` accepts a `Raster`, so raw TIFF bytes such as `content` must first pass through `RS_FromGeoTiff`. Nesting the calls avoids serializing the whole raster as one value. Materializing the whole raster first, for example by caching or writing it, can exceed the [single raster size limit](../Raster-Constructors/RS_FromGeoTiff.md) before tiling runs. Each resulting tile must also fit within that limit.
+
 SQL example:
 
 ```sql


### PR DESCRIPTION
## Did you read the Contributor Guide?

Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/).

## Is this PR related to a ticket?

Refs #1776.

## What changes were proposed in this PR?

Serializing an oversized raster can fail with an unhelpful exception in Kryo's `Unsafe.copyMemory`. Check the required output size before copying pixel banks and report the required bytes, the limit, and how to produce smaller tiles with the raster reader or `RS_TileExplode`.

The check uses the actual backing array lengths and accounts for existing output and bank headers. It covers all supported pixel types and preserves the existing path for stream-backed outputs. Regression tests cover oversized banks, size accounting, and small child rasters backed by large parent images.

This is a diagnostic improvement. The roughly 2 GiB limit and serialization format remain unchanged. It does not address the separate TIFF metadata `EOFException` reported later in the issue.

## How was this patch tested?

With Java 11, 42 targeted serialization tests passed, including three new regression tests:

```bash
mvn -B -pl common -am \
  -Dtest=DataBufferSerializerTest,SampleModelSerializerTest,CRSSerializerTest,KryoUtilTest,SerdeTest \
  -Dsurefire.failIfNoSpecifiedTests=false verify
```

The two oversized-buffer tests failed against the original implementation and passed with the new diagnostic. Maven verification, Spotless, and all applicable pre-commit checks passed.

For a Spark runtime check, used Spark 3.5.0, Java 17.0.13, released Sedona 1.9.1, and geotools-wrapper 1.9.1-33.5, replacing only the candidate serializer class. The [representative WRI raster used in the issue reproduction](https://github.com/apache/sedona/issues/1776#issuecomment-5607231386) now reports **3,732,481,104 required bytes versus 2,147,483,639 allowed**. Nested tiling and raster-reader tiling returned five sampled tiles each, including non-NoData pixels in the reader sample. Metadata-only access returned the correct full dimensions.

The Spark check used a patched release jar, not a full current-master Spark build. Tiling validation sampled output; it did not scan every tile.

## Did this PR include necessary documentation updates?

Yes. Added the single-raster size limit and explicit tiling examples to `RS_FromGeoTiff` and `RS_TileExplode`, including the need to decode TIFF bytes and tile before materializing the whole raster.
