### PR TITLE
[GH-3333] Handle leading nulls in local GeoSeries construction

### DIFF
--- a/python/sedona/spark/geopandas/geoseries.py
+++ b/python/sedona/spark/geopandas/geoseries.py
@@ -737,8 +737,22 @@ class GeoSeries(GeoFrame, pspd.Series):
 
             pd_series = pd_series.astype(object)
 
-            # Initialize the parent class PySpark Series with the pandas Series.
-            super().__init__(data=pd_series)
+            if (
+                not pd_series.empty
+                and pd_series.isna().iloc[0]
+                and any(isinstance(value, BaseGeometry) for value in pd_series)
+            ):
+                # Spark 3.5 infers object UDTs from the first value. WKB lets
+                # leading missing values retain geometry type without reordering.
+                wkb_series = (
+                    gpd.GeoSeries(pd_series.where(pd_series.notna(), None))
+                    .to_wkb(include_srid=True)
+                    .rename(pd_series.name)
+                )
+                ps_series = pspd.Series(wkb_series).spark.transform(stc.ST_GeomFromWKB)
+                super().__init__(data=ps_series._anchor, index=ps_series._col_label)
+            else:
+                super().__init__(data=pd_series)
 
         # Ensure we're storing geometry types.
         if (

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -677,6 +677,92 @@ class TestGeoSeries(TestGeopandasBase):
         sgpd_series = sgpd.GeoSeries(obj)
         assert isinstance(sgpd_series, sgpd.GeoSeries)
 
+    @pytest.mark.parametrize(
+        "wrap",
+        [list, tuple, np.asarray, pd.Series, gpd.GeoSeries, gpd.array.from_shapely],
+        ids=["list", "tuple", "numpy", "pandas", "geopandas", "geometry_array"],
+    )
+    def test_constructor_leading_null_local_inputs(self, wrap):
+        from geopandas.testing import assert_geoseries_equal
+
+        _ = self.spark
+        values = [None, Point(1, 0), None, Point()]
+        result = GeoSeries(wrap(values))
+
+        assert_geoseries_equal(
+            result.to_geopandas(), gpd.GeoSeries(values), check_index_type=False
+        )
+        assert result.crs is None
+
+    @pytest.mark.parametrize(
+        "missing", [None, np.nan, pd.NA, pd.NaT, np.datetime64("NaT")]
+    )
+    def test_constructor_leading_missing_values(self, missing):
+        from geopandas.testing import assert_geoseries_equal
+
+        _ = self.spark
+        result = GeoSeries([missing, Point(1, 0), missing])
+
+        assert_geoseries_equal(
+            result.to_geopandas(),
+            gpd.GeoSeries([None, Point(1, 0), None]),
+            check_index_type=False,
+        )
+
+    @pytest.mark.parametrize(
+        "name, inherited_crs, crs",
+        [
+            (None, None, None),
+            ("geometry", "EPSG:4326", None),
+            (("geometry", "shape"), "EPSG:4326", "EPSG:3857"),
+        ],
+    )
+    def test_constructor_leading_null_metadata(self, name, inherited_crs, crs):
+        from geopandas.testing import assert_geoseries_equal
+
+        _ = self.spark
+        index = pd.MultiIndex.from_tuples(
+            [("b", 2), ("a", 1), ("b", 2)], names=["letter", "number"]
+        )
+        values = [None, Point(1, 0, 2), Point(3, 4)]
+        local = gpd.GeoSeries(values, index=index, name=name, crs=inherited_crs)
+        result = GeoSeries(local, crs=crs)
+        expected = gpd.GeoSeries(
+            values, index=index, name=name, crs=crs or inherited_crs
+        )
+
+        assert result.name == name
+        assert_geoseries_equal(result.to_geopandas(), expected)
+        assert_geoseries_equal(
+            local, gpd.GeoSeries(values, index=index, name=name, crs=inherited_crs)
+        )
+
+    @pytest.mark.parametrize("values", [[], [None, None], [Point(1, 0), None]])
+    def test_constructor_null_and_empty_controls(self, values):
+        from geopandas.testing import assert_geoseries_equal
+
+        _ = self.spark
+        assert_geoseries_equal(
+            GeoSeries(values).to_geopandas(),
+            gpd.GeoSeries(values),
+            check_index_type=False,
+        )
+
+    def test_constructor_leading_null_preserves_embedded_srid(self):
+        from shapely import wkb
+        from sedona.spark.sql.types import GeometryType
+
+        _ = self.spark
+        point = wkb.loads(wkb.dumps(Point(1, 2, 3), srid=4326))
+        result = GeoSeries([None, point])
+
+        assert result.spark.data_type == GeometryType()
+        assert result.crs is None
+        assert result.spark.transform(stf.ST_SRID).to_pandas().dropna().tolist() == [
+            4326
+        ]
+        assert result.spark.transform(stf.ST_Z).to_pandas().dropna().tolist() == [3]
+
     def test_constructor_pandas_on_spark(self):
         obj = ps.Series([Point(x, x) for x in range(3)])
         sgpd_series = GeoSeries(obj)


### PR DESCRIPTION
## Did you read the Contributor Guide?

Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/).

## Is this PR related to a ticket?

Closes #3333.

## What changes were proposed in this PR?

On Spark 3.5, local input such as `GeoSeries([None, Point(1, 2)])` fails with `ArrowInvalid`: pandas-on-Spark checks the first value to infer the geometry type, so a leading null prevents it from recognizing later geometries.

For local input that starts with a missing value and contains a geometry, normalize missing entries, encode the values as well-known binary (WKB) with embedded SRIDs, and construct the geometry column with `ST_GeomFromWKB`. Restore the original Series name after WKB conversion. This preserves input order, index, name, geometry dimensions, and existing CRS handling. Other constructor paths remain unchanged.

## How was this patch tested?

The new tests produced 13 `ArrowInvalid` failures on the unchanged Spark 3.5 constructor, with three controls passing. A separate regression check caught both pandas and NumPy `NaT` values before missing-value normalization was added.

31 focused GeoSeries constructor, conversion, and CRS tests passed on each of Spark 3.5.0 and 4.1.1. Coverage includes local list, tuple, NumPy, pandas, GeoPandas, and GeometryArray inputs; missing-value variants; duplicate MultiIndex order; names; inherited and explicit CRS; empty geometries; and embedded SRID/Z preservation.

Current Python source was tested with cached JVM jars: released Sedona 1.9.1 for Spark 3.5 and a prior local 2.0.0-SNAPSHOT build for Spark 4.1. No fresh JVM rebuild was performed. Formatting and pre-commit checks passed.

## Did this PR include necessary documentation updates?

No documentation changes are needed. This fixes an existing constructor path without changing the public API.
