### PR TITLE
[GH-3344] GeoPandas: expose valid spatial index predicates

### DIFF
--- a/docs/setup/release-notes.md
+++ b/docs/setup/release-notes.md
@@ -65,6 +65,7 @@
 * [<a href='https://github.com/apache/sedona/issues/3273'>GH-3273</a>] - Implement distributed GeoSeries and GeoDataFrame polygonal coverage validation and invalid-edge diagnostics
 * [<a href='https://github.com/apache/sedona/issues/3281'>GH-3281</a>] - Implement `GeoDataFrame.from_features` for in-memory GeoJSON-like features
 * [<a href='https://github.com/apache/sedona/issues/3288'>GH-3288</a>] - Implement `GeoDataFrame.from_dict` for in-memory dictionaries
+* [<a href='https://github.com/apache/sedona/issues/3344'>GH-3344</a>] - Expose `SpatialIndex.valid_query_predicates`
 
 ### Bug Fixes
 

--- a/python/sedona/spark/geopandas/sindex.py
+++ b/python/sedona/spark/geopandas/sindex.py
@@ -82,7 +82,8 @@ class SpatialIndex:
 
     @property
     def valid_query_predicates(self) -> set:
-        """Return the supported values for the ``query`` predicate.
+        """
+        Return the supported values for the ``query`` predicate.
 
         .. versionadded:: 2.0.0
 

--- a/python/sedona/spark/geopandas/sindex.py
+++ b/python/sedona/spark/geopandas/sindex.py
@@ -80,6 +80,20 @@ class SpatialIndex:
                 "Invalid type for `geometry`. Expected np.array, GeoSeries, or PySparkDataFrame."
             )
 
+    @property
+    def valid_query_predicates(self) -> set:
+        """Return the supported values for the ``query`` predicate.
+
+        .. versionadded:: 2.0.0
+
+        Returns
+        -------
+        set
+            A new set containing ``None``, ``"intersects"``, and ``"contains"``.
+            ``None`` selects the default ``"intersects"`` behavior.
+        """
+        return {None, *ALLOWED_PREDICATES}
+
     def query(self, geometry: BaseGeometry, predicate: str = None, sort: bool = False):
         """
         Query the spatial index for geometries that intersect the given geometry.

--- a/python/tests/geopandas/test_sindex.py
+++ b/python/tests/geopandas/test_sindex.py
@@ -94,6 +94,32 @@ class TestSpatialIndex(TestBase):
         assert hasattr(self.polygons, "sindex")
         assert hasattr(self.lines, "sindex")
 
+    @pytest.mark.parametrize("distributed", [False, True])
+    def test_valid_query_predicates(self, distributed):
+        geometries = [Point(0, 0), Point(1, 1), Point(2, 2)]
+        sindex = (
+            GeoSeries(geometries).sindex
+            if distributed
+            else SpatialIndex(np.array(geometries))
+        )
+        assert sindex.valid_query_predicates == {None, "intersects", "contains"}
+
+        for predicate in sindex.valid_query_predicates:
+            result = sindex.query(box(0.5, 0.5, 1.5, 1.5), predicate=predicate)
+            assert list(result) == ([Point(1, 1)] if distributed else [1])
+
+    @pytest.mark.parametrize("geometries", [[], [Point(0, 0)]])
+    def test_valid_query_predicates_returns_independent_set(self, geometries):
+        sindex = SpatialIndex(np.array(geometries, dtype=object))
+        predicates = sindex.valid_query_predicates
+        predicates.clear()
+        predicates.add("within")
+
+        assert sindex.valid_query_predicates == {None, "intersects", "contains"}
+        if geometries:
+            with pytest.raises(ValueError, match="Predicate must be"):
+                sindex.query(Point(0, 0), predicate="within")
+
     def test_geodataframe_sindex_property_exists(self):
         """Test that the sindex property exists on GeoDataFrame."""
         assert hasattr(self.points.to_geoframe(), "sindex")


### PR DESCRIPTION
## Did you read the Contributor Guide?

Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/).

## Is this PR related to a ticket?

Yes, the PR name follows the format `[GH-XXX] my subject`.

Closes #3344. Part of #2230.

## What changes were proposed in this PR?

Add the read-only `SpatialIndex.valid_query_predicates` property. It returns a fresh set containing `None`, `"intersects"`, and `"contains"`, using the same supported-predicate list as `query()`.

This only exposes the accepted predicate values. It does not add predicates or change query execution.

## How was this patch tested?

From the `python` directory:

```bash
python -m pytest tests/geopandas/test_sindex.py -q --disable-warnings
```

- Spark 3.5.4: 21 passed.
- Spark 4.1.1: 21 passed.
- The four new parameterized cases failed with the missing-property `AttributeError` before implementation. They cover querying with every advertised predicate on local and Spark-backed indexes, empty indexes, and isolation of the returned set.
- Repository formatting and lint hooks passed for both changed files.

## Did this PR include necessary documentation updates?

Yes, this adds a public API. Its docstring documents the returned predicates and the default behavior, with `versionadded:: 2.0.0` for the current `v2.0.0` development release.
