### PR TITLE
[GH-3355] Pull the MinIO test image from quay.io

### DIFF
--- a/spark/common/src/test/scala/org/apache/sedona/sql/OsmReaderTest.scala
+++ b/spark/common/src/test/scala/org/apache/sedona/sql/OsmReaderTest.scala
@@ -22,6 +22,7 @@ import io.minio.{ListObjectsArgs, MakeBucketArgs, MinioClient}
 import org.apache.spark.sql.functions.col
 import org.scalatest.matchers.should.Matchers
 import org.testcontainers.containers.MinIOContainer
+import org.testcontainers.utility.DockerImageName
 
 import java.io.FileInputStream
 
@@ -110,7 +111,10 @@ class OsmReaderTest extends TestBaseScala with Matchers {
     }
 
     it("should be able to read from osm file on s3") {
-      val container = new MinIOContainer("minio/minio:latest")
+      val container = new MinIOContainer(
+        DockerImageName
+          .parse("quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z")
+          .asCompatibleSubstituteFor("minio/minio"))
 
       container.start()
 

--- a/spark/spark-3.5/src/test/scala/org/apache/sedona/sql/GeoPackageReaderTest.scala
+++ b/spark/spark-3.5/src/test/scala/org/apache/sedona/sql/GeoPackageReaderTest.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.types.{BinaryType, BooleanType, DateType, DoubleType
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.testcontainers.containers.MinIOContainer
+import org.testcontainers.utility.DockerImageName
 
 import java.io.FileInputStream
 import java.sql.{Date, Timestamp}
@@ -310,7 +311,10 @@ class GeoPackageReaderTest extends TestBaseScala with Matchers {
 
   describe("Reading from S3") {
     it("should be able to read files from S3") {
-      val container = new MinIOContainer("minio/minio:latest")
+      val container = new MinIOContainer(
+        DockerImageName
+          .parse("quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z")
+          .asCompatibleSubstituteFor("minio/minio"))
 
       container.start()
 

--- a/spark/spark-4.0/src/test/scala/org/apache/sedona/sql/GeoPackageReaderTest.scala
+++ b/spark/spark-4.0/src/test/scala/org/apache/sedona/sql/GeoPackageReaderTest.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.types.{BinaryType, BooleanType, DateType, DoubleType
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.testcontainers.containers.MinIOContainer
+import org.testcontainers.utility.DockerImageName
 
 import java.io.FileInputStream
 import java.sql.{Date, Timestamp}
@@ -310,7 +311,10 @@ class GeoPackageReaderTest extends TestBaseScala with Matchers {
 
   describe("Reading from S3") {
     it("should be able to read files from S3") {
-      val container = new MinIOContainer("minio/minio:latest")
+      val container = new MinIOContainer(
+        DockerImageName
+          .parse("quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z")
+          .asCompatibleSubstituteFor("minio/minio"))
 
       container.start()
 

--- a/spark/spark-4.1/src/test/scala/org/apache/sedona/sql/GeoPackageReaderTest.scala
+++ b/spark/spark-4.1/src/test/scala/org/apache/sedona/sql/GeoPackageReaderTest.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.types.{BinaryType, BooleanType, DateType, DoubleType
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.testcontainers.containers.MinIOContainer
+import org.testcontainers.utility.DockerImageName
 
 import java.io.FileInputStream
 import java.sql.{Date, Timestamp}
@@ -310,7 +311,10 @@ class GeoPackageReaderTest extends TestBaseScala with Matchers {
 
   describe("Reading from S3") {
     it("should be able to read files from S3") {
-      val container = new MinIOContainer("minio/minio:latest")
+      val container = new MinIOContainer(
+        DockerImageName
+          .parse("quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z")
+          .asCompatibleSubstituteFor("minio/minio"))
 
       container.start()
 


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #3355

## What changes were proposed in this PR?

Docker Hub no longer serves the `minio/minio` repository, so every Testcontainers-based MinIO test fails to start and, with fail-fast, takes the whole `Scala and Java build` matrix down. This switches the four call sites (`OsmReaderTest` and the three `GeoPackageReaderTest` copies) to the same image on quay.io, pinned to a release tag instead of `latest`:

```scala
new MinIOContainer(
  DockerImageName
    .parse("quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z")
    .asCompatibleSubstituteFor("minio/minio"))
```

`asCompatibleSubstituteFor` is required because `MinIOContainer` asserts that the image is compatible with `minio/minio`. `RELEASE.2025-09-07T16-13-09Z` is the build quay's `latest` tag points at today, so this is the image the tests were already using.

## How was this patch tested?

- Test sources of `spark/common` and `spark/spark-3.5` compile with the change.
- The container tests need Docker, which is not available on my machine, so the real verification is this PR's CI run: the previously failing `OsmReaderTest` and `GeoPackageReaderTest` S3 cases should now start their MinIO container and pass.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
