### PR TITLE
[GH-3351][Python] Preserve generated GeoArrow column names

### DIFF
--- a/python/sedona/spark/geoarrow/geoarrow.py
+++ b/python/sedona/spark/geoarrow/geoarrow.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Callable, List
 from sedona.spark.sql.st_functions import ST_AsEWKB
 from pyspark.sql import SparkSession
 from pyspark.sql import DataFrame
+from pyspark.sql.functions import col
 from pyspark.sql.types import StructType, StructField, DataType, ArrayType, MapType
 
 from sedona.spark.sql.types import GeometryType
@@ -59,8 +60,8 @@ def dataframe_to_arrow(df, crs=None):
     if not any(col_is_geometry):
         return dataframe_to_arrow_raw(df)
 
-    df_columns = list(df)
     df_column_names = df.schema.fieldNames()
+    df_columns = [col("`" + name.replace("`", "``") + "`") for name in df_column_names]
     for i, is_geom in enumerate(col_is_geometry):
         if is_geom:
             df_columns[i] = ST_AsEWKB(df_columns[i]).alias(df_column_names[i])

--- a/python/tests/utils/test_geoarrow.py
+++ b/python/tests/utils/test_geoarrow.py
@@ -62,6 +62,14 @@ class TestGeoArrow(TestBase):
             assert field.metadata[b"ARROW:extension:name"] == b"geoarrow.wkb"
             assert field.metadata[b"ARROW:extension:metadata"] == b"{}"
 
+    def test_to_geoarrow_with_unaliased_geometry_expression(self):
+        geo_df = TestGeoArrow.spark.sql("SELECT ST_Point(1.0, 2.0)")
+
+        geo_table = dataframe_to_arrow(geo_df)
+
+        assert geo_table.column_names == ["st_point(1.0, 2.0)"]
+        assert geo_table.num_rows == 1
+
     def test_to_geoarrow_with_geometry_with_srid(self):
         schema = StructType().add("wkt", StringType())
         wkt_df = TestGeoArrow.spark.createDataFrame(zip(TEST_WKT), schema)


### PR DESCRIPTION
## Did you read the Contributor Guide?

Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/).

## Is this PR related to a ticket?

Yes. Closes #3351.

## What changes were proposed in this PR?

`dataframe_to_arrow()` previously used `list(df)` to build its input expressions. Spark resolves a generated geometry name such as `st_point(1.0, 2.0)` as a dotted path, so conversion fails before GeoArrow encoding runs.

Build explicit, backtick-quoted Spark column expressions from the schema names, escaping embedded backticks, before applying `ST_AsEWKB`. The original field name is still restored with `alias`, so generated geometry expressions retain their expected Arrow column name.

## How was this patch tested?

- Added a regression using `SELECT ST_Point(1.0, 2.0)` without an alias.
- Manually reproduced the issue: the unchanged path raised Spark's dotted-name `AnalysisException`; with this patch the input and Arrow table both reported `['st_point(1.0, 2.0)']` and one row.
- `python/tests/utils/test_geoarrow.py`: 7 passed, 1 optional GeoArrow-types test skipped.
- Black formatting check, `compileall`, and `git diff --check` passed.

## Did this PR include necessary documentation updates?

No documentation changes are needed. This restores conversion for an existing DataFrame shape without changing the public API.
